### PR TITLE
Reserve commit point during S3 copy

### DIFF
--- a/src/main/java/com/slack/kaldb/logstore/CheckedRunnable.java
+++ b/src/main/java/com/slack/kaldb/logstore/CheckedRunnable.java
@@ -1,0 +1,7 @@
+package com.slack.kaldb.logstore;
+
+/** A {@link Runnable}-like interface which allows throwing checked exceptions. */
+@FunctionalInterface
+public interface CheckedRunnable<E extends Exception> {
+  void run() throws E;
+}

--- a/src/main/java/com/slack/kaldb/logstore/IndexCommitRefHolder.java
+++ b/src/main/java/com/slack/kaldb/logstore/IndexCommitRefHolder.java
@@ -1,0 +1,29 @@
+package com.slack.kaldb.logstore;
+
+import java.io.Closeable;
+import java.io.IOException;
+import org.apache.lucene.index.IndexCommit;
+
+/**
+ * This class takes a snapshot of the current index usually by calling
+ * SnapshotDeletionPolicy#snapshot and a runnable which should close the underlying resource ( call
+ * SnapshotDeletionPolicy#release )
+ */
+public class IndexCommitRefHolder implements Closeable {
+  private final CheckedRunnable<IOException> onClose;
+  private final IndexCommit indexCommit;
+
+  public IndexCommitRefHolder(IndexCommit indexCommit, CheckedRunnable<IOException> onClose) {
+    this.indexCommit = indexCommit;
+    this.onClose = onClose;
+  }
+
+  @Override
+  public void close() throws IOException {
+    onClose.run();
+  }
+
+  public IndexCommit getIndexCommit() {
+    return indexCommit;
+  }
+}

--- a/src/main/java/com/slack/kaldb/logstore/LogStore.java
+++ b/src/main/java/com/slack/kaldb/logstore/LogStore.java
@@ -2,7 +2,6 @@ package com.slack.kaldb.logstore;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collection;
 import org.apache.lucene.search.SearcherManager;
 
 /* An interface that implements a read and write interface for the LogStore */
@@ -24,6 +23,7 @@ public interface LogStore<T> {
 
   Path getDirectory();
 
-  Collection<String> activeFiles();
+  IndexCommitRefHolder acquireLatestCommit() throws IOException;
+
   // TODO: Add an isReadOnly and setReadOnly API here.
 }

--- a/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreImpl.java
+++ b/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreImpl.java
@@ -7,8 +7,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -16,7 +14,6 @@ import java.util.UUID;
 import org.apache.commons.io.FileUtils;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
