### PR TITLE
Expose metrics via /metrics endpoint in prometheus exposition format. Configurable server port.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,9 @@
         <protobuf.version>3.12.0</protobuf.version>
         <grpc.version>1.30.0</grpc.version>
         <armeria.version>1.4.0</armeria.version>
+        <micrometer.version>1.5.1</micrometer.version>
+        <jackson.version>2.11.1</jackson.version>
+        <lucene.version>8.4.1</lucene.version>
     </properties>
 
     <repositories>
@@ -80,27 +83,27 @@
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
-            <version>8.4.1</version>
+            <version>${lucene.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-queries</artifactId>
-            <version>8.4.1</version>
+            <version>${lucene.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-test-framework</artifactId>
-            <version>8.4.1</version>
+            <version>${lucene.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-analyzers-common</artifactId>
-            <version>8.4.1</version>
+            <version>${lucene.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-queryparser</artifactId>
-            <version>8.4.1</version>
+            <version>${lucene.version}</version>
         </dependency>
 
         <!-- Kafka writer dependencies -->
@@ -114,19 +117,19 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.11.1</version>
+            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.11.1</version>
+            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.11.1</version>
+            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>
@@ -135,10 +138,16 @@
             <version>30.0-jre</version>
         </dependency>
 
+        <!-- micrometer dependencies -->
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
-            <version>1.5.1</version>
+            <version>${micrometer.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>${micrometer.version}</version>
         </dependency>
 
         <!-- BlobFs dependencies -->

--- a/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -76,7 +76,7 @@ public class Kaldb {
     new JvmGcMetrics().bindTo(prometheusMeterRegistry);
     new ProcessorMetrics().bindTo(prometheusMeterRegistry);
     new JvmThreadMetrics().bindTo(prometheusMeterRegistry);
-    LOG.info("Done Registering standard JVM metrics.");
+    LOG.info("Done registering standard JVM metrics.");
   }
 
   public void close() {

--- a/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -29,11 +29,11 @@ import org.slf4j.LoggerFactory;
 public class Kaldb {
   private static final Logger LOG = LoggerFactory.getLogger(Kaldb.class);
 
-  private final PrometheusMeterRegistry prometheusMeterRegistry;
+  private static final PrometheusMeterRegistry prometheusMeterRegistry =
+      new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
 
   public Kaldb(Path configFilePath) throws IOException {
     LOG.info("Starting Metrics setup.");
-    prometheusMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
     Metrics.addRegistry(prometheusMeterRegistry);
     LOG.info("Finished metrics setup.");
 

--- a/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -33,10 +33,7 @@ public class Kaldb {
       new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
 
   public Kaldb(Path configFilePath) throws IOException {
-    LOG.info("Starting Metrics setup.");
     Metrics.addRegistry(prometheusMeterRegistry);
-    LOG.info("Finished metrics setup.");
-
     KaldbConfig.initFromFile(configFilePath);
   }
 
@@ -79,6 +76,7 @@ public class Kaldb {
     new JvmGcMetrics().bindTo(prometheusMeterRegistry);
     new ProcessorMetrics().bindTo(prometheusMeterRegistry);
     new JvmThreadMetrics().bindTo(prometheusMeterRegistry);
+    LOG.info("Done Registering standard JVM metrics.");
   }
 
   public void close() {

--- a/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -67,7 +67,6 @@ public class Kaldb {
   }
 
   private void setupMetrics() {
-    // TODO: Setup prom metrics.
     // Expose JVM metrics.
     new ClassLoaderMetrics().bindTo(prometheusMeterRegistry);
     new JvmMemoryMetrics().bindTo(prometheusMeterRegistry);

--- a/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -1,10 +1,12 @@
 package com.slack.kaldb.server;
 
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.grpc.GrpcMeterIdPrefixFunction;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
+import com.linecorp.armeria.server.metric.MetricCollectingService;
 import com.slack.kaldb.config.KaldbConfig;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
@@ -49,6 +51,8 @@ public class Kaldb {
 
     // Create an API server to serve the search requests.
     ServerBuilder sb = Server.builder();
+    sb.decorator(
+        MetricCollectingService.newDecorator(GrpcMeterIdPrefixFunction.of("grpc.service")));
     sb.http(8080);
     sb.service("/ping", (ctx, req) -> HttpResponse.of("pong!"));
     sb.service("/metrics", (ctx, req) -> HttpResponse.of(prometheusMeterRegistry.scrape()));

--- a/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -31,7 +31,6 @@ public class Kaldb {
 
   public Kaldb(Path configFilePath) throws IOException {
     LOG.info("Starting Metrics setup.");
-    // TODO: Initialize metrics and set up a metrics end point.
     prometheusMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
     Metrics.addRegistry(prometheusMeterRegistry);
     LOG.info("Finished metrics setup.");

--- a/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -61,7 +61,7 @@ public class Kaldb {
     Server server = sb.build();
     CompletableFuture<Void> serverFuture = server.start();
     serverFuture.join();
-    LOG.info("Started server on port: %d", serverPort);
+    LOG.info("Started server on port: {}", serverPort);
 
     // TODO: Instead of passing in the indexer, consider creating an interface or make indexer of
     // subclass of this class?

--- a/src/main/proto/kaldb_configs.proto
+++ b/src/main/proto/kaldb_configs.proto
@@ -8,6 +8,7 @@ message KaldbConfig {
     KafkaConfig kafkaConfig = 1;
     S3Config s3Config = 2;
     IndexerConfig indexerConfig = 3;
+    int32 serverPort = 4;
 }
 
 message KafkaConfig {

--- a/src/test/java/com/slack/kaldb/config/KaldbConfigTest.java
+++ b/src/test/java/com/slack/kaldb/config/KaldbConfigTest.java
@@ -107,6 +107,7 @@ public class KaldbConfigTest {
     final KaldbConfigs.KaldbConfig config = KaldbConfig.get();
 
     assertThat(config).isNotNull();
+    assertThat(config.getServerPort()).isEqualTo(8080);
     final KaldbConfigs.KafkaConfig kafkaCfg = config.getKafkaConfig();
     assertThat(kafkaCfg.getKafkaTopic()).isEqualTo("testTopic");
     assertThat(kafkaCfg.getKafkaTopicPartition()).isEqualTo("1");
@@ -137,6 +138,7 @@ public class KaldbConfigTest {
   public void testEmptyJsonStringInit() throws InvalidProtocolBufferException {
     KaldbConfigs.KaldbConfig config = KaldbConfig.fromJsonConfig("{}");
 
+    assertThat(config.getServerPort()).isZero();
     final KaldbConfigs.KafkaConfig kafkaCfg = config.getKafkaConfig();
     assertThat(kafkaCfg.getKafkaTopicPartition()).isEmpty();
     assertThat(kafkaCfg.getKafkaBootStrapServers()).isEmpty();
@@ -153,12 +155,12 @@ public class KaldbConfigTest {
     assertThat(s3Config.getS3EndPoint()).isEmpty();
 
     final KaldbConfigs.IndexerConfig indexerConfig = config.getIndexerConfig();
-    assertThat(indexerConfig.getMaxMessagesPerChunk()).isEqualTo(0);
-    assertThat(indexerConfig.getMaxBytesPerChunk()).isEqualTo(0);
-    assertThat(indexerConfig.getCommitDurationSecs()).isEqualTo(0);
-    assertThat(indexerConfig.getRefreshDurationSecs()).isEqualTo(0);
-    assertThat(indexerConfig.getStaleDurationSecs()).isEqualTo(0);
-    assertThat(indexerConfig.getDataDirectory()).isEqualTo("");
-    assertThat(indexerConfig.getDataTransformer()).isEqualTo("");
+    assertThat(indexerConfig.getMaxMessagesPerChunk()).isZero();
+    assertThat(indexerConfig.getMaxBytesPerChunk()).isZero();
+    assertThat(indexerConfig.getCommitDurationSecs()).isZero();
+    assertThat(indexerConfig.getRefreshDurationSecs()).isZero();
+    assertThat(indexerConfig.getStaleDurationSecs()).isZero();
+    assertThat(indexerConfig.getDataDirectory()).isEmpty();
+    assertThat(indexerConfig.getDataTransformer()).isEmpty();
   }
 }

--- a/src/test/resources/test_config.json
+++ b/src/test/resources/test_config.json
@@ -23,5 +23,6 @@
     "staleDurationSecs": 7200,
     "dataTransformer": "api_log",
     "dataDirectory": "/tmp"
-  }
+  },
+  "serverPort": 8080
 }


### PR DESCRIPTION
Add a prometheus metrics endpoint.

Tested on dev server.

Make server port configurable. Print server port so we can ping the server.