### PR TITLE
Improve TestKakfaServer reliability

### DIFF
--- a/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
+++ b/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
@@ -237,10 +237,10 @@ public class KaldbDistributedQueryServiceTest {
                 .setBucketCount(2)
                 .build());
 
-    assertThat(searchResponse.getHitsCount()).isEqualTo(100);
-    assertThat(searchResponse.getTotalCount()).isEqualTo(200);
     assertThat(searchResponse.getTotalNodes()).isEqualTo(2);
     assertThat(searchResponse.getFailedNodes()).isEqualTo(0);
+    assertThat(searchResponse.getTotalCount()).isEqualTo(200);
+    assertThat(searchResponse.getHitsCount()).isEqualTo(100);
   }
 
   @Test
@@ -257,9 +257,9 @@ public class KaldbDistributedQueryServiceTest {
                 .setBucketCount(2)
                 .build());
 
-    assertThat(searchResponse.getHitsCount()).isEqualTo(100);
-    assertThat(searchResponse.getTotalCount()).isEqualTo(100);
     assertThat(searchResponse.getTotalNodes()).isEqualTo(2);
     assertThat(searchResponse.getFailedNodes()).isEqualTo(1);
+    assertThat(searchResponse.getTotalCount()).isEqualTo(100);
+    assertThat(searchResponse.getHitsCount()).isEqualTo(100);
   }
 }

--- a/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -142,6 +142,7 @@ public class KaldbIndexerTest {
     kaldbIndexer = new KaldbIndexer(chunkManager, messageTransformer, kafkaWriter);
     kaldbIndexer.startAsync();
     kaldbIndexer.awaitRunning(15, TimeUnit.SECONDS);
+    await().until(() -> kafkaServer.getConnectedConsumerGroups() == 1);
 
     GrpcServiceBuilder searchBuilder =
         GrpcService.builder()


### PR DESCRIPTION
Our `KaldbKafkaConsumer` does not currently provide a Kafka config for `auto.offset.reset`, which means [it defaults](https://docs.confluent.io/platform/current/installation/configuration/consumer-configs.html) to `latest`. This means there exists a race condition in our tests if you attempt to produce messages to the broker prior to the consumer being online. The recent Guava services refactor removed a bunch of `Thread.sleep` calls in our tests, which made this race condition even more likely.

This code adds a method you can now use to see if the consumer is connected before attempting to produce messages.