### PR TITLE
Add Error Prone Compiler Check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -332,13 +332,39 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.1</version>
                 <configuration>
                     <compilerVersion>${javac.target}</compilerVersion>
                     <source>${javac.target}</source>
                     <testSource>${javac.target}</testSource>
                     <target>${javac.target}</target>
-                    <compilerArgument>-Xlint:unchecked</compilerArgument>
+                    <fork>true</fork>
+                    <compilerArgs>
+                        <arg>-XDcompilePolicy=simple</arg>
+                        <arg>-Xplugin:ErrorProne</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+                    </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.google.errorprone</groupId>
+                            <artifactId>error_prone_core</artifactId>
+                            <version>2.6.0</version>
+                        </path>
+                        <!-- Other annotation processors go here.
+
+                        If 'annotationProcessorPaths' is set, processors will no longer be
+                        discovered on the regular -classpath; see also 'Using Error Prone
+                        together with other annotation processors' below. -->
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/slack/kaldb/chunk/ChunkManager.java
+++ b/src/main/java/com/slack/kaldb/chunk/ChunkManager.java
@@ -319,7 +319,7 @@ public class ChunkManager<T> {
     LOG.info("Closed chunk manager.");
   }
 
-  public void removeStaleChunks(List<Map.Entry<Long, Chunk<T>>> staleChunks) {
+  public void removeStaleChunks(List<Map.Entry<String, Chunk<T>>> staleChunks) {
     if (staleChunks.isEmpty()) return;
 
     LOG.info("Stale chunks to be removed are: {}", staleChunks);


### PR DESCRIPTION
Add Error Prone check at compile time to catch any bugs that can be caught by static analysis

This also fixes a bug that was found

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project kaldb: Compilation failure: Compilation failure: 
[ERROR] /Users/vthacker/slack-repos/kaldb/src/main/java/com/slack/kaldb/chunk/ChunkManager.java:[334,36] error: [CollectionIncompatibleType] Argument 'entry.getKey()' should not be passed to this method; its type Long is not compatible with its collection's type argument String
[ERROR]     (see https://errorprone.info/bugpattern/CollectionIncompatibleType)
[ERROR] /Users/vthacker/slack-repos/kaldb/src/main/java/com/slack/kaldb/chunk/ChunkManager.java:[341,31] error: [CollectionIncompatibleType] Argument 'entry.getKey()' should not be passed to this method; its type Long is not compatible with its collection's type argument String
[ERROR]     (see https://errorprone.info/bugpattern/CollectionIncompatibleType)
[ERROR] -> [Help 1]
```