### PR TITLE
Add more chunk info

### DIFF
--- a/src/main/java/com/slack/kaldb/chunk/ChunkInfo.java
+++ b/src/main/java/com/slack/kaldb/chunk/ChunkInfo.java
@@ -44,6 +44,28 @@ public class ChunkInfo {
   // and snapshotting and is not useful afterwards.
   private long chunkSnapshotTimeEpochSecs;
 
+  public long getNumDocs() {
+    return numDocs;
+  }
+
+  public void setNumDocs(long numDocs) {
+    this.numDocs = numDocs;
+  }
+
+  public long getChunkSize() {
+    return chunkSize;
+  }
+
+  public void setChunkSize(long chunkSize) {
+    this.chunkSize = chunkSize;
+  }
+
+  // Number of docs in this chunk
+  private long numDocs;
+
+  // Size of the chunk
+  private long chunkSize;
+
   public ChunkInfo(String chunkId, long chunkCreationTimeEpochSecs) {
     ensureTrue(chunkId != null && !chunkId.isEmpty(), "Invalid chunk dataset name " + chunkId);
     ensureTrue(
@@ -134,6 +156,10 @@ public class ChunkInfo {
         + dataEndTimeEpochSecs
         + ", chunkSnapshotTime="
         + chunkSnapshotTimeEpochSecs
+        + ", numDocs="
+        + numDocs
+        + ", chunkSize="
+        + chunkSize
         + '}';
   }
 
@@ -147,7 +173,9 @@ public class ChunkInfo {
         && dataStartTimeEpochSecs == chunkInfo.dataStartTimeEpochSecs
         && dataEndTimeEpochSecs == chunkInfo.dataEndTimeEpochSecs
         && chunkSnapshotTimeEpochSecs == chunkInfo.chunkSnapshotTimeEpochSecs
-        && Objects.equals(chunkId, chunkInfo.chunkId);
+        && Objects.equals(chunkId, chunkInfo.chunkId)
+        && numDocs == chunkInfo.numDocs
+        && chunkSize == chunkInfo.chunkSize;
   }
 
   @Override
@@ -158,6 +186,8 @@ public class ChunkInfo {
         chunkLastUpdatedTimeSecsEpochSecs,
         dataStartTimeEpochSecs,
         dataEndTimeEpochSecs,
-        chunkSnapshotTimeEpochSecs);
+        chunkSnapshotTimeEpochSecs,
+        numDocs,
+        chunkSize);
   }
 }

--- a/src/main/java/com/slack/kaldb/chunk/ChunkManager.java
+++ b/src/main/java/com/slack/kaldb/chunk/ChunkManager.java
@@ -169,6 +169,8 @@ public class ChunkManager<T> {
           currentIndexedMessages,
           currentIndexedBytes,
           currentChunk.id());
+      currentChunk.info().setNumDocs(currentIndexedMessages);
+      currentChunk.info().setChunkSize(currentIndexedBytes);
       doRollover(currentChunk);
     }
   }


### PR DESCRIPTION
When there is a chunk rollover exception I want to know a little more about the chunk - i.e how many docs are there , what is the approx size


```
[ERROR] 2021-06-11 15:36:16.405 [pool-5-thread-1] KaldbKafkaConsumer - FATAL: Unhandled exception 
com.slack.kaldb.chunk.ChunkRollOverInProgressException: The chunk roll over ChunkInfo{chunkId='log_data__1623425768842', chunkCreationTimeSecsSinceEpoch=1623425768, chunkLastUpdatedTimeSecsSinceEpoch=1623425776, dataStartTimeSecsSinceEpoch=1623383651, dataEndTimeSecsSinceEpoch=1623388438, chunkSnapshotTime=0} is already in progress.It is not recommended to index faster than we can roll over, since we may not be able to keep up.
	at com.slack.kaldb.chunk.ChunkManager.doRollover(ChunkManager.java:212) ~[kaldb.jar:?]
	at com.slack.kaldb.chunk.ChunkManager.addMessage(ChunkManager.java:172) ~[kaldb.jar:?]
	at com.slack.kaldb.writer.LogMessageWriterImpl.insertRecord(LogMessageWriterImpl.java:111) ~[kaldb.jar:?]
	at com.slack.kaldb.writer.kafka.KaldbKafkaWriter.consumeMessages(KaldbKafkaWriter.java:111) ~
```