### PR TITLE
Refactor cache node ZK path

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
@@ -111,9 +111,9 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
             slotName, Metadata.CacheSlotState.FREE, "", Instant.now().toEpochMilli());
     cacheSlotMetadataStore.createSync(cacheSlotMetadata);
 
-    CacheSlotMetadataStore cacheSlotNodeMetadataStore =
+    CacheSlotMetadataStore cacheSlotListenerMetadataStore =
         new CacheSlotMetadataStore(metadataStoreService.getMetadataStore(), slotName, true);
-    cacheSlotNodeMetadataStore.addListener(cacheNodeListener());
+    cacheSlotListenerMetadataStore.addListener(cacheNodeListener());
     previousSlotState = Metadata.CacheSlotState.FREE;
 
     Collection<Tag> meterTags = ImmutableList.of(Tag.of("slotName", slotName));

--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/CachingChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/CachingChunkManager.java
@@ -1,15 +1,13 @@
 package com.slack.kaldb.chunkManager;
 
 import static com.slack.kaldb.config.KaldbConfig.DEFAULT_START_STOP_DURATION;
-import static com.slack.kaldb.config.KaldbConfig.REPLICA_STORE_ZK_PATH;
-import static com.slack.kaldb.config.KaldbConfig.SEARCH_METADATA_STORE_ZK_PATH;
-import static com.slack.kaldb.config.KaldbConfig.SNAPSHOT_METADATA_STORE_ZK_PATH;
 
 import com.slack.kaldb.blobfs.s3.S3BlobFs;
 import com.slack.kaldb.chunk.ReadOnlyChunkImpl;
 import com.slack.kaldb.chunk.SearchContext;
 import com.slack.kaldb.config.KaldbConfig;
 import com.slack.kaldb.logstore.LogMessage;
+import com.slack.kaldb.metadata.cache.CacheSlotMetadataStore;
 import com.slack.kaldb.metadata.replica.ReplicaMetadataStore;
 import com.slack.kaldb.metadata.search.SearchMetadataStore;
 import com.slack.kaldb.metadata.snapshot.SnapshotMetadataStore;
