### PR TITLE
Add support for histogram response

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,8 +1,8 @@
 nodeRoles: [${NODE_ROLES:-QUERY,INDEX}]
 
 indexerConfig:
-  maxMessagesPerChunk: ${INDEXER_MAX_MESSAGES_PER_CHUNK:-100}
-  maxBytesPerChunk: ${INDEXER_MAX_BYTES_PER_CHUNK:-100000}
+  maxMessagesPerChunk: ${INDEXER_MAX_MESSAGES_PER_CHUNK:-100000}
+  maxBytesPerChunk: ${INDEXER_MAX_BYTES_PER_CHUNK:-1000000}
   commitDurationSecs: ${INDEXER_COMMIT_DURATION_SECS:-10}
   refreshDurationSecs: ${INDEXER_REFRESH_DURATION_SECS:-11}
   staleDurationSecs: ${INDEXER_STALE_DURATION_SECS:-7200}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,10 +30,13 @@ services:
       - 3000:3000
     volumes:
       - ./config/grafana/provisioning:/etc/grafana/provisioning
+      - ../slack-kaldb-app:/var/lib/grafana/plugins
     environment:
       GF_AUTH_DISABLE_LOGIN_FORM: "true"
       GF_AUTH_ANONYMOUS_ENABLED: "true"
       GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin"
+      GF_PATHS_PLUGINS: "/var/lib/grafana/plugins"
+      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: "slack-kaldb-app"
 
   grafana7:
     image: 'grafana/grafana:7.3.6'

--- a/src/main/java/com/slack/kaldb/elasticsearchApi/searchRequest/EsSearchRequest.java
+++ b/src/main/java/com/slack/kaldb/elasticsearchApi/searchRequest/EsSearchRequest.java
@@ -60,12 +60,16 @@ public class EsSearchRequest {
   }
 
   public KaldbSearch.SearchRequest toKaldbSearchRequest() {
+    // eventually this will likely be configurable from the UI
+    int bucketCount = 60;
+
     return KaldbSearch.SearchRequest.newBuilder()
         .setIndexName(getIndex())
         .setQueryString(getQuery())
         .setStartTimeEpochMs(getRange().getGteEpochMillis())
         .setEndTimeEpochMs(getRange().getLteEpochMillis())
         .setHowMany(getSize())
+        .setBucketCount(bucketCount)
         .build();
   }
 

--- a/src/main/java/com/slack/kaldb/elasticsearchApi/searchResponse/AggregationBucketResponse.java
+++ b/src/main/java/com/slack/kaldb/elasticsearchApi/searchResponse/AggregationBucketResponse.java
@@ -5,12 +5,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class AggregationBucketResponse {
 
   @JsonProperty("key")
-  private final long key;
+  private final double key;
 
   @JsonProperty("doc_count")
-  private final long docCount;
+  private final double docCount;
 
-  public AggregationBucketResponse(long key, long docCount) {
+  public AggregationBucketResponse(double key, double docCount) {
     this.key = key;
     this.docCount = docCount;
   }


### PR DESCRIPTION
Adds support for returning histogram responses. As we intend to move away from the ES compatible API I only added the minimal amount of support required to support a single `date_histogram` reponse.