### PR TITLE
Indexing Benchmark Additions

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -5,31 +5,30 @@ Add JMH Dependencies
 
 To run it we can use:
 
-Compile code and benchmarks - 
+Run All Benchmark
 ```
-mvn package -DskipTests=true
-```
-
-Run all benchmarks - 
-```
-java -jar benchmarks/target/benchmarks.jar
+./jmh.sh
 ```
 
-Format - 
+Run a single benchmark Benchmark
 ```
-mvn fmt:format -f benchmarks/pom.xml
+./jmh.sh IndexingBenchmark
 ```
 
 To run it from IntelliJ directly https://plugins.jetbrains.com/plugin/7529-jmh-java-microbenchmark-harness
 
 To find all the JMH supported options use the `-h` flag
 ```
-java -jar benchmarks/target/benchmarks.jar -h
+./jmh.sh -h
 ```
 
 For example to run a benchmark with async profiler
 
 ```
-java -jar benchmarks/target/benchmarks.jar -prof "async:libPath=/Users/vthacker/async-profiler-2.0-macos-x64/build/libasyncProfiler.so;dir=benchmarks/jmh-output/async-profiler/;output=flamegraph;direction=forward"
+./jmh.sh -prof "async:libPath=/Users/vthacker/async-profiler-2.0-macos-x64/build/libasyncProfiler.so;dir=jmh-output/async-profiler/;output=flamegraph;direction=forward"
 ```
 
+Format Code Before Committing -
+```
+mvn fmt:format -f benchmarks/pom.xml
+```

--- a/benchmarks/jmh.sh
+++ b/benchmarks/jmh.sh
@@ -1,11 +1,8 @@
-gcArgs="-XX:+UseG1GC -Xms4g -Xmx4g -XX:MaxGCPauseMillis=10"
-loggingArgs="-Dlog4j.configurationFile=./log4j2.xml"
-
 echo "Building Project"
 mvn clean package -DskipTests=true --file ../pom.xml
 
 echo "JMH benchmarks start"
 
-exec java $loggingArgs $gcArgs -jar ../benchmarks/target/benchmarks.jar "$@"
+exec java -Dlog4j.configurationFile=./log4j2.xml -Xms4g -Xmx4g $gcArgs -jar ../benchmarks/target/benchmarks.jar "$@"
 
 echo "JMH benchmarks done"

--- a/benchmarks/jmh.sh
+++ b/benchmarks/jmh.sh
@@ -1,0 +1,11 @@
+gcArgs="-XX:+UseG1GC -Xms4g -Xmx4g -XX:MaxGCPauseMillis=10"
+loggingArgs="-Dlog4j.configurationFile=./log4j2.xml"
+
+echo "Building Project"
+mvn clean package -DskipTests=true --file ../pom.xml
+
+echo "JMH benchmarks start"
+
+exec java $loggingArgs $gcArgs -jar ../benchmarks/target/benchmarks.jar "$@"
+
+echo "JMH benchmarks done"

--- a/benchmarks/log4j2.xml
+++ b/benchmarks/log4j2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration monitorInterval="30" status="WARN" shutdownHook="disable">
+
+    <Appenders>
+        <Console name="console" target="SYSTEM_OUT">
+            <PatternLayout  pattern="[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n" />
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <AsyncRoot level="${env:LOG_LEVEL:-info}">
+            <AppenderRef ref="console"/>
+        </AsyncRoot>
+    </Loggers>
+
+</Configuration>

--- a/benchmarks/src/main/java/com/slack/kaldb/IndexingBenchmark.java
+++ b/benchmarks/src/main/java/com/slack/kaldb/IndexingBenchmark.java
@@ -52,30 +52,10 @@ public class IndexingBenchmark {
             tempDirectory.toFile(), commitInterval, refreshInterval, registry);
 
     String message =
