### PR TITLE
KalDB - Enable DocService amd Request Logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -428,6 +428,8 @@
                                         <Main-Class>com.slack.kaldb.server.Kaldb</Main-Class>
                                     </manifestEntries>
                                 </transformer>
+                                <!-- Needed for Armeria DocService -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
                             <filters>
                                 <filter>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <http.core.version>4.4.9</http.core.version>
         <protobuf.version>3.12.0</protobuf.version>
         <grpc.version>1.30.0</grpc.version>
-        <armeria.version>1.4.0</armeria.version>
+        <armeria.version>1.8.0</armeria.version>
         <micrometer.version>1.5.1</micrometer.version>
         <jackson.version>2.11.1</jackson.version>
         <lucene.version>8.4.1</lucene.version>
@@ -466,11 +466,14 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>0.6.1</version>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}
-                    </protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}
-                    </pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+                    <writeDescriptorSet>true</writeDescriptorSet>
+                    <includeDependenciesInDescriptorSet>true</includeDependenciesInDescriptorSet>
+                    <includeSourceInfoInDescriptorSet>true</includeSourceInfoInDescriptorSet>
+                    <descriptorSetOutputDirectory>${project.build.outputDirectory}/META-INF/armeria/grpc</descriptorSetOutputDirectory>
+                    <descriptorSetFileName>${project.build.finalName}.dsc</descriptorSetFileName>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -14,6 +14,8 @@ import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.server.logging.LoggingServiceBuilder;
 import com.linecorp.armeria.server.metric.MetricCollectingService;
 import com.slack.kaldb.config.KaldbConfig;
+import com.slack.kaldb.proto.service.KaldbSearch;
+import com.slack.kaldb.proto.service.KaldbServiceGrpc;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;

--- a/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -63,9 +63,6 @@ public class Kaldb {
         MetricCollectingService.newDecorator(GrpcMeterIdPrefixFunction.of("grpc.service")));
     sb.decorator(getLoggingServiceBuilder().newDecorator());
     sb.http(serverPort);
-    // TODO: ScheduledExecutorService is unbounded . Wrap in a ThreadPoolExecutor and bound it in the future
-    // Configure num threads based on CPU core count?
-    sb.blockingTaskExecutor(Executors.newScheduledThreadPool(10), true);
     sb.service("/health", HealthCheckService.builder().build());
     sb.service("/metrics", (ctx, req) -> HttpResponse.of(prometheusMeterRegistry.scrape()));
     sb.serviceUnder("/docs", new DocService());

--- a/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
+++ b/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
@@ -130,9 +130,7 @@ public class KaldbIndexer {
     this.chunkManager = chunkManager;
 
     // Create a protobuf handler service that calls chunkManager on search.
-    grpcServiceBuilder
-        .addService(new KaldbService<>(chunkManager))
-        .addService(ProtoReflectionService.newInstance());
+    grpcServiceBuilder.addService(new KaldbService<>(chunkManager)).enableUnframedRequests(true);
 
     LogMessageWriterImpl logMessageWriterImpl =
         new LogMessageWriterImpl(chunkManager, messageTransformer);


### PR DESCRIPTION
I want to manually test the query service for a single node search

Looks like we already have KalDBService registered ( The registry happens within KalDBIndexer and I hadn't realized this ) 

Anyways since the query service is registered I want to test it

To do that this PR enabled the DocService

It also enables request logging  - Example log line

```
[INFO ] 2021-06-11 02:25:54.778 [armeria-common-worker-epoll-2-2] LoggingService - [sreqId=f69b7f18, chanId=3a7c22a9, raddr=ip:61936, laddr=ip:8081][h1c://kaldb-service-traces-dev-1/metrics#GET] Response: {startTime=2021-06-11T02:25:54.777Z(1623378354777000), length=39873B, duration=473µs(473053ns), totalDuration=5318µs(5318716ns), headers=[:status=200, content-type=text/plain; charset=utf-8, content-length=39873]}
```