### PR TITLE
A ZK based MetadataStore with basic CRUD operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <micrometer.version>1.5.1</micrometer.version>
         <jackson.version>2.11.1</jackson.version>
         <lucene.version>8.4.1</lucene.version>
+        <curator.version>5.1.0</curator.version>
     </properties>
 
     <repositories>
@@ -77,6 +78,18 @@
                     <artifactId>grpc-core</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <!-- Apache curator dependencies -->
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-client</artifactId>
+            <version>${curator.version}</version>
         </dependency>
 
         <!-- Lucene dependencies -->
@@ -264,6 +277,13 @@
             <artifactId>assertj-core</artifactId>
             <version>3.17.2</version>
             <scope>test</scope>
+        </dependency>
+
+        <!-- Apache curator dependencies -->
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <version>${curator.version}</version>
         </dependency>
 
         <!-- BlobFs test dependencies -->

--- a/src/main/java/com/slack/kaldb/metadata/InternalMetadataStoreException.java
+++ b/src/main/java/com/slack/kaldb/metadata/InternalMetadataStoreException.java
@@ -1,0 +1,11 @@
+package com.slack.kaldb.metadata;
+
+public class InternalMetadataStoreException extends RuntimeException {
+  public InternalMetadataStoreException(String msg) {
+    super(msg);
+  }
+
+  public InternalMetadataStoreException(String msg, Throwable t) {
+    super(msg, t);
+  }
+}

--- a/src/main/java/com/slack/kaldb/metadata/MetadataStore.java
+++ b/src/main/java/com/slack/kaldb/metadata/MetadataStore.java
@@ -1,0 +1,26 @@
+package com.slack.kaldb.metadata;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import java.util.List;
+
+/**
+ * An interface for the physical metadata store that abstracts the details of the underlying
+ * implementation.
+ */
+public interface MetadataStore {
+  void close();
+
+  ListenableFuture<?> createEphemeralNode(String path, String data);
+
+  ListenableFuture<?> create(String path, String data, boolean createMissingParents);
+
+  ListenableFuture<Boolean> exists(String path);
+
+  ListenableFuture<?> put(String path, String data);
+
+  ListenableFuture<String> get(String path);
+
+  ListenableFuture<?> delete(String path);
+
+  ListenableFuture<List<String>> getChildren(String path);
+}

--- a/src/main/java/com/slack/kaldb/metadata/NoNodeException.java
+++ b/src/main/java/com/slack/kaldb/metadata/NoNodeException.java
@@ -1,0 +1,11 @@
+package com.slack.kaldb.metadata;
+
+public class NoNodeException extends RuntimeException {
+  public NoNodeException(String msg) {
+    super(msg);
+  }
+
+  public NoNodeException(String msg, Throwable t) {
+    super(msg, t);
+  }
+}

--- a/src/main/java/com/slack/kaldb/metadata/NodeExistsException.java
+++ b/src/main/java/com/slack/kaldb/metadata/NodeExistsException.java
@@ -1,0 +1,11 @@
+package com.slack.kaldb.metadata;
+
+public class NodeExistsException extends RuntimeException {
+  public NodeExistsException(String msg) {
+    super(msg);
+  }
+
+  public NodeExistsException(String msg, Throwable t) {
+    super(msg, t);
+  }
+}

--- a/src/main/java/com/slack/kaldb/metadata/ZookeeperMetadataStore.java
+++ b/src/main/java/com/slack/kaldb/metadata/ZookeeperMetadataStore.java
@@ -29,9 +29,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Metadata Store implements a store in zookeeper. This class interacts with ZK using the apache
- * curator library. It also abstracts it's users from the details of ZK and provides a simpler
- * higher level API.
+ * ZookeeperMetadataStore implements a store in zookeeper. This class interacts with ZK using the
+ * apache curator library. It also abstracts it's users from the details of ZK and provides a
+ * simpler higher level API.
  *
  * <p>All the public calls in this class are executed in it's own thread pool which makes the API
  * non-blocking while allowing for parallelism. The actual methods are implemented as private

