### PR TITLE
No Need for  KalDBMergeScheduler DEBUG logging

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -8,9 +8,12 @@
     </Appenders>
 
     <Loggers>
+        <!--
+        Enable for DEBUG logging
         <Logger name="com.slack.kaldb.logstore.index.KalDBMergeScheduler" level="debug" additivity="true">
             <appender-ref ref="console" />
         </Logger>
+        -->
         <AsyncRoot level="${env:LOG_LEVEL:-info}">
             <AppenderRef ref="console"/>
         </AsyncRoot>


### PR DESCRIPTION
We don't need to debug the merge scheduler right now