### PR TITLE
Make KalDBConfig non static

### DIFF
--- a/src/main/java/com/slack/kaldb/chunk/ChunkRollOverStrategyImpl.java
+++ b/src/main/java/com/slack/kaldb/chunk/ChunkRollOverStrategyImpl.java
@@ -2,8 +2,6 @@ package com.slack.kaldb.chunk;
 
 import static com.slack.kaldb.util.ArgValidationUtils.ensureTrue;
 
-import com.slack.kaldb.config.KaldbConfig;
-
 /**
  * This class implements a rolls over a chunk when the chunk reaches a specific size or when a chunk
  * hits a max message limit.
@@ -11,12 +9,6 @@ import com.slack.kaldb.config.KaldbConfig;
  * <p>TODO: Also consider rolling over a chunk based on the time range for messages in the chunk.
  */
 public class ChunkRollOverStrategyImpl implements ChunkRollOverStrategy {
-
-  public static ChunkRollOverStrategyImpl fromConfig() {
-    return new ChunkRollOverStrategyImpl(
-        KaldbConfig.get().getIndexerConfig().getMaxBytesPerChunk(),
-        KaldbConfig.get().getIndexerConfig().getMaxMessagesPerChunk());
-  }
 
   private final long maxBytesPerChunk;
   private final long maxMessagesPerChunk;

--- a/src/main/java/com/slack/kaldb/config/KaldbConfig.java
+++ b/src/main/java/com/slack/kaldb/config/KaldbConfig.java
@@ -14,48 +14,26 @@ import java.nio.file.Path;
  * <p>TODO: Set reasonable defaults for the config values.
  */
 public class KaldbConfig {
-  private static KaldbConfig _instance = null;
 
   // Parse a json string as a KaldbConfig proto struct.
   @VisibleForTesting
-  static KaldbConfigs.KaldbConfig fromJsonConfig(String jsonStr)
+  public static KaldbConfigs.KaldbConfig fromJsonConfig(String jsonStr)
       throws InvalidProtocolBufferException {
     KaldbConfigs.KaldbConfig.Builder kaldbConfigBuilder = KaldbConfigs.KaldbConfig.newBuilder();
     JsonFormat.parser().ignoringUnknownFields().merge(jsonStr, kaldbConfigBuilder);
     return kaldbConfigBuilder.build();
   }
 
-  @VisibleForTesting
-  public static void reset() {
-    _instance = null;
-  }
-
-  public static void initFromFile(Path cfgFilePath) throws IOException {
-    if (_instance == null) {
-      if (Files.notExists(cfgFilePath)) {
-        throw new IllegalArgumentException(
-            "Missing config file at: " + cfgFilePath.toAbsolutePath().toString());
-      }
-
-      initFromJsonStr(Files.readString(cfgFilePath));
+  public static KaldbConfigs.KaldbConfig initFromFile(Path cfgFilePath) throws IOException {
+    if (Files.notExists(cfgFilePath)) {
+      throw new IllegalArgumentException(
+          "Missing config file at: " + cfgFilePath.toAbsolutePath().toString());
     }
+    return initFromJsonStr(Files.readString(cfgFilePath));
   }
 
-  public static void initFromJsonStr(String jsonCfgString) throws InvalidProtocolBufferException {
-    initFromConfigObject(fromJsonConfig(jsonCfgString));
-  }
-
-  public static void initFromConfigObject(KaldbConfigs.KaldbConfig config) {
-    _instance = new KaldbConfig(config);
-  }
-
-  public static KaldbConfigs.KaldbConfig get() {
-    return _instance.config;
-  }
-
-  private final KaldbConfigs.KaldbConfig config;
-
-  private KaldbConfig(KaldbConfigs.KaldbConfig config) {
-    this.config = config;
+  public static KaldbConfigs.KaldbConfig initFromJsonStr(String jsonCfgString)
+      throws InvalidProtocolBufferException {
+    return fromJsonConfig(jsonCfgString);
   }
 }

--- a/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreConfig.java
+++ b/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreConfig.java
@@ -2,7 +2,6 @@ package com.slack.kaldb.logstore;
 
 import static com.slack.kaldb.util.ArgValidationUtils.ensureTrue;
 
-import com.slack.kaldb.config.KaldbConfig;
 import com.slack.kaldb.proto.config.KaldbConfigs;
 import java.io.File;
 import java.time.Duration;
@@ -38,15 +37,15 @@ public class LuceneIndexStoreConfig {
   static final Duration defaultCommitDuration = Duration.ofSeconds(15);
   static final Duration defaultRefreshDuration = Duration.ofSeconds(15);
 
-  public static Duration getCommitDuration() {
-    KaldbConfigs.IndexerConfig indexerCfg = KaldbConfig.get().getIndexerConfig();
+  public static Duration getCommitDuration(KaldbConfigs.KaldbConfig config) {
+    KaldbConfigs.IndexerConfig indexerCfg = config.getIndexerConfig();
     return indexerCfg.getCommitDurationSecs() != 0
         ? Duration.ofSeconds(indexerCfg.getCommitDurationSecs())
         : defaultCommitDuration;
   }
 
-  public static Duration getRefreshDuration() {
-    KaldbConfigs.IndexerConfig indexerCfg = KaldbConfig.get().getIndexerConfig();
+  public static Duration getRefreshDuration(KaldbConfigs.KaldbConfig config) {
+    KaldbConfigs.IndexerConfig indexerCfg = config.getIndexerConfig();
     return indexerCfg.getRefreshDurationSecs() != 0
         ? Duration.ofSeconds(indexerCfg.getRefreshDurationSecs())
         : defaultRefreshDuration;

--- a/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreImpl.java
+++ b/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreImpl.java
@@ -1,12 +1,12 @@
 package com.slack.kaldb.logstore;
 
 import com.slack.kaldb.logstore.index.KalDBMergeScheduler;
+import com.slack.kaldb.proto.config.KaldbConfigs;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.util.Optional;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -58,26 +58,18 @@ public class LuceneIndexStoreImpl implements LogStore<LogMessage> {
   private final Counter commitsCounter;
   private final Counter refreshesCounter;
 
-  public static LuceneIndexStoreImpl makeLogStore(File dataDirectory, MeterRegistry metricsRegistry)
-      throws IOException {
-    return makeLogStore(
-        dataDirectory,
-        LuceneIndexStoreConfig.getCommitDuration(),
-        LuceneIndexStoreConfig.getRefreshDuration(),
-        metricsRegistry);
-  }
-
   public static LuceneIndexStoreImpl makeLogStore(
-      File dataDirectory,
-      Duration commitInterval,
-      Duration refreshInterval,
-      MeterRegistry metricsRegistry)
+      File dataDirectory, MeterRegistry metricsRegistry, KaldbConfigs.KaldbConfig config)
       throws IOException {
     // TODO: Move all these config values into chunk?
     // TODO: Chunk should create log store?
     LuceneIndexStoreConfig indexStoreCfg =
         new LuceneIndexStoreConfig(
-            commitInterval, refreshInterval, dataDirectory.getAbsolutePath(), 8, false);
+            LuceneIndexStoreConfig.getCommitDuration(config),
+            LuceneIndexStoreConfig.getRefreshDuration(config),
+            dataDirectory.getAbsolutePath(),
+            8,
+            false);
 
     // TODO: set ignore property exceptions via CLI flag.
     return new LuceneIndexStoreImpl(

--- a/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaWriter.java
+++ b/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaWriter.java
@@ -1,7 +1,6 @@
 package com.slack.kaldb.writer.kafka;
 
 import com.google.common.base.Stopwatch;
-import com.slack.kaldb.config.KaldbConfig;
 import com.slack.kaldb.proto.config.KaldbConfigs;
 import com.slack.kaldb.writer.MessageWriter;
 import io.micrometer.core.instrument.Counter;
@@ -22,8 +21,8 @@ public class KaldbKafkaWriter extends KaldbKafkaConsumer {
   public static long END_OFFSET_STALE_DELAY_SECS = 10;
 
   public static KaldbKafkaWriter fromConfig(
-      MessageWriter messageWriter, MeterRegistry meterRegistry) {
-    KaldbConfigs.KafkaConfig kafkaCfg = KaldbConfig.get().getKafkaConfig();
+      MessageWriter messageWriter, MeterRegistry meterRegistry, KaldbConfigs.KaldbConfig config) {
+    KaldbConfigs.KafkaConfig kafkaCfg = config.getKafkaConfig();
     return fromConfig(kafkaCfg, messageWriter, meterRegistry);
   }
 

--- a/src/test/java/com/slack/kaldb/chunk/ChunkCleanerTaskTest.java
+++ b/src/test/java/com/slack/kaldb/chunk/ChunkCleanerTaskTest.java
@@ -28,10 +28,14 @@ public class ChunkCleanerTaskTest {
 
   @Before
   public void setUp() throws IOException {
-    KaldbConfigUtil.initEmptyConfig();
     metricsRegistry = new SimpleMeterRegistry();
     chunkManagerUtil =
-        new ChunkManagerUtil<>(S3_MOCK_RULE, metricsRegistry, 10 * 1024 * 1024 * 1024L, 10L);
+        new ChunkManagerUtil<>(
+            S3_MOCK_RULE,
+            metricsRegistry,
+            10 * 1024 * 1024 * 1024L,
+            10L,
+            KaldbConfigUtil.initEmptyConfig());
   }
 
   @After

--- a/src/test/java/com/slack/kaldb/chunk/ChunkManagerTest.java
+++ b/src/test/java/com/slack/kaldb/chunk/ChunkManagerTest.java
@@ -89,7 +89,8 @@ public class ChunkManagerTest {
             s3BlobFs,
             S3_TEST_BUCKET,
             MoreExecutors.newDirectExecutorService(),
-            3000);
+            3000,
+            KaldbConfigUtil.initEmptyConfig());
 
     List<LogMessage> messages = MessageUtil.makeMessagesWithTimeDifference(1, 100);
     int actualChunkSize = 0;
@@ -159,7 +160,8 @@ public class ChunkManagerTest {
             s3BlobFs,
             S3_TEST_BUCKET,
             MoreExecutors.newDirectExecutorService(),
-            3000);
+            3000,
+            KaldbConfigUtil.initEmptyConfig());
 
     List<LogMessage> messages = MessageUtil.makeMessagesWithTimeDifference(1, 15);
     for (LogMessage m : messages) {
@@ -193,7 +195,8 @@ public class ChunkManagerTest {
             s3BlobFs,
             S3_TEST_BUCKET,
             rollOverExecutor,
-            3000);
+            3000,
+            KaldbConfigUtil.initEmptyConfig());
 
     // Add a message
     LogMessage msg1 = MessageUtil.makeMessage(1);
@@ -228,7 +231,8 @@ public class ChunkManagerTest {
             s3BlobFs,
             S3_TEST_BUCKET,
             MoreExecutors.newDirectExecutorService(),
-            3000);
+            3000,
+            KaldbConfigUtil.initEmptyConfig());
 
     // Add a message
     LogMessage msg1 = MessageUtil.makeMessage(1);
@@ -280,7 +284,8 @@ public class ChunkManagerTest {
             s3BlobFs,
             S3_TEST_BUCKET,
             rollOverExecutor,
-            3000);
+            3000,
+            KaldbConfigUtil.initEmptyConfig());
 
     List<LogMessage> messages = MessageUtil.makeMessagesWithTimeDifference(1, 25);
     // Add 11 messages to initiate first roll over.
@@ -318,7 +323,8 @@ public class ChunkManagerTest {
             s3BlobFs,
             S3_TEST_BUCKET,
             MoreExecutors.newDirectExecutorService(),
-            3000);
+            3000,
+            KaldbConfigUtil.initEmptyConfig());
 
     List<LogMessage> messages = MessageUtil.makeMessagesWithTimeDifference(1, 25);
     // Add 11 messages to initiate first roll over.
@@ -392,7 +398,8 @@ public class ChunkManagerTest {
             s3BlobFs,
             S3_TEST_BUCKET,
             MoreExecutors.newDirectExecutorService(),
-            3000);
+            3000,
+            KaldbConfigUtil.initEmptyConfig());
 
     for (LogMessage m : messages) {
       chunkManager.addMessage(m, m.toString().length(), 100);
@@ -434,7 +441,8 @@ public class ChunkManagerTest {
             s3BlobFs,
             S3_TEST_BUCKET,
             MoreExecutors.newDirectExecutorService(),
-            3000);
+            3000,
+            KaldbConfigUtil.initEmptyConfig());
 
     for (LogMessage m : messages) {
       chunkManager.addMessage(m, m.toString().length(), 100);
@@ -551,7 +559,8 @@ public class ChunkManagerTest {
             s3BlobFs,
             S3_TEST_BUCKET,
             ChunkManager.makeDefaultRollOverExecutor(),
-            10000);
+            10000,
+            KaldbConfigUtil.initEmptyConfig());
 
     // Adding a messages very quickly when running a rollover in background would result in an
     // exception.
@@ -577,7 +586,8 @@ public class ChunkManagerTest {
             s3BlobFs,
             S3_TEST_BUCKET,
             ChunkManager.makeDefaultRollOverExecutor(),
-            10000);
+            10000,
+            KaldbConfigUtil.initEmptyConfig());
 
     // Adding a message and close the chunkManager right away should still finish the failed
     // rollover.
@@ -613,7 +623,8 @@ public class ChunkManagerTest {
             s3BlobFs,
             S3_TEST_BUCKET + "Fail", // Missing S3 bucket.
             ChunkManager.makeDefaultRollOverExecutor(),
-            10000);
+            10000,
+            KaldbConfigUtil.initEmptyConfig());
 
     // Adding a message and close the chunkManager right away should still finish the failed
     // rollover.
@@ -650,7 +661,8 @@ public class ChunkManagerTest {
             s3BlobFs,
             S3_TEST_BUCKET + "Fail", // Missing S3 bucket.
             ChunkManager.makeDefaultRollOverExecutor(),
-            10000);
+            10000,
+            KaldbConfigUtil.initEmptyConfig());
 
     for (LogMessage m : messages) {
       chunkManager.addMessage(m, m.toString().length(), 100);
@@ -690,7 +702,8 @@ public class ChunkManagerTest {
             s3BlobFs,
             S3_TEST_BUCKET + "Fail", // Missing S3 bucket.
             MoreExecutors.newDirectExecutorService(),
-            10000);
+            10000,
+            KaldbConfigUtil.initEmptyConfig());
 
     // Adding a messages very quickly when running a rollover in background would result in an
     // exception.
@@ -734,7 +747,8 @@ public class ChunkManagerTest {
             s3BlobFs,
             S3_TEST_BUCKET,
             ChunkManager.makeDefaultRollOverExecutor(),
-            5000);
+            5000,
+            KaldbConfigUtil.initEmptyConfig());
 
     List<LogMessage> messages1 = messages.subList(0, 3);
     List<LogMessage> messages2 = messages.subList(3, 6);
@@ -789,7 +803,8 @@ public class ChunkManagerTest {
             s3BlobFs,
             S3_TEST_BUCKET,
             ChunkManager.makeDefaultRollOverExecutor(),
-            5000);
+            5000,
+            KaldbConfigUtil.initEmptyConfig());
 
     List<LogMessage> messages1 = messages.subList(0, 10);
     List<LogMessage> messages2 = messages.subList(10, 20);