--- a/src/main/java/com/slack/kaldb/metadata/ZookeeperMetadataStore.java
+++ b/src/main/java/com/slack/kaldb/metadata/ZookeeperMetadataStore.java
@@ -1,0 +1,337 @@
+package com.slack.kaldb.metadata;
+
+import static com.slack.kaldb.util.ArgValidationUtils.ensureNonEmptyString;
+import static com.slack.kaldb.util.ArgValidationUtils.ensureTrue;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.slack.kaldb.util.FatalErrorHandler;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.CuratorEventType;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Metadata Store implements a store in zookeeper. This class interacts with ZK using the apache
+ * curator library. It also abstracts it's users from the details of ZK and provides a simpler
+ * higher level API.
+ *
+ * <p>All the public calls in this class are executed in it's own thread pool which makes the API
+ * non-blocking while allowing for parallelism. The actual methods are implemented as private
+ * methods ending in Impl. A corresponding public method is exposed that executes these calls in a
+ * thread pool.
+ *
+ * <p>NOTE: We will use the async as a suffix for methods which run in the background in curator.
+ * So, we don't use it for calls that run in a future pool even though they are technically async.
+ */
+public class ZookeeperMetadataStore implements MetadataStore {
+  private static final Logger LOG = LoggerFactory.getLogger(ZookeeperMetadataStore.class);
+
+  public static final String METADATA_FAILED_COUNTER = "metadata.failed";
+  public static final String ZK_FAILED_COUNTER = "metadata.failed.zk";
+  public static final String METADATA_WRITE_COUNTER = "metadata.write";
+  public static final String METADATA_READ_COUNTER = "metadata.read";
+
+  private final CuratorFramework curator;
+  private final Counter failureCounter;
+  private final Counter zkFailureCounter;
+  private final Counter metadataWriteCounter;
+  private final Counter metadataReadCounter;
+
+  // A thread pool to run all the metadata store operations in.
+  private final ListeningExecutorService metadataExecutorService;
+
+  public ZookeeperMetadataStore(
+      String zkHostPath,
+      String zkPathPrefix,
+      int sessionTimeoutMs,
+      int connectionTimeoutMs,
+      RetryPolicy retryPolicy,
+      FatalErrorHandler fatalErrorHandler,
+      MeterRegistry meterRegistry) {
+    ensureNonEmptyString(zkHostPath, "zkHostPath can't be null or empty");
+    ensureNonEmptyString(zkPathPrefix, "zkPathPrefix can't be null or empty");
+    ensureTrue(sessionTimeoutMs > 0, "sessionTimeoutMs should be a positive number");
+    ensureTrue(connectionTimeoutMs > 0, "connectionTimeoutMs should be a positive number");
+
+    this.failureCounter = meterRegistry.counter(METADATA_FAILED_COUNTER);
+    this.zkFailureCounter = meterRegistry.counter(ZK_FAILED_COUNTER);
+    this.metadataWriteCounter = meterRegistry.counter(METADATA_WRITE_COUNTER);
+    this.metadataReadCounter = meterRegistry.counter(METADATA_READ_COUNTER);
+
+    // TODO: Pass the thread pool in a constructor so we can use direct executor in tests if needed.
+    // Create an executor service that runs all the ZK operations
+    ThreadFactory metadataStoreThreadFactory =
+        new ThreadFactoryBuilder().setNameFormat("kaldb-metadata-store-pool").build();
+    ThreadPoolExecutor executor =
+        (ThreadPoolExecutor) Executors.newCachedThreadPool(metadataStoreThreadFactory);
+    this.metadataExecutorService =
+        MoreExecutors.listeningDecorator(
+            MoreExecutors.getExitingExecutorService(executor, 1, TimeUnit.SECONDS));
+
+    // TODO: In future add ZK auth credentials can be passed in here.
+    this.curator =
+        CuratorFrameworkFactory.builder()
+            .connectString(zkHostPath)
+            .namespace(zkPathPrefix)
+            .connectionTimeoutMs(connectionTimeoutMs)
+            .sessionTimeoutMs(sessionTimeoutMs)
+            .retryPolicy(retryPolicy)
+            .build();
+
+    // A catch-all handler for any errors we may have missed.
+    curator
+        .getUnhandledErrorListenable()
+        .addListener(
+            (message, exception) -> {
+              LOG.error("Unhandled error {} could be a possible bug", message, exception);
+              failureCounter.increment();
+              throw new RuntimeException(exception);
+            });
+
+    // Log all connection state changes to help debugging.
+    curator
+        .getConnectionStateListenable()
+        .addListener(
+            (curator, connectionState) -> {
+              LOG.info("Curator connection state changed to {}", connectionState);
+            });
+
+    /*
+     * If a ZK session expires, we need to create all the watches and ephemeral nodes again.
+     * In such a case, any ephermeral nodes and watches would expire and need to be re-created.
+     * To keep it simple for now, we terminate the process and let the process initialization
+     * register those nodes.
+     */
+    curator
+        .getCuratorListenable()
+        .addListener(
+            (curator, curatorEvent) -> {
+              if (curatorEvent.getType() == CuratorEventType.WATCHED
+                  && curatorEvent.getWatchedEvent().getState()
+                      == Watcher.Event.KeeperState.Expired) {
+                LOG.warn("The ZK session has expired {}.", curatorEvent.toString());
+                fatalErrorHandler.handleFatal(new Throwable("ZK session expired."));
+              }
+            });
+
+    curator.start();
+    LOG.info(
+        "Started curator server with the following config zkhost: {}, path prefix: {}, "
+            + "connection timeout ms: {}, session timeout ms {} and retry policy {}",
+        zkHostPath,
+        zkPathPrefix,
+        connectionTimeoutMs,
+        sessionTimeoutMs,
+        retryPolicy);
+  }
+
+  public void close() {
+    LOG.info("Closing curator connection.");
+    curator.close();
+    LOG.info("Closed curator connection successfully.");
+  }
+
+  private void createEphemeralNodeImpl(String path, String data) {
+    metadataWriteCounter.increment();
+    LOG.info("Creating ephemeral node at {} with data {}", path, data);
+    try {
+      curator.create().withMode(CreateMode.EPHEMERAL).forPath(path, data.getBytes());
+    } catch (KeeperException.NodeExistsException e) {
+      throw new NodeExistsException(path);
+    } catch (KeeperException e) {
+      zkFailureCounter.increment();
+      LOG.warn("Failed with ZK exception when writing at path {}", path, e);
+      throw new InternalMetadataStoreException("Creating an ephemeral node at " + path);
+    } catch (Exception e) {
+      failureCounter.increment();
+      LOG.error("Failed with an unknown error {}", e.getMessage(), e);
+      throw new InternalMetadataStoreException("Creating node at path " + path);
+    }
+  }
+
+  /** Create an ephermeral node at path */
+  @Override
+  public ListenableFuture<?> createEphemeralNode(String path, String data) {
+    return metadataExecutorService.submit(() -> createEphemeralNodeImpl(path, data));
+  }
+
+  private void createImpl(String path, String data, boolean createMissingParents) {
+    try {
+      LOG.info("Creating a node at {} with data {}.", path, data);
+      metadataWriteCounter.increment();
+      if (createMissingParents) {
+        curator
+            .create()
+            .creatingParentsIfNeeded()
+            .withMode(CreateMode.PERSISTENT)
+            .forPath(path, data.getBytes());
+      } else {
+        curator.create().withMode(CreateMode.PERSISTENT).forPath(path, data.getBytes());
+      }
+    } catch (KeeperException.NodeExistsException e) {
+      throw new NodeExistsException(path);
+    } catch (KeeperException e) {
+      zkFailureCounter.increment();
+      LOG.warn("Failed with a ZK exception when writing to path {}", path, e);
+      throw new InternalMetadataStoreException("Creating a node at path " + path);
+    } catch (Exception e) {
+      failureCounter.increment();
+      LOG.error("Failed with unknown error {}", e.getMessage(), e);
+      throw new InternalMetadataStoreException("Creating a node at path " + path);
+    }
+  }
+
+  /**
+   * Create a persistent node at path. If createMissingParents is true, create the missing parent
+   * folders also to simplify node creation. This is also efficient since we can create a node with
+   * one call to ZK instead of several calls.
+   */
+  @Override
+  public ListenableFuture<?> create(String path, String data, boolean createMissingParents) {
+    return metadataExecutorService.submit(() -> createImpl(path, data, createMissingParents));
+  }
+
+  private Boolean existsImpl(String path) {
+    Stat result;
+    try {
+      metadataReadCounter.increment();
+      LOG.debug("Checking existence of a node at path {}", path);
+      result = curator.checkExists().forPath(path);
+    } catch (KeeperException e) {
+      zkFailureCounter.increment();
+      LOG.warn("Failed with ZK exception when reading from path {}", path, e);
+      throw new InternalMetadataStoreException("Checking exists for path " + path);
+    } catch (Exception e) {
+      failureCounter.increment();
+      LOG.error("Failed with unknown error {}", e.getMessage(), e);
+      throw new InternalMetadataStoreException("Checking exists for path " + path);
+    }
+    return result != null;
+  }
+
+  /** Check if a path exists in store. */
+  @Override
+  public ListenableFuture<Boolean> exists(String path) {
+    return metadataExecutorService.submit(() -> existsImpl(path));
+  }
+
+  /** Store data in path. Throw exception if node doesn't exist. */
+  private void putImpl(String path, String data) {
+    try {
+      metadataWriteCounter.increment();
+      LOG.info("Setting data for node at {} to {}", path, data);
+      curator.setData().forPath(path, data.getBytes());
+    } catch (KeeperException.NoNodeException e) {
+      throw new NoNodeException(path);
+    } catch (KeeperException e) {
+      zkFailureCounter.increment();
+      LOG.warn("Failed with an error when updating node at path {}", path, e);
+      throw new InternalMetadataStoreException("Updating node at path " + path);
+    } catch (Exception e) {
+      failureCounter.increment();
+      LOG.error("Failed with an unknown error {}", e.getMessage(), e);
+      throw new InternalMetadataStoreException("Updating node at path " + path);
+    }
+  }
+
+  @Override
+  public ListenableFuture<?> put(String path, String data) {
+    return metadataExecutorService.submit(() -> putImpl(path, data));
+  }
+
+  // TODO: Consider fetching the data in background if it results in better perf due to batching.
+  private String getImpl(String path) {
+    String result = "";
+    try {
+      metadataReadCounter.increment();
+      LOG.debug("Fetching data for node at {}", path);
+      byte[] data = curator.getData().forPath(path);
+      if (data != null) {
+        result = new String(data);
+      } else {
+        throw new InternalMetadataStoreException("Get returned no data");
+      }
+    } catch (KeeperException.NoNodeException e) {
+      throw new NoNodeException(path);
+    } catch (KeeperException e) {
+      zkFailureCounter.increment();
+      LOG.warn("Failed with a ZK exception when getting path {}", path, e);
+      throw new InternalMetadataStoreException("Get a node at path " + path);
+    } catch (Exception e) {
+      failureCounter.increment();
+      LOG.error("Failed with an unknown error {}", e.getMessage(), e);
+      throw new InternalMetadataStoreException("Fetching node at " + path);
+    }
+    return result;
+  }
+
+  @Override
+  public ListenableFuture<String> get(String path) {
+    return metadataExecutorService.submit(() -> getImpl(path));
+  }
+
+  private void deleteImpl(String path) {
+    try {
+      metadataWriteCounter.increment();
+      LOG.info("Deleting node at {}", path);
+      curator.delete().forPath(path);
+    } catch (KeeperException.NoNodeException e) {
+      throw new NoNodeException(path);
+    } catch (KeeperException e) {
+      zkFailureCounter.increment();
+      LOG.warn("Failed with a ZK exception when deleting node at {}", path, e);
+      throw new InternalMetadataStoreException("Deleting node at " + path);
+    } catch (Exception e) {
+      failureCounter.increment();
+      LOG.error("Failed with an unknown error {}", e.getMessage(), e);
+      throw new InternalMetadataStoreException("Deleting node at " + path);
+    }
+  }
+
+  @Override
+  public ListenableFuture<?> delete(String path) {
+    return metadataExecutorService.submit(() -> deleteImpl(path));
+  }
+
+  private List<String> getChildrenImpl(String path) {
+    List<String> result = Collections.emptyList();
+    try {
+      metadataReadCounter.increment();
+      result = curator.getChildren().forPath(path).stream().collect(Collectors.toList());
+    } catch (KeeperException.NoNodeException e) {
+      throw new NoNodeException(path);
+    } catch (KeeperException e) {
+      zkFailureCounter.increment();
+      LOG.warn("Failed with a ZK exception when getting children at {}", path, e);
+      throw new InternalMetadataStoreException("Getting children for " + path);
+    } catch (Exception e) {
+      failureCounter.increment();
+      LOG.error("Failed with an unknown error {}", e.getMessage(), e);
+      throw new InternalMetadataStoreException("Fetching children at " + path);
+    }
+    return result;
+  }
+
+  @Override
+  public ListenableFuture<List<String>> getChildren(String path) {
+    return metadataExecutorService.submit(() -> getChildrenImpl(path));
+  }
+}

