### PR TITLE
Add gzip compression to responses

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
@@ -69,7 +69,7 @@ public class ElasticsearchApiService {
 
     SearchResponseMetadata responseMetadata = new SearchResponseMetadata(0, responses);
     return HttpResponse.of(
-        HttpStatus.OK, MediaType.JSON, objectMapper.writeValueAsString(responseMetadata));
+        HttpStatus.OK, MediaType.JSON_UTF_8, objectMapper.writeValueAsString(responseMetadata));
   }
 
   private EsSearchResponse doSearch(EsSearchRequest request) throws IOException {

--- a/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
@@ -12,6 +12,7 @@ import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.brave.BraveService;
 import com.linecorp.armeria.server.docs.DocService;
+import com.linecorp.armeria.server.encoding.EncodingService;
 import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
 import com.linecorp.armeria.server.healthcheck.HealthCheckService;
@@ -68,10 +69,15 @@ public class ArmeriaService extends AbstractIdleService {
 
     sb.annotatedService(new ElasticsearchApiService(searcher));
 
+    addCompression(sb);
     addManagementEndpoints(sb);
     addTracing(sb);
 
     return sb.build();
+  }
+
+  private void addCompression(ServerBuilder sb) {
+    sb.decorator(EncodingService.builder().newDecorator());
   }
 
   private void addTracing(ServerBuilder sb) {


### PR DESCRIPTION
Also switches response to `JSON_UTF_8`, as that is supported by the EncodingService by default.