### PR TITLE
add a ignore commit revs list

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Convert Kaldb project to a multi project build
+a6582a5f1e73ef69058b6a51b602328873498ab0


### PR DESCRIPTION
Maybe github ( https://github.community/t/support-ignore-revs-file-in-githubs-blame-view/3256 )  or other git blame UIs will one day start reading this file ( the name is the default filename ) and automatically skip this commit - If not we can manually do it using https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt