### PR TITLE
Update Grafana docker config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,11 +32,13 @@ services:
       - ./config/grafana/provisioning:/etc/grafana/provisioning
       - ../slack-kaldb-app:/var/lib/grafana/plugins
     environment:
+      GF_LOG_MODE: "console file"
+      GF_LOG_LEVEL: "debug"
       GF_AUTH_DISABLE_LOGIN_FORM: "true"
       GF_AUTH_ANONYMOUS_ENABLED: "true"
       GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin"
       GF_PATHS_PLUGINS: "/var/lib/grafana/plugins"
-      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: "slack-kaldb-app"
+      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: "slack-kaldb-app,slack-kaldb-app-backend-datasource"
 
   grafana7:
     image: 'grafana/grafana:7.3.6'


### PR DESCRIPTION
Adds better Grafana logging for troubleshooting backend datastore issues. Also adds the new datastore ID to the allowed unsigned list.