### PR TITLE
Enable ERROR logging

### DIFF
--- a/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -1,11 +1,8 @@
 package com.slack.kaldb.server;
 
-import com.linecorp.armeria.common.HttpHeaderNames;
-import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.grpc.GrpcMeterIdPrefixFunction;
 import com.linecorp.armeria.common.logging.LogLevel;
-import com.linecorp.armeria.common.logging.RegexBasedSanitizer;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.docs.DocService;
@@ -24,11 +21,10 @@ import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
-
-import io.netty.handler.codec.http.DefaultHttpHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,6 +79,7 @@ public class Kaldb {
 
   private LoggingServiceBuilder getLoggingServiceBuilder() {
     return LoggingService.builder()
+        // Not logging any successful response, say prom scraping /metrics every 30 seconds at INFO
         .successfulResponseLogLevel(LogLevel.DEBUG)
         .failureResponseLogLevel(LogLevel.ERROR)
         // Remove all headers to be sure we aren't leaking any auth/cookie info

--- a/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -1,13 +1,17 @@
 package com.slack.kaldb.server;
 
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.grpc.GrpcMeterIdPrefixFunction;
+import com.linecorp.armeria.common.logging.LogLevel;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.docs.DocService;
 import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
 import com.linecorp.armeria.server.healthcheck.HealthCheckService;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.server.logging.LoggingServiceBuilder;
 import com.linecorp.armeria.server.metric.MetricCollectingService;
 import com.slack.kaldb.config.KaldbConfig;
 import io.micrometer.core.instrument.Metrics;
@@ -53,6 +57,7 @@ public class Kaldb {
     ServerBuilder sb = Server.builder();
     sb.decorator(
         MetricCollectingService.newDecorator(GrpcMeterIdPrefixFunction.of("grpc.service")));
+    sb.decorator(getLoggingServiceBuilder().newDecorator());
     sb.http(serverPort);
     sb.service("/health", HealthCheckService.builder().build());
     sb.service("/metrics", (ctx, req) -> HttpResponse.of(prometheusMeterRegistry.scrape()));
@@ -70,6 +75,23 @@ public class Kaldb {
 
     // TODO: On CTRL-C shut down the process cleanly. Ensure no write locks in indexer. Guava
     // ServiceManager?
+  }
+
+  private LoggingServiceBuilder getLoggingServiceBuilder() {
+    return LoggingService.builder()
+        .successfulResponseLogLevel(LogLevel.DEBUG)
+        .failureResponseLogLevel(LogLevel.ERROR)
+        .requestHeadersSanitizer((ctx, headers) -> {
+          if (headers.contains(HttpHeaderNames.AUTHORIZATION)) {
+            headers =
+                headers
+                    .toBuilder()
+                    .removeAndThen(HttpHeaderNames.AUTHORIZATION)
+                    .add(HttpHeaderNames.AUTHORIZATION, "present_but_scrubbed")
+                    .build();
+          }
+          return headers;
+        });
   }
 
   private void setupMetrics() {

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -9,7 +9,7 @@
 
     <Loggers>
         <Logger name="com.slack.kaldb.logstore.index.KalDBMergeScheduler" level="debug" additivity="true">
-            <appender-ref ref="onsole" />
+            <appender-ref ref="console" />
         </Logger>
         <AsyncRoot level="${env:LOG_LEVEL:-info}">
             <AppenderRef ref="console"/>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -9,7 +9,7 @@
 
     <Loggers>
         <Logger name="com.slack.kaldb.logstore.index.KalDBMergeScheduler" level="debug" additivity="true">
-            <appender-ref ref="console" />
+            <appender-ref ref="onsole" />
         </Logger>
         <AsyncRoot level="${env:LOG_LEVEL:-info}">
             <AppenderRef ref="console"/>


### PR DESCRIPTION
Previously if a request fails with this error there is no stack trace in the logs so it's impossible to figure out what went wrong

```
http-status: 500, Internal Server Error
Caused by: 
grpc-status: 2, UNKNOWN
``` 


With the change we'll see an error like this in the log

```
[ERROR] 2021-06-14 17:59:10.852 [armeria-common-worker-epoll-2-2] LoggingService - [sreqId=ee1eaa3e, chanId=9018bb72, raddr=10.181.24.71:50360, laddr=10.216.32.198:8081][h1c://kaldb-service-traces-dev-1/slack.proto.kaldb.KaldbService/Search#POST] Response: {startTime=2021-06-14T17:59:10.840Z(1623693550840000), length=75B, duration=593µs(593208ns), totalDuration=37700µs(37700189ns), cause=io.grpc.StatusException: UNKNOWN, headers=[:status=500, content-type=text/plain; charset=utf-8, grpc-status=2, content-length=75], content=CompletableRpcResponse{cause=io.grpc.StatusException: UNKNOWN}}
io.grpc.StatusException: UNKNOWN
	at io.grpc.Status.asException(Status.java:541) ~[kaldb.jar:?]
	at com.linecorp.armeria.internal.common.grpc.GrpcLogUtil.rpcResponse(GrpcLogUtil.java:58) ~[kaldb.jar:?]
	at com.linecorp.armeria.server.grpc.ArmeriaServerCall.closeListener(ArmeriaServerCall.java:530) ~[kaldb.jar:?]
	at com.linecorp.armeria.server.grpc.ArmeriaServerCall.doClose(ArmeriaServerCall.java:369) ~[kaldb.jar:?]
	at com.linecorp.armeria.server.grpc.ArmeriaServerCall.close(ArmeriaServerCall.java:334) ~[kaldb.jar:?]
	at com.linecorp.armeria.server.grpc.ArmeriaServerCall.invokeHalfClose(ArmeriaServerCall.java:508) ~[kaldb.jar:?]
	at com.linecorp.armeria.server.grpc.ArmeriaServerCall.onComplete(ArmeriaServerCall.java:483) ~[kaldb.jar:?]
	at com.linecorp.armeria.common.stream.AbstractStreamMessage$CloseEvent.notifySubscriber(AbstractStreamMessage.java:265) ~[kaldb.jar:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.notifySubscriberOfCloseEvent0(DefaultStreamMessage.java:284) ~[kaldb.jar:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.notifySubscriberOfCloseEvent(DefaultStreamMessage.java:276) ~[kaldb.jar:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.handleCloseEvent(DefaultStreamMessage.java:448) ~[kaldb.jar:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.notifySubscriber0(DefaultStreamMessage.java:391) ~[kaldb.jar:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.doRequest(DefaultStreamMessage.java:259) ~[kaldb.jar:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.request(DefaultStreamMessage.java:242) ~[kaldb.jar:?]
	at com.linecorp.armeria.common.stream.AbstractStreamMessage$SubscriptionImpl.request(AbstractStreamMessage.java:218) ~[kaldb.jar:?]
	at com.linecorp.armeria.server.grpc.ArmeriaServerCall.onSubscribe(ArmeriaServerCall.java:408) ~[kaldb.jar:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.subscribe(DefaultStreamMessage.java:147) ~[kaldb.jar:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.subscribe(DefaultStreamMessage.java:130) ~[kaldb.jar:?]
	at com.linecorp.armeria.common.stream.AbstractStreamMessage.subscribe(AbstractStreamMessage.java:67) ~[kaldb.jar:?]
	at com.linecorp.armeria.server.grpc.ArmeriaServerCall.startDeframing(ArmeriaServerCall.java:621) ~[kaldb.jar:?]
	at com.linecorp.armeria.server.grpc.FramedGrpcService.doPost(FramedGrpcService.java:212) ~[kaldb.jar:?]
	at com.linecorp.armeria.server.AbstractHttpService.serve(AbstractHttpService.java:57) ~[kaldb.jar:?]
	at com.linecorp.armeria.server.AbstractHttpService.serve(AbstractHttpService.java:42) ~[kaldb.jar:?]
	at com.linecorp.armeria.server.grpc.UnframedGrpcService.frameAndServe(UnframedGrpcService.java:218) ~[kaldb.jar:?]
	at com.linecorp.armeria.server.grpc.UnframedGrpcService.lambda$serve$0(UnframedGrpcService.java:187) ~[kaldb.jar:?]
	at java.util.concurrent.CompletableFuture.uniHandle(CompletableFuture.java:930) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniHandle.tryFire(CompletableFuture.java:907) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
	at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2073) ~[?:?]
	at com.linecorp.armeria.common.HttpMessageAggregator.onComplete(HttpMessageAggregator.java:92) ~[kaldb.jar:?]
	at com.linecorp.armeria.common.stream.AbstractStreamMessage$CloseEvent.notifySubscriber(AbstractStreamMessage.java:265) ~[kaldb.jar:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.notifySubscriberOfCloseEvent0(DefaultStreamMessage.java:284) ~[kaldb.jar:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.notifySubscriberOfCloseEvent(DefaultStreamMessage.java:276) ~[kaldb.jar:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.handleCloseEvent(DefaultStreamMessage.java:448) ~[kaldb.jar:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.notifySubscriber0(DefaultStreamMessage.java:391) ~[kaldb.jar:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.notifySubscriber(DefaultStreamMessage.java:338) ~[kaldb.jar:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.addObjectOrEvent(DefaultStreamMessage.java:324) ~[kaldb.jar:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.close(DefaultStreamMessage.java:455) ~[kaldb.jar:?]
	at com.linecorp.armeria.server.Http1RequestDecoder.channelRead(Http1RequestDecoder.java:253) ~[kaldb.jar:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[kaldb.jar:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[kaldb.jar:?]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[kaldb.jar:?]
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103) ~[kaldb.jar:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[kaldb.jar:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[kaldb.jar:?]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[kaldb.jar:?]
	at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436) ~[kaldb.jar:?]
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324) ~[kaldb.jar:?]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296) ~[kaldb.jar:?]
	at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251) ~[kaldb.jar:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[kaldb.jar:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[kaldb.jar:?]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[kaldb.jar:?]
	at io.netty.handler.logging.LoggingHandler.channelRead(LoggingHandler.java:271) ~[kaldb.jar:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[kaldb.jar:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[kaldb.jar:?]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[kaldb.jar:?]
	at io.netty.handler.flush.FlushConsolidationHandler.channelRead(FlushConsolidationHandler.java:152) ~[kaldb.jar:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[kaldb.jar:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[kaldb.jar:?]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[kaldb.jar:?]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) ~[kaldb.jar:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[kaldb.jar:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[kaldb.jar:?]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) ~[kaldb.jar:?]
	at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:795) ~[kaldb.jar:?]
	at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:480) ~[kaldb.jar:?]
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:378) [kaldb.jar:?]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989) [kaldb.jar:?]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [kaldb.jar:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [kaldb.jar:?]
	at java.lang.Thread.run(Thread.java:829) [?:?]
Caused by: java.lang.IllegalArgumentException: indexName should be a non-empty string
	at com.slack.kaldb.util.ArgValidationUtils.ensureNonEmptyString(ArgValidationUtils.java:6) ~[kaldb.jar:?]
	at com.slack.kaldb.logstore.search.LogIndexSearcherImpl.search(LogIndexSearcherImpl.java:80) ~[kaldb.jar:?]
	at com.slack.kaldb.chunk.ReadWriteChunkImpl.query(ReadWriteChunkImpl.java:192) ~[kaldb.jar:?]
	at com.slack.kaldb.chunk.ChunkManager.query(ChunkManager.java:272) ~[kaldb.jar:?]
	at com.slack.kaldb.server.KaldbService.doSearch(KaldbService.java:72) ~[kaldb.jar:?]
	at com.slack.kaldb.server.KaldbService.search(KaldbService.java:82) ~[kaldb.jar:?]
	at com.slack.kaldb.proto.service.KaldbServiceGrpc$MethodHandlers.invoke(KaldbServiceGrpc.java:217) ~[kaldb.jar:?]
	at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:172) ~[kaldb.jar:?]
	at com.linecorp.armeria.server.grpc.ArmeriaServerCall.invokeHalfClose(ArmeriaServerCall.java:498) ~[kaldb.jar:?]
	... 66 more

```