### PR TITLE
Refactor Query Layer

### DIFF
--- a/src/main/java/com/slack/kaldb/server/KaldbLocalSearcher.java
+++ b/src/main/java/com/slack/kaldb/server/KaldbLocalSearcher.java
@@ -14,12 +14,12 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class KaldbService<T> extends KaldbServiceGrpc.KaldbServiceImplBase {
-  private static final Logger LOG = LoggerFactory.getLogger(KaldbService.class);
+public class KaldbLocalSearcher<T> extends KaldbServiceGrpc.KaldbServiceImplBase {
+  private static final Logger LOG = LoggerFactory.getLogger(KaldbLocalSearcher.class);
 
   private final ChunkManager<T> chunkManager;
 
-  public KaldbService(ChunkManager<T> chunkManager) {
+  public KaldbLocalSearcher(ChunkManager<T> chunkManager) {
     this.chunkManager = chunkManager;
   }
 

--- a/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -151,14 +151,14 @@ public class KaldbIndexerTest {
     ServerBuilder sb = Server.builder();
     sb.http(0);
     sb.service("/ping", (ctx, req) -> HttpResponse.of("pong!"));
-    GrpcServiceBuilder searchServiceBuilder = GrpcService.builder();
     KaldbIndexer indexer =
         new KaldbIndexer(
-            searchServiceBuilder,
-            chunkManager,
-            KaldbIndexer.dataTransformerMap.get("api_log"),
-            metricsRegistry);
-    server = sb.service(searchServiceBuilder.build()).build();
+            chunkManager, KaldbIndexer.dataTransformerMap.get("api_log"), metricsRegistry);
+    GrpcServiceBuilder searchBuilder =
+        GrpcService.builder()
+            .addService(new KaldbLocalSearcher<>(indexer.getChunkManager()))
+            .enableUnframedRequests(true);
+    server = sb.service(searchBuilder.build()).build();
     server.start().join();
 
     indexer.start();

--- a/src/test/java/com/slack/kaldb/server/KaldbLocalSearcherTest.java
+++ b/src/test/java/com/slack/kaldb/server/KaldbLocalSearcherTest.java
@@ -33,13 +33,13 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class KaldbServiceTest {
+public class KaldbLocalSearcherTest {
   @ClassRule public static final S3MockRule S3_MOCK_RULE = S3MockRule.builder().silent().build();
 
   @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
 
   private ChunkManagerUtil<LogMessage> chunkManagerUtil;
-  private KaldbService<LogMessage> kaldbService;
+  private KaldbLocalSearcher<LogMessage> kaldbLocalSearcher;
   private SimpleMeterRegistry metricsRegistry;
 
   @Before
@@ -48,7 +48,7 @@ public class KaldbServiceTest {
     metricsRegistry = new SimpleMeterRegistry();
     chunkManagerUtil =
         new ChunkManagerUtil<>(S3_MOCK_RULE, metricsRegistry, 10 * 1024 * 1024 * 1024L, 100);
-    kaldbService = new KaldbService<>(chunkManagerUtil.chunkManager);
+    kaldbLocalSearcher = new KaldbLocalSearcher<>(chunkManagerUtil.chunkManager);
   }
 
   @After
@@ -81,7 +81,7 @@ public class KaldbServiceTest {
     KaldbSearch.SearchRequest.Builder searchRequestBuilder = KaldbSearch.SearchRequest.newBuilder();
 
     KaldbSearch.SearchResult response =
-        kaldbService.doSearch(
+        kaldbLocalSearcher.doSearch(
             searchRequestBuilder
                 .setIndexName(MessageUtil.TEST_INDEX_NAME)
                 .setQueryString("Message100")
@@ -143,7 +143,7 @@ public class KaldbServiceTest {
     KaldbSearch.SearchRequest.Builder searchRequestBuilder = KaldbSearch.SearchRequest.newBuilder();
 
     KaldbSearch.SearchResult response =
-        kaldbService.doSearch(
+        kaldbLocalSearcher.doSearch(
             searchRequestBuilder
                 .setIndexName(MessageUtil.TEST_INDEX_NAME)
                 .setQueryString("blah")
@@ -192,7 +192,7 @@ public class KaldbServiceTest {
 
     // TODO: Query multiple chunks.
     KaldbSearch.SearchResult response =
-        kaldbService.doSearch(
+        kaldbLocalSearcher.doSearch(
             searchRequestBuilder
                 .setIndexName(MessageUtil.TEST_INDEX_NAME)
                 .setQueryString("Message1")
@@ -240,7 +240,7 @@ public class KaldbServiceTest {
     KaldbSearch.SearchRequest.Builder searchRequestBuilder = KaldbSearch.SearchRequest.newBuilder();
 
     KaldbSearch.SearchResult response =
-        kaldbService.doSearch(
+        kaldbLocalSearcher.doSearch(
             searchRequestBuilder
                 .setIndexName(MessageUtil.TEST_INDEX_NAME)
                 .setQueryString("Message1")
@@ -293,7 +293,7 @@ public class KaldbServiceTest {
 
     KaldbSearch.SearchRequest.Builder searchRequestBuilder = KaldbSearch.SearchRequest.newBuilder();
 
-    kaldbService.doSearch(
+    kaldbLocalSearcher.doSearch(
         searchRequestBuilder
             .setIndexName(MessageUtil.TEST_INDEX_NAME)
             .setQueryString("Message1")
@@ -324,7 +324,7 @@ public class KaldbServiceTest {
     grpcCleanup.register(
         InProcessServerBuilder.forName(serverName)
             .directExecutor()
-            .addService(new KaldbService<>(chunkManager))
+            .addService(new KaldbLocalSearcher<>(chunkManager))
             .build()
             .start());
 
@@ -403,7 +403,7 @@ public class KaldbServiceTest {
     grpcCleanup.register(
         InProcessServerBuilder.forName(serverName)
             .directExecutor()
-            .addService(new KaldbService<>(chunkManager))
+            .addService(new KaldbLocalSearcher<>(chunkManager))
             .build()
             .start());
 


### PR DESCRIPTION
This PR does two small things

1. Rename `KaldbService` to `KaldbSearcher` - This will serve as the query layer for local data search
2. Extract out adding the search service from the indexer code  - We want to take advantage of this in a followup PR which will add a multi node search query layer