-        "{\"ip_address\":\"3.86.63.133\",\"http_method\":\"POST\",\"method\":\"callbacks.flannel.verifyToken\","
-            + "\"enterprise\":\"E012Y1ZD5PU\",\"team\":\"T012YTS8XKM\",\"user\":\"U012YTS942X\",\"status\":\"ok\","
-            + "\"http_params\":\"flannel_host=flannelbe-dev-iad-iaz2&include_permissions=falseth\","
-            + "\"ua\":\"Slack-Flannel-Web\\/vef2bd:4046\",\"unique_id\":\"YB2RcPgcUv7PCuIbo8posQAAoDg\","
-            + "\"request_queue_time\":2262,\"microtime_elapsed\":14168,\"mysql_query_count\":0,\"mysql_query_time\":0,"
-            + "\"mysql_conns_count\":0,\"mysql_conns_time\":0,\"mysql_rows_count\":0,\"mysql_rows_affected\":0,"
-            + "\"mc_queries_count\":11,\"mc_queries_time\":6782,\"frl_time\":0,\"init_time\":1283,"
-            + "\"api_dispatch_time\":0,\"api_output_time\":0,\"api_output_size\":0,\"api_strict\":false,"
-            + "\"ekm_decrypt_reqs_time\":0,\"ekm_decrypt_reqs_count\":0,\"ekm_encrypt_reqs_time\":0,"
-            + "\"ekm_encrypt_reqs_count\":0,\"grpc_req_count\":0,\"grpc_req_time\":0,\"agenda_req_count\":0,"
-            + "\"agenda_req_time\":0,\"trace\":\"#route_main() -> lib_controller.php:69#Controller::handlePost() "
-            + "-> Controller.hack:58#CallbackApiController::handleRequest() -> api.php:45#local_callbacks_api_main_inner() "
-            + "-> api.php:250#api_dispatch() -> lib_api.php:179#api_callbacks_flannel_verifyToken() ->"
-            + " api__callbacks_flannel.php:1714#api_output_fb_thrift() -> lib_api_output.php:390#_api_output_log_call()\","
-            + "\"client_connection_state\":\"unset\",\"ms_requests_count\":0,\"ms_requests_time\":0,"
-            + "\"token_type\":\"cookie\",\"limited_access_requester_workspace\":\"\",\"limited_access_allowed_workspaces\":\"\","
-            + "\"repo_auth\":true,\"cf_id\":\"6999afc7b6:haproxy-edge-dev-iad-igu2\",\"external_user\":\"W012XXXFC\","
-            + "\"timestamp\":\"2021-02-05 10:41:52.340\",\"git_sha\":\"unknown\",\"hhvm_version\":\"4.39.0\","
-            + "\"slath\":\"callbacks.flannel.verifyToken\",\"php_type\":\"api\",\"webapp_cluster_pbucket\":0,"
-            + "\"webapp_cluster_name\":\"callbacks\",\"webapp_cluster_nest\":\"normal\","
-            + "\"dev_env\":\"dev-main\",\"pay_product_level\":\"enterprise\",\"type\":\"api_log\",\"level\":\"info\"}";
+        "{\"ip_address\":\"127.0.0.1\",\"http_method\":\"POST\",\"method\":callbacks.test,\"enterprise\":\"E1234ABCD56\",\"team\":\"T98765XYZ12\",\"user\":\"U000111222A\",\"status\":\"ok\",\"http_params\":\"param1=value1&param2=value2&param3=false\",\"ua\":\"Hello-World-Web\\/vef2bd:1234\",\"unique_id\":\"YBBccDDuu17CxYza6abcDEFzYzz\",\"request_queue_time\":2262,\"microtime_elapsed\":1418,\"mysql_query_count\":0,\"mysql_query_time\":0,\"mysql_conns_count\":0,\"mysql_conns_time\":0,\"mysql_rows_count\":0,\"mysql_rows_affected\":0,\"my_queries_count\":11,\"my_queries_time\":6782,\"frl_time\":0,\"init_time\":1283,\"api_dispatch_time\":0,\"api_output_time\":0,\"api_output_size\":0,\"api_strict\":false,\"decrypt_reqs_time\":0,\"decrypt_reqs_count\":0,\"encrypt_reqs_time\":0,\"encrypt_reqs_count\":0,\"grpc_req_count\":0,\"grpc_req_time\":0,\"service_req_count\":0,\"service_req_time\":0,\"trace\":\"#route_main() -> lib_controller.php:12#Controller::handlePost() -> Controller.php:58#CallbackApiController::handleRequest() -> api.php:100#local_callbacks_api_main_inner() -> api.php:250#api_dispatch() -> lib_api.php:000#api_callbacks_service_verifyToken() -> api__callbacks_service.php:1500#api_output_fb_thrift() -> lib_api_output.php:390#_api_output_log_call()\",\"client_connection_state\":\"unset\",\"ms_requests_count\":0,\"ms_requests_time\":0,\"token_type\":\"cookie\",\"another_param\":\"\",\"another_value\":\"\",\"auth\":true,\"ab_id\":\"1234abc12d:host-abc-dev-region-1234\",\"external_user\":\"W012XYZAB\",\"timestamp\":\"2021-02-05 10:41:52.340\",\"sha\":\"unknown\",\"php_version\":\"5.11.0\",\"paramX\":\"yet.another.value\",\"php_type\":\"api\",\"bucket_type_something\":0,\"cluster_name\":\"cluster\",\"cluster_param\":\"normal\",\"env\":\"env-value\",\"last_param\":\"lastvalue\",\"level\":\"info\"};";
 
     String indexName = "hhvm-api_log";
