### PR TITLE
[DRAFT] Distributed query test fix

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ChunkManager.java
@@ -306,6 +306,8 @@ public class ChunkManager<T> extends AbstractIdleService {
                 chunkFuture ->
                     chunkFuture.exceptionally(
                         err -> {
+                          LOG.error("Error searching chunk future", err);
+
                           // We catch IllegalArgumentException ( and any other exception that
                           // represents a parse failure ) and instead of returning an empty result
                           // we throw back an error to the user

--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ChunkManager.java
@@ -284,10 +284,10 @@ public class ChunkManager<T> extends AbstractIdleService {
    * We will not aggregate locally for future use-cases that have complex group by etc
    */
   public CompletableFuture<SearchResult<T>> query(SearchQuery query) {
-
     SearchResult<T> errorResult =
         new SearchResult<>(new ArrayList<>(), 0, 0, new ArrayList<>(), 0, 0, 1, 0);
 
+    LOG.warn("Beginning chunkmanager query");
     List<CompletableFuture<SearchResult<T>>> queries =
         chunkMap
             .values()

--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadWriteChunkImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadWriteChunkImpl.java
@@ -211,7 +211,8 @@ public class ReadWriteChunkImpl<T> implements Chunk<T> {
             query.endTimeEpochMs,
             query.howMany,
             query.bucketCount);
-    LOG.warn(String.format("Finished logSearcher query in %s micros", result.tookMicros));
+    LOG.warn(
+        String.format("Finished logSearcher query in %s milliseconds", result.tookMicros / 1000));
     return result;
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadWriteChunkImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadWriteChunkImpl.java
@@ -202,12 +202,16 @@ public class ReadWriteChunkImpl<T> implements Chunk<T> {
 
   @Override
   public SearchResult<T> query(SearchQuery query) {
-    return logSearcher.search(
-        query.indexName,
-        query.queryStr,
-        query.startTimeEpochMs,
-        query.endTimeEpochMs,
-        query.howMany,
-        query.bucketCount);
+    LOG.warn("Beginning logSearcher query");
+    SearchResult<T> result =
+        logSearcher.search(
+            query.indexName,
+            query.queryStr,
+            query.startTimeEpochMs,
+            query.endTimeEpochMs,
+            query.howMany,
+            query.bucketCount);
+    LOG.warn(String.format("Finished logSearcher query in %s micros", result.tookMicros));
+    return result;
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
@@ -84,22 +84,24 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
       KaldbSearch.SearchRequest request,
       StreamObserver<KaldbSearch.SearchResult> responseObserver) {
     LOG.warn("Beginning distributed query");
-    super.search(request, new StreamObserver<>() {
-      @Override
-      public void onNext(KaldbSearch.SearchResult value) {
-        responseObserver.onNext(value);
-      }
+    super.search(
+        request,
+        new StreamObserver<>() {
+          @Override
+          public void onNext(KaldbSearch.SearchResult value) {
+            responseObserver.onNext(value);
+          }
 
-      @Override
-      public void onError(Throwable t) {
-        responseObserver.onError(t);
-      }
+          @Override
+          public void onError(Throwable t) {
+            responseObserver.onError(t);
+          }
 
-      @Override
-      public void onCompleted() {
-        responseObserver.onCompleted();
-        LOG.warn("Distributed search complete, responseObserver notified");
-      }
-    });
+          @Override
+          public void onCompleted() {
+            responseObserver.onCompleted();
+            LOG.warn("Distributed search complete, responseObserver notified");
+          }
+        });
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
@@ -50,7 +50,13 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
 
     return futures
         .stream()
-        .map(result -> result.exceptionally(ex -> error))
+        .map(
+            result ->
+                result.exceptionally(
+                    ex -> {
+                      LOG.error("Result exception", ex);
+                      return error;
+                    }))
         .collect(CompletableFutures.joinList());
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbLocalQueryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbLocalQueryService.java
@@ -29,22 +29,24 @@ public class KaldbLocalQueryService<T> extends KaldbQueryServiceBase {
       KaldbSearch.SearchRequest request,
       StreamObserver<KaldbSearch.SearchResult> responseObserver) {
     LOG.warn("Beginning local query");
-    super.search(request, new StreamObserver<>() {
-      @Override
-      public void onNext(KaldbSearch.SearchResult value) {
-        responseObserver.onNext(value);
-      }
+    super.search(
+        request,
+        new StreamObserver<>() {
+          @Override
+          public void onNext(KaldbSearch.SearchResult value) {
+            responseObserver.onNext(value);
+          }
 
-      @Override
-      public void onError(Throwable t) {
-        responseObserver.onError(t);
-      }
+          @Override
+          public void onError(Throwable t) {
+            responseObserver.onError(t);
+          }
 
-      @Override
-      public void onCompleted() {
-        responseObserver.onCompleted();
-        LOG.warn("Local search complete, responseObserver notified");
-      }
-    });
+          @Override
+          public void onCompleted() {
+            responseObserver.onCompleted();
+            LOG.warn("Local search complete, responseObserver notified");
+          }
+        });
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbLocalQueryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbLocalQueryService.java
@@ -3,9 +3,13 @@ package com.slack.kaldb.logstore.search;
 import com.slack.kaldb.chunk.ChunkManager;
 import com.slack.kaldb.proto.service.KaldbSearch;
 import com.slack.kaldb.server.KaldbQueryServiceBase;
+import io.grpc.stub.StreamObserver;
 import java.util.concurrent.CompletableFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class KaldbLocalQueryService<T> extends KaldbQueryServiceBase {
+  private static final Logger LOG = LoggerFactory.getLogger(KaldbLocalQueryService.class);
 
   private final ChunkManager<T> chunkManager;
 
@@ -18,5 +22,13 @@ public class KaldbLocalQueryService<T> extends KaldbQueryServiceBase {
     SearchQuery query = SearchResultUtils.fromSearchRequest(request);
     CompletableFuture<SearchResult<T>> searchResult = chunkManager.query(query);
     return SearchResultUtils.toSearchResultProto(searchResult);
+  }
+
+  @Override
+  public void search(
+      KaldbSearch.SearchRequest request,
+      StreamObserver<KaldbSearch.SearchResult> responseObserver) {
+    LOG.warn("Beginning local query");
+    super.search(request, responseObserver);
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbLocalQueryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbLocalQueryService.java
@@ -29,6 +29,22 @@ public class KaldbLocalQueryService<T> extends KaldbQueryServiceBase {
       KaldbSearch.SearchRequest request,
       StreamObserver<KaldbSearch.SearchResult> responseObserver) {
     LOG.warn("Beginning local query");
-    super.search(request, responseObserver);
+    super.search(request, new StreamObserver<>() {
+      @Override
+      public void onNext(KaldbSearch.SearchResult value) {
+        responseObserver.onNext(value);
+      }
+
+      @Override
+      public void onError(Throwable t) {
+        responseObserver.onError(t);
+      }
+
+      @Override
+      public void onCompleted() {
+        responseObserver.onCompleted();
+        LOG.warn("Local search complete, responseObserver notified");
+      }
+    });
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/server/KaldbQueryServiceBase.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/KaldbQueryServiceBase.java
@@ -4,10 +4,13 @@ import com.slack.kaldb.proto.service.KaldbSearch;
 import com.slack.kaldb.proto.service.KaldbServiceGrpc;
 import io.grpc.stub.StreamObserver;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class KaldbQueryServiceBase extends KaldbServiceGrpc.KaldbServiceImplBase {
+  protected final ExecutorService queryServiceExecutor = Executors.newFixedThreadPool(16);
 
   private static final Logger LOG = LoggerFactory.getLogger(KaldbQueryServiceBase.class);
 
@@ -26,7 +29,8 @@ public abstract class KaldbQueryServiceBase extends KaldbServiceGrpc.KaldbServic
                 responseObserver.onNext(result);
                 responseObserver.onCompleted();
               }
-            });
+            },
+            queryServiceExecutor);
   }
 
   public abstract CompletableFuture<KaldbSearch.SearchResult> doSearch(

--- a/kaldb/src/main/java/com/slack/kaldb/server/KaldbQueryServiceBase.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/KaldbQueryServiceBase.java
@@ -1,5 +1,6 @@
 package com.slack.kaldb.server;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.slack.kaldb.proto.service.KaldbSearch;
 import com.slack.kaldb.proto.service.KaldbServiceGrpc;
 import io.grpc.stub.StreamObserver;
@@ -10,7 +11,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class KaldbQueryServiceBase extends KaldbServiceGrpc.KaldbServiceImplBase {
-  protected final ExecutorService queryServiceExecutor = Executors.newFixedThreadPool(16);
+  protected final ExecutorService queryServiceExecutor =
+      Executors.newFixedThreadPool(
+          16, new ThreadFactoryBuilder().setNameFormat("kaldb-query-executor-%d").build());
 
   private static final Logger LOG = LoggerFactory.getLogger(KaldbQueryServiceBase.class);
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
@@ -38,8 +38,12 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class KaldbDistributedQueryServiceTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KaldbDistributedQueryServiceTest.class);
 
   @ClassRule public static final S3MockRule S3_MOCK_RULE = S3MockRule.builder().silent().build();
   private static SimpleMeterRegistry indexerMetricsRegistry1 = new SimpleMeterRegistry();
@@ -245,6 +249,7 @@ public class KaldbDistributedQueryServiceTest {
 
   @Test
   public void testSearchWithOneShardTimeout() {
+    LOG.warn("----------- testSearchWithOneShardTimeout -------------");
     KaldbDistributedQueryService.READ_TIMEOUT_MS = 2000;
     KaldbSearch.SearchResult searchResponse =
         queryServiceStub.search(

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
@@ -183,13 +183,17 @@ public class KaldbDistributedQueryServiceTest {
       return Server.builder()
           .http(kaldbConfig.getIndexerConfig().getServerPort())
           .verboseResponses(true)
-          .service(GrpcService.builder().addService(wrapperService).build())
+          .service(
+              GrpcService.builder()
+                  .addService(wrapperService)
+                  .useBlockingTaskExecutor(true)
+                  .build())
           .build();
     } else {
       return Server.builder()
           .http(kaldbConfig.getIndexerConfig().getServerPort())
           .verboseResponses(true)
-          .service(GrpcService.builder().addService(service).build())
+          .service(GrpcService.builder().addService(service).useBlockingTaskExecutor(true).build())
           .build();
     }
   }

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbTimeoutLocalQueryService.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbTimeoutLocalQueryService.java
@@ -23,6 +23,7 @@ public class KaldbTimeoutLocalQueryService extends KaldbServiceGrpc.KaldbService
       KaldbSearch.SearchRequest request,
       StreamObserver<KaldbSearch.SearchResult> responseObserver) {
     try {
+      LOG.warn(String.format("Delaying search by %s ms", waitMS));
       Thread.sleep(waitMS);
     } catch (InterruptedException e) {
       LOG.warn("Pause interrupted" + e);


### PR DESCRIPTION
This PR provides a dedicated threadpool for the distributed query, instead of relying on the `ForkJoinPool`. It appears in some circumstances on the Github runners we are saturating the `ForkJoinPool`, which causes some code that expects to run in parallel to instead run sequentially. 

This additionally increasing the logging when we have an exception during the distributed query.