### PR TITLE
Improve shutdown procedure for tests

### DIFF
--- a/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
+++ b/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
@@ -182,4 +182,8 @@ abstract class KaldbKafkaConsumer {
     stop = true;
     return kafkaConsumerFuture;
   }
+
+  public boolean isShutdown() {
+    return kafkaConsumerService.isShutdown();
+  }
 }

--- a/src/test/java/com/slack/kaldb/metadata/zookeeper/ZookeeperMetadataStoreImplTest.java
+++ b/src/test/java/com/slack/kaldb/metadata/zookeeper/ZookeeperMetadataStoreImplTest.java
@@ -51,7 +51,6 @@ public class ZookeeperMetadataStoreImplTest {
 
   @After
   public void tearDown() throws IOException, NoSuchFieldException, IllegalAccessException {
-    closeZookeeperClientConnection();
     metadataStore.close();
     testingServer.close();
     meterRegistry.close();
@@ -484,6 +483,9 @@ public class ZookeeperMetadataStoreImplTest {
     Throwable ephemeralEx = catchThrowable(() -> metadataStore.createEphemeralNode(root, "").get());
     assertThat(ephemeralEx.getCause()).isInstanceOf(InternalMetadataStoreException.class);
     assertThat(getCount(ZK_FAILED_COUNTER, meterRegistry)).isEqualTo(7);
+
+    // close the underlying zookeeper connection to ensure it's correctly removed
+    closeZookeeperClientConnection();
   }
 
   @Test
@@ -502,6 +504,9 @@ public class ZookeeperMetadataStoreImplTest {
 
     // The FatalErrorHandler is incremented async in a separate thread
     await().until(() -> countingFatalErrorHandler.getCount() == 1);
+
+    // close the underlying zookeeper connection to ensure it's correctly removed
+    closeZookeeperClientConnection();
   }
 
   /**

--- a/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -33,6 +33,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -73,9 +74,9 @@ public class KaldbIndexerTest {
   @After
   public void tearDown()
       throws IOException, ExecutionException, InterruptedException, NoSuchFieldException,
-          IllegalAccessException {
+          IllegalAccessException, TimeoutException {
     if (server != null) {
-      server.stop().join();
+      server.stop().get(30, TimeUnit.SECONDS);
     }
     if (kaldbIndexer != null) {
       kaldbIndexer.close();

--- a/src/test/java/com/slack/kaldb/server/KaldbQueryServiceTest.java
+++ b/src/test/java/com/slack/kaldb/server/KaldbQueryServiceTest.java
@@ -132,20 +132,20 @@ public class KaldbQueryServiceTest {
 
   @AfterClass
   public static void shutdownServer() throws Exception {
-    if (kaldbIndexer != null) {
-      kaldbIndexer.close();
-    }
-    if (kafkaServer != null) {
-      kafkaServer.close();
+    if (queryServer != null) {
+      queryServer.stop().get(30, TimeUnit.SECONDS);
     }
     if (indexerMetricsRegistry != null) {
       indexerMetricsRegistry.close();
     }
+    if (kaldbIndexer != null) {
+      kaldbIndexer.close();
+    }
     if (indexingServer != null) {
       indexingServer.stop().get(30, TimeUnit.SECONDS);
     }
-    if (queryServer != null) {
-      queryServer.stop().get(30, TimeUnit.SECONDS);
+    if (kafkaServer != null) {
+      kafkaServer.close();
     }
   }
 

--- a/src/test/java/com/slack/kaldb/server/KaldbQueryServiceTest.java
+++ b/src/test/java/com/slack/kaldb/server/KaldbQueryServiceTest.java
@@ -142,10 +142,10 @@ public class KaldbQueryServiceTest {
       indexerMetricsRegistry.close();
     }
     if (indexingServer != null) {
-      indexingServer.stop().join();
+      indexingServer.stop().get(30, TimeUnit.SECONDS);
     }
     if (queryServer != null) {
-      queryServer.stop().join();
+      queryServer.stop().get(30, TimeUnit.SECONDS);
     }
   }
 

--- a/src/test/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumerTest.java
+++ b/src/test/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.github.charithe.kafka.EphemeralKafkaBroker;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.slack.kaldb.testlib.TestKafkaServer;
+import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -67,7 +68,9 @@ public class KaldbKafkaConsumerTest {
     }
 
     @After
-    public void tearDown() throws ExecutionException, InterruptedException, TimeoutException {
+    public void tearDown()
+        throws ExecutionException, InterruptedException, TimeoutException, NoSuchFieldException,
+            IllegalAccessException, IOException {
       ListenableFuture<?> future = testConsumer.triggerShutdown();
       future.get(1, TimeUnit.SECONDS);
       assertThat(future.isDone()).isTrue();


### PR DESCRIPTION
This should address several issues we have in our tests with the following classes due to leftover threads and/or race conditions.

* `ZookeeperMetadataStoreImplTest`
* `KaldbIndexerTest`
* `KaldbQueryServiceTest`
* `KaldbKafkaConsumerTest`

There still seems to be an issue with the `ZookeeperMetadataStoreImplTest` occasionally failing waiting for the `countingFatalErrorHandler` to be incremented, and the `KaldbQueryServiceTest` occasionally fails when the `queryServer` does not to respond to query or shutdown.