### PR TITLE
Create LogMessage Once in Indexing JMH Test

### DIFF
--- a/benchmarks/src/main/java/com/slack/kaldb/IndexingBenchmark.java
+++ b/benchmarks/src/main/java/com/slack/kaldb/IndexingBenchmark.java
@@ -30,6 +30,8 @@ public class IndexingBenchmark {
   LuceneIndexStoreImpl logStore;
   private Random random;
 
+  private LogMessage logMessage;
+
   @Setup(Level.Iteration)
   public void createIndexer() throws IOException {
     random = new Random();
@@ -41,6 +43,11 @@ public class IndexingBenchmark {
     logStore =
         LuceneIndexStoreImpl.makeLogStore(
             tempDirectory.toFile(), commitInterval, refreshInterval, registry);
+
+    Map<String, Object> fieldMap = new HashMap<>();
+    fieldMap.put(LogMessage.ReservedField.TIMESTAMP.fieldName, timestamp);
+    fieldMap.put(LogMessage.ReservedField.MESSAGE.fieldName, "Log Message");
+    logMessage = new LogMessage("testindex", "INFO", "1", fieldMap);
   }
 
   @TearDown(Level.Iteration)
@@ -54,10 +61,6 @@ public class IndexingBenchmark {
 
   @Benchmark
   public void measureIndexing() {
-    Map<String, Object> fieldMap = new HashMap<>();
-    fieldMap.put(LogMessage.ReservedField.TIMESTAMP.fieldName, timestamp);
-    fieldMap.put(LogMessage.ReservedField.MESSAGE.fieldName, "Log Message");
-    LogMessage logMessage = new LogMessage("testindex", "INFO", "1", fieldMap);
     logStore.addMessage(logMessage);
   }
 }


### PR DESCRIPTION
Create the log message during the setup phase. In the future we will try loading some real world sample data instead of this one dummy document

This will help us measure more of the "indexing" part

Before the change

```
Benchmark                                  Mode  Cnt       Score      Error  Units
IndexingBenchmark.measureIndexing         thrpt   25  165375.592 ± 7276.432  ops/s
IndexingBenchmark.measureIndexing:·async  thrpt              NaN               ---

```

After the change

```
Benchmark                                  Mode  Cnt       Score       Error  Units
IndexingBenchmark.measureIndexing         thrpt   25  228756.406 ± 19531.416  ops/s
IndexingBenchmark.measureIndexing:·async  thrpt              NaN                ---
```

Before Flamegraph

![image](https://user-images.githubusercontent.com/158041/128105831-77d4fbfe-5019-4800-92b3-27117ce227e1.png)

After Flamegraph

![image](https://user-images.githubusercontent.com/158041/128106816-e1a52e79-f70c-4f4b-9891-b423c9348d27.png)


This shows that getting the timestamp from the log message is slow since we need to use a date formatting. Optimizing that ( if possible? ) is not part of this indexing benchmark suite