### PR TITLE
Cleanup SearchResult API - Remove count parameter

### DIFF
--- a/src/main/java/com/slack/kaldb/logstore/search/LogIndexSearcherImpl.java
+++ b/src/main/java/com/slack/kaldb/logstore/search/LogIndexSearcherImpl.java
@@ -99,11 +99,9 @@ public class LogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
         Collector collectorChain = MultiCollector.wrap(topFieldCollector, statsCollector);
 
         searcher.search(query, collectorChain);
-        int count = 0;
         List<LogMessage> results;
         if (howMany > 0) {
           ScoreDoc[] hits = topFieldCollector.topDocs().scoreDocs;
-          count = hits.length;
           results =
               Stream.of(hits)
                   .map(hit -> buildLogMessage(searcher, hit))
@@ -116,7 +114,6 @@ public class LogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
 
         elapsedTime.stop();
         return new SearchResult<>(
-            count,
             results,
             elapsedTime.elapsed(TimeUnit.MICROSECONDS),
             histogram.count(),

--- a/src/main/java/com/slack/kaldb/logstore/search/SearchResult.java
+++ b/src/main/java/com/slack/kaldb/logstore/search/SearchResult.java
@@ -4,7 +4,6 @@ import com.slack.kaldb.histogram.HistogramBucket;
 import java.util.List;
 
 public class SearchResult<T> {
-  public final int count;
   public final long totalCount;
 
   // TODO: Make hits an iterator.
@@ -24,7 +23,6 @@ public class SearchResult<T> {
   // TODO: Make search result a protobuf?
   // TODO: Move stats into a separate struct.
   public SearchResult(
-      int count,
       List<T> hits,
       long tookMicros,
       long totalCount,
@@ -33,7 +31,6 @@ public class SearchResult<T> {
       int totalNodes,
       int totalSnapshots,
       int snapshotsWithReplicas) {
-    this.count = count;
     this.hits = hits;
     this.tookMicros = tookMicros;
     this.totalCount = totalCount;

--- a/src/main/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImpl.java
+++ b/src/main/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImpl.java
@@ -55,7 +55,6 @@ public class SearchResultAggregatorImpl<T extends LogMessage> implements SearchR
             .collect(Collectors.toList());
 
     return new SearchResult<T>(
-        resultHits.size(),
         resultHits,
         tookMicros,
         totalCount,

--- a/src/main/java/com/slack/kaldb/server/KaldbService.java
+++ b/src/main/java/com/slack/kaldb/server/KaldbService.java
@@ -37,7 +37,6 @@ public class KaldbService<T> extends KaldbServiceGrpc.KaldbServiceImplBase {
       throws JsonProcessingException {
 
     KaldbSearch.SearchResult.Builder searchResultBuilder = KaldbSearch.SearchResult.newBuilder();
-    searchResultBuilder.setCount(searchResult.count);
     searchResultBuilder.setTotalCount(searchResult.totalCount);
     searchResultBuilder.setTookMicros(searchResult.tookMicros);
     searchResultBuilder.setFailedNodes(searchResult.failedNodes);

--- a/src/main/proto/kaldb_search.proto
+++ b/src/main/proto/kaldb_search.proto
@@ -15,7 +15,6 @@ message SearchRequest {
 }
 
 message SearchResult {
-  int64 count = 1;
   int64 total_count = 2;
   repeated string hits = 3;
   repeated HistogramBucket buckets = 4;

--- a/src/test/java/com/slack/kaldb/chunk/ReadWriteChunkImplTest.java
+++ b/src/test/java/com/slack/kaldb/chunk/ReadWriteChunkImplTest.java
@@ -77,9 +77,19 @@ public class ReadWriteChunkImplTest {
       chunk.commit();
 
       SearchResult<LogMessage> results =
+          chunk.query(new SearchQuery(MessageUtil.TEST_INDEX_NAME, "*:*", 0, MAX_TIME, 10, 1000));
+      assertThat(results.totalCount).isEqualTo(100);
+
+      results =
           chunk.query(
               new SearchQuery(MessageUtil.TEST_INDEX_NAME, "Message1", 0, MAX_TIME, 10, 1000));
-      assertThat(results.hits.size()).isEqualTo(1);
+      assertThat(results.totalCount).isEqualTo(1);
+
+      results =
+          chunk.query(
+              new SearchQuery(MessageUtil.TEST_INDEX_NAME, "Message*", 0, MAX_TIME, 10, 1000));
+      assertThat(results.totalCount).isEqualTo(100);
+      assertThat(results.hits.size()).isEqualTo(10);
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, registry)).isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, registry)).isEqualTo(0);

--- a/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
+++ b/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
@@ -174,7 +174,6 @@ public class LogIndexSearcherImplTest {
         strictLogStore.logSearcher.search(
             TEST_INDEX_NAME, "baby", timeEpochMs(time), timeEpochMs(time.plusSeconds(2)), 10, 1);
     assertThat(babies.hits.size()).isEqualTo(1);
-    assertThat(babies.count).isEqualTo(1);
     assertThat(babies.totalCount).isEqualTo(1);
     assertThat(babies.buckets.size()).isEqualTo(1);
     assertThat(babies.buckets.get(0).getCount()).isEqualTo(1);
@@ -191,7 +190,6 @@ public class LogIndexSearcherImplTest {
     assertThat(apples.hits.stream().map(m -> m.id).collect(Collectors.toList()))
         .isEqualTo(Arrays.asList("5", "3"));
     assertThat(apples.hits.size()).isEqualTo(2);
-    assertThat(apples.count).isEqualTo(2);
     assertThat(apples.totalCount).isEqualTo(3); // total count is 3, hits is 2.
     assertThat(apples.buckets.size()).isEqualTo(1);
     assertThat(apples.buckets.get(0).getCount()).isEqualTo(3);
@@ -231,7 +229,6 @@ public class LogIndexSearcherImplTest {
     SearchResult<LogMessage> car =
         strictLogStore.logSearcher.search(
             TEST_INDEX_NAME, "car", timeEpochMs(time), timeEpochMs(time.plusSeconds(10)), 2, 1);
-    assertThat(car.count).isEqualTo(0);
     assertThat(car.totalCount).isEqualTo(0);
 
     // Commit but no refresh. Item is still not available for search.
@@ -245,7 +242,6 @@ public class LogIndexSearcherImplTest {
     SearchResult<LogMessage> carAfterCommit =
         strictLogStore.logSearcher.search(
             TEST_INDEX_NAME, "car", timeEpochMs(time), timeEpochMs(time.plusSeconds(10)), 2, 1);
-    assertThat(carAfterCommit.count).isEqualTo(0);
     assertThat(carAfterCommit.totalCount).isEqualTo(0);
 
     // Car can be searched after refresh.
@@ -259,7 +255,6 @@ public class LogIndexSearcherImplTest {
     SearchResult<LogMessage> carAfterRefresh =
         strictLogStore.logSearcher.search(
             TEST_INDEX_NAME, "car", timeEpochMs(time), timeEpochMs(time.plusSeconds(10)), 2, 1);
-    assertThat(carAfterRefresh.count).isEqualTo(1);
     assertThat(carAfterRefresh.totalCount).isEqualTo(1);
 
     // Add another message to search, refresh but don't commit.
@@ -299,7 +294,6 @@ public class LogIndexSearcherImplTest {
         strictLogStore.logSearcher.search(TEST_INDEX_NAME, "", 0, MAX_TIME, 1000, 1);
 
     assertThat(allIndexItems.hits.size()).isEqualTo(4);
-    assertThat(allIndexItems.count).isEqualTo(4);
     assertThat(allIndexItems.totalCount).isEqualTo(4);
     assertThat(allIndexItems.buckets.size()).isEqualTo(1);
     assertThat(allIndexItems.buckets.get(0).getCount()).isEqualTo(4);
@@ -322,7 +316,6 @@ public class LogIndexSearcherImplTest {
         strictLogStore.logSearcher.search(TEST_INDEX_NAME + "miss", "apple", 0, MAX_TIME, 1000, 1);
 
     assertThat(allIndexItems.hits.size()).isEqualTo(0);
-    assertThat(allIndexItems.count).isEqualTo(0);
     assertThat(allIndexItems.totalCount).isEqualTo(0);
     assertThat(allIndexItems.buckets.size()).isEqualTo(1);
     assertThat(allIndexItems.buckets.get(0).getCount()).isEqualTo(0);
@@ -336,7 +329,6 @@ public class LogIndexSearcherImplTest {
     SearchResult<LogMessage> elephants =
         strictLogStore.logSearcher.search(TEST_INDEX_NAME, "elephant", 0, MAX_TIME, 1000, 1);
     assertThat(elephants.hits.size()).isEqualTo(0);
-    assertThat(elephants.count).isEqualTo(0);
     assertThat(elephants.totalCount).isEqualTo(0);
     assertThat(elephants.buckets.size()).isEqualTo(1);
     assertThat(elephants.buckets.get(0).getCount()).isEqualTo(0);
@@ -350,7 +342,6 @@ public class LogIndexSearcherImplTest {
         strictLogStore.logSearcher.search(
             TEST_INDEX_NAME, "baby", timeEpochMs(time), timeEpochMs(time.plusSeconds(10)), 100, 0);
     assertThat(babies.hits.size()).isEqualTo(2);
-    assertThat(babies.count).isEqualTo(2);
     assertThat(babies.totalCount).isEqualTo(2);
     assertThat(babies.buckets.size()).isEqualTo(0);
   }
@@ -363,7 +354,6 @@ public class LogIndexSearcherImplTest {
         strictLogStore.logSearcher.search(
             TEST_INDEX_NAME, "baby", timeEpochMs(time), timeEpochMs(time.plusSeconds(10)), 0, 1);
     assertThat(babies.hits.size()).isEqualTo(0);
-    assertThat(babies.count).isEqualTo(0);
     assertThat(babies.totalCount).isEqualTo(2);
     assertThat(babies.buckets.size()).isEqualTo(1);
     assertThat(babies.buckets.get(0).getHigh()).isEqualTo(timeEpochMs(time.plusSeconds(10)));
@@ -455,7 +445,7 @@ public class LogIndexSearcherImplTest {
             try {
               SearchResult<LogMessage> babies =
                   strictLogStore.logSearcher.search(TEST_INDEX_NAME, "baby", 0, MAX_TIME, 100, 1);
-              if (babies.count != 2) {
+              if (babies.hits.size() != 2) {
                 searchFailures.addAndGet(1);
               } else {
                 successfulRuns.addAndGet(1);

--- a/src/test/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImplTest.java
+++ b/src/test/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImplTest.java
@@ -25,7 +25,6 @@ public class SearchResultAggregatorImplTest {
       int totalSnapshots,
       int snapshotsWithReplicas) {
     return new SearchResult<>(
-        messages.size(),
         messages,
         tookMs,
         totalCount,
@@ -298,7 +297,6 @@ public class SearchResultAggregatorImplTest {
     SearchResult<LogMessage> aggSearchResult =
         new SearchResultAggregatorImpl<>().aggregate(searchResults, searchQuery);
 
-    assertThat(aggSearchResult.count).isEqualTo(0);
     assertThat(aggSearchResult.hits.size()).isZero();
     assertThat(aggSearchResult.tookMicros).isEqualTo(tookMs + 1);
     assertThat(aggSearchResult.failedNodes).isEqualTo(0);
@@ -395,7 +393,6 @@ public class SearchResultAggregatorImplTest {
     SearchResult<LogMessage> aggSearchResult =
         new SearchResultAggregatorImpl<>().aggregate(searchResults, searchQuery);
 
-    assertThat(aggSearchResult.count).isEqualTo(0);
     assertThat(aggSearchResult.hits.size()).isZero();
     assertThat(aggSearchResult.tookMicros).isEqualTo(tookMs + 1);
     assertThat(aggSearchResult.failedNodes).isEqualTo(0);

--- a/src/test/java/com/slack/kaldb/logstore/search/StatsCollectorTest.java
+++ b/src/test/java/com/slack/kaldb/logstore/search/StatsCollectorTest.java
@@ -53,7 +53,6 @@ public class StatsCollectorTest {
             TEST_INDEX_NAME, "", timeEpochMs(time), timeEpochMs(time.plusSeconds(4 * 60)), 0, 5);
 
     assertThat(allIndexItems.hits.size()).isEqualTo(0);
-    assertThat(allIndexItems.count).isEqualTo(0);
     assertThat(allIndexItems.totalCount).isEqualTo(5);
     assertThat(allIndexItems.buckets.size()).isEqualTo(5);
 

--- a/src/test/java/com/slack/kaldb/server/KaldbServiceTest.java
+++ b/src/test/java/com/slack/kaldb/server/KaldbServiceTest.java
@@ -91,7 +91,7 @@ public class KaldbServiceTest {
                 .setBucketCount(2)
                 .build());
 
-    assertThat(response.getCount()).isEqualTo(1);
+    assertThat(response.getHitsCount()).isEqualTo(1);
     assertThat(response.getTookMicros()).isNotZero();
     assertThat(response.getTotalCount()).isEqualTo(1);
     assertThat(response.getFailedNodes()).isZero();
@@ -153,7 +153,7 @@ public class KaldbServiceTest {
                 .setBucketCount(2)
                 .build());
 
-    assertThat(response.getCount()).isZero();
+    assertThat(response.getHitsCount()).isZero();
     assertThat(response.getTotalCount()).isZero();
     assertThat(response.getTookMicros()).isNotZero();
     assertThat(response.getTotalCount()).isZero();
@@ -203,7 +203,7 @@ public class KaldbServiceTest {
                 .build());
 
     // Count is 0, but totalCount is 1, since there is 1 hit, but none are to be retrieved.
-    assertThat(response.getCount()).isEqualTo(0);
+    assertThat(response.getHitsCount()).isEqualTo(0);
     assertThat(response.getTotalCount()).isEqualTo(1);
     assertThat(response.getTookMicros()).isNotZero();
     assertThat(response.getFailedNodes()).isZero();
@@ -250,7 +250,7 @@ public class KaldbServiceTest {
                 .setBucketCount(0)
                 .build());
 
-    assertThat(response.getCount()).isEqualTo(1);
+    assertThat(response.getHitsCount()).isEqualTo(1);
     assertThat(response.getTotalCount()).isEqualTo(1);
     assertThat(response.getTookMicros()).isNotZero();
     assertThat(response.getFailedNodes()).isZero();
@@ -350,7 +350,7 @@ public class KaldbServiceTest {
                 .build());
 
     // Validate search response
-    assertThat(response.getCount()).isEqualTo(1);
+    assertThat(response.getHitsCount()).isEqualTo(1);
     assertThat(response.getTookMicros()).isNotZero();
     assertThat(response.getTotalCount()).isEqualTo(1);
     assertThat(response.getFailedNodes()).isZero();


### PR DESCRIPTION
The `count` and `total_count` parameters can cause confusion - 

Essentially `count` is the number of results returned. While `total_count` is the number of hits

Since we always return the `count` number of results finding count is as simple as getting the size of the search results.

Hopefully this change makes the API clear and also when writing tests we don't mix `count and total_count` for times when test cases add/match less than 10 docs and both values can be the same 