### PR TITLE
Add temporary config option for query indexer lookup

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -32,6 +32,7 @@ tracingConfig:
   zipkinEndpoint: ${ZIPKIN_TRACING_ENDPOINT:-}
 
 queryConfig:
+  tmpIndexNodes:  [${KALDB_INDEX_NODES:-}]
   serverConfig:
     serverPort: ${KALDB_QUERY_SERVER_PORT:-8081}
     serverAddress: ${KALDB_QUERY_SERVER_ADDRESS:-localhost}

--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -25,6 +25,7 @@ import io.micrometer.prometheus.PrometheusMeterRegistry;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -107,6 +108,8 @@ public class Kaldb {
 
     if (roles.contains(KaldbConfigs.NodeRole.QUERY)) {
       KaldbDistributedQueryService searcher = new KaldbDistributedQueryService();
+      KaldbDistributedQueryService.servers =
+          new ArrayList<>(KaldbConfig.get().getQueryConfig().getTmpIndexNodesList());
       final int serverPort = KaldbConfig.get().getQueryConfig().getServerConfig().getServerPort();
       ArmeriaService armeriaService =
           new ArmeriaService(serverPort, prometheusMeterRegistry, searcher, "kalDbQuery");

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -56,6 +56,7 @@ message TracingConfig {
 
 message QueryServiceConfig {
     ServerConfig serverConfig = 1;
+    repeated string tmpIndexNodes = 2;
 }
 
 message IndexerConfig {


### PR DESCRIPTION
Temporary configuration option for defining index servers for query nodes