### PR TITLE
Add Guava services, service manager

### DIFF
--- a/src/main/java/com/slack/kaldb/server/ArmeriaService.java
+++ b/src/main/java/com/slack/kaldb/server/ArmeriaService.java
@@ -1,0 +1,107 @@
+package com.slack.kaldb.server;
+
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.grpc.GrpcMeterIdPrefixFunction;
+import com.linecorp.armeria.common.logging.LogLevel;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.docs.DocService;
+import com.linecorp.armeria.server.grpc.GrpcService;
+import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
+import com.linecorp.armeria.server.healthcheck.HealthCheckService;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.server.logging.LoggingServiceBuilder;
+import com.linecorp.armeria.server.management.ManagementService;
+import com.linecorp.armeria.server.metric.MetricCollectingService;
+import com.slack.kaldb.elasticsearchApi.ElasticsearchApiService;
+import com.slack.kaldb.proto.service.KaldbServiceGrpc;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ArmeriaService extends AbstractIdleService {
+  private final Logger LOG = LoggerFactory.getLogger(ArmeriaService.class);
+
+  private final PrometheusMeterRegistry prometheusMeterRegistry;
+  private final KaldbServiceGrpc.KaldbServiceImplBase searcher;
+  private final String serviceName;
+  private final Server server;
+  private final int serverPort;
+
+  public ArmeriaService(
+      int serverPort,
+      PrometheusMeterRegistry prometheusMeterRegistry,
+      KaldbServiceGrpc.KaldbServiceImplBase searcher) {
+    this(serverPort, prometheusMeterRegistry, searcher, null);
+  }
+
+  public ArmeriaService(
+      int serverPort,
+      PrometheusMeterRegistry prometheusMeterRegistry,
+      KaldbServiceGrpc.KaldbServiceImplBase searcher,
+      String serviceName) {
+    this.serverPort = serverPort;
+    this.prometheusMeterRegistry = prometheusMeterRegistry;
+    this.searcher = searcher;
+    this.serviceName = serviceName;
+    this.server = getServer();
+  }
+
+  public Server getServer() {
+    ServerBuilder sb = Server.builder();
+    GrpcServiceBuilder searchBuilder =
+        GrpcService.builder().addService(searcher).enableUnframedRequests(true);
+    sb.service(searchBuilder.build());
+
+    sb.annotatedService(new ElasticsearchApiService(searcher));
+
+    addManagementEndpoints(sb, serverPort);
+
+    return sb.build();
+  }
+
+  private void addManagementEndpoints(ServerBuilder sb, int serverPort) {
+    sb.decorator(
+        MetricCollectingService.newDecorator(GrpcMeterIdPrefixFunction.of("grpc.service")));
+    sb.decorator(getLoggingServiceBuilder().newDecorator());
+    sb.http(serverPort);
+    sb.service("/health", HealthCheckService.builder().build());
+    sb.service("/metrics", (ctx, req) -> HttpResponse.of(prometheusMeterRegistry.scrape()));
+    sb.serviceUnder("/docs", new DocService());
+    sb.serviceUnder("/internal/management/", ManagementService.of());
+  }
+
+  private LoggingServiceBuilder getLoggingServiceBuilder() {
+    return LoggingService.builder()
+        // Not logging any successful response, say prom scraping /metrics every 30 seconds at INFO
+        .successfulResponseLogLevel(LogLevel.DEBUG)
+        .failureResponseLogLevel(LogLevel.ERROR)
+        // Remove all headers to be sure we aren't leaking any auth/cookie info
+        .requestHeadersSanitizer((ctx, headers) -> DefaultHttpHeaders.EMPTY_HEADERS);
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    CompletableFuture<Void> serverFuture = server.start();
+    serverFuture.get(15, TimeUnit.SECONDS);
+    LOG.info("Started on port: {}", serverPort);
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    LOG.info("Shutting down");
+    server.closeAsync().get(15, TimeUnit.SECONDS);
+  }
+
+  @Override
+  protected String serviceName() {
+    if (this.serviceName != null) {
+      return this.serviceName;
+    }
+    return super.serviceName();
+  }
+}

--- a/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
+++ b/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
@@ -6,10 +6,11 @@ import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import com.slack.kaldb.chunk.ChunkRollOverException;
 import com.slack.kaldb.util.RuntimeHalterImpl;
 import java.io.IOException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Properties;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
@@ -147,7 +148,7 @@ abstract class KaldbKafkaConsumer extends AbstractExecutionThreadService {
 
     if (consumer != null) {
       LOG.info("Closing kafka consumer.");
-      consumer.close(15, TimeUnit.SECONDS);
+      consumer.close(Duration.of(15, ChronoUnit.SECONDS));
       LOG.info("Closed kafka consumer.");
     }
   }