--- a/src/test/java/com/slack/kaldb/chunk/ChunkRollOverStrategyImplTest.java
+++ b/src/test/java/com/slack/kaldb/chunk/ChunkRollOverStrategyImplTest.java
@@ -19,15 +19,11 @@ public class ChunkRollOverStrategyImplTest {
             + "  }\n"
             + "}\n";
 
-    KaldbConfig.initFromJsonStr(testIndexerCfg);
+    KaldbConfigs.KaldbConfig config = KaldbConfig.initFromJsonStr(testIndexerCfg);
 
-    final KaldbConfigs.IndexerConfig indexerCfg = KaldbConfig.get().getIndexerConfig();
+    final KaldbConfigs.IndexerConfig indexerCfg = config.getIndexerConfig();
     assertThat(indexerCfg.getMaxMessagesPerChunk()).isEqualTo(1);
     assertThat(indexerCfg.getMaxBytesPerChunk()).isEqualTo(100);
-
-    ChunkRollOverStrategyImpl chunkRollOverStrategy = ChunkRollOverStrategyImpl.fromConfig();
-    assertThat(chunkRollOverStrategy.getMaxBytesPerChunk()).isEqualTo(100);
-    assertThat(chunkRollOverStrategy.getMaxMessagesPerChunk()).isEqualTo(1);
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/slack/kaldb/config/KaldbConfigTest.java
+++ b/src/test/java/com/slack/kaldb/config/KaldbConfigTest.java
@@ -7,21 +7,9 @@ import com.slack.kaldb.proto.config.KaldbConfigs;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 public class KaldbConfigTest {
-
-  @Before
-  public void setUp() {
-    KaldbConfig.reset();
-  }
-
-  @After
-  public void tearDown() {
-    KaldbConfig.reset();
-  }
 
   @Test(expected = IllegalArgumentException.class)
   public void testInitWithMissingConfigFile() throws IOException {
@@ -104,8 +92,7 @@ public class KaldbConfigTest {
   public void testParseKaldbConfigFile() throws IOException {
     final File cfgFile =
         new File(getClass().getClassLoader().getResource("test_config.json").getFile());
-    KaldbConfig.initFromFile(cfgFile.toPath());
-    final KaldbConfigs.KaldbConfig config = KaldbConfig.get();
+    final KaldbConfigs.KaldbConfig config = KaldbConfig.initFromFile(cfgFile.toPath());
 
     assertThat(config).isNotNull();
     assertThat(config.getServerPort()).isEqualTo(8080);

--- a/src/test/java/com/slack/kaldb/server/KaldbLocalSearcherTest.java
+++ b/src/test/java/com/slack/kaldb/server/KaldbLocalSearcherTest.java
@@ -12,6 +12,7 @@ import com.slack.kaldb.chunk.ChunkManager;
 import com.slack.kaldb.chunk.RollOverChunkTask;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.logstore.LogWireMessage;
+import com.slack.kaldb.proto.config.KaldbConfigs;
 import com.slack.kaldb.proto.service.KaldbSearch;
 import com.slack.kaldb.proto.service.KaldbServiceGrpc;
 import com.slack.kaldb.testlib.ChunkManagerUtil;
@@ -44,10 +45,11 @@ public class KaldbLocalSearcherTest {
 
   @Before
   public void setUp() throws InvalidProtocolBufferException {
-    KaldbConfigUtil.initEmptyConfig();
+    KaldbConfigs.KaldbConfig config = KaldbConfigUtil.initEmptyConfig();
     metricsRegistry = new SimpleMeterRegistry();
     chunkManagerUtil =
-        new ChunkManagerUtil<>(S3_MOCK_RULE, metricsRegistry, 10 * 1024 * 1024 * 1024L, 100);
+        new ChunkManagerUtil<>(
+            S3_MOCK_RULE, metricsRegistry, 10 * 1024 * 1024 * 1024L, 100, config);
     kaldbLocalSearcher = new KaldbLocalSearcher<>(chunkManagerUtil.chunkManager);
   }
 

--- a/src/test/java/com/slack/kaldb/testlib/ChunkManagerUtil.java
+++ b/src/test/java/com/slack/kaldb/testlib/ChunkManagerUtil.java
@@ -7,6 +7,7 @@ import com.slack.kaldb.blobfs.s3.S3BlobFs;
 import com.slack.kaldb.chunk.ChunkManager;
 import com.slack.kaldb.chunk.ChunkRollOverStrategy;
 import com.slack.kaldb.chunk.ChunkRollOverStrategyImpl;
+import com.slack.kaldb.proto.config.KaldbConfigs;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.File;
 import java.io.IOException;
@@ -30,7 +31,8 @@ public class ChunkManagerUtil<T> {
       S3MockRule s3MockRule,
       MeterRegistry meterRegistry,
       long maxBytesPerChunk,
-      long maxMessagesPerChunk) {
+      long maxMessagesPerChunk,
+      KaldbConfigs.KaldbConfig config) {
 
     tempFolder = Files.createTempDir(); // TODO: don't use beta func.
     // create an S3 client and a bucket for test
@@ -52,11 +54,13 @@ public class ChunkManagerUtil<T> {
             s3BlobFs,
             S3_TEST_BUCKET,
             MoreExecutors.newDirectExecutorService(),
-            10000);
+            10000,
+            config);
   }
 
-  public ChunkManagerUtil(S3MockRule s3MockRule, MeterRegistry meterRegistry) {
-    this(s3MockRule, meterRegistry, 10 * 1024 * 1024 * 1024L, 10L);
+  public ChunkManagerUtil(
+      S3MockRule s3MockRule, MeterRegistry meterRegistry, KaldbConfigs.KaldbConfig config) {
+    this(s3MockRule, meterRegistry, 10 * 1024 * 1024 * 1024L, 10L, config);
   }
 
   public void close() throws IOException {

--- a/src/test/java/com/slack/kaldb/testlib/KaldbConfigUtil.java
+++ b/src/test/java/com/slack/kaldb/testlib/KaldbConfigUtil.java
@@ -2,10 +2,11 @@ package com.slack.kaldb.testlib;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.slack.kaldb.config.KaldbConfig;
+import com.slack.kaldb.proto.config.KaldbConfigs;
 
 public class KaldbConfigUtil {
   // Initialize kaldb config with empty for tests.
-  public static void initEmptyConfig() throws InvalidProtocolBufferException {
-    KaldbConfig.initFromJsonStr("{}");
+  public static KaldbConfigs.KaldbConfig initEmptyConfig() throws InvalidProtocolBufferException {
+    return KaldbConfig.initFromJsonStr("{}");
   }
 }

--- a/src/test/java/com/slack/kaldb/writer/LogMessageWriterImplTest.java
+++ b/src/test/java/com/slack/kaldb/writer/LogMessageWriterImplTest.java
@@ -19,6 +19,7 @@ import com.slack.kaldb.chunk.ChunkManager;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.logstore.search.SearchQuery;
 import com.slack.kaldb.logstore.search.SearchResult;
+import com.slack.kaldb.proto.config.KaldbConfigs;
 import com.slack.kaldb.testlib.ChunkManagerUtil;
 import com.slack.kaldb.testlib.KaldbConfigUtil;
 import com.slack.kaldb.testlib.MessageUtil;
@@ -51,10 +52,11 @@ public class LogMessageWriterImplTest {
 
   @Before
   public void setUp() throws InvalidProtocolBufferException {
-    KaldbConfigUtil.initEmptyConfig();
+    KaldbConfigs.KaldbConfig config = KaldbConfigUtil.initEmptyConfig();
     metricsRegistry = new SimpleMeterRegistry();
     chunkManagerUtil =
-        new ChunkManagerUtil<>(S3_MOCK_RULE, metricsRegistry, 10 * 1024 * 1024 * 1024L, 100);
+        new ChunkManagerUtil<>(
+            S3_MOCK_RULE, metricsRegistry, 10 * 1024 * 1024 * 1024L, 100, config);
   }
 
   @After
@@ -454,8 +456,9 @@ public class LogMessageWriterImplTest {
     final String msgType = "test_message_type";
 
     SimpleMeterRegistry localMetricsRegistry = new SimpleMeterRegistry();
+    KaldbConfigs.KaldbConfig config = KaldbConfigUtil.initEmptyConfig();
     ChunkManagerUtil<LogMessage> localChunkManagerUtil =
-        new ChunkManagerUtil<>(S3_MOCK_RULE, localMetricsRegistry, 1000L, 100);
+        new ChunkManagerUtil<>(S3_MOCK_RULE, localMetricsRegistry, 1000L, 100, config);
 
     List<Trace.Span> spans =
         IntStream.range(0, 15)


### PR DESCRIPTION
make config non static - this helps us write test cases where we can spin up two KalDB servers within the same JVM

We can't do that if the config is static as we want the ability for each server to start with a different config