@@ -58,14 +56,13 @@ public class CachingChunkManager<T> extends ChunkManager<T> {
     metadataStoreService.awaitRunning(DEFAULT_START_STOP_DURATION);
 
     ReplicaMetadataStore replicaMetadataStore =
-        new ReplicaMetadataStore(
-            metadataStoreService.getMetadataStore(), REPLICA_STORE_ZK_PATH, false);
+        new ReplicaMetadataStore(metadataStoreService.getMetadataStore(), false);
     SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(
-            metadataStoreService.getMetadataStore(), SNAPSHOT_METADATA_STORE_ZK_PATH, false);
+        new SnapshotMetadataStore(metadataStoreService.getMetadataStore(), false);
     SearchMetadataStore searchMetadataStore =
-        new SearchMetadataStore(
-            metadataStoreService.getMetadataStore(), SEARCH_METADATA_STORE_ZK_PATH, false);
+        new SearchMetadataStore(metadataStoreService.getMetadataStore(), false);
+    CacheSlotMetadataStore cacheSlotMetadataStore =
+        new CacheSlotMetadataStore(metadataStoreService.getMetadataStore(), false);
 
     for (int i = 0; i < slotCountPerInstance; i++) {
       chunkList.add(
@@ -76,6 +73,7 @@ public class CachingChunkManager<T> extends ChunkManager<T> {
               searchContext,
               s3Bucket,
               dataDirectoryPrefix,
+              cacheSlotMetadataStore,
               replicaMetadataStore,
               snapshotMetadataStore,
               searchMetadataStore));

--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/IndexingChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/IndexingChunkManager.java
@@ -309,17 +309,10 @@ public class IndexingChunkManager<T> extends ChunkManager<T> {
     LOG.info("Starting indexing chunk manager");
     metadataStoreService.awaitRunning(KaldbConfig.DEFAULT_START_STOP_DURATION);
 
-    searchMetadataStore =
-        new SearchMetadataStore(
-            metadataStoreService.getMetadataStore(),
-            KaldbConfig.SEARCH_METADATA_STORE_ZK_PATH,
-            false);
+    searchMetadataStore = new SearchMetadataStore(metadataStoreService.getMetadataStore(), false);
 
     snapshotMetadataStore =
-        new SnapshotMetadataStore(
-            metadataStoreService.getMetadataStore(),
-            KaldbConfig.SNAPSHOT_METADATA_STORE_ZK_PATH,
-            false);
+        new SnapshotMetadataStore(metadataStoreService.getMetadataStore(), false);
 
     // TODO: Move this registration closer to chunk metadata
     SearchMetadata searchMetadata =

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaCreatorService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaCreatorService.java
@@ -1,7 +1,6 @@
 package com.slack.kaldb.clusterManager;
 
 import static com.slack.kaldb.config.KaldbConfig.DEFAULT_START_STOP_DURATION;
-import static com.slack.kaldb.config.KaldbConfig.REPLICA_STORE_ZK_PATH;
 
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.slack.kaldb.metadata.core.KaldbMetadataStoreChangeListener;
@@ -39,9 +38,7 @@ public class ReplicaCreatorService extends AbstractIdleService {
     LOG.info("Starting replica creator service");
     metadataStoreService.awaitRunning(DEFAULT_START_STOP_DURATION);
 
-    replicaMetadataStore =
-        new ReplicaMetadataStore(
-            metadataStoreService.getMetadataStore(), REPLICA_STORE_ZK_PATH, true);
+    replicaMetadataStore = new ReplicaMetadataStore(metadataStoreService.getMetadataStore(), true);
     replicaMetadataStore.addListener(replicaNodeListener());
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/config/KaldbConfig.java
+++ b/kaldb/src/main/java/com/slack/kaldb/config/KaldbConfig.java
@@ -25,12 +25,6 @@ public class KaldbConfig {
   public static Duration DEFAULT_START_STOP_DURATION = Duration.ofSeconds(15);
   public static final int DEFAULT_ZK_TIMEOUT_SECS = 15;
 
-  // Zookeeper paths for meta data stores.
-  public static final String SEARCH_METADATA_STORE_ZK_PATH = "/search";
-  public static final String SNAPSHOT_METADATA_STORE_ZK_PATH = "/snapshots";
-  public static final String CACHE_SLOT_STORE_ZK_PATH = "/cacheSlot";
-  public static final String REPLICA_STORE_ZK_PATH = "/replica";
-
   private static KaldbConfig _instance = null;
 
   // Parse a json string as a KaldbConfig proto struct.

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadata.java
@@ -4,8 +4,6 @@ import com.slack.kaldb.metadata.core.KaldbMetadata;
 import com.slack.kaldb.proto.metadata.Metadata;
 
 public class CacheSlotMetadata extends KaldbMetadata {
-  public static final String METADATA_SLOT_NAME = "SLOT";
-
   public final Metadata.CacheSlotState cacheSlotState;
   public final String replicaId;
   public final long updatedTimeUtc;
@@ -42,18 +40,16 @@ public class CacheSlotMetadata extends KaldbMetadata {
 
   @Override
   public String toString() {
-    return "CacheNodeMetadata{"
-        + "name='"
-        + name
-        + '\''
-        + ", cacheSlotState='"
+    return "CacheSlotMetadata{"
+        + "cacheSlotState="
         + cacheSlotState
-        + '\''
         + ", replicaId='"
         + replicaId
         + '\''
         + ", updatedTimeUtc='"
         + updatedTimeUtc
+        + ", name='"
+        + name
         + '\''
         + '}';
   }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStore.java
@@ -6,15 +6,25 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class CacheSlotMetadataStore extends EphemeralMutableMetadataStore<CacheSlotMetadata> {
-
   private static final Logger LOG = LoggerFactory.getLogger(CacheSlotMetadataStore.class);
+  public static final String CACHE_SLOT_ZK_PATH = "/cacheSlot";
 
-  public CacheSlotMetadataStore(
-      MetadataStore metadataStore, String snapshotStorePath, boolean shouldCache) throws Exception {
+  public CacheSlotMetadataStore(MetadataStore metadataStore, boolean shouldCache) throws Exception {
     super(
         shouldCache,
         true,
-        snapshotStorePath,
+        CACHE_SLOT_ZK_PATH,
+        metadataStore,
+        new CacheSlotMetadataSerializer(),
+        LOG);
+  }
+
+  public CacheSlotMetadataStore(
+      MetadataStore metadataStore, String cacheSlotName, boolean shouldCache) throws Exception {
+    super(
+        shouldCache,
+        false,
+        String.format("%s/%s", CACHE_SLOT_ZK_PATH, cacheSlotName),
         metadataStore,
         new CacheSlotMetadataSerializer(),
         LOG);

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStore.java
@@ -9,6 +9,10 @@ public class CacheSlotMetadataStore extends EphemeralMutableMetadataStore<CacheS
   private static final Logger LOG = LoggerFactory.getLogger(CacheSlotMetadataStore.class);
   public static final String CACHE_SLOT_ZK_PATH = "/cacheSlot";
 
+  /**
+   * Initializes a cache slot metadata store at the CACHE_SLOT_ZK_PATH. This should be used to
+   * create/update the cache slots, and for listening to all cache slot events.
+   */
   public CacheSlotMetadataStore(MetadataStore metadataStore, boolean shouldCache) throws Exception {
     super(
         shouldCache,
@@ -19,6 +23,11 @@ public class CacheSlotMetadataStore extends EphemeralMutableMetadataStore<CacheS
         LOG);
   }
 
+  /**
+   * Initializes a cache slot metadata store at CACHE_SLOT_ZK_PATH/{cacheSlotName}. This should be
+   * used to add listeners to specific cache slots, and is not expected to be used for mutating any
+   * nodes.
+   */
   public CacheSlotMetadataStore(
       MetadataStore metadataStore, String cacheSlotName, boolean shouldCache) throws Exception {
     super(

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadataStore.java
@@ -7,10 +7,15 @@ import org.slf4j.LoggerFactory;
 
 public class ReplicaMetadataStore extends PersistentMutableMetadataStore<ReplicaMetadata> {
   private static final Logger LOG = LoggerFactory.getLogger(ReplicaMetadataStore.class);
+  public static final String REPLICA_STORE_ZK_PATH = "/replica";
 
-  public ReplicaMetadataStore(
-      MetadataStore metadataStore, String snapshotStorePath, boolean shouldCache) throws Exception {
+  public ReplicaMetadataStore(MetadataStore metadataStore, boolean shouldCache) throws Exception {
     super(
-        shouldCache, false, snapshotStorePath, metadataStore, new ReplicaMetadataSerializer(), LOG);
+        shouldCache,
+        false,
+        REPLICA_STORE_ZK_PATH,
+        metadataStore,
+        new ReplicaMetadataSerializer(),
+        LOG);
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/search/SearchMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/search/SearchMetadataStore.java
@@ -6,11 +6,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SearchMetadataStore extends EphemeralMutableMetadataStore<SearchMetadata> {
+  public static final String SEARCH_METADATA_STORE_ZK_PATH = "/search";
 
   private static final Logger LOG = LoggerFactory.getLogger(SearchMetadataStore.class);
 
-  public SearchMetadataStore(MetadataStore metadataStore, String storeFolder, boolean shouldCache)
-      throws Exception {
-    super(shouldCache, false, storeFolder, metadataStore, new SearchMetadataSerializer(), LOG);
+  public SearchMetadataStore(MetadataStore metadataStore, boolean shouldCache) throws Exception {
+    super(
+        shouldCache,
+        false,
+        SEARCH_METADATA_STORE_ZK_PATH,
+        metadataStore,
+        new SearchMetadataSerializer(),
+        LOG);
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataStore.java
@@ -6,17 +6,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SnapshotMetadataStore extends PersistentMutableMetadataStore<SnapshotMetadata> {
+  public static final String SNAPSHOT_METADATA_STORE_ZK_PATH = "/snapshots";
 
   private static final Logger LOG = LoggerFactory.getLogger(SnapshotMetadataStore.class);
 
   // TODO: Add a setup method to initialize the store?
 
-  public SnapshotMetadataStore(
-      MetadataStore metadataStore, String snapshotStorePath, boolean shouldCache) throws Exception {
+  public SnapshotMetadataStore(MetadataStore metadataStore, boolean shouldCache) throws Exception {
     super(
         shouldCache,
         false,
-        snapshotStorePath,
+        SNAPSHOT_METADATA_STORE_ZK_PATH,
         metadataStore,
         new SnapshotMetadataSerializer(),
         LOG);

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -1,9 +1,6 @@
 package com.slack.kaldb.chunk;
 
 import static com.slack.kaldb.config.KaldbConfig.DEFAULT_START_STOP_DURATION;
-import static com.slack.kaldb.config.KaldbConfig.REPLICA_STORE_ZK_PATH;
-import static com.slack.kaldb.config.KaldbConfig.SEARCH_METADATA_STORE_ZK_PATH;
-import static com.slack.kaldb.config.KaldbConfig.SNAPSHOT_METADATA_STORE_ZK_PATH;
 import static com.slack.kaldb.logstore.BlobFsUtils.copyToS3;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.COMMITS_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_FAILED_COUNTER;
@@ -99,14 +96,13 @@ public class ReadOnlyChunkImplTest {
     metadataStoreService.awaitRunning(DEFAULT_START_STOP_DURATION);
 
     ReplicaMetadataStore replicaMetadataStore =
-        new ReplicaMetadataStore(
-            metadataStoreService.getMetadataStore(), REPLICA_STORE_ZK_PATH, false);
+        new ReplicaMetadataStore(metadataStoreService.getMetadataStore(), false);
     SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(
-            metadataStoreService.getMetadataStore(), SNAPSHOT_METADATA_STORE_ZK_PATH, false);
+        new SnapshotMetadataStore(metadataStoreService.getMetadataStore(), false);
     SearchMetadataStore searchMetadataStore =
-        new SearchMetadataStore(
-            metadataStoreService.getMetadataStore(), SEARCH_METADATA_STORE_ZK_PATH, true);
+        new SearchMetadataStore(metadataStoreService.getMetadataStore(), true);
+    CacheSlotMetadataStore cacheSlotMetadataStore =
+        new CacheSlotMetadataStore(metadataStoreService.getMetadataStore(), false);
 
     String replicaId = "foo";
     String snapshotId = "bar";
@@ -124,6 +120,7 @@ public class ReadOnlyChunkImplTest {
             SearchContext.fromConfig(kaldbConfig.getCacheConfig().getServerConfig()),
             kaldbConfig.getS3Config().getS3Bucket(),
             kaldbConfig.getCacheConfig().getDataDirectory(),
+            cacheSlotMetadataStore,
             replicaMetadataStore,
             snapshotMetadataStore,
             searchMetadataStore);
@@ -131,7 +128,7 @@ public class ReadOnlyChunkImplTest {
     // wait for chunk to register
     await().until(() -> readOnlyChunk.getChunkMetadataState() == Metadata.CacheSlotState.FREE);
 
-    assignReplicaToChunk(replicaId, readOnlyChunk);
+    assignReplicaToChunk(cacheSlotMetadataStore, replicaId, readOnlyChunk);
 
     // ensure that the chunk was marked LIVE
     await().until(() -> readOnlyChunk.getChunkMetadataState() == Metadata.CacheSlotState.LIVE);
@@ -199,14 +196,13 @@ public class ReadOnlyChunkImplTest {
     metadataStoreService.awaitRunning(DEFAULT_START_STOP_DURATION);
 
     ReplicaMetadataStore replicaMetadataStore =
-        new ReplicaMetadataStore(
-            metadataStoreService.getMetadataStore(), REPLICA_STORE_ZK_PATH, false);
+        new ReplicaMetadataStore(metadataStoreService.getMetadataStore(), false);
     SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(
-            metadataStoreService.getMetadataStore(), SNAPSHOT_METADATA_STORE_ZK_PATH, false);
+        new SnapshotMetadataStore(metadataStoreService.getMetadataStore(), false);
     SearchMetadataStore searchMetadataStore =
-        new SearchMetadataStore(
-            metadataStoreService.getMetadataStore(), SEARCH_METADATA_STORE_ZK_PATH, true);
+        new SearchMetadataStore(metadataStoreService.getMetadataStore(), true);
+    CacheSlotMetadataStore cacheSlotMetadataStore =
+        new CacheSlotMetadataStore(metadataStoreService.getMetadataStore(), false);
 
     String replicaId = "foo";
     String snapshotId = "bar";
@@ -223,6 +219,7 @@ public class ReadOnlyChunkImplTest {
             SearchContext.fromConfig(kaldbConfig.getCacheConfig().getServerConfig()),
             kaldbConfig.getS3Config().getS3Bucket(),
             kaldbConfig.getCacheConfig().getDataDirectory(),
+            cacheSlotMetadataStore,
             replicaMetadataStore,
             snapshotMetadataStore,
             searchMetadataStore);
@@ -230,7 +227,7 @@ public class ReadOnlyChunkImplTest {
     // wait for chunk to register
     await().until(() -> readOnlyChunk.getChunkMetadataState() == Metadata.CacheSlotState.FREE);
 
-    assignReplicaToChunk(replicaId, readOnlyChunk);
+    assignReplicaToChunk(cacheSlotMetadataStore, replicaId, readOnlyChunk);
 
     // assert that the chunk was released back to free
     await().until(() -> readOnlyChunk.getChunkMetadataState() == Metadata.CacheSlotState.FREE);
@@ -262,14 +259,13 @@ public class ReadOnlyChunkImplTest {
     metadataStoreService.awaitRunning(DEFAULT_START_STOP_DURATION);
 
     ReplicaMetadataStore replicaMetadataStore =
-        new ReplicaMetadataStore(
-            metadataStoreService.getMetadataStore(), REPLICA_STORE_ZK_PATH, false);
+        new ReplicaMetadataStore(metadataStoreService.getMetadataStore(), false);
     SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(
-            metadataStoreService.getMetadataStore(), SNAPSHOT_METADATA_STORE_ZK_PATH, false);
+        new SnapshotMetadataStore(metadataStoreService.getMetadataStore(), false);
     SearchMetadataStore searchMetadataStore =
-        new SearchMetadataStore(
-            metadataStoreService.getMetadataStore(), SEARCH_METADATA_STORE_ZK_PATH, true);
+        new SearchMetadataStore(metadataStoreService.getMetadataStore(), true);
+    CacheSlotMetadataStore cacheSlotMetadataStore =
+        new CacheSlotMetadataStore(metadataStoreService.getMetadataStore(), false);
 
     String replicaId = "foo";
     String snapshotId = "bar";
@@ -286,6 +282,7 @@ public class ReadOnlyChunkImplTest {
             SearchContext.fromConfig(kaldbConfig.getCacheConfig().getServerConfig()),
             kaldbConfig.getS3Config().getS3Bucket(),
             kaldbConfig.getCacheConfig().getDataDirectory(),
+            cacheSlotMetadataStore,
             replicaMetadataStore,
             snapshotMetadataStore,
             searchMetadataStore);
@@ -293,7 +290,7 @@ public class ReadOnlyChunkImplTest {
     // wait for chunk to register
     await().until(() -> readOnlyChunk.getChunkMetadataState() == Metadata.CacheSlotState.FREE);
 
-    assignReplicaToChunk(replicaId, readOnlyChunk);
+    assignReplicaToChunk(cacheSlotMetadataStore, replicaId, readOnlyChunk);
 
     // assert that the chunk was released back to free
     await().until(() -> readOnlyChunk.getChunkMetadataState() == Metadata.CacheSlotState.FREE);
@@ -325,14 +322,13 @@ public class ReadOnlyChunkImplTest {
     metadataStoreService.awaitRunning(DEFAULT_START_STOP_DURATION);
 
     ReplicaMetadataStore replicaMetadataStore =
-        new ReplicaMetadataStore(
-            metadataStoreService.getMetadataStore(), REPLICA_STORE_ZK_PATH, false);
+        new ReplicaMetadataStore(metadataStoreService.getMetadataStore(), false);
     SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(
-            metadataStoreService.getMetadataStore(), SNAPSHOT_METADATA_STORE_ZK_PATH, false);
+        new SnapshotMetadataStore(metadataStoreService.getMetadataStore(), false);
     SearchMetadataStore searchMetadataStore =
-        new SearchMetadataStore(
-            metadataStoreService.getMetadataStore(), SEARCH_METADATA_STORE_ZK_PATH, true);
+        new SearchMetadataStore(metadataStoreService.getMetadataStore(), true);
+    CacheSlotMetadataStore cacheSlotMetadataStore =
+        new CacheSlotMetadataStore(metadataStoreService.getMetadataStore(), false);
 
     String replicaId = "foo";
     String snapshotId = "bar";
@@ -350,6 +346,7 @@ public class ReadOnlyChunkImplTest {
             SearchContext.fromConfig(kaldbConfig.getCacheConfig().getServerConfig()),
             kaldbConfig.getS3Config().getS3Bucket(),
             kaldbConfig.getCacheConfig().getDataDirectory(),
+            cacheSlotMetadataStore,
             replicaMetadataStore,
             snapshotMetadataStore,
             searchMetadataStore);
@@ -357,7 +354,7 @@ public class ReadOnlyChunkImplTest {
     // wait for chunk to register
     await().until(() -> readOnlyChunk.getChunkMetadataState() == Metadata.CacheSlotState.FREE);
 
-    assignReplicaToChunk(replicaId, readOnlyChunk);
+    assignReplicaToChunk(cacheSlotMetadataStore, replicaId, readOnlyChunk);
 
     // ensure that the chunk was marked LIVE
     await().until(() -> readOnlyChunk.getChunkMetadataState() == Metadata.CacheSlotState.LIVE);
@@ -400,14 +397,14 @@ public class ReadOnlyChunkImplTest {
     metadataStoreService.awaitTerminated(DEFAULT_START_STOP_DURATION);
   }
 
-  private void assignReplicaToChunk(String replicaId, ReadOnlyChunkImpl<LogMessage> readOnlyChunk) {
-    CacheSlotMetadataStore cacheSlotMetadataStore = readOnlyChunk.cacheSlotMetadataStore;
-    CacheSlotMetadata cacheSlotMetadata = cacheSlotMetadataStore.getCached().get(0);
-
+  private void assignReplicaToChunk(
+      CacheSlotMetadataStore cacheSlotMetadataStore,
+      String replicaId,
+      ReadOnlyChunkImpl<LogMessage> readOnlyChunk) {
     // update chunk to assigned
     CacheSlotMetadata updatedCacheSlotMetadata =
         new CacheSlotMetadata(
-            cacheSlotMetadata.name,
+            readOnlyChunk.slotName,
             Metadata.CacheSlotState.ASSIGNED,
             replicaId,
             Instant.now().toEpochMilli());
@@ -417,8 +414,7 @@ public class ReadOnlyChunkImplTest {
   private void initializeZkSnapshot(MetadataStoreService metadataStoreService, String snapshotId)
       throws Exception {
     SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(
-            metadataStoreService.getMetadataStore(), SNAPSHOT_METADATA_STORE_ZK_PATH, false);
+        new SnapshotMetadataStore(metadataStoreService.getMetadataStore(), false);
     snapshotMetadataStore
         .create(
             new SnapshotMetadata(
@@ -436,8 +432,7 @@ public class ReadOnlyChunkImplTest {
       MetadataStoreService metadataStoreService, String replicaId, String snapshotId)
       throws Exception {
     ReplicaMetadataStore replicaMetadataStore =
-        new ReplicaMetadataStore(
-            metadataStoreService.getMetadataStore(), REPLICA_STORE_ZK_PATH, false);
+        new ReplicaMetadataStore(metadataStoreService.getMetadataStore(), false);
     replicaMetadataStore
         .create(new ReplicaMetadata(replicaId, snapshotId))
         .get(5, TimeUnit.SECONDS);

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
@@ -1,6 +1,6 @@
 package com.slack.kaldb.metadata.core;
 
-import static com.slack.kaldb.config.KaldbConfig.SNAPSHOT_METADATA_STORE_ZK_PATH;
+import static com.slack.kaldb.metadata.snapshot.SnapshotMetadataStore.SNAPSHOT_METADATA_STORE_ZK_PATH;
 import static com.slack.kaldb.metadata.zookeeper.ZookeeperCachedMetadataStoreImpl.CACHE_ERROR_COUNTER;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
 import static com.slack.kaldb.testlib.ZkUtils.closeZookeeperClientConnection;

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/search/SearchMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/search/SearchMetadataStoreTest.java
@@ -46,7 +46,7 @@ public class SearchMetadataStoreTest {
 
   @Test
   public void testSearchMetadataStoreIsNotUpdatable() throws Exception {
-    store = new SearchMetadataStore(zkMetadataStore, "/search", true);
+    store = new SearchMetadataStore(zkMetadataStore, true);
     SearchMetadata searchMetadata = new SearchMetadata("test", "snapshot", "http");
     Throwable ex = catchThrowable(() -> store.update(searchMetadata));
     assertThat(ex).isInstanceOf(UnsupportedOperationException.class);


### PR DESCRIPTION
Removes unnecessary additional node depth, and moves path configs internal to appropriate stores.

Previous:
```
/cacheNode/{slotName}/SLOT
```

Now:
```
/cacheSlot/{slotName}
```