### PR TITLE
Add merge metrics

### DIFF
--- a/src/main/java/com/slack/kaldb/logstore/index/KalDBMergeScheduler.java
+++ b/src/main/java/com/slack/kaldb/logstore/index/KalDBMergeScheduler.java
@@ -1,0 +1,63 @@
+package com.slack.kaldb.logstore.index;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.lucene.index.ConcurrentMergeScheduler;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.MergePolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KalDBMergeScheduler extends ConcurrentMergeScheduler {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KalDBMergeScheduler.class);
+  private MeterRegistry metricsRegistry;
+
+  public static final String STALL_TIME = "kaldb_index_merge_stall_time_ms";
+  private final Counter stallCounter;
+
+  public static final String STALL_THREADS = "kaldb_index_merge_stall_threads";
+  static AtomicInteger activeStallThreadsCount = new AtomicInteger(0);
+
+  public static final String MERGE_COUNTER = "kaldb_index_merge_count";
+  private final Counter mergeCounter;
+
+  public KalDBMergeScheduler(MeterRegistry metricsRegistry) {
+    this.metricsRegistry = metricsRegistry;
+    stallCounter = this.metricsRegistry.counter(STALL_TIME);
+    activeStallThreadsCount = this.metricsRegistry.gauge(STALL_THREADS, new AtomicInteger());
+    this.mergeCounter = this.metricsRegistry.counter(MERGE_COUNTER);
+  }
+
+  protected void doMerge(IndexWriter writer, MergePolicy.OneMerge merge) throws IOException {
+    // We can use `merge` to get more stats when we want to tune further
+    LOG.debug("Starting merge");
+    mergeCounter.increment();
+    super.doMerge(writer, merge);
+    LOG.debug("Ending merge");
+  }
+
+  /**
+   * ConcurrentMergeScheduler#maybeStall provides a good description of what this method does. Here
+   * I want to explain our motivation for adding metrics around this - This method is called when we
+   * call IndexWriter#commit ( which calls ConcurrentMergeScheduler#merge which calls this method )
+   * We want to capture how many indexing threads are blocked because merges are falling behind We
+   * also want to capture total stalled time The motivation being we could optimize indexing ( say
+   * offline indexing ) based on this knowledge https://issues.apache.org/jira/browse/LUCENE-6119
+   * has details on why Lucene added auto IO throttle
+   */
+  protected synchronized boolean maybeStall(IndexWriter writer) {
+    long startTime = System.nanoTime();
+    activeStallThreadsCount.incrementAndGet();
+
+    boolean paused = super.maybeStall(writer);
+
+    long elapsed = System.nanoTime() - startTime;
+    stallCounter.increment(elapsed);
+    activeStallThreadsCount.decrementAndGet();
+
+    return paused;
+  }
+}

--- a/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
+++ b/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
@@ -61,7 +61,6 @@ public class LuceneIndexStoreImplTest {
           findAllMessages(
               forgivingLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "Message1", 10, 1);
       assertThat(results.size()).isEqualTo(1);
-      assertThat(forgivingLogStore.metricsRegistry.getMeters().size()).isEqualTo(4);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, forgivingLogStore.metricsRegistry)).isEqualTo(0);
@@ -114,7 +113,6 @@ public class LuceneIndexStoreImplTest {
           findAllMessages(
               forgivingLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "identifier", 1000, 1);
       assertThat(results.size()).isEqualTo(100);
-      assertThat(forgivingLogStore.metricsRegistry.getMeters().size()).isEqualTo(4);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, forgivingLogStore.metricsRegistry)).isEqualTo(0);
@@ -129,7 +127,6 @@ public class LuceneIndexStoreImplTest {
           findAllMessages(
               forgivingLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "identifier", 1, 1);
       assertThat(results.size()).isEqualTo(1);
-      assertThat(forgivingLogStore.metricsRegistry.getMeters().size()).isEqualTo(4);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, forgivingLogStore.metricsRegistry)).isEqualTo(0);
@@ -148,7 +145,6 @@ public class LuceneIndexStoreImplTest {
           findAllMessages(
               forgivingLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "identifier", 1000, 1);
       assertThat(results.size()).isEqualTo(100);
-      assertThat(forgivingLogStore.metricsRegistry.getMeters().size()).isEqualTo(4);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, forgivingLogStore.metricsRegistry)).isEqualTo(0);
@@ -166,7 +162,6 @@ public class LuceneIndexStoreImplTest {
           findAllMessages(
               forgivingLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "identifier", 1000, 1);
       assertThat(results.size()).isEqualTo(100);
-      assertThat(forgivingLogStore.metricsRegistry.getMeters().size()).isEqualTo(4);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, forgivingLogStore.metricsRegistry)).isEqualTo(0);
@@ -192,7 +187,6 @@ public class LuceneIndexStoreImplTest {
           findAllMessages(
               strictLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "identifier", 1000, 1);
       assertThat(results.size()).isEqualTo(99);
-      assertThat(strictLogStore.metricsRegistry.getMeters().size()).isEqualTo(4);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry))
           .isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
