### PR TITLE
Add local Kafka test util

### DIFF
--- a/kaldb/src/test/java/com/slack/kaldb/util/LocalKafkaSeed.java
+++ b/kaldb/src/test/java/com/slack/kaldb/util/LocalKafkaSeed.java
@@ -1,0 +1,27 @@
+package com.slack.kaldb.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.github.charithe.kafka.EphemeralKafkaBroker;
+import com.slack.kaldb.testlib.TestKafkaServer;
+import java.time.Instant;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class LocalKafkaSeed {
+
+  /**
+   * Initializes local kafka broker with sample messages occurring in the immediate future.
+   *
+   * <p>This test is intended for local debugging purposes, and will be executed manually as needed.
+   */
+  @Ignore
+  @Test
+  public void seedLocalBrokerWithSampleData()
+      throws ExecutionException, InterruptedException, JsonProcessingException, TimeoutException {
+    EphemeralKafkaBroker broker = EphemeralKafkaBroker.create(9092, 2181);
+    final Instant startTime = Instant.now();
+    TestKafkaServer.produceMessagesToKafka(broker, startTime);
+  }
+}


### PR DESCRIPTION
Adds the ability to easily seed the local Kafka instance with messages that can be consumed by the Indexer.