### PR TITLE
Add management service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <http.core.version>4.4.9</http.core.version>
         <protobuf.version>3.12.0</protobuf.version>
         <grpc.version>1.30.0</grpc.version>
-        <armeria.version>1.4.0</armeria.version>
+        <armeria.version>1.8.0</armeria.version>
         <micrometer.version>1.5.1</micrometer.version>
         <jackson.version>2.11.1</jackson.version>
         <lucene.version>8.4.1</lucene.version>

--- a/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -11,6 +11,7 @@ import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
 import com.linecorp.armeria.server.healthcheck.HealthCheckService;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.server.logging.LoggingServiceBuilder;
+import com.linecorp.armeria.server.management.ManagementService;
 import com.linecorp.armeria.server.metric.MetricCollectingService;
 import com.slack.kaldb.config.KaldbConfig;
 import io.micrometer.core.instrument.Metrics;
@@ -61,6 +62,7 @@ public class Kaldb {
     sb.service("/health", HealthCheckService.builder().build());
     sb.service("/metrics", (ctx, req) -> HttpResponse.of(prometheusMeterRegistry.scrape()));
     sb.serviceUnder("/docs", new DocService());
+    sb.serviceUnder("/internal/management/", ManagementService.of());
 
     // Create a protobuf handler service that calls chunkManager on search.
     GrpcServiceBuilder searchBuilder =


### PR DESCRIPTION
I was browsing through the release notes of Armeria and noticed that in version 1.7 ( https://armeria.dev/release-notes/1.7.0 ) they added a cool new management service

So this PR upgrades Armeria + Adds the management service to take a thread/heap dump 