--- a/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
+++ b/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
@@ -2,17 +2,13 @@ package com.slack.kaldb.writer.kafka;
 
 import static java.lang.Integer.parseInt;
 
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.ListeningExecutorService;
-import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import com.slack.kaldb.chunk.ChunkRollOverException;
 import com.slack.kaldb.util.RuntimeHalterImpl;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Properties;
-import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
@@ -24,16 +20,19 @@ import org.slf4j.LoggerFactory;
  * be run in a separate thread. Further, it is also important to shutdown the consumer cleanly so
  * that we can guarantee that the data is indexed only once.
  */
-abstract class KaldbKafkaConsumer {
+abstract class KaldbKafkaConsumer extends AbstractExecutionThreadService {
   private static final Logger LOG = LoggerFactory.getLogger(KaldbKafkaConsumer.class);
 
-  private final KafkaConsumer<String, byte[]> consumer;
+  private KafkaConsumer<String, byte[]> consumer;
 
   private final String kafkaTopic;
   private final int kafkaTopicPartition;
-  private boolean stop;
-  private final ListeningExecutorService kafkaConsumerService;
-  private ListenableFuture<?> kafkaConsumerFuture;
+  private final String kafkaTopicPartitionStr;
+  private final String kafkaBootStrapServers;
+  private final String kafkaClientGroup;
+  private final String enableKafkaAutoCommit;
+  private final String kafkaAutoCommitInterval;
+  private final String kafkaSessionTimeout;
 
   public KaldbKafkaConsumer(
       String kafkaTopic,
@@ -43,8 +42,6 @@ abstract class KaldbKafkaConsumer {
       String enableKafkaAutoCommit,
       String kafkaAutoCommitInterval,
       String kafkaSessionTimeout) {
-
-    stop = false;
     LOG.info(
         "Kafka params are: kafkaTopicName: {}, kafkaTopicPartition: {}, "
             + "kafkaBootstrapServers:{}, kafkaClientGroup: {}, kafkaAutoCommit:{}, "
@@ -74,32 +71,13 @@ abstract class KaldbKafkaConsumer {
     }
 
     this.kafkaTopic = kafkaTopic;
+    this.kafkaTopicPartitionStr = kafkaTopicPartitionStr;
     this.kafkaTopicPartition = parseInt(kafkaTopicPartitionStr);
-
-    // Create kafka consumer
-    this.consumer =
-        buildKafkaConsumer(
-            kafkaBootStrapServers,
-            kafkaClientGroup,
-            enableKafkaAutoCommit,
-            kafkaAutoCommitInterval);
-
-    if (kafkaTopicPartitionStr.isEmpty()) {
-      LOG.info("Subscribing to kafka topic {}", kafkaTopic);
-      consumer.subscribe(
-          Collections.singletonList(kafkaTopic), new KafkaConsumerRebalanceListener());
-    } else {
-      // TODO: Consider using sticky consumer instead of assign?
-      LOG.info(
-          "Assigned to kafka topic {} and partition {}", this.kafkaTopic, this.kafkaTopicPartition);
-      consumer.assign(
-          Collections.singletonList(new TopicPartition(this.kafkaTopic, kafkaTopicPartition)));
-    }
-
-    kafkaConsumerService =
-        MoreExecutors.listeningDecorator(
-            MoreExecutors.getExitingExecutorService(
-                (ThreadPoolExecutor) Executors.newFixedThreadPool(1), 2, TimeUnit.SECONDS));
+    this.kafkaBootStrapServers = kafkaBootStrapServers;
+    this.kafkaClientGroup = kafkaClientGroup;
+    this.enableKafkaAutoCommit = enableKafkaAutoCommit;
+    this.kafkaAutoCommitInterval = kafkaAutoCommitInterval;
+    this.kafkaSessionTimeout = kafkaSessionTimeout;
   }
 
   private KafkaConsumer<String, byte[]> buildKafkaConsumer(
@@ -121,26 +99,35 @@ abstract class KaldbKafkaConsumer {
     return new KafkaConsumer<>(props);
   }
 
-  public ListenableFuture<?> start() {
+  @Override
+  public void startUp() {
     LOG.info("Starting kafka consumer.");
 
-    // We can only have one consumer per class. So, throw an exception if it's called twice.
-    if (kafkaConsumerFuture != null) {
-      throw new IllegalStateException("Start shouldn't be called twice.");
-    }
+    // Create kafka consumer
+    this.consumer =
+        buildKafkaConsumer(
+            kafkaBootStrapServers,
+            kafkaClientGroup,
+            enableKafkaAutoCommit,
+            kafkaAutoCommitInterval);
 
-    kafkaConsumerFuture = kafkaConsumerService.submit(this::run);
-    return kafkaConsumerFuture;
+    if (kafkaTopicPartitionStr.isEmpty()) {
+      LOG.info("Subscribing to kafka topic {}", kafkaTopic);
+      consumer.subscribe(
+          Collections.singletonList(kafkaTopic), new KafkaConsumerRebalanceListener());
+    } else {
+      // TODO: Consider using sticky consumer instead of assign?
+      LOG.info(
+          "Assigned to kafka topic {} and partition {}", this.kafkaTopic, this.kafkaTopicPartition);
+      consumer.assign(
+          Collections.singletonList(new TopicPartition(this.kafkaTopic, kafkaTopicPartition)));
+    }
   }
 
-  private void run() {
-    while (true) {
+  @Override
+  protected void run() {
+    while (isRunning()) {
       try {
-        if (stop) {
-          close();
-          break;
-        }
-
         long kafkaPollTimeoutMs = 100;
         consumeMessages(kafkaPollTimeoutMs);
       } catch (RejectedExecutionException e) {
@@ -157,6 +144,12 @@ abstract class KaldbKafkaConsumer {
         new RuntimeHalterImpl().handleFatal(e);
       }
     }
+
+    if (consumer != null) {
+      LOG.info("Closing kafka consumer.");
+      consumer.close(15, TimeUnit.SECONDS);
+      LOG.info("Closed kafka consumer.");
+    }
   }
 
   protected KafkaConsumer<String, byte[]> getConsumer() {
@@ -168,22 +161,4 @@ abstract class KaldbKafkaConsumer {
   }
 
   abstract void consumeMessages(long kafkaPollTimeoutMs) throws IOException;
-
-  private void close() {
-    if (stop && consumer != null) {
-      LOG.info("Closing kafka consumer.");
-      consumer.close();
-      kafkaConsumerService.shutdown();
-      LOG.info("Closed kafka consumer.");
-    }
-  }
-
-  public ListenableFuture<?> triggerShutdown() {
-    stop = true;
-    return kafkaConsumerFuture;
-  }
-
-  public boolean isShutdown() {
-    return kafkaConsumerService.isShutdown();
-  }
 }

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration monitorInterval="30" status="WARN">
+<Configuration monitorInterval="30" status="WARN" shutdownHook="disable">
+    <!-- we handle shutdown hook directly in Kaldb.addShutdownHook -->
 
     <Appenders>
         <Console name="console" target="SYSTEM_OUT">

--- a/src/test/java/com/slack/kaldb/chunk/ChunkCleanerTaskTest.java
+++ b/src/test/java/com/slack/kaldb/chunk/ChunkCleanerTaskTest.java
@@ -18,6 +18,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -29,7 +30,7 @@ public class ChunkCleanerTaskTest {
   private ChunkManagerUtil<LogMessage> chunkManagerUtil;
 
   @Before
-  public void setUp() throws IOException {
+  public void setUp() throws IOException, TimeoutException {
     KaldbConfigUtil.initEmptyIndexerConfig();
     metricsRegistry = new SimpleMeterRegistry();
     chunkManagerUtil =
@@ -37,7 +38,7 @@ public class ChunkCleanerTaskTest {
   }
 
   @After
-  public void tearDown() throws IOException {
+  public void tearDown() throws IOException, TimeoutException {
     metricsRegistry.close();
     if (chunkManagerUtil != null) {
       chunkManagerUtil.close();

--- a/src/test/java/com/slack/kaldb/logstore/search/KaldbLocalQueryServiceTest.java
+++ b/src/test/java/com/slack/kaldb/logstore/search/KaldbLocalQueryServiceTest.java
@@ -30,6 +30,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 import org.junit.*;
 
 public class KaldbLocalQueryServiceTest {
@@ -42,7 +43,7 @@ public class KaldbLocalQueryServiceTest {
   private SimpleMeterRegistry metricsRegistry;
 
   @Before
-  public void setUp() throws InvalidProtocolBufferException {
+  public void setUp() throws InvalidProtocolBufferException, TimeoutException {
     KaldbConfigUtil.initEmptyIndexerConfig();
     metricsRegistry = new SimpleMeterRegistry();
     chunkManagerUtil =
@@ -51,7 +52,7 @@ public class KaldbLocalQueryServiceTest {
   }
 
   @After
-  public void tearDown() throws IOException {
+  public void tearDown() throws IOException, TimeoutException {
     if (chunkManagerUtil != null) {
       chunkManagerUtil.close();
     }

--- a/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
+++ b/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
@@ -999,7 +999,7 @@ public class KaldbMetadataStoreTest {
       notificationCountDownLatch.await();
       assertThat(store.getCached().isEmpty()).isTrue();
       assertThat(store.list().get().isEmpty()).isTrue();
-      assertThat(notificationCounter.get()).isEqualTo(1);
+      await().until(() -> notificationCounter.get() == 1);
     }
 
     @Test

--- a/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -5,6 +5,7 @@ import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_RECEIVED_CO
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
 import static com.slack.kaldb.testlib.TestKafkaServer.produceMessagesToKafka;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import com.adobe.testing.s3mock.junit4.S3MockRule;
 import com.github.charithe.kafka.EphemeralKafkaBroker;
@@ -28,13 +29,10 @@ import com.slack.kaldb.testlib.MessageUtil;
 import com.slack.kaldb.testlib.TestKafkaServer;
 import com.slack.kaldb.writer.kafka.KaldbKafkaWriter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -73,14 +71,13 @@ public class KaldbIndexerTest {
   }
 
   @After
-  public void tearDown()
-      throws IOException, ExecutionException, InterruptedException, NoSuchFieldException,
-          IllegalAccessException, TimeoutException {
+  public void tearDown() throws Exception {
     if (server != null) {
       server.stop().get(30, TimeUnit.SECONDS);
     }
     if (kaldbIndexer != null) {
-      kaldbIndexer.close();
+      kaldbIndexer.stopAsync();
+      kaldbIndexer.awaitTerminated(15, TimeUnit.SECONDS);
     }
     kafkaServer.close();
   }
@@ -135,6 +132,9 @@ public class KaldbIndexerTest {
     kaldbIndexer =
         new KaldbIndexer(
             chunkManager, KaldbIndexer.dataTransformerMap.get("api_log"), metricsRegistry);
+    kaldbIndexer.startAsync();
+    kaldbIndexer.awaitRunning(15, TimeUnit.SECONDS);
+
     GrpcServiceBuilder searchBuilder =
         GrpcService.builder()
             .addService(new KaldbLocalQueryService<>(kaldbIndexer.getChunkManager()))
@@ -144,20 +144,16 @@ public class KaldbIndexerTest {
     // wait at most 10 seconds to start before throwing an exception
     server.start().get(10, TimeUnit.SECONDS);
 
-    kaldbIndexer.start();
-    Thread.sleep(1000); // Wait for consumer start.
-
     // Produce messages to kafka, so the indexer can consume them.
     produceMessagesToKafka(broker, startTime);
-    Thread.sleep(1000); // Wait for consumer to finish consumption and roll over chunk.
 
     // No need to commit the active chunk since the last chunk is already closed.
-    assertThat(chunkManager.getChunkMap().size()).isEqualTo(1);
-    assertThat(getCount(MESSAGES_RECEIVED_COUNTER, metricsRegistry)).isEqualTo(100);
+    await().until(() -> chunkManager.getChunkMap().size() == 1);
+    await().until(() -> getCount(MESSAGES_RECEIVED_COUNTER, metricsRegistry) == 100);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, metricsRegistry)).isEqualTo(0);
     assertThat(getCount(RollOverChunkTask.ROLLOVERS_INITIATED, metricsRegistry)).isEqualTo(1);
     assertThat(getCount(RollOverChunkTask.ROLLOVERS_FAILED, metricsRegistry)).isEqualTo(0);
-    assertThat(getCount(RollOverChunkTask.ROLLOVERS_COMPLETED, metricsRegistry)).isEqualTo(1);
+    await().until(() -> getCount(RollOverChunkTask.ROLLOVERS_COMPLETED, metricsRegistry) == 1);
     assertThat(getCount(KaldbKafkaWriter.RECORDS_RECEIVED_COUNTER, metricsRegistry)).isEqualTo(100);
     assertThat(getCount(KaldbKafkaWriter.RECORDS_FAILED_COUNTER, metricsRegistry)).isEqualTo(0);
 
@@ -174,6 +170,9 @@ public class KaldbIndexerTest {
     assertThat(searchResponse.getTotalNodes()).isEqualTo(1);
     assertThat(searchResponse.getTotalSnapshots()).isEqualTo(1);
     assertThat(searchResponse.getSnapshotsWithReplicas()).isEqualTo(1);
+
+    chunkManager.stopAsync();
+    chunkManager.awaitTerminated(15, TimeUnit.SECONDS);
 
     // TODO: delete expired data cleanly.
   }

--- a/src/test/java/com/slack/kaldb/testlib/KaldbConfigUtil.java
+++ b/src/test/java/com/slack/kaldb/testlib/KaldbConfigUtil.java
@@ -40,6 +40,7 @@ public class KaldbConfigUtil {
             .setCommitDurationSecs(10)
             .setRefreshDurationSecs(10)
             .setStaleDurationSecs(7200)
+            .setDataTransformer("log_message")
             .build();
 
     KaldbConfigs.QueryServiceConfig queryConfig =

--- a/src/test/java/com/slack/kaldb/writer/LogMessageWriterImplTest.java
+++ b/src/test/java/com/slack/kaldb/writer/LogMessageWriterImplTest.java
@@ -30,6 +30,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -50,7 +51,7 @@ public class LogMessageWriterImplTest {
   private SimpleMeterRegistry metricsRegistry;
 
   @Before
-  public void setUp() throws InvalidProtocolBufferException {
+  public void setUp() throws InvalidProtocolBufferException, TimeoutException {
     KaldbConfigUtil.initEmptyIndexerConfig();
     metricsRegistry = new SimpleMeterRegistry();
     chunkManagerUtil =
@@ -58,7 +59,7 @@ public class LogMessageWriterImplTest {
   }
 
   @After
-  public void tearDown() throws IOException {
+  public void tearDown() throws IOException, TimeoutException {
     if (chunkManagerUtil != null) {
       chunkManagerUtil.close();
     }
@@ -447,7 +448,7 @@ public class LogMessageWriterImplTest {
   }
 
   @Test
-  public void testAvgMessageSizeCalculationOnSpanIngestion() throws IOException {
+  public void testAvgMessageSizeCalculationOnSpanIngestion() throws IOException, TimeoutException {
     final String traceId = "t1";
     final long timestampMicros = 1612550512340953L;
     final long durationMicros = 500000L;


### PR DESCRIPTION
Rewrites Armeria, KaldbIndexer, KaldbKafkaConsumer, and ChunkManager as Guava services.

At a high level, this moves initialization of all of these classes into `Kaldb.class`, and then registers them with the Guava `ServiceManager`. All of these services are "started" at the same time, and use `awaitRunning()` to defer their own startup until their dependencies are running. At shutdown if a service has a requirement that a dependency is shutdown first, it issues a `stopAync()` to the service and then `awaitTerminated()` until it is safe to continue.

We currently are using `AbstractIdleService` and `AbstractExecutionThreadService`, depending on the specific class in question. https://github.com/google/guava/wiki/ServiceExplained 

```
[INFO ] 2021-07-30 15:50:14.088 [KaldbKafkaWriter] KaldbKafkaConsumer - Starting kafka consumer.
[INFO ] 2021-07-30 15:50:14.091 [kaldbIndexerService STARTING] KaldbIndexer - Starting indexing into Kaldb.
[INFO ] 2021-07-30 15:50:14.091 [ChunkManager STARTING] ChunkManager - Starting chunk manager
[INFO ] 2021-07-30 15:50:14.433 [armeriaQueryService STARTING] ArmeriaService - Started on port: 8081
[INFO ] 2021-07-30 15:50:14.435 [armeriaIndexService STARTING] ArmeriaService - Started on port: 8080

..

[INFO ] 2021-07-30 15:51:44.176 [armeriaQueryService STOPPING] ArmeriaService - Shutting down
[INFO ] 2021-07-30 15:51:44.176 [kaldbIndexerService STOPPING] KaldbIndexer - Shutting down Kaldb indexer.
[INFO ] 2021-07-30 15:51:44.176 [kaldbIndexerService STOPPING] KaldbIndexer - Waiting for Kafka consumer to close.
[INFO ] 2021-07-30 15:51:44.177 [ChunkManager STOPPING] ChunkManager - Closing chunk manager.
[INFO ] 2021-07-30 15:51:44.177 [armeriaIndexService STOPPING] ArmeriaService - Shutting down
[INFO ] 2021-07-30 15:51:44.177 [ChunkManager STOPPING] ChunkManager - Roll over future completed successfully.
[INFO ] 2021-07-30 15:51:44.178 [ChunkManager STOPPING] ChunkManager - Closed chunk manager.
[INFO ] 2021-07-30 15:51:44.221 [kaldbIndexerService STOPPING] KaldbIndexer - Closed Kafka consumer cleanly
[INFO ] 2021-07-30 15:51:44.221 [kaldbIndexerService STOPPING] KaldbIndexer - Kaldb indexer is closed.
[INFO ] 2021-07-30 15:51:46.308 [Thread-0] Kaldb - Shutting down log4j2

```