### PR TITLE
Improve test execution time & reliability

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,6 +22,12 @@ jobs:
       with:
         java-version: '11'
         distribution: 'adopt'
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
     - name: Ensure code is formatted. 
       run: mvn com.coveo:fmt-maven-plugin:check --file pom.xml
     - name: Build with Maven

--- a/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -32,6 +32,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -135,7 +136,9 @@ public class KaldbIndexerTest {
             .addService(new KaldbLocalSearcher<>(indexer.getChunkManager()))
             .enableUnframedRequests(true);
     server = sb.service(searchBuilder.build()).build();
-    server.start().join();
+
+    // wait at most 10 seconds to start before throwing an exception
+    server.start().get(10, TimeUnit.SECONDS);
 
     indexer.start();
     Thread.sleep(1000); // Wait for consumer start.

--- a/src/test/java/com/slack/kaldb/server/KaldbQueryServiceTest.java
+++ b/src/test/java/com/slack/kaldb/server/KaldbQueryServiceTest.java
@@ -25,6 +25,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -68,7 +69,9 @@ public class KaldbQueryServiceTest {
     KaldbConfig.initFromConfigObject(kaldbConfig);
 
     indexingServer = newIndexingServer(kaldbConfig);
-    indexingServer.start().join();
+
+    // wait at most 10 seconds to start before throwing an exception
+    indexingServer.start().get(10, TimeUnit.SECONDS);
 
     // Produce messages to kafka, so the indexer can consume them.
     final Instant startTime =
@@ -80,7 +83,9 @@ public class KaldbQueryServiceTest {
     // Don't respect the queryPort from the config - In case multiple tests run in parallel this
     // gives us a better chance to avoid port collisions
     queryServer = newQueryServer(kaldbConfig, (indexingServer.activeLocalPort() + 1));
-    queryServer.start().join();
+
+    // wait at most 10 seconds to start before throwing an exception
+    queryServer.start().get(10, TimeUnit.SECONDS);
 
     // We want to query the indexing server
     List<String> servers = new ArrayList<>();

--- a/src/test/java/com/slack/kaldb/util/CountingFatalErrorHandler.java
+++ b/src/test/java/com/slack/kaldb/util/CountingFatalErrorHandler.java
@@ -1,14 +1,16 @@
 package com.slack.kaldb.util;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 public class CountingFatalErrorHandler implements FatalErrorHandler {
-  private int count = 0;
+  private final AtomicInteger count = new AtomicInteger(0);
 
   @Override
   public void handleFatal(Throwable t) {
-    count = count + 1;
+    count.incrementAndGet();
   }
 
   public int getCount() {
-    return count;
+    return count.get();
   }
 }


### PR DESCRIPTION
This ended up being an assortment of improvements to our test execution:

* Added maven dependency caching per [Github guide](https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies). This results in ~ 20% faster test builds for our current use case.
* Fixed a test race condition with `CountingFatalErrorHandler` - also made this threadsafe as depending on the curator listener configuration can run in a separate threadpool.
*  Swapped test implementation of completable futures from `join()` to `get()`. This allows us to throw a checked exception if they do not return within the specified time. The `KaldbQueryServiceTest` appears to be intermittently hanging until the build job times out, and this is an attempt to identify where this is occurring.