--- a/src/main/java/com/slack/kaldb/util/FatalErrorHandler.java
+++ b/src/main/java/com/slack/kaldb/util/FatalErrorHandler.java
@@ -1,0 +1,11 @@
+package com.slack.kaldb.util;
+
+/**
+ * FatalErrorHandler is an interface for handling fatal errors. This is needed since Log4j2 no
+ * longer has a log.fatal level.
+ *
+ * <p>We implement this class as an interface so we can switch out the implementation in unit tests.
+ */
+public interface FatalErrorHandler {
+  void handleFatal(Throwable t);
+}

--- a/src/main/java/com/slack/kaldb/util/RuntimeHalterImpl.java
+++ b/src/main/java/com/slack/kaldb/util/RuntimeHalterImpl.java
@@ -1,0 +1,16 @@
+package com.slack.kaldb.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RuntimeHalterImpl implements FatalErrorHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(RuntimeHalterImpl.class);
+
+  @Override
+  public void handleFatal(Throwable t) {
+    t.printStackTrace();
+    LOG.error("Runtime halter is called probably on an unrecoverable error. Stopping the VM.", t);
+    // TODO: Make the exit more cleaner, once the system is more stable.
+    System.exit(1);
+  }
+}

--- a/src/main/java/com/slack/kaldb/util/ShutdownUtil.java
+++ b/src/main/java/com/slack/kaldb/util/ShutdownUtil.java
@@ -1,9 +1,0 @@
-package com.slack.kaldb.util;
-
-public class ShutdownUtil {
-
-  public static void fatalShutdown() {
-    // TODO: Make the exit more cleaner, once the system is more stable.
-    System.exit(1);
-  }
-}

