### PR TITLE
Upgrade dependencies, fix event loop issue, cleanup logging

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -32,7 +32,7 @@ tracingConfig:
   zipkinEndpoint: ${ZIPKIN_TRACING_ENDPOINT:-}
 
 queryConfig:
-  tmpIndexNodes:  [${KALDB_INDEX_NODES:-}]
+  tmpIndexNodes:  [${KALDB_INDEX_NODES:-gproto+http://localhost:8080}]
   serverConfig:
     serverPort: ${KALDB_QUERY_SERVER_PORT:-8081}
     serverAddress: ${KALDB_QUERY_SERVER_ADDRESS:-localhost}

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -13,12 +13,12 @@
         <javac.target>11</javac.target>
         <uberjar.name>kaldb</uberjar.name>
         <http.client.version>4.5.13</http.client.version>
-        <http.core.version>4.4.9</http.core.version>
-        <protobuf.version>3.12.0</protobuf.version>
-        <grpc.version>1.30.0</grpc.version>
-        <armeria.version>1.8.0</armeria.version>
+        <http.core.version>4.4.14</http.core.version>
+        <protobuf.version>3.17.3</protobuf.version>
+        <grpc.version>1.40.1</grpc.version>
+        <armeria.version>1.11.0</armeria.version>
         <micrometer.version>1.5.1</micrometer.version>
-        <jackson.version>2.11.1</jackson.version>
+        <jackson.version>2.12.5</jackson.version>
         <lucene.version>8.4.1</lucene.version>
         <curator.version>5.1.0</curator.version>
         <log4j.version>2.14.1</log4j.version>

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
@@ -32,6 +32,7 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
 
   private KaldbServiceGrpc.KaldbServiceFutureStub getKaldbServiceGrpcClient(String server) {
     return Clients.newClient(server, KaldbServiceGrpc.KaldbServiceFutureStub.class)
+        .withCompression("gzip")
         .withInterceptors(GrpcTracing.newBuilder(Tracing.current()).build().newClientInterceptor());
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
@@ -68,7 +68,10 @@ public class ArmeriaService extends AbstractIdleService {
   public Server getServer() {
     ServerBuilder sb = Server.builder();
     GrpcServiceBuilder searchBuilder =
-        GrpcService.builder().addService(searcher).enableUnframedRequests(true);
+        GrpcService.builder()
+            .addService(searcher)
+            .enableUnframedRequests(true)
+            .useBlockingTaskExecutor(true);
     sb.service(searchBuilder.build());
 
     sb.annotatedService(new ElasticsearchApiService(searcher));

--- a/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
@@ -135,6 +135,8 @@ public class ArmeriaService extends AbstractIdleService {
         // Not logging any successful response, say prom scraping /metrics every 30 seconds at INFO
         .successfulResponseLogLevel(LogLevel.DEBUG)
         .failureResponseLogLevel(LogLevel.ERROR)
+        // Remove the content to prevent blowing up the logs
+        .responseContentSanitizer((ctx, content) -> "truncated")
         // Remove all headers to be sure we aren't leaking any auth/cookie info
         .requestHeadersSanitizer((ctx, headers) -> DefaultHttpHeaders.EMPTY_HEADERS);
   }


### PR DESCRIPTION
* Upgrades several dependencies, adds example to tmpIndexNode format for local dev.
* Configured Armeria to use a dedicated event loop for the server instead of relying on the common event pool - which is shared with the clients
* Moves GRPC to blocked task executor - not directly needed but reduces concerns about event loop performance
* Cleanup logging - should prevent excessive logs on errors where the entire response body was logged