### PR TITLE
Add a MetadataStoreService

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -36,3 +36,11 @@ queryConfig:
   serverConfig:
     serverPort: ${KALDB_QUERY_SERVER_PORT:-8081}
     serverAddress: ${KALDB_QUERY_SERVER_ADDRESS:-localhost}
+
+metadataStoreConfig:
+  zookeeperConfig:
+    zkConnectString: "127.0.0.1:2181"
+    zkPathPrefix: "kaldb"
+    zkSessionTimeoutMs: 1000
+    zkConnectionTimeoutMs: 1500
+    sleepBetweenRetriesMs: 500

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -39,8 +39,8 @@ queryConfig:
 
 metadataStoreConfig:
   zookeeperConfig:
-    zkConnectString: "127.0.0.1:2181"
-    zkPathPrefix: "kaldb"
-    zkSessionTimeoutMs: 1000
-    zkConnectionTimeoutMs: 1500
-    sleepBetweenRetriesMs: 500
+    zkConnectString: ${KALDB_ZK_CONNECTION_STRING:-localhost:2181}
+    zkPathPrefix: ${KALDB_ZK_PATH_PREFIX:-kaldb}
+    zkSessionTimeoutMs: ${KALDB_ZK_SESSION_TIMEOUT_MS:-5000}
+    zkConnectionTimeoutMs: ${KALDB_ZK_CONNECT_TIMEOUT_MS:-500}
+    sleepBetweenRetriesMs: ${KALDB_ZK_SLEEP_RETRIES_MS:-100}

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -18,7 +18,7 @@
         <grpc.version>1.40.1</grpc.version>
         <armeria.version>1.11.0</armeria.version>
         <micrometer.version>1.5.1</micrometer.version>
-        <jackson.version>2.12.5</jackson.version>
+        <jackson.version>2.10.5</jackson.version>
         <lucene.version>8.4.1</lucene.version>
         <curator.version>5.1.0</curator.version>
         <log4j.version>2.14.1</log4j.version>
@@ -320,6 +320,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        
         <!-- Apache curator dependencies -->
         <dependency>
             <groupId>org.apache.curator</groupId>

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/search/SearchMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/search/SearchMetadataStore.java
@@ -1,7 +1,6 @@
 package com.slack.kaldb.metadata.search;
 
 import com.slack.kaldb.metadata.core.EphemeralMutableMetadataStore;
-import com.slack.kaldb.metadata.core.MetadataSerializer;
 import com.slack.kaldb.metadata.zookeeper.MetadataStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,12 +9,8 @@ public class SearchMetadataStore extends EphemeralMutableMetadataStore<SearchMet
 
   private static final Logger LOG = LoggerFactory.getLogger(SearchMetadataStore.class);
 
