### PR TITLE
[Draft] Field conflicts when type conversion to text is disabled.

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LogDocumentBuilderImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LogDocumentBuilderImpl.java
@@ -202,7 +202,7 @@ public class LogDocumentBuilderImpl implements DocumentBuilder<LogMessage> {
     // Match int
     if (value instanceof Integer) {
       int intValue = (Integer) value;
-      if (desc.propertyType.equals(PropertyType.INTEGER)) {
+      if (!desc.propertyType.equals(PropertyType.INTEGER)) {
         // TODO: Add a test to ensure IntPoint works as well as IntField.
         // TODO: GetStoreEnum field is missing as a param.
         if (desc.isIndexed) {

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreImpl.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 import org.apache.commons.io.FileUtils;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
@@ -185,7 +186,9 @@ public class LuceneIndexStoreImpl implements LogStore<LogMessage> {
     try {
       messagesReceivedCounter.increment();
       if (indexWriter.isPresent()) {
-        indexWriter.get().addDocument(documentBuilder.fromMessage(message));
+        final Document doc = documentBuilder.fromMessage(message);
+        LOG.info(doc.toString());
+        indexWriter.get().addDocument(doc);
       } else {
         LOG.warn("IndexWriter should never be null when adding a message");
         throw new IllegalStateException("Index writer should never be null when adding a message");

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/FieldConflictsTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/FieldConflictsTest.java
@@ -156,6 +156,16 @@ public class FieldConflictsTest {
             1);
     assertThat(searchByString.size()).isEqualTo(1);
 
+    final String conflictingTypeByExactString = conflictingFieldName + ":\"1\"";
+    Collection<LogMessage> searchByExactString =
+        findAllMessages(
+            strictLogStore.logSearcher,
+            MessageUtil.TEST_INDEX_NAME,
+            conflictingTypeByExactString,
+            1000,
+            1);
+    assertThat(searchByExactString.size()).isEqualTo(1);
+
     final String conflictingTypeByNumber = conflictingFieldName + ":200";
     Collection<LogMessage> searchByNumber =
         findAllMessages(

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/FieldConflictsTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/FieldConflictsTest.java
@@ -51,7 +51,7 @@ public class FieldConflictsTest {
         new LogMessage(
             MessageUtil.TEST_INDEX_NAME,
             "INFO",
-            "1",
+            "2",
             Map.of(
                 LogMessage.ReservedField.TIMESTAMP.fieldName,
                 MessageUtil.getCurrentLogDate(),
@@ -100,6 +100,24 @@ public class FieldConflictsTest {
   public void testFieldConflictingFieldTypeWithDifferentValue() throws InterruptedException {
     final String conflictingFieldName = "conflictingField";
 
+    LogMessage msg0 =
+        new LogMessage(
+            MessageUtil.TEST_INDEX_NAME,
+            "INFO",
+            "0",
+            Map.of(
+                LogMessage.ReservedField.TIMESTAMP.fieldName,
+                MessageUtil.getCurrentLogDate(),
+                LogMessage.ReservedField.MESSAGE.fieldName,
+                "Test message",
+                LogMessage.ReservedField.TAG.fieldName,
+                "foo-bar",
+                LogMessage.ReservedField.HOSTNAME.fieldName,
+                "host1-dc2.abc.com",
+                conflictingFieldName,
+                "1"));
+    strictLogStore.logStore.addMessage(msg0);
+
     LogMessage msg1 =
         new LogMessage(
             MessageUtil.TEST_INDEX_NAME,
@@ -115,14 +133,14 @@ public class FieldConflictsTest {
                 LogMessage.ReservedField.HOSTNAME.fieldName,
                 "host1-dc2.abc.com",
                 conflictingFieldName,
-                "1"));
+                "one"));
     strictLogStore.logStore.addMessage(msg1);
 
     LogMessage msg2 =
         new LogMessage(
             MessageUtil.TEST_INDEX_NAME,
             "INFO",
-            "1",
+            "2",
             Map.of(
                 LogMessage.ReservedField.TIMESTAMP.fieldName,
                 MessageUtil.getCurrentLogDate(),
@@ -144,7 +162,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> resultsByHost =
         findAllMessages(
             strictLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, queryByHost, 1000, 1);
-    assertThat(resultsByHost.size()).isEqualTo(2);
+    assertThat(resultsByHost.size()).isEqualTo(3);
 
     final String conflictingTypeByString = conflictingFieldName + ":1";
     Collection<LogMessage> searchByString =
@@ -165,6 +183,26 @@ public class FieldConflictsTest {
             1000,
             1);
     assertThat(searchByExactString.size()).isEqualTo(1);
+
+    final String conflictingTypeByString1 = conflictingFieldName + ":one";
+    Collection<LogMessage> searchByString1 =
+        findAllMessages(
+            strictLogStore.logSearcher,
+            MessageUtil.TEST_INDEX_NAME,
+            conflictingTypeByString1,
+            1000,
+            1);
+    assertThat(searchByString1.size()).isEqualTo(1);
+
+    final String conflictingTypeByExactString1 = conflictingFieldName + ":\"one\"";
+    Collection<LogMessage> searchByExactString1 =
+        findAllMessages(
+            strictLogStore.logSearcher,
+            MessageUtil.TEST_INDEX_NAME,
+            conflictingTypeByExactString1,
+            1000,
+            1);
+    assertThat(searchByExactString1.size()).isEqualTo(1);
 
     final String conflictingTypeByNumber = conflictingFieldName + ":200";
     Collection<LogMessage> searchByNumber =

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/FieldConflictsTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/FieldConflictsTest.java
@@ -83,7 +83,7 @@ public class FieldConflictsTest {
             conflictingTypeByNumber,
             1000,
             1);
-    assertThat(searchByInt.size()).isEqualTo(2);
+    assertThat(searchByInt.size()).isEqualTo(1); // only text field can be retrieved.
 
     final String conflictingTypeExactMatch = conflictingFieldName + ":\"1\"";
     Collection<LogMessage> searchByNumber =
@@ -93,7 +93,7 @@ public class FieldConflictsTest {
             conflictingTypeExactMatch,
             1000,
             1);
-    assertThat(searchByNumber.size()).isEqualTo(2);
+    assertThat(searchByNumber.size()).isEqualTo(1); // only text field can be retrieved.
   }
 
   @Test
@@ -212,7 +212,7 @@ public class FieldConflictsTest {
             conflictingTypeByNumber,
             1000,
             1);
-    assertThat(searchByNumber.size()).isEqualTo(1);
+    assertThat(searchByNumber.size()).isEqualTo(0); // Can't retrieve int field.
 
     final String conflictingTypeByNumberString = conflictingFieldName + ":\"200\"";
     Collection<LogMessage> searchByNumberString =
@@ -222,6 +222,6 @@ public class FieldConflictsTest {
             conflictingTypeByNumberString,
             1000,
             1);
-    assertThat(searchByNumberString.size()).isEqualTo(1);
+    assertThat(searchByNumberString.size()).isEqualTo(0); // Can't retrieve int field.
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/FieldConflictsTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/FieldConflictsTest.java
@@ -1,0 +1,179 @@
+package com.slack.kaldb.logstore;
+
+import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.findAllMessages;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import brave.Tracing;
+import com.slack.kaldb.testlib.MessageUtil;
+import com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class FieldConflictsTest {
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    Tracing.newBuilder().build();
+  }
+
+  @Rule
+  public TemporaryLogStoreAndSearcherRule strictLogStore =
+      new TemporaryLogStoreAndSearcherRule(false);
+
+  public FieldConflictsTest() throws IOException {}
+
+  @Test
+  public void testFieldConflictingFieldTypeWithSameValue() throws InterruptedException {
+    final String conflictingFieldName = "conflictingField";
+
+    LogMessage msg1 =
+        new LogMessage(
+            MessageUtil.TEST_INDEX_NAME,
+            "INFO",
+            "1",
+            Map.of(
+                LogMessage.ReservedField.TIMESTAMP.fieldName,
+                MessageUtil.getCurrentLogDate(),
+                LogMessage.ReservedField.MESSAGE.fieldName,
+                "Test message",
+                LogMessage.ReservedField.TAG.fieldName,
+                "foo-bar",
+                LogMessage.ReservedField.HOSTNAME.fieldName,
+                "host1-dc2.abc.com",
+                conflictingFieldName,
+                "1"));
+    strictLogStore.logStore.addMessage(msg1);
+
+    LogMessage msg2 =
+        new LogMessage(
+            MessageUtil.TEST_INDEX_NAME,
+            "INFO",
+            "1",
+            Map.of(
+                LogMessage.ReservedField.TIMESTAMP.fieldName,
+                MessageUtil.getCurrentLogDate(),
+                LogMessage.ReservedField.MESSAGE.fieldName,
+                "Test message",
+                LogMessage.ReservedField.TAG.fieldName,
+                "foo-bar",
+                LogMessage.ReservedField.HOSTNAME.fieldName,
+                "host1-dc2.abc.com",
+                conflictingFieldName,
+                1));
+    strictLogStore.logStore.addMessage(msg2);
+
+    strictLogStore.logStore.commit();
+    strictLogStore.logStore.refresh();
+    Thread.sleep(1000);
+
+    final String queryByHost = "hostname:host1-dc2.abc.com";
+    Collection<LogMessage> resultsByHost =
+        findAllMessages(
+            strictLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, queryByHost, 1000, 1);
+    assertThat(resultsByHost.size()).isEqualTo(2);
+
+    final String conflictingTypeByNumber = conflictingFieldName + ":1";
+    Collection<LogMessage> searchByInt =
+        findAllMessages(
+            strictLogStore.logSearcher,
+            MessageUtil.TEST_INDEX_NAME,
+            conflictingTypeByNumber,
+            1000,
+            1);
+    assertThat(searchByInt.size()).isEqualTo(2);
+
+    final String conflictingTypeExactMatch = conflictingFieldName + ":\"1\"";
+    Collection<LogMessage> searchByNumber =
+        findAllMessages(
+            strictLogStore.logSearcher,
+            MessageUtil.TEST_INDEX_NAME,
+            conflictingTypeExactMatch,
+            1000,
+            1);
+    assertThat(searchByNumber.size()).isEqualTo(2);
+  }
+
+  @Test
+  public void testFieldConflictingFieldTypeWithDifferentValue() throws InterruptedException {
+    final String conflictingFieldName = "conflictingField";
+
+    LogMessage msg1 =
+        new LogMessage(
+            MessageUtil.TEST_INDEX_NAME,
+            "INFO",
+            "1",
+            Map.of(
+                LogMessage.ReservedField.TIMESTAMP.fieldName,
+                MessageUtil.getCurrentLogDate(),
+                LogMessage.ReservedField.MESSAGE.fieldName,
+                "Test message",
+                LogMessage.ReservedField.TAG.fieldName,
+                "foo-bar",
+                LogMessage.ReservedField.HOSTNAME.fieldName,
+                "host1-dc2.abc.com",
+                conflictingFieldName,
+                "1"));
+    strictLogStore.logStore.addMessage(msg1);
+
+    LogMessage msg2 =
+        new LogMessage(
+            MessageUtil.TEST_INDEX_NAME,
+            "INFO",
+            "1",
+            Map.of(
+                LogMessage.ReservedField.TIMESTAMP.fieldName,
+                MessageUtil.getCurrentLogDate(),
+                LogMessage.ReservedField.MESSAGE.fieldName,
+                "Test message",
+                LogMessage.ReservedField.TAG.fieldName,
+                "foo-bar",
+                LogMessage.ReservedField.HOSTNAME.fieldName,
+                "host1-dc2.abc.com",
+                conflictingFieldName,
+                200));
+    strictLogStore.logStore.addMessage(msg2);
+
+    strictLogStore.logStore.commit();
+    strictLogStore.logStore.refresh();
+    Thread.sleep(1000);
+
+    final String queryByHost = "hostname:host1-dc2.abc.com";
+    Collection<LogMessage> resultsByHost =
+        findAllMessages(
+            strictLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, queryByHost, 1000, 1);
+    assertThat(resultsByHost.size()).isEqualTo(2);
+
+    final String conflictingTypeByString = conflictingFieldName + ":1";
+    Collection<LogMessage> searchByString =
+        findAllMessages(
+            strictLogStore.logSearcher,
+            MessageUtil.TEST_INDEX_NAME,
+            conflictingTypeByString,
+            1000,
+            1);
+    assertThat(searchByString.size()).isEqualTo(1);
+
+    final String conflictingTypeByNumber = conflictingFieldName + ":200";
+    Collection<LogMessage> searchByNumber =
+        findAllMessages(
+            strictLogStore.logSearcher,
+            MessageUtil.TEST_INDEX_NAME,
+            conflictingTypeByNumber,
+            1000,
+            1);
+    assertThat(searchByNumber.size()).isEqualTo(1);
+
+    final String conflictingTypeByNumberString = conflictingFieldName + ":\"200\"";
+    Collection<LogMessage> searchByNumberString =
+        findAllMessages(
+            strictLogStore.logSearcher,
+            MessageUtil.TEST_INDEX_NAME,
+            conflictingTypeByNumberString,
+            1000,
+            1);
+    assertThat(searchByNumberString.size()).isEqualTo(1);
+  }
+}


### PR DESCRIPTION
This diff shows the field conflict issue when type conversion is disabled and how it affects the search query. As we can see in the updated test, we can only query for the string fields via the query parser.

Currently, only the int field is changed to keep the diff simple, but that might cause some unit tests to fail.

This diff is for demo only, so don't merge this.

