### PR TITLE
Cleaner `mvn package`

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -96,7 +96,21 @@
                                 </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
+
                             <filters>
+                                <filter>
+                                    <!--
+                                        Shading signed JARs will fail without this.
+                                        http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                                    -->
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <!-- Exclude module-info.class since it breaks strong encapsulation. -->
+                                        <exclude>module-info.class</exclude>
+                                        <exclude>META-INF/**</exclude>
+                                        <exclude>LICENSE</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
                         </configuration>
                     </execution>
@@ -104,7 +118,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.0.0-M1</version>
+                <version>2.8.1</version>
             </plugin>
         </plugins>
     </build>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -117,10 +117,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.1</version>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -109,6 +109,7 @@
                                         <exclude>module-info.class</exclude>
                                         <exclude>META-INF/**</exclude>
                                         <exclude>LICENSE</exclude>
+                                        <exclude>codegen-resources/**</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -501,7 +501,7 @@
                                         <!-- Exclude module-info.class since it breaks strong encapsulation. -->
                                         <exclude>module-info.class</exclude>
                                         <exclude>META-INF/**</exclude>
-                                        <exclude>*</exclude>
+                                        <exclude>codegen-resources/**</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -281,9 +281,9 @@
             <version>${grpc.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.2</version>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>1.3.5</version>
         </dependency>
 
         <!-- For parsing JSON protobufs. Use jackson? -->

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -498,9 +498,10 @@
                                     -->
                                     <artifact>*:*</artifact>
                                     <excludes>
-                                        <exclude>META-INF/*.SF</exclude>
-                                        <exclude>META-INF/*.DSA</exclude>
-                                        <exclude>META-INF/*.RSA</exclude>
+                                        <!-- Exclude module-info.class since it breaks strong encapsulation. -->
+                                        <exclude>module-info.class</exclude>
+                                        <exclude>META-INF/**</exclude>
+                                        <exclude>*</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -568,10 +568,6 @@
                     <version>2.5</version>
                 </plugin>
                 <plugin>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.1</version>
-                </plugin>
-                <plugin>
                     <artifactId>maven-install-plugin</artifactId>
                     <version>2.5.1</version>
                 </plugin>


### PR DESCRIPTION
Currently, the `mvn package` command emits a lot of warnings since there are duplicate MANIFEST files. In this diff, we do a first pass to  update the build files for a cleaner mvn package command. 

Also, replaced the deprecated javax.annotation package with jakarta.annotation package to clear some warnings.

To have a warning free mvn package step, we still need to resolve overlapping netty package issues. 
