### PR TITLE
Make IndexName Optional

### DIFF
--- a/src/main/java/com/slack/kaldb/logstore/search/LogIndexSearcherImpl.java
+++ b/src/main/java/com/slack/kaldb/logstore/search/LogIndexSearcherImpl.java
@@ -1,6 +1,5 @@
 package com.slack.kaldb.logstore.search;
 
-import static com.slack.kaldb.util.ArgValidationUtils.ensureNonEmptyString;
 import static com.slack.kaldb.util.ArgValidationUtils.ensureNonNullString;
 import static com.slack.kaldb.util.ArgValidationUtils.ensureTrue;
 
@@ -77,7 +76,9 @@ public class LogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
       int howMany,
       int bucketCount) {
 
-    ensureNonEmptyString(indexName, "indexName should be a non-empty string");
+    if (indexName == null) {
+      indexName = "";
+    }
     ensureNonNullString(queryStr, "query should be a non-empty string");
     ensureTrue(startTimeMsEpoch >= 0, "start time should be non-negative value");
     ensureTrue(startTimeMsEpoch < endTimeMsEpoch, "end time should be greater than start time");
@@ -167,7 +168,9 @@ public class LogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
       String indexName, String queryStr, long startTimeMsEpoch, long endTimeMsEpoch)
       throws ParseException {
     Builder queryBuilder = new Builder();
-    queryBuilder.add(new TermQuery(new Term(SystemField.INDEX.fieldName, indexName)), Occur.MUST);
+    if (!indexName.isEmpty()) {
+      queryBuilder.add(new TermQuery(new Term(SystemField.INDEX.fieldName, indexName)), Occur.MUST);
+    }
     queryBuilder.add(
         LongPoint.newRangeQuery(
             SystemField.TIME_SINCE_EPOCH.fieldName, startTimeMsEpoch, endTimeMsEpoch),

--- a/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
+++ b/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
@@ -148,6 +148,14 @@ public class LogIndexSearcherImplTest {
     assertThat(
             strictLogStore
                 .logSearcher
+                .search("", "test1", timeEpochMs(time), timeEpochMs(time.plusSeconds(10)), 100, 1)
+                .hits
+                .size())
+        .isEqualTo(2);
+
+    assertThat(
+            strictLogStore
+                .logSearcher
                 .search(
                     "idx12", "test1", timeEpochMs(time), timeEpochMs(time.plusSeconds(10)), 100, 1)
                 .hits
@@ -358,18 +366,12 @@ public class LogIndexSearcherImplTest {
     assertThat(babies.buckets.get(0).getCount()).isEqualTo(2);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testEmptyIndexName() {
     LocalDateTime time = LocalDateTime.ofEpochSecond(1593365471, 0, ZoneOffset.UTC);
     loadTestData(time);
-    strictLogStore.logSearcher.search("", "test", 0, MAX_TIME, 1000, 1);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testNullIndexName() {
-    LocalDateTime time = LocalDateTime.ofEpochSecond(1593365471, 0, ZoneOffset.UTC);
-    loadTestData(time);
-    strictLogStore.logSearcher.search(null, "test", 0, MAX_TIME, 1000, 1);
+    assertThat(strictLogStore.logSearcher.search("", "*:*", 0, MAX_TIME, 1000, 1).hits.size())
+        .isEqualTo(5);
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Allow searching across all indexes - This allows you to discover the indexes out there 

In the future I think we should restrict this again and maybe allow multiple values even.

But for now let's disable it so that we can test basic queries