@@ -210,7 +204,6 @@ public class LuceneIndexStoreImplTest {
           findAllMessages(
               strictLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "identifier", 1000, 1);
       assertThat(results.size()).isEqualTo(99);
-      assertThat(strictLogStore.metricsRegistry.getMeters().size()).isEqualTo(4);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry))
           .isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
@@ -225,7 +218,6 @@ public class LuceneIndexStoreImplTest {
           IntStream.range(1, 10000).boxed().map(String::valueOf).collect(Collectors.joining(""));
       MessageUtil.addFieldToMessage(msg, "hugefield", hugeField);
       strictLogStore.logStore.addMessage(msg);
-      assertThat(strictLogStore.metricsRegistry.getMeters().size()).isEqualTo(4);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
       // Counters not set since no commit.
@@ -302,7 +294,6 @@ public class LuceneIndexStoreImplTest {
               strictLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "hostname:com.abc", 1000, 1);
       assertThat(results8.size()).isEqualTo(0);
 
-      assertThat(strictLogStore.metricsRegistry.getMeters().size()).isEqualTo(4);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
       assertThat(getCount(REFRESHES_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
@@ -326,7 +317,6 @@ public class LuceneIndexStoreImplTest {
           findAllMessages(
               testLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "Message1", 100, 1);
       assertThat(results.size()).isEqualTo(1);
-      assertThat(testLogStore.metricsRegistry.getMeters().size()).isEqualTo(4);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, testLogStore.metricsRegistry)).isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, testLogStore.metricsRegistry)).isEqualTo(0);
       assertThat(getCount(REFRESHES_COUNTER, testLogStore.metricsRegistry)).isEqualTo(1);
@@ -362,7 +352,6 @@ public class LuceneIndexStoreImplTest {
           findAllMessages(
               strictLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "Message1", 100, 1);
       assertThat(results.size()).isEqualTo(1);
-      assertThat(strictLogStore.metricsRegistry.getMeters().size()).isEqualTo(4);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry))
           .isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
@@ -427,7 +416,6 @@ public class LuceneIndexStoreImplTest {
           findAllMessages(
               strictLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "Message1", 100, 1);
       assertThat(results.size()).isEqualTo(1);
-      assertThat(strictLogStore.metricsRegistry.getMeters().size()).isEqualTo(4);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry))
           .isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
@@ -512,7 +500,6 @@ public class LuceneIndexStoreImplTest {
           findAllMessages(testLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "Message1", 10, 1);
       assertThat(results.size()).isEqualTo(1);
 
-      assertThat(testLogStore.metricsRegistry.getMeters().size()).isEqualTo(4);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, testLogStore.metricsRegistry)).isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, testLogStore.metricsRegistry)).isEqualTo(0);
       assertThat(getCount(REFRESHES_COUNTER, testLogStore.metricsRegistry))

--- a/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
+++ b/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
@@ -55,7 +55,6 @@ public class LogIndexSearcherImplTest {
     strictLogStore.logStore.commit();
     strictLogStore.logStore.refresh();
 
-    assertThat(strictLogStore.metricsRegistry.getMeters().size()).isEqualTo(4);
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(2);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
     assertThat(getCount(REFRESHES_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
@@ -119,7 +118,6 @@ public class LogIndexSearcherImplTest {
     strictLogStore.logStore.commit();
     strictLogStore.logStore.refresh();
 
-    assertThat(strictLogStore.metricsRegistry.getMeters().size()).isEqualTo(4);
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(2);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
     assertThat(getCount(REFRESHES_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
@@ -211,7 +209,6 @@ public class LogIndexSearcherImplTest {
             TEST_INDEX_NAME, "baby", timeEpochMs(time), timeEpochMs(time.plusSeconds(10)), 2, 1);
     assertThat(baby.hits.size()).isEqualTo(1);
     assertThat(baby.hits.get(0).id).isEqualTo("2");
-    assertThat(strictLogStore.metricsRegistry.getMeters().size()).isEqualTo(4);
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(2);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
     assertThat(getCount(REFRESHES_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);

--- a/src/test/java/com/slack/kaldb/logstore/search/StatsCollectorTest.java
+++ b/src/test/java/com/slack/kaldb/logstore/search/StatsCollectorTest.java
@@ -61,7 +61,6 @@ public class StatsCollectorTest {
       assertThat(bucket.getCount()).isEqualTo(1);
     }
 
-    assertThat(strictLogStore.metricsRegistry.getMeters().size()).isEqualTo(4);
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(5);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
     assertThat(getCount(REFRESHES_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);


### PR DESCRIPTION
Add merge metrics to gain insights into how merging performs during indexing loads

The default merge scheduler is CMS so we extend that and add metrics in the wrapper merge scheduler