-  public SearchMetadataStore(
-      boolean shouldCache,
-      String storeFolder,
-      MetadataStore metadataStore,
-      MetadataSerializer<SearchMetadata> metadataSerializer)
+  public SearchMetadataStore(MetadataStore metadataStore, String storeFolder, boolean shouldCache)
       throws Exception {
-    super(shouldCache, false, storeFolder, metadataStore, metadataSerializer, LOG);
+    super(shouldCache, false, storeFolder, metadataStore, new SearchMetadataSerializer(), LOG);
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/zookeeper/ZookeeperMetadataStoreImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/zookeeper/ZookeeperMetadataStoreImpl.java
@@ -10,7 +10,9 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.slack.kaldb.metadata.core.KaldbMetadata;
 import com.slack.kaldb.metadata.core.MetadataSerializer;
+import com.slack.kaldb.proto.config.KaldbConfigs;
 import com.slack.kaldb.util.FatalErrorHandler;
+import com.slack.kaldb.util.RuntimeHalterImpl;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.ArrayList;
@@ -23,6 +25,7 @@ import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.CuratorEventType;
+import org.apache.curator.retry.RetryNTimes;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Watcher;
@@ -50,6 +53,20 @@ public class ZookeeperMetadataStoreImpl implements MetadataStore {
   public static final String ZK_FAILED_COUNTER = "metadata.failed.zk";
   public static final String METADATA_WRITE_COUNTER = "metadata.write";
   public static final String METADATA_READ_COUNTER = "metadata.read";
+
+  private static final int ZK_RETRY_COUNT = 3;
+
+  public static ZookeeperMetadataStoreImpl fromConfig(
+      MeterRegistry meterRegistry, KaldbConfigs.ZookeeperConfig zkConfig) {
+    return new ZookeeperMetadataStoreImpl(
+        zkConfig.getZkConnectString(),
+        zkConfig.getZkPathPrefix(),
+        zkConfig.getZkSessionTimeoutMs(),
+        zkConfig.getZkConnectionTimeoutMs(),
+        new RetryNTimes(ZK_RETRY_COUNT, zkConfig.getSleepBetweenRetriesMs()),
+        new RuntimeHalterImpl(),
+        meterRegistry);
+  }
 
   private final CuratorFramework curator;
   private final Counter failureCounter;

--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -77,6 +77,9 @@ public class Kaldb {
 
     HashSet<KaldbConfigs.NodeRole> roles = new HashSet<>(KaldbConfig.get().getNodeRolesList());
 
+    MetadataStoreService metadataStoreService = new MetadataStoreService(prometheusMeterRegistry);
+    services.add(metadataStoreService);
+
     if (roles.contains(KaldbConfigs.NodeRole.INDEX)) {
 
       ChunkManager<LogMessage> chunkManager = ChunkManager.fromConfig(prometheusMeterRegistry);
@@ -94,8 +97,7 @@ public class Kaldb {
       KaldbKafkaWriter kafkaWriter =
           KaldbKafkaWriter.fromConfig(logMessageWriterImpl, prometheusMeterRegistry);
       services.add(kafkaWriter);
-
-      KaldbIndexer indexer = new KaldbIndexer(chunkManager, messageTransformer, kafkaWriter);
+      KaldbIndexer indexer = new KaldbIndexer(chunkManager, kafkaWriter);
       services.add(indexer);
 
       KaldbLocalQueryService<LogMessage> searcher =

--- a/kaldb/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
@@ -91,10 +91,7 @@ public class KaldbIndexer extends AbstractIdleService {
    * messages, persist the indexed messages and metadata successfully and then close the
    * chunkManager and then the consumer,
    */
-  public KaldbIndexer(
-      ChunkManager<LogMessage> chunkManager,
-      LogMessageTransformer messageTransformer,
-      KaldbKafkaWriter kafkaWriter) {
+  public KaldbIndexer(ChunkManager<LogMessage> chunkManager, KaldbKafkaWriter kafkaWriter) {
     checkNotNull(chunkManager, "Chunk manager can't be null");
     this.chunkManager = chunkManager;
     this.kafkaWriter = kafkaWriter;

--- a/kaldb/src/main/java/com/slack/kaldb/server/MetadataStoreService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/MetadataStoreService.java
@@ -1,0 +1,38 @@
+package com.slack.kaldb.server;
+
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.slack.kaldb.config.KaldbConfig;
+import com.slack.kaldb.metadata.zookeeper.MetadataStore;
+import com.slack.kaldb.metadata.zookeeper.ZookeeperMetadataStoreImpl;
+import com.slack.kaldb.proto.config.KaldbConfigs;
+import io.micrometer.core.instrument.MeterRegistry;
+
+public class MetadataStoreService extends AbstractIdleService {
+  private final MeterRegistry meterRegistry;
+  private final KaldbConfigs.ZookeeperConfig zookeeperConfig;
+  private MetadataStore metadataStore;
+
+  public MetadataStoreService(MeterRegistry meterRegistry) {
+    this(meterRegistry, KaldbConfig.get().getMetadataStoreConfig().getZookeeperConfig());
+  }
+
+  public MetadataStoreService(
+      MeterRegistry meterRegistry, KaldbConfigs.ZookeeperConfig zookeeperConfig) {
+    this.meterRegistry = meterRegistry;
+    this.zookeeperConfig = zookeeperConfig;
+  }
+
+  @Override
+  protected void startUp() {
+    metadataStore = ZookeeperMetadataStoreImpl.fromConfig(meterRegistry, zookeeperConfig);
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    metadataStore.close();
+  }
+
+  public MetadataStore getMetadataStore() {
+    return metadataStore;
+  }
+}

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -37,9 +37,9 @@ message MetadataStoreConfig {
 message ZookeeperConfig {
     string zkConnectString = 1;
     string zkPathPrefix = 2;
-    int64 zkSessionTimeoutMs = 3;
-    int64 zkConnectionTimeoutMs = 4;
-    int64 sleepBetweenRetriesMs = 5;
+    int32 zkSessionTimeoutMs = 3;
+    int32 zkConnectionTimeoutMs = 4;
+    int32 sleepBetweenRetriesMs = 5;
 }
 
 message S3Config {

--- a/kaldb/src/test/java/com/slack/kaldb/config/KaldbConfigTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/config/KaldbConfigTest.java
@@ -187,8 +187,8 @@ public class KaldbConfigTest {
 
     final KaldbConfigs.MetadataStoreConfig metadataStoreConfig = config.getMetadataStoreConfig();
     final KaldbConfigs.ZookeeperConfig zookeeperConfig = metadataStoreConfig.getZookeeperConfig();
-    assertThat(zookeeperConfig.getZkConnectString()).isEqualTo("zk://1.2.3.4:9092");
-    assertThat(zookeeperConfig.getZkPathPrefix()).isEqualTo("/root/zkPath");
+    assertThat(zookeeperConfig.getZkConnectString()).isEqualTo("1.2.3.4:9092");
+    assertThat(zookeeperConfig.getZkPathPrefix()).isEqualTo("zkPrefix");
     assertThat(zookeeperConfig.getZkSessionTimeoutMs()).isEqualTo(1000);
     assertThat(zookeeperConfig.getZkConnectionTimeoutMs()).isEqualTo(1500);
     assertThat(zookeeperConfig.getSleepBetweenRetriesMs()).isEqualTo(500);
@@ -247,8 +247,8 @@ public class KaldbConfigTest {
 
     final KaldbConfigs.MetadataStoreConfig metadataStoreConfig = config.getMetadataStoreConfig();
     final KaldbConfigs.ZookeeperConfig zookeeperConfig = metadataStoreConfig.getZookeeperConfig();
-    assertThat(zookeeperConfig.getZkConnectString()).isEqualTo("zk://1.2.3.4:9092");
-    assertThat(zookeeperConfig.getZkPathPrefix()).isEqualTo("/root/zkPath");
+    assertThat(zookeeperConfig.getZkConnectString()).isEqualTo("1.2.3.4:9092");
+    assertThat(zookeeperConfig.getZkPathPrefix()).isEqualTo("zkPrefix");
     assertThat(zookeeperConfig.getZkSessionTimeoutMs()).isEqualTo(1000);
     assertThat(zookeeperConfig.getZkConnectionTimeoutMs()).isEqualTo(1500);
     assertThat(zookeeperConfig.getSleepBetweenRetriesMs()).isEqualTo(500);

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
@@ -81,7 +81,9 @@ public class KaldbDistributedQueryServiceTest {
             TEST_KAFKA_PARTITION_1,
             KALDB_TEST_CLIENT,
             TEST_S3_BUCKET,
-            8081);
+            8081,
+            "",
+            "");
 
     // Needed to set refresh/commit interval etc
     // Will be same for both indexing servers
@@ -102,7 +104,9 @@ public class KaldbDistributedQueryServiceTest {
             TEST_KAFKA_PARTITION_2,
             KALDB_TEST_CLIENT,
             TEST_S3_BUCKET,
-            8081);
+            8081,
+            "",
+            "");
 
     // Set it to the new config so that the new kafka writer picks up this config
     KaldbConfig.initFromConfigObject(kaldbConfig2);
@@ -170,8 +174,7 @@ public class KaldbDistributedQueryServiceTest {
     kafkaWriter.startAsync();
     kafkaWriter.awaitRunning(DEFAULT_START_STOP_DURATION);
 
-    KaldbIndexer indexer =
-        new KaldbIndexer(chunkManagerUtil.chunkManager, messageTransformer, kafkaWriter);
+    KaldbIndexer indexer = new KaldbIndexer(chunkManagerUtil.chunkManager, kafkaWriter);
     indexer.startAsync();
     indexer.awaitRunning(DEFAULT_START_STOP_DURATION);
 

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/search/SearchMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/search/SearchMetadataStoreTest.java
@@ -46,8 +46,7 @@ public class SearchMetadataStoreTest {
 
   @Test
   public void testSearchMetadataStoreIsNotUpdatable() throws Exception {
-    store =
-        new SearchMetadataStore(true, "/search", zkMetadataStore, new SearchMetadataSerializer());
+    store = new SearchMetadataStore(zkMetadataStore, "/search", true);
     SearchMetadata searchMetadata = new SearchMetadata("test", "snapshot", "http");
     Throwable ex = catchThrowable(() -> store.update(searchMetadata));
     assertThat(ex).isInstanceOf(UnsupportedOperationException.class);

--- a/kaldb/src/test/java/com/slack/kaldb/server/KalDbIntegrationTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KalDbIntegrationTest.java
@@ -1,0 +1,84 @@
+package com.slack.kaldb.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.slack.kaldb.config.KaldbConfig;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KalDbIntegrationTest {
+  private static final Logger LOG = LoggerFactory.getLogger(KalDbIntegrationTest.class);
+
+  private Kaldb kaldb;
+  private final ObjectMapper om = new ObjectMapper();
+
+  @Before
+  public void start() throws IOException {
+    KaldbConfig.reset();
+    kaldb = new Kaldb(Path.of("../config/config.yaml"));
+    LOG.info("Starting kalDb with the resolved configs: {}", KaldbConfig.get().toString());
+    kaldb.start();
+    kaldb.serviceManager.awaitHealthy();
+  }
+
+  @After
+  public void shutdown() {
+    kaldb.shutdown();
+    KaldbConfig.reset();
+  }
+
+  private String getResponse(String url) {
+    try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+      HttpGet httpGet = new HttpGet(url);
+      try (CloseableHttpResponse httpResponse = httpclient.execute(httpGet)) {
+        HttpEntity entity = httpResponse.getEntity();
+
+        String response = EntityUtils.toString(entity);
+        EntityUtils.consume(entity);
+        return response;
+      }
+    } catch (IOException e) {
+      return null;
+    }
+  }
+
+  @Test
+  public void testIndexStartupHealthcheck() throws JsonProcessingException {
+    String response =
+        getResponse(
+            String.format(
+                "http://localhost:%s/health",
+                KaldbConfig.get().getIndexerConfig().getServerConfig().getServerPort()));
+    HashMap<String, Object> map = om.readValue(response, HashMap.class);
+
+    LOG.info(String.format("Response from healthcheck - '%s'", response));
+    assertThat(map.get("healthy")).isEqualTo(true);
+  }
+
+  @Test
+  public void testQueryStartupHealthcheck() throws JsonProcessingException {
+    String response =
+        getResponse(
+            String.format(
+                "http://localhost:%s/health",
+                KaldbConfig.get().getQueryConfig().getServerConfig().getServerPort()));
+    HashMap<String, Object> map = om.readValue(response, HashMap.class);
+
+    LOG.info(String.format("Response from healthcheck - '%s'", response));
+    assertThat(map.get("healthy")).isEqualTo(true);
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -127,7 +127,9 @@ public class KaldbIndexerTest {
             TEST_KAFKA_PARTITION,
             KALDB_TEST_CLIENT,
             TEST_S3_BUCKET,
-            8081);
+            8081,
+            "",
+            "");
     KaldbConfig.initFromConfigObject(kaldbCfg);
 
     LogMessageTransformer messageTransformer = KaldbIndexer.dataTransformerMap.get("api_log");
@@ -142,7 +144,7 @@ public class KaldbIndexerTest {
     ServerBuilder sb = Server.builder();
     sb.http(kaldbCfg.getIndexerConfig().getServerConfig().getServerPort());
     sb.service("/ping", (ctx, req) -> HttpResponse.of("pong!"));
-    kaldbIndexer = new KaldbIndexer(chunkManager, messageTransformer, kafkaWriter);
+    kaldbIndexer = new KaldbIndexer(chunkManager, kafkaWriter);
     kaldbIndexer.startAsync();
     kaldbIndexer.awaitRunning(DEFAULT_START_STOP_DURATION);
     await().until(() -> kafkaServer.getConnectedConsumerGroups() == 1);

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/KaldbConfigUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/KaldbConfigUtil.java
@@ -17,7 +17,9 @@ public class KaldbConfigUtil {
       int kafkaPartition,
       String kafkaClientGroup,
       String s3Bucket,
-      int queryPort) {
+      int queryPort,
+      String metadataZkConnectionString,
+      String metadataZkPathPrefix) {
     KaldbConfigs.KafkaConfig kafkaConfig =
         KaldbConfigs.KafkaConfig.newBuilder()
             .setKafkaTopic(kafkaTopic)
@@ -47,6 +49,17 @@ public class KaldbConfigUtil {
             .setDataTransformer("log_message")
             .build();
 
+    KaldbConfigs.ZookeeperConfig zkConfig =
+        KaldbConfigs.ZookeeperConfig.newBuilder()
+            .setZkConnectString(metadataZkConnectionString)
+            .setZkPathPrefix(metadataZkPathPrefix)
+            .setZkSessionTimeoutMs(15000)
+            .setZkConnectionTimeoutMs(15000)
+            .setSleepBetweenRetriesMs(1000)
+            .build();
+    KaldbConfigs.MetadataStoreConfig metadataStoreConfig =
+        KaldbConfigs.MetadataStoreConfig.newBuilder().setZookeeperConfig(zkConfig).build();
+
     KaldbConfigs.QueryServiceConfig queryConfig =
         KaldbConfigs.QueryServiceConfig.newBuilder()
             .setServerConfig(
@@ -61,6 +74,7 @@ public class KaldbConfigUtil {
         .setS3Config(s3Config)
         .setIndexerConfig(indexerConfig)
         .setQueryConfig(queryConfig)
+        .setMetadataStoreConfig(metadataStoreConfig)
         .build();
   }
 }

--- a/kaldb/src/test/resources/test_config.json
+++ b/kaldb/src/test/resources/test_config.json
@@ -38,8 +38,8 @@
   },
   "metadataStoreConfig": {
     "zookeeperConfig": {
-      "zkConnectString": "zk://1.2.3.4:9092",
-      "zkPathPrefix":  "/root/zkPath",
+      "zkConnectString": "1.2.3.4:9092",
+      "zkPathPrefix":  "zkPrefix",
       "zkSessionTimeoutMs": 1000,
       "zkConnectionTimeoutMs": 1500,
       "sleepBetweenRetriesMs": 500

--- a/kaldb/src/test/resources/test_config.yaml
+++ b/kaldb/src/test/resources/test_config.yaml
@@ -35,8 +35,8 @@ s3Config:
 
 metadataStoreConfig:
   zookeeperConfig:
-    zkConnectString: "zk://1.2.3.4:9092"
-    zkPathPrefix: "/root/zkPath"
+    zkConnectString: "1.2.3.4:9092"
+    zkPathPrefix: "zkPrefix"
     zkSessionTimeoutMs: 1000
     zkConnectionTimeoutMs: 1500
     sleepBetweenRetriesMs: 500


### PR DESCRIPTION
Reintroduces the `MetadataStoreService` originally proposed in #101, and rolled back in #115.

This includes fixes for the missing configs, updates the tests to assert that the correct curator strings are provided, and adds an integration test to assert that `KalDb` can successfully start and pass a simple healthcheck.