### PR TITLE
Add JMH Dependencies

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,7 +28,9 @@ jobs:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
-    - name: Ensure code is formatted. 
+    - name: Ensure code is formatted
       run: mvn com.coveo:fmt-maven-plugin:check --file pom.xml
+    - name: Ensure jmh benchmark code is formatted
+      run: mvn com.coveo:fmt-maven-plugin:check --file benchmarks/pom.xml
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -1,0 +1,113 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>JMH Samples</name>
+    <groupId>com.slack.kaldb</groupId>
+    <artifactId>benchmarks</artifactId>
+    <version>0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <licenses>
+        <license>
+            <name>MIT</name>
+            <url>https://opensource.org/licenses/MIT</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.slack.kaldb</groupId>
+            <artifactId>kaldb</artifactId>
+            <version>0.1-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jmh.version>1.32</jmh.version>
+        <javac.target>11</javac.target>
+        <uberjar.name>benchmarks</uberjar.name>
+    </properties>
+
+    <build>
+        <plugins>
+            <!-- Format code automatically during build using google's style guide.-->
+            <plugin>
+                <groupId>com.coveo</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>2.6.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <compilerVersion>${javac.target}</compilerVersion>
+                    <source>${javac.target}</source>
+                    <target>${javac.target}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
+                <configuration>
+                    <forkMode>always</forkMode>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>${uberjar.name}</finalName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.0.0-M1</version>
+            </plugin>
+        </plugins>
+
+    </build>
+
+</project>

--- a/benchmarks/src/main/java/com/slack/kaldb/IndexingBenchmark.java
+++ b/benchmarks/src/main/java/com/slack/kaldb/IndexingBenchmark.java
@@ -1,0 +1,63 @@
+package com.slack.kaldb;
+
+import com.slack.kaldb.logstore.LogMessage;
+import com.slack.kaldb.logstore.LuceneIndexStoreImpl;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Stream;
+import org.openjdk.jmh.annotations.*;
+
+@State(Scope.Thread)
+public class IndexingBenchmark {
+
+  private final Duration commitInterval = Duration.ofSeconds(5 * 60);
+  private final Duration refreshInterval = Duration.ofSeconds(5 * 60);
+  String timestamp;
+
+  private Path tempDirectory;
+  private MeterRegistry registry;
+  LuceneIndexStoreImpl logStore;
+  private Random random;
+
+  @Setup(Level.Iteration)
+  public void createIndexer() throws IOException {
+    random = new Random();
+    timestamp = Instant.now().toString();
+    registry = new SimpleMeterRegistry();
+    tempDirectory =
+        Files.createDirectories(
+            Paths.get("jmh", String.valueOf(random.nextInt(Integer.MAX_VALUE))));
+    logStore =
+        LuceneIndexStoreImpl.makeLogStore(
+            tempDirectory.toFile(), commitInterval, refreshInterval, registry);
+  }
+
+  @TearDown(Level.Iteration)
+  public void tearDown() throws IOException {
+    logStore.close();
+    try (Stream<Path> walk = Files.walk(tempDirectory)) {
+      walk.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+    }
+    registry.close();
+  }
+
+  @Benchmark
+  public void measureIndexing() {
+    Map<String, Object> fieldMap = new HashMap<>();
+    fieldMap.put(LogMessage.ReservedField.TIMESTAMP.fieldName, timestamp);
+    fieldMap.put(LogMessage.ReservedField.MESSAGE.fieldName, "Log Message");
+    LogMessage logMessage = new LogMessage("testindex", "INFO", "1", fieldMap);
+    logStore.addMessage(logMessage);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -586,8 +586,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
                     <configuration>
-                        <source>11</source>
-                        <target>11</target>
+                        <source>${javac.target}</source>
+                        <target>${javac.target}</target>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
Add JMH Dependencies

To run it we can use


Compile -  `mvn package -DskipTests=true -f benchmarks/pom.xml `
 
Run -  `java -jar benchmarks/target/benchmarks.jar IndexingBenchmark`

Format - `mvn fmt:format -f benchmarks/pom.xml`


or run it from IntelliJ directly https://plugins.jetbrains.com/plugin/7529-jmh-java-microbenchmark-harness


Example output

```
Result "com.slack.kaldb.IndexingBenchmark.measureIndexing":
  106102.831 ±(99.9%) 8195.356 ops/s [Average]
  (min, avg, max) = (79329.269, 106102.831, 128929.146), stdev = 10940.566
  CI (99.9%): [97907.475, 114298.187] (assumes normal distribution)


# Run complete. Total time: 00:09:07

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

Benchmark                           Mode  Cnt       Score      Error  Units
IndexingBenchmark.measureIndexing  thrpt   25  106102.831 ± 8195.356  ops/s

```

Pro tip - `java -jar benchmarks/target/benchmarks.jar -h` - is a goldmine of options - for example dumping results into JSON, profiling the test run etc
