### PR TITLE
Add initital tracing integration

### DIFF
--- a/.run/KalDb_index.run.xml
+++ b/.run/KalDb_index.run.xml
@@ -1,5 +1,8 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="KalDb" type="Application" factoryName="Application">
+  <configuration default="false" name="KalDb Index Node" type="Application" factoryName="Application">
+    <envs>
+      <env name="NODE_ROLES" value="INDEX" />
+    </envs>
     <option name="MAIN_CLASS_NAME" value="com.slack.kaldb.server.Kaldb" />
     <module name="kaldb" />
     <option name="PROGRAM_PARAMETERS" value="config/config.yaml" />

--- a/.run/KalDb_query.run.xml
+++ b/.run/KalDb_query.run.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="KalDb Query Node" type="Application" factoryName="Application">
+    <envs>
+      <env name="NODE_ROLES" value="QUERY" />
+    </envs>
+    <option name="MAIN_CLASS_NAME" value="com.slack.kaldb.server.Kaldb" />
+    <module name="kaldb" />
+    <option name="PROGRAM_PARAMETERS" value="config/config.yaml" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -26,6 +26,8 @@ s3Config:
   s3EndPoint: ${S3_ENDPOINT:-http://localhost:9090}
   s3Bucket: ${S3_BUCKET:-test-s3-bucket}
 
+tracingConfig:
+  zipkinEndpoint: ${ZIPKIN_TRACING_ENDPOINT:-http://localhost:9411/api/v2/spans}
 
 queryConfig:
   serverPort: ${KALDB_QUERY_SERVER_PORT:-8081}

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -77,6 +77,11 @@
         </dependency>
         <dependency>
             <groupId>com.linecorp.armeria</groupId>
+            <artifactId>armeria-brave</artifactId>
+            <version>${armeria.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.linecorp.armeria</groupId>
             <artifactId>armeria-grpc</artifactId>
             <version>${armeria.version}</version>
             <exclusions>
@@ -393,6 +398,25 @@
             <groupId>com.spotify</groupId>
             <artifactId>futures-extra</artifactId>
             <version>4.2.0</version>
+        </dependency>
+
+        <!-- Zipkin -->
+        <dependency>
+            <groupId>io.zipkin.brave</groupId>
+            <artifactId>brave-instrumentation-grpc</artifactId>
+            <version>5.13.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.zipkin.brave</groupId>
+            <artifactId>brave-context-log4j2</artifactId>
+            <version>5.13.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.zipkin.reporter2</groupId>
+            <artifactId>zipkin-sender-urlconnection</artifactId>
+            <version>2.16.3</version>
         </dependency>
 
     </dependencies>

--- a/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
@@ -1,11 +1,16 @@
 package com.slack.kaldb.server;
 
+import brave.Tracing;
+import brave.context.log4j2.ThreadContextScopeDecorator;
+import brave.handler.SpanHandler;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.brave.RequestContextCurrentTraceContext;
 import com.linecorp.armeria.common.grpc.GrpcMeterIdPrefixFunction;
 import com.linecorp.armeria.common.logging.LogLevel;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.brave.BraveService;
 import com.linecorp.armeria.server.docs.DocService;
 import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
@@ -14,6 +19,7 @@ import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.server.logging.LoggingServiceBuilder;
 import com.linecorp.armeria.server.management.ManagementService;
 import com.linecorp.armeria.server.metric.MetricCollectingService;
+import com.slack.kaldb.config.KaldbConfig;
 import com.slack.kaldb.elasticsearchApi.ElasticsearchApiService;
 import com.slack.kaldb.proto.service.KaldbServiceGrpc;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
@@ -22,6 +28,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import zipkin2.reporter.Sender;
+import zipkin2.reporter.brave.AsyncZipkinSpanHandler;
+import zipkin2.reporter.urlconnection.URLConnectionSender;
 
 public class ArmeriaService extends AbstractIdleService {
   private final Logger LOG = LoggerFactory.getLogger(ArmeriaService.class);
@@ -59,12 +68,38 @@ public class ArmeriaService extends AbstractIdleService {
 
     sb.annotatedService(new ElasticsearchApiService(searcher));
 
-    addManagementEndpoints(sb, serverPort);
+    addManagementEndpoints(sb);
+    addTracing(sb);
 
     return sb.build();
   }
 
-  private void addManagementEndpoints(ServerBuilder sb, int serverPort) {
+  private void addTracing(ServerBuilder sb) {
+    String endpoint = KaldbConfig.get().getTracingConfig().getZipkinEndpoint();
+    SpanHandler spanHandler = new SpanHandler() {};
+
+    if (!endpoint.isBlank()) {
+      LOG.info(String.format("Trace reporting enabled: %s", endpoint));
+      Sender sender = URLConnectionSender.create(endpoint);
+      spanHandler = AsyncZipkinSpanHandler.create(sender);
+    } else {
+      LOG.info("Trace reporting disabled");
+    }
+
+    // always add a tracer, even if we're not reporting
+    Tracing tracing =
+        Tracing.newBuilder()
+            .localServiceName(this.serviceName)
+            .currentTraceContext(
+                RequestContextCurrentTraceContext.builder()
+                    .addScopeDecorator(ThreadContextScopeDecorator.get())
+                    .build())
+            .addSpanHandler(spanHandler)
+            .build();
+    sb.decorator(BraveService.newDecorator(tracing));
+  }
+
+  private void addManagementEndpoints(ServerBuilder sb) {
     sb.decorator(
         MetricCollectingService.newDecorator(GrpcMeterIdPrefixFunction.of("grpc.service")));
     sb.decorator(getLoggingServiceBuilder().newDecorator());

--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -101,7 +101,7 @@ public class Kaldb {
           new KaldbLocalQueryService<>(indexer.getChunkManager());
       final int serverPort = KaldbConfig.get().getIndexerConfig().getServerPort();
       ArmeriaService armeriaService =
-          new ArmeriaService(serverPort, prometheusMeterRegistry, searcher, "armeriaIndexService");
+          new ArmeriaService(serverPort, prometheusMeterRegistry, searcher, "kalDbIndex");
       services.add(armeriaService);
     }
 
@@ -109,7 +109,7 @@ public class Kaldb {
       KaldbDistributedQueryService searcher = new KaldbDistributedQueryService();
       final int serverPort = KaldbConfig.get().getQueryConfig().getServerPort();
       ArmeriaService armeriaService =
-          new ArmeriaService(serverPort, prometheusMeterRegistry, searcher, "armeriaQueryService");
+          new ArmeriaService(serverPort, prometheusMeterRegistry, searcher, "kalDbQuery");
       services.add(armeriaService);
     }
 

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -17,6 +17,7 @@ message KaldbConfig {
     QueryServiceConfig queryConfig = 4;
     MetadataStoreConfig metadataStoreConfig = 5;
     repeated NodeRole nodeRoles = 6;
+    TracingConfig tracingConfig = 7;
 }
 
 message KafkaConfig {
@@ -47,6 +48,10 @@ message S3Config {
     string s3Region = 3;
     string s3EndPoint = 4;
     string s3Bucket = 5;
+}
+
+message TracingConfig {
+    string zipkinEndpoint = 1;
 }
 
 message QueryServiceConfig {

--- a/kaldb/src/main/resources/log4j2.xml
+++ b/kaldb/src/main/resources/log4j2.xml
@@ -4,7 +4,7 @@
 
     <Appenders>
         <Console name="console" target="SYSTEM_OUT">
-            <PatternLayout  pattern="[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n" />
+            <PatternLayout  pattern="[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %notEmpty{[trace=%X{traceId}/%X{spanId}]} %c{1} - %msg%n" />
         </Console>
     </Appenders>
 

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ChunkManagerTest.java
@@ -13,6 +13,7 @@ import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.MAX_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
+import brave.Tracing;
 import com.adobe.testing.s3mock.junit4.S3MockRule;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
@@ -56,6 +57,7 @@ public class ChunkManagerTest {
 
   @Before
   public void setUp() throws InvalidProtocolBufferException {
+    Tracing.newBuilder().build();
     KaldbConfigUtil.initEmptyIndexerConfig();
     metricsRegistry = new SimpleMeterRegistry();
     // create an S3 client and a bucket for test

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -3,6 +3,7 @@ package com.slack.kaldb.chunk;
 import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.MAX_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import brave.Tracing;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.logstore.LuceneIndexStoreImpl;
 import com.slack.kaldb.logstore.search.SearchQuery;
@@ -32,6 +33,7 @@ public class ReadOnlyChunkImplTest {
 
   @Before
   public void setUp() throws IOException {
+    Tracing.newBuilder().build();
     registry = new SimpleMeterRegistry();
     File localStore = temporaryFolder.newFolder();
 

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadWriteChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadWriteChunkImplTest.java
@@ -12,6 +12,7 @@ import static com.slack.kaldb.testlib.MetricsUtil.getCount;
 import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.MAX_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import brave.Tracing;
 import com.adobe.testing.s3mock.junit4.S3MockRule;
 import com.slack.kaldb.blobfs.s3.S3BlobFs;
 import com.slack.kaldb.logstore.LogMessage;
@@ -58,6 +59,7 @@ public class ReadWriteChunkImplTest {
 
     @Before
     public void setUp() throws IOException {
+      Tracing.newBuilder().build();
       registry = new SimpleMeterRegistry();
       final LuceneIndexStoreImpl logStore =
           LuceneIndexStoreImpl.makeLogStore(

--- a/kaldb/src/test/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiServiceTest.java
@@ -2,6 +2,7 @@ package com.slack.kaldb.elasticsearchApi;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import brave.Tracing;
 import com.adobe.testing.s3mock.junit4.S3MockRule;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -47,6 +48,7 @@ public class ElasticsearchApiServiceTest {
 
   @Before
   public void setUp() throws IOException, TimeoutException {
+    Tracing.newBuilder().build();
     KaldbConfigUtil.initEmptyIndexerConfig();
 
     // create an S3 client and a bucket for test

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
@@ -14,6 +14,7 @@ import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.addMessag
 import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.findAllMessages;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import brave.Tracing;
 import com.adobe.testing.s3mock.junit4.S3MockRule;
 import com.slack.kaldb.blobfs.LocalBlobFs;
 import com.slack.kaldb.blobfs.s3.S3BlobFs;
@@ -35,6 +36,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.lucene.index.IndexCommit;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,6 +50,11 @@ import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 @SuppressWarnings("unused")
 @RunWith(Enclosed.class)
 public class LuceneIndexStoreImplTest {
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    Tracing.newBuilder().build();
+  }
+
   public static class TestsWithForgivingLogStore {
     @Rule
     public TemporaryLogStoreAndSearcherRule forgivingLogStore =

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
@@ -6,6 +6,7 @@ import static com.slack.kaldb.testlib.TestKafkaServer.produceMessagesToKafka;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import brave.Tracing;
 import com.adobe.testing.s3mock.junit4.S3MockRule;
 import com.github.charithe.kafka.EphemeralKafkaBroker;
 import com.linecorp.armeria.client.Clients;
@@ -65,6 +66,7 @@ public class KaldbDistributedQueryServiceTest {
   @BeforeClass
   // TODO: This test is very similar to KaldbIndexerTest - explore a TestRule based setup
   public static void initialize() throws Exception {
+    Tracing.newBuilder().build();
     kafkaServer = new TestKafkaServer();
 
     EphemeralKafkaBroker broker = kafkaServer.getBroker();

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
@@ -7,6 +7,7 @@ import static com.slack.kaldb.testlib.MetricsUtil.getCount;
 import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.MAX_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import brave.Tracing;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule;
 import java.io.IOException;
@@ -16,6 +17,7 @@ import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -26,6 +28,11 @@ public class LogIndexSearcherImplTest {
       new TemporaryLogStoreAndSearcherRule(false);
 
   public LogIndexSearcherImplTest() throws IOException {}
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    Tracing.newBuilder().build();
+  }
 
   private void loadTestData(Instant time) {
     strictLogStore.logStore.addMessage(

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImplTest.java
@@ -3,6 +3,7 @@ package com.slack.kaldb.logstore.search;
 import static com.slack.kaldb.testlib.HistogramUtil.makeHistogram;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import brave.Tracing;
 import com.linecorp.armeria.internal.shaded.futures.CompletableFutures;
 import com.slack.kaldb.histogram.Histogram;
 import com.slack.kaldb.histogram.HistogramBucket;
@@ -17,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+import org.junit.Before;
 import org.junit.Test;
 
 public class SearchResultAggregatorImplTest {
@@ -38,6 +40,11 @@ public class SearchResultAggregatorImplTest {
         totalNodes,
         totalSnapshots,
         snapshotsWithReplicas);
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    Tracing.newBuilder().build();
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -7,6 +7,7 @@ import static com.slack.kaldb.testlib.TestKafkaServer.produceMessagesToKafka;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import brave.Tracing;
 import com.adobe.testing.s3mock.junit4.S3MockRule;
 import com.github.charithe.kafka.EphemeralKafkaBroker;
 import com.linecorp.armeria.client.Clients;
@@ -64,6 +65,7 @@ public class KaldbIndexerTest {
 
   @Before
   public void setUp() throws Exception {
+    Tracing.newBuilder().build();
     KaldbConfigUtil.initEmptyIndexerConfig();
     metricsRegistry = new SimpleMeterRegistry();
     chunkManagerUtil =

--- a/kaldb/src/test/java/com/slack/kaldb/server/SearchResultTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/SearchResultTest.java
@@ -2,6 +2,7 @@ package com.slack.kaldb.server;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import brave.Tracing;
 import com.slack.kaldb.histogram.HistogramBucket;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.logstore.search.SearchResult;
@@ -18,7 +19,7 @@ public class SearchResultTest {
 
   @Test
   public void testSearchResultObjectConversions() throws Exception {
-
+    Tracing.newBuilder().build();
     List<LogMessage> logMessages = new ArrayList<>();
     Random random = new Random();
 

--- a/kaldb/src/test/java/com/slack/kaldb/writer/LogMessageWriterImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/LogMessageWriterImplTest.java
@@ -10,6 +10,7 @@ import static com.slack.kaldb.testlib.SpanUtil.makeSpanBuilder;
 import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.MAX_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import brave.Tracing;
 import com.adobe.testing.s3mock.junit4.S3MockRule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
@@ -52,6 +53,7 @@ public class LogMessageWriterImplTest {
 
   @Before
   public void setUp() throws InvalidProtocolBufferException, TimeoutException {
+    Tracing.newBuilder().build();
     KaldbConfigUtil.initEmptyIndexerConfig();
     metricsRegistry = new SimpleMeterRegistry();
     chunkManagerUtil =


### PR DESCRIPTION
Adds support for reporting Zipkin compatible traces, using Brave via the Armeria integration. Also adds a first-pass of instrumentation for the query path.

Also supports log4j2 integration:

> [INFO ] 2021-08-13 12:06:54.352 [armeria-common-worker-nio-2-2] **[trace=c93ded37a0cf9253/f168fe4bb68bc187]** Flags - com.linecorp.armeria.useOpenSsl: true (default)

![Screen Shot 2021-08-13 at 3 11 09 PM](https://user-images.githubusercontent.com/771133/129423257-06a47e3f-2b50-4dc8-b006-22c96d57e262.png)
![Screen Shot 2021-08-13 at 3 11 22 PM](https://user-images.githubusercontent.com/771133/129423259-21eb7e77-02c4-429f-b22e-aef444b09493.png)
![Screen Shot 2021-08-13 at 3 11 38 PM](https://user-images.githubusercontent.com/771133/129423263-eec077ee-9cc6-4104-95b1-cfff31b0b793.png)