@@ -52,6 +49,7 @@ public class LuceneIndexStoreImpl implements LogStore<LogMessage> {
   private final IndexWriterConfig indexWriterConfig;
   private final FSDirectory indexDirectory;
   private final Timer timer;
+  private final SnapshotDeletionPolicy snapshotDeletionPolicy;
   private Optional<IndexWriter> indexWriter;
 
   // Stats counters.
@@ -96,7 +94,10 @@ public class LuceneIndexStoreImpl implements LogStore<LogMessage> {
     this.documentBuilder = documentBuilder;
 
     this.analyzer = new StandardAnalyzer();
-    indexWriterConfig = buildIndexWriterConfig(this.analyzer, this.config, registry);
+    this.snapshotDeletionPolicy =
+        new SnapshotDeletionPolicy(new KeepOnlyLastCommitDeletionPolicy());
+    indexWriterConfig =
+        buildIndexWriterConfig(this.analyzer, this.snapshotDeletionPolicy, this.config, registry);
     indexDirectory = new NIOFSDirectory(config.indexFolder(id).toPath());
     indexWriter = Optional.of(new IndexWriter(indexDirectory, indexWriterConfig));
     this.searcherManager = new SearcherManager(indexWriter.get(), false, false, null);
@@ -132,7 +133,10 @@ public class LuceneIndexStoreImpl implements LogStore<LogMessage> {
   }
 
   private IndexWriterConfig buildIndexWriterConfig(
-      Analyzer analyzer, LuceneIndexStoreConfig config, MeterRegistry metricsRegistry) {
+      Analyzer analyzer,
+      SnapshotDeletionPolicy snapshotDeletionPolicy,
+      LuceneIndexStoreConfig config,
+      MeterRegistry metricsRegistry) {
     final IndexWriterConfig indexWriterCfg =
         new IndexWriterConfig(analyzer)
             .setOpenMode(IndexWriterConfig.OpenMode.CREATE)
@@ -140,7 +144,8 @@ public class LuceneIndexStoreImpl implements LogStore<LogMessage> {
             .setUseCompoundFile(false)
             .setMergeScheduler(new KalDBMergeScheduler(metricsRegistry))
             .setIndexDeletionPolicy(
-                new SnapshotDeletionPolicy(new KeepOnlyLastCommitDeletionPolicy()));
+                new SnapshotDeletionPolicy(new KeepOnlyLastCommitDeletionPolicy()))
+            .setIndexDeletionPolicy(snapshotDeletionPolicy);
 
     if (config.enableTracing) {
       indexWriterCfg.setInfoStream(System.out);
@@ -239,21 +244,17 @@ public class LuceneIndexStoreImpl implements LogStore<LogMessage> {
   }
 
   @Override
-  public Collection<String> activeFiles() {
-    if (indexWriter.isEmpty()) {
-      throw new IllegalStateException(
-          "This function shouldn't be called when index writer is null");
-    }
+  public IndexCommitRefHolder acquireLatestCommit() throws IOException {
+    IndexCommit indexCommit = snapshotDeletionPolicy.snapshot();
+    return new IndexCommitRefHolder(indexCommit, () -> decIndexCommitRef(indexCommit));
+  }
 
-    DirectoryReader directoryReader;
+  private void decIndexCommitRef(IndexCommit indexCommit) {
     try {
-      directoryReader = DirectoryReader.open(indexDirectory);
-      IndexCommit indexCommit = directoryReader.getIndexCommit();
-      return indexCommit.getFileNames();
+      snapshotDeletionPolicy.release(indexCommit);
     } catch (IOException e) {
-      LOG.error("Error getting activeFiles for index writer: " + id, e);
+      LOG.warn("Tried to release index commit but failed", e);
     }
-    return Collections.emptyList();
   }
 
   /**

--- a/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
+++ b/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
@@ -359,7 +359,11 @@ public class LuceneIndexStoreImplTest {
       assertThat(getCount(COMMITS_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
 
       Path dirPath = logStore.getDirectory().toAbsolutePath();
-      Collection<String> activeFiles = logStore.activeFiles();
+      Collection<String> activeFiles;
+      try (IndexCommitRefHolder ref = logStore.acquireLatestCommit()) {
+        activeFiles = ref.getIndexCommit().getFileNames();
+      }
+      assertThat(activeFiles).isNotNull();
 
       LocalBlobFs localBlobFs = new LocalBlobFs();
       logStore.close();
@@ -423,7 +427,11 @@ public class LuceneIndexStoreImplTest {
       assertThat(getCount(COMMITS_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
 
       Path dirPath = logStore.getDirectory().toAbsolutePath();
-      Collection<String> activeFiles = logStore.activeFiles();
+      Collection<String> activeFiles;
+      try (IndexCommitRefHolder ref = logStore.acquireLatestCommit()) {
+        activeFiles = ref.getIndexCommit().getFileNames();
+      }
+      assertThat(activeFiles).isNotNull();
       LocalBlobFs blobFs = new LocalBlobFs();
       logStore.close();
       strictLogStore.logSearcher.close();


### PR DESCRIPTION
Currently when we copy the files over to S3 we risk files being changed under-the-hood by lucene. Lucene can add/remove files in the index as and when documents get flushed/committed to disk 

We should use the `SnapshotDeletionPolicy#snapshot` and `SnapshotDeletionPolicy#release` API to ensure we're copying a point in time of the index that who's reference we can hold onto while the copying task is running.

```
// starting to roll over
[INFO ] 2021-04-23 11:01:59.048 [pool-3-thread-1] RollOverChunkTask - Start chunk roll over ChunkInfo{chunkId='log_data__1619200835341', chunkCreationTimeSecsSinceEpoch=1619200835, chunkLastUpdatedTimeSecsSinceEpoch=1619200919, dataStartTimeSecsSinceEpoch=1619062542, dataEndTimeSecsSinceEpoch=1619113903, chunkSnapshotTime=0}

[INFO ] 2021-04-23 11:01:59.048 [pool-3-thread-1] ReadWriteChunkImpl - Started RW chunk pre-snapshot ChunkInfo{chunkId='log_data__1619200835341', chunkCreationTimeSecsSinceEpoch=1619200835, chunkLastUpdatedTimeSecsSinceEpoch=1619200919, dataStartTimeSecsSinceEpoch=1619062542, dataEndTimeSecsSinceEpoch=1619113903, chunkSnapshotTime=0}

// Calling commit and then SearcherManager#maybeRefresh()
[INFO ] 2021-04-23 11:01:59.048 [pool-3-thread-1] LuceneIndexStoreImpl - Indexer starting commit for: /mnt/kaldb/data/indices/a48e3955-947b-4a87-a8ed-366a295a8a78

//Copying to S3 then throws this error ( sometimes )

[ERROR] 2021-04-23 11:02:06.392 [pool-3-thread-1] ReadWriteChunkImpl - Exception when copying RW chunk ChunkInfo{chunkId='log_data__1619200835341', chunkCreationTimeSecsSinceEpoch=1619200835, chunkLastUpdatedTimeSecsSinceEpoch=1619200919, dataStartTimeSecsSinceEpoch=1619062542, dataEndTimeSecsSinceEpoch=1619113903, chunkSnapshotTime=0} to S3.
java.io.UncheckedIOException: java.nio.file.NoSuchFileException: /mnt/kaldb/data/indices/a48e3955-947b-4a87-a8ed-366a295a8a78/_1f.dii
        at software.amazon.awssdk.utils.FunctionalUtils.asRuntimeException(FunctionalUtils.java:180) ~[kaldb.jar:?]
        at software.amazon.awssdk.utils.FunctionalUtils.lambda$safeSupplier$4(FunctionalUtils.java:110) ~[kaldb.jar:?]
        at software.amazon.awssdk.utils.FunctionalUtils.invokeSafely(FunctionalUtils.java:136) ~[kaldb.jar:?]
        at software.amazon.awssdk.core.sync.RequestBody.fromFile(RequestBody.java:88) ~[kaldb.jar:?]
        at software.amazon.awssdk.services.s3.S3Client.putObject(S3Client.java:15622) ~[kaldb.jar:?]
        at com.slack.kaldb.blobfs.s3.S3BlobFs.copyFromLocalFile(S3BlobFs.java:442) ~[kaldb.jar:?]
        at com.slack.kaldb.logstore.BlobFsUtils.copyToS3(BlobFsUtils.java:28) ~[kaldb.jar:?]
        at com.slack.kaldb.chunk.ReadWriteChunkImpl.snapshotToS3(ReadWriteChunkImpl.java:126) [kaldb.jar:?]
        at com.slack.kaldb.chunk.RollOverChunkTask.call(RollOverChunkTask.java:50) [kaldb.jar:?]
        at com.slack.kaldb.chunk.RollOverChunkTask.call(RollOverChunkTask.java:11) [kaldb.jar:?]
        at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:125) [kaldb.jar:?]
        at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:69) [kaldb.jar:?]
        at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:78) [kaldb.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:834) [?:?]
Caused by: java.nio.file.NoSuchFileException: /mnt/kaldb/data/indices/a48e3955-947b-4a87-a8ed-366a295a8a78/_1f.dii
        at sun.nio.fs.UnixException.translateToIOException(UnixException.java:92) ~[?:?]
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111) ~[?:?]
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116) ~[?:?]
        at sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:55) ~[?:?]
        at sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:145) ~[?:?]
        at sun.nio.fs.LinuxFileSystemProvider.readAttributes(LinuxFileSystemProvider.java:99) ~[?:?]
        at java.nio.file.Files.readAttributes(Files.java:1763) ~[?:?]
        at java.nio.file.Files.size(Files.java:2380) ~[?:?]
        at software.amazon.awssdk.core.sync.RequestBody.lambda$fromFile$0(RequestBody.java:88) ~[kaldb.jar:?]
        at software.amazon.awssdk.utils.FunctionalUtils.lambda$safeSupplier$4(FunctionalUtils.java:108) ~[kaldb.jar:?]
        ... 14 more
```