-    String host = "slack-www-hhvm-dev-dev-callbacks-iad-j8zj";
+    String host = "company-www-php-dev-cluster-abc-x8ab";
     long timestamp = 1612550512340953000L;
     Murron.MurronMessage testMurronMsg =
         Murron.MurronMessage.newBuilder()

--- a/benchmarks/src/main/java/com/slack/kaldb/IndexingBenchmark.java
+++ b/benchmarks/src/main/java/com/slack/kaldb/IndexingBenchmark.java
@@ -1,21 +1,26 @@
 package com.slack.kaldb;
 
+import com.google.protobuf.ByteString;
+import com.slack.kaldb.logstore.DocumentBuilder;
+import com.slack.kaldb.logstore.LogDocumentBuilderImpl;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.logstore.LuceneIndexStoreImpl;
+import com.slack.kaldb.writer.LogMessageWriterImpl;
+import com.slack.service.murron.Murron;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Random;
 import java.util.stream.Stream;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.record.TimestampType;
 import org.apache.lucene.document.*;
 import org.apache.lucene.index.IndexWriter;
 import org.openjdk.jmh.annotations.*;
@@ -31,42 +36,73 @@ public class IndexingBenchmark {
   LuceneIndexStoreImpl logStore;
   private Random random;
 
+  private ConsumerRecord<String, byte[]> kafkaRecord;
   private LogMessage logMessage;
-  private Document logDocument;
+  private Document luceneDocument;
 
   @Setup(Level.Iteration)
-  public void createIndexer() throws IOException {
+  public void createIndexer() throws Exception {
     random = new Random();
-    Instant timestamp = Instant.now();
     registry = new SimpleMeterRegistry();
     tempDirectory =
         Files.createDirectories(
-            Paths.get(
-                "benchmarks", "jmh-output", String.valueOf(random.nextInt(Integer.MAX_VALUE))));
+            Paths.get("jmh-output", String.valueOf(random.nextInt(Integer.MAX_VALUE))));
     logStore =
         LuceneIndexStoreImpl.makeLogStore(
             tempDirectory.toFile(), commitInterval, refreshInterval, registry);
 
-    Map<String, Object> fieldMap = new HashMap<>();
-    fieldMap.put(LogMessage.ReservedField.TIMESTAMP.fieldName, timestamp.toString());
-    fieldMap.put(LogMessage.ReservedField.MESSAGE.fieldName, "Log Message");
-    logMessage = new LogMessage("testindex", "INFO", "1", fieldMap);
+    String message =
+        "{\"ip_address\":\"3.86.63.133\",\"http_method\":\"POST\",\"method\":\"callbacks.flannel.verifyToken\","
+            + "\"enterprise\":\"E012Y1ZD5PU\",\"team\":\"T012YTS8XKM\",\"user\":\"U012YTS942X\",\"status\":\"ok\","
+            + "\"http_params\":\"flannel_host=flannelbe-dev-iad-iaz2&include_permissions=falseth\","
+            + "\"ua\":\"Slack-Flannel-Web\\/vef2bd:4046\",\"unique_id\":\"YB2RcPgcUv7PCuIbo8posQAAoDg\","
+            + "\"request_queue_time\":2262,\"microtime_elapsed\":14168,\"mysql_query_count\":0,\"mysql_query_time\":0,"
+            + "\"mysql_conns_count\":0,\"mysql_conns_time\":0,\"mysql_rows_count\":0,\"mysql_rows_affected\":0,"
+            + "\"mc_queries_count\":11,\"mc_queries_time\":6782,\"frl_time\":0,\"init_time\":1283,"
+            + "\"api_dispatch_time\":0,\"api_output_time\":0,\"api_output_size\":0,\"api_strict\":false,"
+            + "\"ekm_decrypt_reqs_time\":0,\"ekm_decrypt_reqs_count\":0,\"ekm_encrypt_reqs_time\":0,"
+            + "\"ekm_encrypt_reqs_count\":0,\"grpc_req_count\":0,\"grpc_req_time\":0,\"agenda_req_count\":0,"
+            + "\"agenda_req_time\":0,\"trace\":\"#route_main() -> lib_controller.php:69#Controller::handlePost() "
+            + "-> Controller.hack:58#CallbackApiController::handleRequest() -> api.php:45#local_callbacks_api_main_inner() "
+            + "-> api.php:250#api_dispatch() -> lib_api.php:179#api_callbacks_flannel_verifyToken() ->"
+            + " api__callbacks_flannel.php:1714#api_output_fb_thrift() -> lib_api_output.php:390#_api_output_log_call()\","
+            + "\"client_connection_state\":\"unset\",\"ms_requests_count\":0,\"ms_requests_time\":0,"
+            + "\"token_type\":\"cookie\",\"limited_access_requester_workspace\":\"\",\"limited_access_allowed_workspaces\":\"\","
+            + "\"repo_auth\":true,\"cf_id\":\"6999afc7b6:haproxy-edge-dev-iad-igu2\",\"external_user\":\"W012XXXFC\","
+            + "\"timestamp\":\"2021-02-05 10:41:52.340\",\"git_sha\":\"unknown\",\"hhvm_version\":\"4.39.0\","
+            + "\"slath\":\"callbacks.flannel.verifyToken\",\"php_type\":\"api\",\"webapp_cluster_pbucket\":0,"
+            + "\"webapp_cluster_name\":\"callbacks\",\"webapp_cluster_nest\":\"normal\","
+            + "\"dev_env\":\"dev-main\",\"pay_product_level\":\"enterprise\",\"type\":\"api_log\",\"level\":\"info\"}";
 
-    // inlines LogDocumentBuilderImpl#fromMessage
-    logDocument = new Document();
-    logDocument.add(new TextField("index", "testindex", Field.Store.NO));
-    logDocument.add(new TextField("id", "1", Field.Store.NO));
-    logDocument.add(new TextField("type", "INFO", Field.Store.NO));
-    logDocument.add(new TextField("message", "Log Message", Field.Store.NO));
+    String indexName = "hhvm-api_log";
+    String host = "slack-www-hhvm-dev-dev-callbacks-iad-j8zj";
+    long timestamp = 1612550512340953000L;
+    Murron.MurronMessage testMurronMsg =
+        Murron.MurronMessage.newBuilder()
+            .setMessage(ByteString.copyFrom(message.getBytes(StandardCharsets.UTF_8)))
+            .setType(indexName)
+            .setHost(host)
+            .setTimestamp(timestamp)
+            .build();
 
-    logDocument.add(new LongPoint("_timesinceepoch", timestamp.toEpochMilli()));
-    logDocument.add(new NumericDocValuesField("_timesinceepoch", timestamp.toEpochMilli()));
+    kafkaRecord =
+        new ConsumerRecord<>(
+            "testTopic",
+            1,
+            10,
+            0L,
+            TimestampType.CREATE_TIME,
+            0L,
+            0,
+            0,
+            "testKey",
+            testMurronMsg.toByteString().toByteArray());
 
-    String value =
-        "{\"id\":\"1\",\"source\":{\"@timestamp\":\""
-            + timestamp.toString()
-            + "\",\"message\":\"Log Message\"},\"index\":\"testindex\",\"type\":\"INFO\"}";
-    logDocument.add(new StoredField("_source", value));
+    logMessage = LogMessageWriterImpl.apiLogTransformer.toLogMessage(kafkaRecord).get(0);
+
+    DocumentBuilder<LogMessage> documentBuilder = LogDocumentBuilderImpl.build(false);
+
+    luceneDocument = documentBuilder.fromMessage(logMessage);
   }
 
   @TearDown(Level.Iteration)
@@ -79,15 +115,23 @@ public class IndexingBenchmark {
   }
 
   @Benchmark
-  public void measureIndexing() {
+  public void measureIndexingAsKafkaSerializedDocument() throws Exception {
+    // Mimic LogMessageWriterImpl#insertRecord kinda without the chunk rollover logic
+    LogMessage localLogMessage =
+        LogMessageWriterImpl.apiLogTransformer.toLogMessage(kafkaRecord).get(0);
+    logStore.addMessage(localLogMessage);
+  }
+
+  @Benchmark
+  public void measureIndexingAsLogMessage() {
     logStore.addMessage(logMessage);
   }
 
   @Benchmark
-  public void measureIndexingToLuceneDirectly() {
+  public void measureIndexingAsLuceneDocument() {
     IndexWriter indexWriter = logStore.getIndexWriter();
     try {
-      indexWriter.addDocument(logDocument);
+      indexWriter.addDocument(luceneDocument);
     } catch (IOException e) {
       e.printStackTrace();
     }


### PR DESCRIPTION
This PR adds a wrapper script that builds and runs the benchmark

Additionally it adds a new indexing benchmark that shows the cost of serialization of kafka messages -> log message -> lucene document

All tests now use the same source data 

```
./jmh.sh

...

Benchmark                                                    Mode  Cnt      Score      Error  Units
IndexingBenchmark.measureIndexingAsKafkaSerializedDocument  thrpt   25  11569.396 ±  501.808  ops/s
IndexingBenchmark.measureIndexingAsLogMessage               thrpt   25  17219.988 ± 1450.424  ops/s
IndexingBenchmark.measureIndexingAsLuceneDocument           thrpt   25  24389.935 ±  699.650  ops/s
```