--- a/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
+++ b/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
@@ -6,7 +6,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.slack.kaldb.chunk.ChunkRollOverException;
-import com.slack.kaldb.util.ShutdownUtil;
+import com.slack.kaldb.util.RuntimeHalterImpl;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Properties;
@@ -151,10 +151,10 @@ abstract class KaldbKafkaConsumer {
         // Once we hit these exceptions, we likely have an issue related to storage. So, terminate
         // the program, since consuming more messages from Kafka would only make the issue worse.
         LOG.error("FATAL: Encountered an unrecoverable storage exception.", e);
-        ShutdownUtil.fatalShutdown();
+        new RuntimeHalterImpl().handleFatal(e);
       } catch (Exception e) {
         LOG.error("FATAL: Unhandled exception ", e);
-        ShutdownUtil.fatalShutdown();
+        new RuntimeHalterImpl().handleFatal(e);
       }
     }
   }

--- a/src/test/java/com/slack/kaldb/metadata/ZookeeperMetadataStoreTest.java
+++ b/src/test/java/com/slack/kaldb/metadata/ZookeeperMetadataStoreTest.java
@@ -1,0 +1,496 @@
+package com.slack.kaldb.metadata;
+
+import static com.slack.kaldb.metadata.ZookeeperMetadataStore.METADATA_FAILED_COUNTER;
+import static com.slack.kaldb.metadata.ZookeeperMetadataStore.METADATA_READ_COUNTER;
+import static com.slack.kaldb.metadata.ZookeeperMetadataStore.METADATA_WRITE_COUNTER;
+import static com.slack.kaldb.metadata.ZookeeperMetadataStore.ZK_FAILED_COUNTER;
+import static com.slack.kaldb.testlib.MetricsUtil.getCount;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import com.slack.kaldb.util.CountingFatalErrorHandler;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import org.apache.curator.retry.RetryNTimes;
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ZookeeperMetadataStoreTest {
+  private TestingServer testingServer;
+  private ZookeeperMetadataStore metadataStore;
+  private MeterRegistry meterRegistry;
+  private CountingFatalErrorHandler countingFatalErrorHandler;
+
+  @Before
+  public void setUp() throws Exception {
+    meterRegistry = new SimpleMeterRegistry();
+    // NOTE: Sometimes the ZK server fails to start. Handle it more gracefully, if tests are flaky.
+    testingServer = new TestingServer();
+    countingFatalErrorHandler = new CountingFatalErrorHandler();
+    metadataStore =
+        new ZookeeperMetadataStore(
+            testingServer.getConnectString(),
+            "test",
+            1000,
+            1000,
+            new RetryNTimes(1, 500),
+            countingFatalErrorHandler,
+            meterRegistry);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    metadataStore.close();
+    testingServer.close();
+    meterRegistry.close();
+  }
+
+  @Test
+  public void testCreateAndGetWithoutParents() throws ExecutionException, InterruptedException {
+    final String rootNode = "/rootNode";
+    final String rootNodeData = "rootNodeData";
+    final String childNode = "/childNode1";
+    final String childNodeData = "childNodeData";
+    final String childNode2 = "/childNode2";
+    final String childNodeData2 = "";
+
+    assertThat(getCount(METADATA_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
+    assertThat(metadataStore.create(rootNode, rootNodeData, false).get()).isNull();
+    assertThat(metadataStore.create(rootNode + childNode, childNodeData, false).get()).isNull();
+    assertThat(getCount(METADATA_WRITE_COUNTER, meterRegistry)).isEqualTo(2);
+    assertThat(metadataStore.create("/rootNode/childNode2", childNodeData2, false).get()).isNull();
+    assertThat(getCount(METADATA_WRITE_COUNTER, meterRegistry)).isEqualTo(3);
+    assertThat(metadataStore.get(rootNode).get()).isEqualTo(rootNodeData);
+    assertThat(getCount(METADATA_READ_COUNTER, meterRegistry)).isEqualTo(1);
+    assertThat(metadataStore.get(rootNode + childNode).get()).isEqualTo(childNodeData);
+    assertThat(metadataStore.get("/rootNode/childNode1").get()).isEqualTo(childNodeData);
+    assertThat(metadataStore.get(rootNode + childNode2).get()).isEqualTo(childNodeData2);
+
+    assertThat(getCount(METADATA_WRITE_COUNTER, meterRegistry)).isEqualTo(3);
+    assertThat(getCount(METADATA_READ_COUNTER, meterRegistry)).isEqualTo(4);
+    assertThat(getCount(ZK_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
+    assertThat(getCount(METADATA_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
+  }
+
+  @Test
+  public void testGetMissingNodeThrowsException() throws ExecutionException, InterruptedException {
+    Throwable throwable1 = catchThrowable(() -> metadataStore.get("/missing").get());
+    assertThat(throwable1.getCause()).isInstanceOf(NoNodeException.class);
+
+    metadataStore.create("/rootNode", "", true).get();
+    metadataStore.create("/rootNode/child", "", true).get();
+    assertThat(metadataStore.get("/rootNode").get()).isEqualTo("");
+    assertThat(metadataStore.get("/rootNode/child").get()).isEqualTo("");
+
+    Throwable throwable2 = catchThrowable(() -> metadataStore.get("/rootNode/missing").get());
+    assertThat(throwable2.getCause()).isInstanceOf(NoNodeException.class);
+
+    Throwable throwable3 =
+        catchThrowable(() -> metadataStore.create("/root/c1/c2", "", false).get());
+    assertThat(throwable3.getCause()).isInstanceOf(InternalMetadataStoreException.class);
+
+    assertThat(getCount(METADATA_WRITE_COUNTER, meterRegistry)).isEqualTo(3);
+    assertThat(getCount(METADATA_READ_COUNTER, meterRegistry)).isEqualTo(4);
+    assertThat(getCount(ZK_FAILED_COUNTER, meterRegistry)).isEqualTo(1);
+    assertThat(getCount(METADATA_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
+  }
+
+  @Test
+  public void testCreateAndGetWithParents() throws ExecutionException, InterruptedException {
+    assertThat(metadataStore.create("/root/1/2/3", "123", true).get()).isNull();
+    assertThat(metadataStore.create("/root/1/4", "14", true).get()).isNull();
+    assertThat(metadataStore.create("/root/2/4", "24", true).get()).isNull();
+    assertThat(metadataStore.exists("/root/1").get()).isTrue();
+    assertThat(metadataStore.exists("/root/1/2/3").get()).isTrue();
+    assertThat(metadataStore.exists("/root/2").get()).isTrue();
+    assertThat(metadataStore.exists("/root/2/4").get()).isTrue();
+    assertThat(metadataStore.get("/root/1").get()).isEmpty();
+    assertThat(metadataStore.get("/root/1/2").get()).isEmpty();
+    assertThat(metadataStore.get("/root/2").get()).isEmpty();
+    assertThat(metadataStore.get("/root/1/2/3").get()).isEqualTo("123");
+    assertThat(metadataStore.get("/root/1/4").get()).isEqualTo("14");
+    assertThat(metadataStore.get("/root/2/4").get()).isEqualTo("24");
+
+    assertThat(getCount(METADATA_WRITE_COUNTER, meterRegistry)).isEqualTo(3);
+    assertThat(getCount(METADATA_READ_COUNTER, meterRegistry)).isEqualTo(10);
+    assertThat(getCount(ZK_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
+    assertThat(getCount(METADATA_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
+  }
+
+  @Test
+  public void testCreatingExistingNodeThrowsException()
+      throws ExecutionException, InterruptedException {
+    assertThat(metadataStore.create("/root/1/2/3", "123", true).get()).isNull();
+    assertThat(metadataStore.exists("/root/1/2/3").get()).isTrue();
+
+    Throwable throwable1 =
+        catchThrowable(() -> metadataStore.create("/root/1/2/3", "", true).get());
+    assertThat(throwable1.getCause()).isInstanceOf(NodeExistsException.class);
+
+    Throwable throwable2 = catchThrowable(() -> metadataStore.create("/root/1/2", "", true).get());
+    assertThat(throwable2.getCause()).isInstanceOf(NodeExistsException.class);
+
+    Throwable throwable3 = catchThrowable(() -> metadataStore.create("/root/1/2", "", false).get());
+    assertThat(throwable3.getCause()).isInstanceOf(NodeExistsException.class);
+
+    // With different data
+    Throwable throwable4 =
+        catchThrowable(() -> metadataStore.create("/root/1/2", "s", false).get());
+    assertThat(throwable4.getCause()).isInstanceOf(NodeExistsException.class);
+
+    // Creating a folder fails with an internal error
+    Throwable throwable5 =
+        catchThrowable(() -> metadataStore.create("/createAFolder/", "", false).get());
+    assertThat(throwable5.getCause()).isInstanceOf(InternalMetadataStoreException.class);
+
+    assertThat(getCount(METADATA_WRITE_COUNTER, meterRegistry)).isEqualTo(6);
+    assertThat(getCount(METADATA_READ_COUNTER, meterRegistry)).isEqualTo(1);
+    assertThat(getCount(ZK_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
+    assertThat(getCount(METADATA_FAILED_COUNTER, meterRegistry)).isEqualTo(1);
+  }
+
+  @Test
+  public void testExists() throws ExecutionException, InterruptedException {
+    assertThat(metadataStore.create("/root/1/2/3", "123", true).get()).isNull();
+    assertThat(metadataStore.exists("/root/1/2/3").get()).isTrue();
+    assertThat(metadataStore.exists("/root/1").get()).isTrue();
+    assertThat(metadataStore.exists("/root/2").get()).isFalse();
+    assertThat(metadataStore.exists("/root/1/2/3/4").get()).isFalse();
+
+    assertThat(getCount(METADATA_WRITE_COUNTER, meterRegistry)).isEqualTo(1);
+    assertThat(getCount(METADATA_READ_COUNTER, meterRegistry)).isEqualTo(4);
+    assertThat(getCount(ZK_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
+    assertThat(getCount(METADATA_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
+  }
+
+  @Test
+  public void testPutOperation() throws ExecutionException, InterruptedException {
+    String path = "/root/1/2/3";
+    String data = "Data123";
+    assertThat(metadataStore.create(path, data, true).get()).isNull();
+    assertThat(metadataStore.get(path).get()).isEqualTo(data);
+    String updatedNodeData = "newData123";
+    assertThat(metadataStore.put(path, updatedNodeData).get()).isNull();
+    assertThat(metadataStore.get(path).get()).isEqualTo(updatedNodeData);
+
+    Throwable throwable1 = catchThrowable(() -> metadataStore.put("/missing", "m").get());
+    assertThat(throwable1.getCause()).isInstanceOf(NoNodeException.class);
+
+    assertThat(getCount(METADATA_WRITE_COUNTER, meterRegistry)).isEqualTo(3);
+    assertThat(getCount(METADATA_READ_COUNTER, meterRegistry)).isEqualTo(2);
+    assertThat(getCount(ZK_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
+    assertThat(getCount(METADATA_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
+  }
+
+  @Test
+  public void testDeleteOperation() throws ExecutionException, InterruptedException {
+    Throwable throwable1 = catchThrowable(() -> metadataStore.delete("/missing").get());
+    assertThat(throwable1.getCause()).isInstanceOf(NoNodeException.class);
+
+    String path1 = "/root/1/2/3";
+    String path2 = "/root/1/2/4";
+    String path3 = "/root/1/2/5";
+    assertThat(metadataStore.create(path1, "", true).get()).isNull();
+    assertThat(metadataStore.create(path2, "", true).get()).isNull();
+    assertThat(metadataStore.create(path3, "", true).get()).isNull();
+    assertThat(metadataStore.get(path1).get()).isEmpty();
+    assertThat(metadataStore.get(path2).get()).isEmpty();
+    assertThat(metadataStore.get(path3).get()).isEmpty();
+    assertThat(metadataStore.delete(path1).get()).isNull();
+    assertThat(metadataStore.exists(path1).get()).isFalse();
+    assertThat(metadataStore.get(path2).get()).isEmpty();
+    assertThat(metadataStore.get(path3).get()).isEmpty();
+
+    Throwable nestedChildrenEx = catchThrowable(() -> metadataStore.delete("/root/1").get());
+    assertThat(nestedChildrenEx.getCause()).isInstanceOf(InternalMetadataStoreException.class);
+
+    Throwable nodeWithChildrenEx = catchThrowable(() -> metadataStore.delete("/root/1/2").get());
+    assertThat(nodeWithChildrenEx.getCause()).isInstanceOf(InternalMetadataStoreException.class);
+
+    assertThat(metadataStore.delete(path2).get()).isNull();
+    assertThat(metadataStore.delete(path3).get()).isNull();
+    assertThat(metadataStore.exists(path1).get()).isFalse();
+    assertThat(metadataStore.exists(path2).get()).isFalse();
+    assertThat(metadataStore.exists(path3).get()).isFalse();
+    assertThat(metadataStore.exists("/root/1/2").get()).isTrue();
+    assertThat(metadataStore.delete("/root/1/2").get()).isNull();
+    assertThat(metadataStore.exists("/root/1/2").get()).isFalse();
+    assertThat(metadataStore.exists("/root/1").get()).isTrue();
+    assertThat(metadataStore.delete("/root/1").get()).isNull();
+    assertThat(metadataStore.exists("/root/1").get()).isFalse();
+
+    assertThat(getCount(METADATA_WRITE_COUNTER, meterRegistry)).isEqualTo(11);
+    assertThat(getCount(METADATA_READ_COUNTER, meterRegistry)).isEqualTo(13);
+    assertThat(getCount(ZK_FAILED_COUNTER, meterRegistry)).isEqualTo(2);
+    assertThat(getCount(METADATA_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
+  }
+
+  @Test
+  public void testDeleteMissingNode() throws ExecutionException, InterruptedException {
+    Throwable throwable = catchThrowable(() -> metadataStore.delete("/missing").get());
+    assertThat(throwable.getCause()).isInstanceOf(NoNodeException.class);
+
+    assertThat(metadataStore.create("/root", "", true).get()).isNull();
+    assertThat(metadataStore.exists("/root").get()).isTrue();
+
+    Throwable throwable2 = catchThrowable(() -> metadataStore.delete("/root/missing").get());
+    assertThat(throwable2.getCause()).isInstanceOf(NoNodeException.class);
+
+    assertThat(getCount(METADATA_WRITE_COUNTER, meterRegistry)).isEqualTo(3);
+    assertThat(getCount(METADATA_READ_COUNTER, meterRegistry)).isEqualTo(1);
+    assertThat(getCount(ZK_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
+    assertThat(getCount(METADATA_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
+  }
+
+  @Test
+  public void testGetChildrenSimple() throws ExecutionException, InterruptedException {
+    Throwable throwable1 = catchThrowable(() -> metadataStore.getChildren("/root").get());
+    assertThat(throwable1.getCause()).isInstanceOf(NoNodeException.class);
+
+    assertThat(metadataStore.create("/root", "", true).get()).isNull();
+    assertThat(metadataStore.getChildren("/root").get().size()).isZero();
+
+    Throwable throwable2 = catchThrowable(() -> metadataStore.getChildren("/root/1").get());
+    assertThat(throwable2.getCause()).isInstanceOf(NoNodeException.class);
+
+    assertThat(metadataStore.create("/root/1", "test", true).get()).isNull();
+    assertThat(metadataStore.getChildren("/root").get()).hasSameElementsAs(List.of("1"));
+    assertThat(metadataStore.create("/root/2", "test", true).get()).isNull();
+    assertThat(metadataStore.getChildren("/root").get()).hasSameElementsAs(List.of("1", "2"));
+    assertThat(metadataStore.delete("/root/2").get()).isNull();
+    assertThat(metadataStore.exists("/root/2").get()).isFalse();
+    assertThat(metadataStore.getChildren("/root").get()).hasSameElementsAs(List.of("1"));
+
+    // Invalid path
+    Throwable noChildEx = catchThrowable(() -> metadataStore.getChildren("root/21").get());
+    assertThat(noChildEx.getCause()).isInstanceOf(InternalMetadataStoreException.class);
+
+    assertThat(getCount(METADATA_WRITE_COUNTER, meterRegistry)).isEqualTo(4);
+    assertThat(getCount(METADATA_READ_COUNTER, meterRegistry)).isEqualTo(8);
+    assertThat(getCount(ZK_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
+    assertThat(getCount(METADATA_FAILED_COUNTER, meterRegistry)).isEqualTo(1);
+  }
+
+  @Test
+  public void testGetChildrenNested() throws ExecutionException, InterruptedException {
+    String path1 = "/root/1/2/3";
+    String path2 = "/root/1/2/4";
+    String path3 = "/root/1/2/5";
+
+    Throwable beforeNodeCrationEx = catchThrowable(() -> metadataStore.getChildren(path1).get());
+    assertThat(beforeNodeCrationEx.getCause()).isInstanceOf(NoNodeException.class);
+
+    assertThat(metadataStore.create(path1, "", true).get()).isNull();
+    assertThat(metadataStore.create(path2, "", true).get()).isNull();
+    assertThat(metadataStore.create(path3, "", true).get()).isNull();
+    assertThat(metadataStore.get(path1).get()).isEmpty();
+    assertThat(metadataStore.get(path2).get()).isEmpty();
+    assertThat(metadataStore.get(path3).get()).isEmpty();
+
+    List<String> rootChildren = metadataStore.getChildren("/root").get();
+    assertThat(rootChildren.size()).isEqualTo(1);
+    assertThat(rootChildren).hasSameElementsAs(List.of("1"));
+
+    List<String> root1Children = metadataStore.getChildren("/root/1").get();
+    assertThat(root1Children.size()).isEqualTo(1);
+    assertThat(root1Children).hasSameElementsAs(List.of("2"));
+
+    List<String> root12Children = metadataStore.getChildren("/root/1/2").get();
+    assertThat(root12Children.size()).isEqualTo(3);
+    assertThat(root12Children).hasSameElementsAs(List.of("3", "4", "5"));
+
+    String path4 = "/root/1/21";
+    assertThat(metadataStore.create(path4, "", true).get()).isNull();
+    assertThat(metadataStore.get(path4).get()).isEmpty();
+    assertThat(metadataStore.getChildren("/root").get()).hasSameElementsAs(List.of("1"));
+    assertThat(metadataStore.getChildren("/root/1").get()).hasSameElementsAs(List.of("21", "2"));
+    assertThat(metadataStore.getChildren("/root/1/2").get())
+        .hasSameElementsAs(List.of("3", "4", "5"));
+
+    assertThat(metadataStore.getChildren("/root/1/21").get().size()).isZero();
+
+    // Invalid path
+    Throwable noChildEx = catchThrowable(() -> metadataStore.getChildren("root/1/21").get());
+    assertThat(noChildEx.getCause()).isInstanceOf(InternalMetadataStoreException.class);
+
+    assertThat(metadataStore.delete(path3).get()).isNull();
+    assertThat(metadataStore.getChildren("/root").get()).hasSameElementsAs(List.of("1"));
+    assertThat(metadataStore.getChildren("/root/1").get()).hasSameElementsAs(List.of("21", "2"));
+    assertThat(metadataStore.getChildren("/root/1/2").get()).hasSameElementsAs(List.of("3", "4"));
+
+    assertThat(getCount(METADATA_WRITE_COUNTER, meterRegistry)).isEqualTo(5);
+    assertThat(getCount(METADATA_READ_COUNTER, meterRegistry)).isEqualTo(16);
+    assertThat(getCount(ZK_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
+    assertThat(getCount(METADATA_FAILED_COUNTER, meterRegistry)).isEqualTo(1);
+  }
+
+  @Test
+  public void testEphemeralNodeCreateRoot() throws ExecutionException, InterruptedException {
+    final String root = "/ephemeralRoot";
+    final String ephemeralData = "ephemeralData";
+    assertThat(metadataStore.createEphemeralNode(root, ephemeralData).get()).isNull();
+    assertThat(metadataStore.exists(root).get()).isTrue();
+
+    Throwable noEphemeralChildEx =
+        catchThrowable(() -> metadataStore.createEphemeralNode(root + "/child", "").get());
+    assertThat(noEphemeralChildEx.getCause()).isInstanceOf(InternalMetadataStoreException.class);
+
+    assertThat(metadataStore.get(root).get()).isEqualTo(ephemeralData);
+    assertThat(metadataStore.put(root, ephemeralData + "1").get()).isNull();
+    assertThat(metadataStore.get(root).get()).isEqualTo(ephemeralData + "1");
+    assertThat(metadataStore.getChildren(root).get().size()).isZero();
+
+    Throwable duplicateEphemeralEx =
+        catchThrowable(() -> metadataStore.createEphemeralNode(root, "").get());
+    assertThat(duplicateEphemeralEx.getCause()).isInstanceOf(NodeExistsException.class);
+
+    assertThat(metadataStore.delete(root).get()).isNull();
+    assertThat(metadataStore.exists(root).get()).isFalse();
+
+    assertThat(getCount(METADATA_WRITE_COUNTER, meterRegistry)).isEqualTo(5);
+    assertThat(getCount(METADATA_READ_COUNTER, meterRegistry)).isEqualTo(5);
+    assertThat(getCount(ZK_FAILED_COUNTER, meterRegistry)).isEqualTo(1);
+    assertThat(getCount(METADATA_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
+  }
+
+  @Test
+  public void testEphemeralNodeNested() throws ExecutionException, InterruptedException {
+    final String root = "/root/1/2/3";
+    final String persistentChild = root + "/persistent1";
+    final String ephemeralNode = root + "/ephemeral";
+    final String ephemeralNodeData = "ephemeral";
+    assertThat(metadataStore.create(root, "", true).get()).isNull();
+    assertThat(metadataStore.createEphemeralNode(ephemeralNode, ephemeralNodeData).get()).isNull();
+    assertThat(metadataStore.get(ephemeralNode).get()).isEqualTo(ephemeralNodeData);
+    assertThat(metadataStore.create(persistentChild, "", true).get()).isNull();
+    assertThat(metadataStore.getChildren("/root/1").get()).hasSameElementsAs(List.of("2"));
+    assertThat(metadataStore.getChildren(root).get())
+        .hasSameElementsAs(List.of("ephemeral", "persistent1"));
+    assertThat(metadataStore.exists(persistentChild).get()).isTrue();
+    assertThat(metadataStore.exists(ephemeralNode).get()).isTrue();
+
+    Throwable noEphemeralChildEx =
+        catchThrowable(() -> metadataStore.createEphemeralNode(ephemeralNode + "/child", "").get());
+    assertThat(noEphemeralChildEx.getCause()).isInstanceOf(InternalMetadataStoreException.class);
+
+    final String ephemeralNode2 = persistentChild + "/ephemeralChild2";
+    assertThat(metadataStore.createEphemeralNode(ephemeralNode2, ephemeralNodeData).get()).isNull();
+    assertThat(metadataStore.getChildren(persistentChild).get())
+        .hasSameElementsAs(List.of("ephemeralChild2"));
+
+    Throwable deleteWithEphemeralChildEx =
+        catchThrowable(() -> metadataStore.delete(persistentChild).get());
+    assertThat(deleteWithEphemeralChildEx.getCause())
+        .isInstanceOf(InternalMetadataStoreException.class);
+
+    assertThat(metadataStore.delete(ephemeralNode2).get()).isNull();
+    assertThat(metadataStore.exists(ephemeralNode2).get()).isFalse();
+    assertThat(metadataStore.exists(persistentChild).get()).isTrue();
+    assertThat(metadataStore.exists(ephemeralNode).get()).isTrue();
+
+    assertThat(metadataStore.delete(persistentChild).get()).isNull();
+    assertThat(metadataStore.exists(persistentChild).get()).isFalse();
+    assertThat(metadataStore.exists(ephemeralNode).get()).isTrue();
+
+    Throwable duplicateEphemeralEx =
+        catchThrowable(() -> metadataStore.createEphemeralNode(ephemeralNode, "").get());
+    assertThat(duplicateEphemeralEx.getCause()).isInstanceOf(NodeExistsException.class);
+
+    assertThat(metadataStore.delete(ephemeralNode).get()).isNull();
+    assertThat(metadataStore.exists(ephemeralNode).get()).isFalse();
+    assertThat(metadataStore.delete(root).get()).isNull();
+    assertThat(metadataStore.exists(root).get()).isFalse();
+
+    assertThat(getCount(METADATA_WRITE_COUNTER, meterRegistry)).isEqualTo(11);
+    assertThat(getCount(METADATA_READ_COUNTER, meterRegistry)).isEqualTo(13);
+    assertThat(getCount(ZK_FAILED_COUNTER, meterRegistry)).isEqualTo(2);
+    assertThat(getCount(METADATA_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
+  }
+
+  @Test
+  public void testEphemeralNodeWithClientRestart() throws ExecutionException, InterruptedException {
+    final String ephemeralRoot = "/ephemeralRoot";
+    final String ephemeralData = "ephemeralData";
+    assertThat(metadataStore.createEphemeralNode(ephemeralRoot, ephemeralData).get()).isNull();
+    assertThat(metadataStore.exists(ephemeralRoot).get()).isTrue();
+    assertThat(metadataStore.get(ephemeralRoot).get()).isEqualTo(ephemeralData);
+
+    // Close and re-open the metadata store.
+    metadataStore.close();
+    metadataStore =
+        new ZookeeperMetadataStore(
+            testingServer.getConnectString(),
+            "test",
+            1000,
+            1000,
+            new RetryNTimes(1, 500),
+            new CountingFatalErrorHandler(),
+            meterRegistry);
+
+    assertThat(metadataStore.exists(ephemeralRoot).get()).isFalse();
+
+    assertThat(getCount(METADATA_WRITE_COUNTER, meterRegistry)).isEqualTo(1);
+    assertThat(getCount(METADATA_READ_COUNTER, meterRegistry)).isEqualTo(3);
+    assertThat(getCount(ZK_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
+    assertThat(getCount(METADATA_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
+  }
+
+  @Test
+  public void testCreateZkServerFailure() throws Exception {
+    String root = "/root/1/2/3";
+    assertThat(metadataStore.create(root, "", true).get()).isNull();
+    assertThat(metadataStore.exists(root).get()).isTrue();
+    assertThat(metadataStore.get(root).get()).isEmpty();
+
+    // Stop ZK server to simulate ZK failure.
+    testingServer.close();
+
+    Throwable createEx = catchThrowable(() -> metadataStore.create(root, "", true).get());
+    assertThat(createEx.getCause()).isInstanceOf(InternalMetadataStoreException.class);
+    assertThat(getCount(ZK_FAILED_COUNTER, meterRegistry)).isEqualTo(1);
+
+    Throwable getEx = catchThrowable(() -> metadataStore.get(root).get());
+    assertThat(getEx.getCause()).isInstanceOf(InternalMetadataStoreException.class);
+    assertThat(getCount(ZK_FAILED_COUNTER, meterRegistry)).isEqualTo(2);
+
+    Throwable existsEx = catchThrowable(() -> metadataStore.exists(root).get());
+    assertThat(existsEx.getCause()).isInstanceOf(InternalMetadataStoreException.class);
+    assertThat(getCount(ZK_FAILED_COUNTER, meterRegistry)).isEqualTo(3);
+
+    Throwable putEx = catchThrowable(() -> metadataStore.put(root, "newtest").get());
+    assertThat(putEx.getCause()).isInstanceOf(InternalMetadataStoreException.class);
+    assertThat(getCount(ZK_FAILED_COUNTER, meterRegistry)).isEqualTo(4);
+
+    Throwable getChildrenEx = catchThrowable(() -> metadataStore.getChildren(root).get());
+    assertThat(getChildrenEx.getCause()).isInstanceOf(InternalMetadataStoreException.class);
+    assertThat(getCount(ZK_FAILED_COUNTER, meterRegistry)).isEqualTo(5);
+
+    Throwable deleteEx = catchThrowable(() -> metadataStore.delete(root).get());
+    assertThat(deleteEx.getCause()).isInstanceOf(InternalMetadataStoreException.class);
+    assertThat(getCount(ZK_FAILED_COUNTER, meterRegistry)).isEqualTo(6);
+
+    Throwable ephemeralEx = catchThrowable(() -> metadataStore.createEphemeralNode(root, "").get());
+    assertThat(ephemeralEx.getCause()).isInstanceOf(InternalMetadataStoreException.class);
+    assertThat(getCount(ZK_FAILED_COUNTER, meterRegistry)).isEqualTo(7);
+  }
+
+  @Test
+  public void testFatalErrorHandlerInvocation() throws Exception {
+    String root = "/root/1/2/3";
+    assertThat(metadataStore.create(root, "", true).get()).isNull();
+    assertThat(metadataStore.exists(root).get()).isTrue();
+    assertThat(metadataStore.get(root).get()).isEmpty();
+
+    // Stop ZK server to simulate ZK failure.
+    testingServer.close();
+    Throwable createEx = catchThrowable(() -> metadataStore.create(root, "", true).get());
+    assertThat(createEx.getCause()).isInstanceOf(InternalMetadataStoreException.class);
+    assertThat(getCount(ZK_FAILED_COUNTER, meterRegistry)).isEqualTo(1);
+    assertThat(countingFatalErrorHandler.getCount()).isEqualTo(1);
+  }
+}

--- a/src/test/java/com/slack/kaldb/util/CountingFatalErrorHandler.java
+++ b/src/test/java/com/slack/kaldb/util/CountingFatalErrorHandler.java
@@ -1,0 +1,14 @@
+package com.slack.kaldb.util;
+
+public class CountingFatalErrorHandler implements FatalErrorHandler {
+  private int count = 0;
+
+  @Override
+  public void handleFatal(Throwable t) {
+    count = count + 1;
+  }
+
+  public int getCount() {
+    return count;
+  }
+}


### PR DESCRIPTION
A ZK based metadata store with basic CRUD operations and unit tests. 

The MetadataStore interface also makes the higher level classes oblivious to underlying implementation thus leaving room for other pluggable physical store implementations in the future.