### PR TITLE
Fix histogram initalization in SearchResultUtils

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -27,7 +27,7 @@ s3Config:
   s3Bucket: ${S3_BUCKET:-test-s3-bucket}
 
 tracingConfig:
-  zipkinEndpoint: ${ZIPKIN_TRACING_ENDPOINT:-http://localhost:9411/api/v2/spans}
+  zipkinEndpoint: ${ZIPKIN_TRACING_ENDPOINT:-}
 
 queryConfig:
   serverPort: ${KALDB_QUERY_SERVER_PORT:-8081}

--- a/config/grafana/provisioning/datasources/automatic.yml
+++ b/config/grafana/provisioning/datasources/automatic.yml
@@ -5,7 +5,26 @@ deleteDatasources:
     orgId: 1
 
 datasources:
-  - name: KalDB
+  - name: KalDB Query
+    type: elasticsearch
+    access: proxy
+    url: "host.docker.internal:8081"
+    password:
+    user:
+    database: testindex
+    basicAuth: false
+    basicAuthUser:
+    basicAuthPassword:
+    withCredentials:
+    isDefault: true
+    jsonData:
+      timeField: "@timestamp"
+      esVersion: 7.0.0
+      maxConcurrentShardRequests: 5
+      logMessageField: "_source"
+      logLevelField: ""
+    version: 1
+  - name: KalDB Index
     type: elasticsearch
     access: proxy
     url: "host.docker.internal:8080"
@@ -16,7 +35,7 @@ datasources:
     basicAuthUser:
     basicAuthPassword:
     withCredentials:
-    isDefault: true
+    isDefault: false
     jsonData:
       timeField: "@timestamp"
       esVersion: 7.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     image: 'grafana/grafana:8.0.3'
     container_name: kaldb_grafana
     ports:
-      - 3000:3000
+      - '3000:3000'
     volumes:
       - ./config/grafana/provisioning:/etc/grafana/provisioning
       - ../slack-kaldb-app:/var/lib/grafana/plugins
@@ -39,18 +39,6 @@ services:
       GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin"
       GF_PATHS_PLUGINS: "/var/lib/grafana/plugins"
       GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: "slack-kaldb-app,slack-kaldb-app-backend-datasource"
-
-  grafana7:
-    image: 'grafana/grafana:7.3.6'
-    container_name: kaldb_grafana7
-    ports:
-      - 3001:3000
-    volumes:
-      - ./config/grafana/provisioning:/etc/grafana/provisioning
-    environment:
-      GF_AUTH_DISABLE_LOGIN_FORM: "true"
-      GF_AUTH_ANONYMOUS_ENABLED: "true"
-      GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin"
 
   s3:
     image: 'adobe/s3mock:2.1.29'

--- a/kaldb/src/main/java/com/slack/kaldb/histogram/HistogramBucket.java
+++ b/kaldb/src/main/java/com/slack/kaldb/histogram/HistogramBucket.java
@@ -13,14 +13,18 @@ public class HistogramBucket implements Comparable<HistogramBucket> {
 
   private double count;
 
-  public HistogramBucket(double low, double high) {
+  public HistogramBucket(double low, double high, double count) {
     if (low >= high) {
       throw new IllegalArgumentException(
           String.format("The low %s should be higher than high %s", low, high));
     }
     this.low = low;
     this.high = high;
-    this.count = 0;
+    this.count = count;
+  }
+
+  public HistogramBucket(double low, double high) {
+    this(low, high, 0);
   }
 
   public void increment(double incr) {

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultUtils.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultUtils.java
@@ -51,7 +51,8 @@ public class SearchResultUtils {
     }
     List<HistogramBucket> histogramBuckets = new ArrayList<>();
     for (KaldbSearch.HistogramBucket protoBucket : protoSearchResult.getBucketsList()) {
-      histogramBuckets.add(new HistogramBucket(protoBucket.getLow(), protoBucket.getHigh()));
+      histogramBuckets.add(
+          new HistogramBucket(protoBucket.getLow(), protoBucket.getHigh(), protoBucket.getCount()));
     }
 
     return new SearchResult<>(


### PR DESCRIPTION
Fixes an issue where histograms were not initialized with a value from the proto results, causing histograms to appear empty from the query server.