### PR TITLE
Add recovery node stub functionality

### DIFF
--- a/.run/KalDb_recovery.run.xml
+++ b/.run/KalDb_recovery.run.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="KalDb Recovery Node" type="Application" factoryName="Application">
+    <envs>
+      <env name="NODE_ROLES" value="RECOVERY" />
+    </envs>
+    <option name="MAIN_CLASS_NAME" value="com.slack.kaldb.server.Kaldb" />
+    <module name="kaldb" />
+    <option name="PROGRAM_PARAMETERS" value="config/config.yaml" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -59,5 +59,5 @@ managerConfig:
 
 recoveryConfig:
   serverConfig:
-    serverPort: ${KALDB_RECOVERY_SERVER_PORT:-8084}
+    serverPort: ${KALDB_RECOVERY_SERVER_PORT:-8085}
     serverAddress: ${KALDB_RECOVERY_SERVER_ADDRESS:-localhost}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,4 +1,4 @@
-nodeRoles: [${NODE_ROLES:-QUERY,INDEX,CACHE,MANAGER}]
+nodeRoles: [${NODE_ROLES:-QUERY,INDEX,CACHE,MANAGER,RECOVERY}]
 
 indexerConfig:
   maxMessagesPerChunk: ${INDEXER_MAX_MESSAGES_PER_CHUNK:-100000}
@@ -56,3 +56,8 @@ managerConfig:
   serverConfig:
     serverPort: ${KALDB_MANAGER_SERVER_PORT:-8083}
     serverAddress: ${KALDB_MANAGER_SERVER_ADDRESS:-localhost}
+
+recoveryConfig:
+  serverConfig:
+    serverPort: ${KALDB_RECOVERY_SERVER_PORT:-8084}
+    serverAddress: ${KALDB_RECOVERY_SERVER_ADDRESS:-localhost}

--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
@@ -54,7 +54,7 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
   private LogIndexSearcher<T> logSearcher;
   private SearchMetadata searchMetadata;
   private Path dataDirectory;
-  private Metadata.CacheSlotState previousSlotState;
+  private Metadata.CacheSlotMetadata.CacheSlotState previousSlotState;
 
   private final String dataDirectoryPrefix;
   private final String s3Bucket;
@@ -108,13 +108,16 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
 
     CacheSlotMetadata cacheSlotMetadata =
         new CacheSlotMetadata(
-            slotName, Metadata.CacheSlotState.FREE, "", Instant.now().toEpochMilli());
+            slotName,
+            Metadata.CacheSlotMetadata.CacheSlotState.FREE,
+            "",
+            Instant.now().toEpochMilli());
     cacheSlotMetadataStore.createSync(cacheSlotMetadata);
 
     CacheSlotMetadataStore cacheSlotListenerMetadataStore =
         new CacheSlotMetadataStore(metadataStoreService.getMetadataStore(), slotName, true);
     cacheSlotListenerMetadataStore.addListener(cacheNodeListener());
-    previousSlotState = Metadata.CacheSlotState.FREE;
+    previousSlotState = Metadata.CacheSlotMetadata.CacheSlotState.FREE;
 
     Collection<Tag> meterTags = ImmutableList.of(Tag.of("slotName", slotName));
     successfulChunkAssignments = meterRegistry.counter(SUCCESSFUL_CHUNK_ASSIGNMENT, meterTags);
@@ -128,17 +131,17 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
   private KaldbMetadataStoreChangeListener cacheNodeListener() {
     return () -> {
       CacheSlotMetadata cacheSlotMetadata = cacheSlotMetadataStore.getNodeSync(slotName);
-      Metadata.CacheSlotState newSlotState = cacheSlotMetadata.cacheSlotState;
+      Metadata.CacheSlotMetadata.CacheSlotState newSlotState = cacheSlotMetadata.cacheSlotState;
 
-      if (newSlotState.equals(Metadata.CacheSlotState.ASSIGNED)) {
+      if (newSlotState.equals(Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED)) {
         LOG.info("Chunk - ASSIGNED received");
-        if (!previousSlotState.equals(Metadata.CacheSlotState.FREE)) {
+        if (!previousSlotState.equals(Metadata.CacheSlotMetadata.CacheSlotState.FREE)) {
           LOG.warn("Unexpected state transition from {} to {}", previousSlotState, newSlotState);
         }
         executorService.submit(() -> handleChunkAssignment(cacheSlotMetadata));
-      } else if (newSlotState.equals(Metadata.CacheSlotState.EVICT)) {
+      } else if (newSlotState.equals(Metadata.CacheSlotMetadata.CacheSlotState.EVICT)) {
         LOG.info("Chunk - EVICT received");
-        if (!previousSlotState.equals(Metadata.CacheSlotState.LIVE)) {
+        if (!previousSlotState.equals(Metadata.CacheSlotMetadata.CacheSlotState.LIVE)) {
           LOG.warn("Unexpected state transition from {} to {}", previousSlotState, newSlotState);
         }
         executorService.submit(this::handleChunkEviction);
@@ -166,7 +169,7 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
   // run concurrently with an assignment
   private synchronized void handleChunkAssignment(CacheSlotMetadata cacheSlotMetadata) {
     try {
-      if (!setChunkMetadataState(Metadata.CacheSlotState.LOADING)) {
+      if (!setChunkMetadataState(Metadata.CacheSlotMetadata.CacheSlotState.LOADING)) {
         throw new InterruptedException("Failed to set chunk metadata state to loading");
       }
 
@@ -189,7 +192,7 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
               new LogIndexSearcherImpl(LogIndexSearcherImpl.searcherManagerFromPath(dataDirectory));
 
       // we first mark the slot LIVE before registering the search metadata as available
-      if (!setChunkMetadataState(Metadata.CacheSlotState.LIVE)) {
+      if (!setChunkMetadataState(Metadata.CacheSlotMetadata.CacheSlotState.LIVE)) {
         throw new InterruptedException("Failed to set chunk metadata state to loading");
       }
 
@@ -200,7 +203,7 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
 
       // if any error occurs during the chunk assignment, try to release the slot for re-assignment,
       // disregarding any errors
-      setChunkMetadataState(Metadata.CacheSlotState.FREE);
+      setChunkMetadataState(Metadata.CacheSlotMetadata.CacheSlotState.FREE);
       LOG.error("Error handling chunk assignment", e);
     }
   }
@@ -218,7 +221,7 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
   // can run concurrently with an eviction
   private synchronized void handleChunkEviction() {
     try {
-      if (!setChunkMetadataState(Metadata.CacheSlotState.EVICTING)) {
+      if (!setChunkMetadataState(Metadata.CacheSlotMetadata.CacheSlotState.EVICTING)) {
         throw new InterruptedException("Failed to set chunk metadata state to evicting");
       }
 
@@ -233,7 +236,7 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
       logSearcher = null;
 
       cleanDirectory();
-      if (!setChunkMetadataState(Metadata.CacheSlotState.FREE)) {
+      if (!setChunkMetadataState(Metadata.CacheSlotMetadata.CacheSlotState.FREE)) {
         throw new InterruptedException("Failed to set chunk metadata state to free");
       }
 
@@ -257,13 +260,15 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
   }
 
   @VisibleForTesting
-  public boolean setChunkMetadataState(Metadata.CacheSlotState newChunkState) {
+  public boolean setChunkMetadataState(Metadata.CacheSlotMetadata.CacheSlotState newChunkState) {
     CacheSlotMetadata chunkMetadata = cacheSlotMetadataStore.getNodeSync(slotName);
     CacheSlotMetadata updatedChunkMetadata =
         new CacheSlotMetadata(
             chunkMetadata.name,
             newChunkState,
-            newChunkState.equals(Metadata.CacheSlotState.FREE) ? "" : chunkMetadata.replicaId,
+            newChunkState.equals(Metadata.CacheSlotMetadata.CacheSlotState.FREE)
+                ? ""
+                : chunkMetadata.replicaId,
             Instant.now().toEpochMilli());
     try {
       cacheSlotMetadataStore.update(updatedChunkMetadata).get(TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -275,7 +280,7 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
   }
 
   @VisibleForTesting
-  public Metadata.CacheSlotState getChunkMetadataState() {
+  public Metadata.CacheSlotMetadata.CacheSlotState getChunkMetadataState() {
     return cacheSlotMetadataStore.getNodeSync(slotName).cacheSlotState;
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadata.java
@@ -4,12 +4,15 @@ import com.slack.kaldb.metadata.core.KaldbMetadata;
 import com.slack.kaldb.proto.metadata.Metadata;
 
 public class CacheSlotMetadata extends KaldbMetadata {
-  public final Metadata.CacheSlotState cacheSlotState;
+  public final Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState;
   public final String replicaId;
   public final long updatedTimeUtc;
 
   public CacheSlotMetadata(
-      String name, Metadata.CacheSlotState cacheSlotState, String replicaId, long updatedTimeUtc) {
+      String name,
+      Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState,
+      String replicaId,
+      long updatedTimeUtc) {
     super(name);
     this.cacheSlotState = cacheSlotState;
     this.replicaId = replicaId;

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializer.java
@@ -10,7 +10,8 @@ public class CacheSlotMetadataSerializer implements MetadataSerializer<CacheSlot
       Metadata.CacheSlotMetadata cacheSlotMetadataProto) {
     return new CacheSlotMetadata(
         cacheSlotMetadataProto.getName(),
-        Metadata.CacheSlotState.valueOf(cacheSlotMetadataProto.getCacheSlotState().name()),
+        Metadata.CacheSlotMetadata.CacheSlotState.valueOf(
+            cacheSlotMetadataProto.getCacheSlotState().name()),
         cacheSlotMetadataProto.getReplicaId(),
         cacheSlotMetadataProto.getUpdatedTimeUtc());
   }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadata.java
@@ -1,0 +1,41 @@
+package com.slack.kaldb.metadata.recovery;
+
+import com.slack.kaldb.metadata.core.KaldbMetadata;
+import com.slack.kaldb.proto.metadata.Metadata;
+import java.util.Objects;
+
+public class RecoveryNodeMetadata extends KaldbMetadata {
+
+  public final Metadata.RecoveryNodeMetadata.RecoveryNodeState recoveryNodeState;
+
+  public RecoveryNodeMetadata(
+      String name, Metadata.RecoveryNodeMetadata.RecoveryNodeState recoveryNodeState) {
+    super(name);
+    this.recoveryNodeState = recoveryNodeState;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    RecoveryNodeMetadata that = (RecoveryNodeMetadata) o;
+    return recoveryNodeState == that.recoveryNodeState;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), recoveryNodeState);
+  }
+
+  @Override
+  public String toString() {
+    return "RecoveryNodeMetadata{"
+        + "name='"
+        + name
+        + '\''
+        + ", recoveryNodeState="
+        + recoveryNodeState
+        + '}';
+  }
+}

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadata.java
@@ -7,11 +7,18 @@ import java.util.Objects;
 public class RecoveryNodeMetadata extends KaldbMetadata {
 
   public final Metadata.RecoveryNodeMetadata.RecoveryNodeState recoveryNodeState;
+  public final String recoveryTaskName;
+  public final long updatedTimeUtc;
 
   public RecoveryNodeMetadata(
-      String name, Metadata.RecoveryNodeMetadata.RecoveryNodeState recoveryNodeState) {
+      String name,
+      Metadata.RecoveryNodeMetadata.RecoveryNodeState recoveryNodeState,
+      String recoveryTaskName,
+      long updatedTimeUtc) {
     super(name);
     this.recoveryNodeState = recoveryNodeState;
+    this.recoveryTaskName = recoveryTaskName;
+    this.updatedTimeUtc = updatedTimeUtc;
   }
 
   @Override
@@ -20,12 +27,14 @@ public class RecoveryNodeMetadata extends KaldbMetadata {
     if (o == null || getClass() != o.getClass()) return false;
     if (!super.equals(o)) return false;
     RecoveryNodeMetadata that = (RecoveryNodeMetadata) o;
-    return recoveryNodeState == that.recoveryNodeState;
+    return updatedTimeUtc == that.updatedTimeUtc
+        && recoveryNodeState == that.recoveryNodeState
+        && recoveryTaskName.equals(that.recoveryTaskName);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), recoveryNodeState);
+    return Objects.hash(super.hashCode(), recoveryNodeState, recoveryTaskName, updatedTimeUtc);
   }
 
   @Override
@@ -36,6 +45,11 @@ public class RecoveryNodeMetadata extends KaldbMetadata {
         + '\''
         + ", recoveryNodeState="
         + recoveryNodeState
+        + ", recoveryTaskName='"
+        + recoveryTaskName
+        + '\''
+        + ", updatedTimeUtc="
+        + updatedTimeUtc
         + '}';
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadata.java
@@ -4,6 +4,10 @@ import com.slack.kaldb.metadata.core.KaldbMetadata;
 import com.slack.kaldb.proto.metadata.Metadata;
 import java.util.Objects;
 
+/**
+ * The recovery node metadata is used to coordinate the availability of recovery node executors and
+ * their recovery task assignments.
+ */
 public class RecoveryNodeMetadata extends KaldbMetadata {
 
   public final Metadata.RecoveryNodeMetadata.RecoveryNodeState recoveryNodeState;

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataSerializer.java
@@ -1,0 +1,38 @@
+package com.slack.kaldb.metadata.recovery;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import com.slack.kaldb.metadata.core.MetadataSerializer;
+import com.slack.kaldb.proto.metadata.Metadata;
+
+public class RecoveryNodeMetadataSerializer implements MetadataSerializer<RecoveryNodeMetadata> {
+
+  private static RecoveryNodeMetadata fromRecoveryNodeMetadataProto(
+      Metadata.RecoveryNodeMetadata recoveryNodeMetadataProto) {
+    return new RecoveryNodeMetadata(
+        recoveryNodeMetadataProto.getName(), recoveryNodeMetadataProto.getRecoveryNodeState());
+  }
+
+  private static Metadata.RecoveryNodeMetadata toRecoveryNodeMetadataProto(
+      RecoveryNodeMetadata metadata) {
+    return Metadata.RecoveryNodeMetadata.newBuilder()
+        .setName(metadata.name)
+        .setRecoveryNodeState(metadata.recoveryNodeState)
+        .build();
+  }
+
+  @Override
+  public String toJsonStr(RecoveryNodeMetadata metadata) throws InvalidProtocolBufferException {
+    if (metadata == null) throw new IllegalArgumentException("metadata object can't be null");
+
+    return printer.print(toRecoveryNodeMetadataProto(metadata));
+  }
+
+  @Override
+  public RecoveryNodeMetadata fromJsonStr(String data) throws InvalidProtocolBufferException {
+    Metadata.RecoveryNodeMetadata.Builder recoveryNodeMetadataBuilder =
+        Metadata.RecoveryNodeMetadata.newBuilder();
+    JsonFormat.parser().ignoringUnknownFields().merge(data, recoveryNodeMetadataBuilder);
+    return fromRecoveryNodeMetadataProto(recoveryNodeMetadataBuilder.build());
+  }
+}

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataSerializer.java
@@ -10,7 +10,10 @@ public class RecoveryNodeMetadataSerializer implements MetadataSerializer<Recove
   private static RecoveryNodeMetadata fromRecoveryNodeMetadataProto(
       Metadata.RecoveryNodeMetadata recoveryNodeMetadataProto) {
     return new RecoveryNodeMetadata(
-        recoveryNodeMetadataProto.getName(), recoveryNodeMetadataProto.getRecoveryNodeState());
+        recoveryNodeMetadataProto.getName(),
+        recoveryNodeMetadataProto.getRecoveryNodeState(),
+        recoveryNodeMetadataProto.getRecoveryTaskName(),
+        recoveryNodeMetadataProto.getUpdatedTimeUtc());
   }
 
   private static Metadata.RecoveryNodeMetadata toRecoveryNodeMetadataProto(
@@ -18,6 +21,8 @@ public class RecoveryNodeMetadataSerializer implements MetadataSerializer<Recove
     return Metadata.RecoveryNodeMetadata.newBuilder()
         .setName(metadata.name)
         .setRecoveryNodeState(metadata.recoveryNodeState)
+        .setRecoveryTaskName(metadata.recoveryTaskName)
+        .setUpdatedTimeUtc(metadata.updatedTimeUtc)
         .build();
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataStore.java
@@ -17,7 +17,7 @@ public class RecoveryNodeMetadataStore extends EphemeralMutableMetadataStore<Rec
       throws Exception {
     super(
         shouldCache,
-        false,
+        true,
         RECOVERY_NODE_ZK_PATH,
         metadataStore,
         new RecoveryNodeMetadataSerializer(),

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataStore.java
@@ -1,0 +1,22 @@
+package com.slack.kaldb.metadata.recovery;
+
+import com.slack.kaldb.metadata.core.EphemeralMutableMetadataStore;
+import com.slack.kaldb.metadata.zookeeper.MetadataStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RecoveryNodeMetadataStore extends EphemeralMutableMetadataStore<RecoveryNodeMetadata> {
+  private static final Logger LOG = LoggerFactory.getLogger(RecoveryNodeMetadataStore.class);
+  public static final String RECOVERY_NODE_ZK_PATH = "/recoveryNode";
+
+  public RecoveryNodeMetadataStore(MetadataStore metadataStore, boolean shouldCache)
+      throws Exception {
+    super(
+        shouldCache,
+        false,
+        RECOVERY_NODE_ZK_PATH,
+        metadataStore,
+        new RecoveryNodeMetadataSerializer(),
+        LOG);
+  }
+}

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataStore.java
@@ -9,12 +9,32 @@ public class RecoveryNodeMetadataStore extends EphemeralMutableMetadataStore<Rec
   private static final Logger LOG = LoggerFactory.getLogger(RecoveryNodeMetadataStore.class);
   public static final String RECOVERY_NODE_ZK_PATH = "/recoveryNode";
 
+  /**
+   * Initializes a recovery node metadata store at the RECOVERY_NODE_ZK_PATH. This should be used to
+   * create/update the recovery nodes, and for listening to all recovery node events.
+   */
   public RecoveryNodeMetadataStore(MetadataStore metadataStore, boolean shouldCache)
       throws Exception {
     super(
         shouldCache,
         false,
         RECOVERY_NODE_ZK_PATH,
+        metadataStore,
+        new RecoveryNodeMetadataSerializer(),
+        LOG);
+  }
+
+  /**
+   * Initializes a recovery node metadata store at RECOVERY_NODE_ZK_PATH/{recoveryNodeName}. This
+   * should be used to add listeners to specific recovery nodes, and is not expected to be used for
+   * mutating any nodes.
+   */
+  public RecoveryNodeMetadataStore(
+      MetadataStore metadataStore, String recoveryNodeName, boolean shouldCache) throws Exception {
+    super(
+        shouldCache,
+        false,
+        String.format("%s/%s", RECOVERY_NODE_ZK_PATH, recoveryNodeName),
         metadataStore,
         new RecoveryNodeMetadataSerializer(),
         LOG);

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadata.java
@@ -1,0 +1,49 @@
+package com.slack.kaldb.metadata.recovery;
+
+import com.slack.kaldb.metadata.core.KaldbMetadata;
+import java.util.Objects;
+
+public class RecoveryTaskMetadata extends KaldbMetadata {
+  public final String partitionId;
+  public final long startOffset;
+  public final long endOffset;
+
+  public RecoveryTaskMetadata(String name, String partitionId, long startOffset, long endOffset) {
+    super(name);
+    this.partitionId = partitionId;
+    this.startOffset = startOffset;
+    this.endOffset = endOffset;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    RecoveryTaskMetadata that = (RecoveryTaskMetadata) o;
+    return startOffset == that.startOffset
+        && endOffset == that.endOffset
+        && partitionId.equals(that.partitionId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), partitionId, startOffset, endOffset);
+  }
+
+  @Override
+  public String toString() {
+    return "RecoveryTaskMetadata{"
+        + "name='"
+        + name
+        + '\''
+        + ", partitionId='"
+        + partitionId
+        + '\''
+        + ", startOffset="
+        + startOffset
+        + ", endOffset="
+        + endOffset
+        + '}';
+  }
+}

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadata.java
@@ -3,6 +3,10 @@ package com.slack.kaldb.metadata.recovery;
 import com.slack.kaldb.metadata.core.KaldbMetadata;
 import java.util.Objects;
 
+/**
+ * The recovery task metadata contains all information required to back-fill messages that have been
+ * previously skipped.
+ */
 public class RecoveryTaskMetadata extends KaldbMetadata {
   public final String partitionId;
   public final long startOffset;

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataSerializer.java
@@ -1,0 +1,43 @@
+package com.slack.kaldb.metadata.recovery;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import com.slack.kaldb.metadata.core.MetadataSerializer;
+import com.slack.kaldb.proto.metadata.Metadata;
+
+public class RecoveryTaskMetadataSerializer implements MetadataSerializer<RecoveryTaskMetadata> {
+
+  private static RecoveryTaskMetadata fromRecoveryTaskMetadataProto(
+      Metadata.RecoveryTaskMetadata recoveryTaskMetadataProto) {
+    return new RecoveryTaskMetadata(
+        recoveryTaskMetadataProto.getName(),
+        recoveryTaskMetadataProto.getPartitionId(),
+        recoveryTaskMetadataProto.getStartOffset(),
+        recoveryTaskMetadataProto.getEndOffset());
+  }
+
+  private static Metadata.RecoveryTaskMetadata toRecoveryTaskMetadataProto(
+      RecoveryTaskMetadata metadata) {
+    return Metadata.RecoveryTaskMetadata.newBuilder()
+        .setName(metadata.name)
+        .setPartitionId(metadata.partitionId)
+        .setStartOffset(metadata.startOffset)
+        .setEndOffset(metadata.endOffset)
+        .build();
+  }
+
+  @Override
+  public String toJsonStr(RecoveryTaskMetadata metadata) throws InvalidProtocolBufferException {
+    if (metadata == null) throw new IllegalArgumentException("metadata object can't be null");
+
+    return printer.print(toRecoveryTaskMetadataProto(metadata));
+  }
+
+  @Override
+  public RecoveryTaskMetadata fromJsonStr(String data) throws InvalidProtocolBufferException {
+    Metadata.RecoveryTaskMetadata.Builder recoveryTaskMetadataBuilder =
+        Metadata.RecoveryTaskMetadata.newBuilder();
+    JsonFormat.parser().ignoringUnknownFields().merge(data, recoveryTaskMetadataBuilder);
+    return fromRecoveryTaskMetadataProto(recoveryTaskMetadataBuilder.build());
+  }
+}

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataStore.java
@@ -1,0 +1,23 @@
+package com.slack.kaldb.metadata.recovery;
+
+import com.slack.kaldb.metadata.core.PersistentMutableMetadataStore;
+import com.slack.kaldb.metadata.zookeeper.MetadataStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RecoveryTaskMetadataStore
+    extends PersistentMutableMetadataStore<RecoveryTaskMetadata> {
+  private static final Logger LOG = LoggerFactory.getLogger(RecoveryTaskMetadataStore.class);
+  public static final String RECOVERY_NODE_ZK_PATH = "/recoveryTask";
+
+  public RecoveryTaskMetadataStore(MetadataStore metadataStore, boolean shouldCache)
+      throws Exception {
+    super(
+        shouldCache,
+        false,
+        RECOVERY_NODE_ZK_PATH,
+        metadataStore,
+        new RecoveryTaskMetadataSerializer(),
+        LOG);
+  }
+}

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataStore.java
@@ -8,14 +8,14 @@ import org.slf4j.LoggerFactory;
 public class RecoveryTaskMetadataStore
     extends PersistentMutableMetadataStore<RecoveryTaskMetadata> {
   private static final Logger LOG = LoggerFactory.getLogger(RecoveryTaskMetadataStore.class);
-  public static final String RECOVERY_NODE_ZK_PATH = "/recoveryTask";
+  public static final String RECOVERY_TASK_ZK_PATH = "/recoveryTask";
 
   public RecoveryTaskMetadataStore(MetadataStore metadataStore, boolean shouldCache)
       throws Exception {
     super(
         shouldCache,
         false,
-        RECOVERY_NODE_ZK_PATH,
+        RECOVERY_TASK_ZK_PATH,
         metadataStore,
         new RecoveryTaskMetadataSerializer(),
         LOG);

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadata.java
@@ -2,6 +2,11 @@ package com.slack.kaldb.metadata.replica;
 
 import com.slack.kaldb.metadata.core.KaldbMetadata;
 
+/**
+ * The replica metadata is used to allow associating multiple cache nodes to a single snapshot. The
+ * cluster manager will create one (or more) replicas per snapshot, depending on configuration and
+ * expected/observed query load.
+ */
 public class ReplicaMetadata extends KaldbMetadata {
 
   public final String snapshotId;

--- a/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
@@ -2,7 +2,10 @@ package com.slack.kaldb.recovery;
 
 import static com.slack.kaldb.config.KaldbConfig.DEFAULT_START_STOP_DURATION;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.slack.kaldb.chunk.SearchContext;
 import com.slack.kaldb.metadata.core.KaldbMetadataStoreChangeListener;
 import com.slack.kaldb.metadata.recovery.RecoveryNodeMetadata;
@@ -11,7 +14,13 @@ import com.slack.kaldb.metadata.recovery.RecoveryTaskMetadataStore;
 import com.slack.kaldb.proto.config.KaldbConfigs;
 import com.slack.kaldb.proto.metadata.Metadata;
 import com.slack.kaldb.server.MetadataStoreService;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +34,18 @@ public class RecoveryService extends AbstractIdleService {
   private RecoveryNodeMetadataStore recoveryNodeMetadataStore;
   private RecoveryNodeMetadataStore recoveryNodeListenerMetadataStore;
   private RecoveryTaskMetadataStore recoveryTaskMetadataStore;
+  private final ExecutorService executorService;
+
+  private Metadata.RecoveryNodeMetadata.RecoveryNodeState recoveryNodePreviousState;
+
+  public static final String RECOVERY_NODE_RECEIVED_ASSIGNMENT =
+      "recovery_node_received_assignment";
+  public static final String RECOVERY_NODE_COMPLETED_ASSIGNMENT =
+      "recovery_node_completed_assignment";
+  public static final String RECOVERY_NODE_FAILED_ASSIGNMENT = "recovery_node_failed_assignment";
+  protected final Counter recoveryNodeReceivedAssignment;
+  protected final Counter recoveryNodeCompletedAssignment;
+  protected final Counter recoveryNodeFailedAssignment;
 
   public RecoveryService(
       KaldbConfigs.RecoveryConfig recoveryConfig,
@@ -33,6 +54,20 @@ public class RecoveryService extends AbstractIdleService {
     this.metadataStoreService = metadataStoreService;
     this.meterRegistry = meterRegistry;
     this.searchContext = SearchContext.fromConfig(recoveryConfig.getServerConfig());
+
+    // we use a single thread executor to allow operations for this recovery node to queue,
+    // guaranteeing that they are executed in the order they were received
+    this.executorService =
+        Executors.newSingleThreadExecutor(
+            new ThreadFactoryBuilder().setNameFormat("recovery-service-%d").build());
+
+    Collection<Tag> meterTags = ImmutableList.of(Tag.of("nodeHostname", searchContext.hostname));
+    recoveryNodeReceivedAssignment =
+        meterRegistry.counter(RECOVERY_NODE_RECEIVED_ASSIGNMENT, meterTags);
+    recoveryNodeCompletedAssignment =
+        meterRegistry.counter(RECOVERY_NODE_COMPLETED_ASSIGNMENT, meterTags);
+    recoveryNodeFailedAssignment =
+        meterRegistry.counter(RECOVERY_NODE_FAILED_ASSIGNMENT, meterTags);
   }
 
   @Override
@@ -47,7 +82,11 @@ public class RecoveryService extends AbstractIdleService {
 
     recoveryNodeMetadataStore.createSync(
         new RecoveryNodeMetadata(
-            searchContext.hostname, Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE));
+            searchContext.hostname,
+            Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE,
+            "",
+            Instant.now().toEpochMilli()));
+    recoveryNodePreviousState = Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE;
 
     recoveryNodeListenerMetadataStore =
         new RecoveryNodeMetadataStore(
@@ -62,9 +101,54 @@ public class RecoveryService extends AbstractIdleService {
 
   private KaldbMetadataStoreChangeListener recoveryNodeListener() {
     return () -> {
-      // on assignment, do indexing between the assigned offsets
-      // once complete (created the snapshot successfully), delete the task and mark ourselves as
-      // free
+      RecoveryNodeMetadata recoveryNodeMetadata =
+          recoveryNodeMetadataStore.getNodeSync(searchContext.hostname);
+      Metadata.RecoveryNodeMetadata.RecoveryNodeState newRecoveryNodeState =
+          recoveryNodeMetadata.recoveryNodeState;
+
+      if (newRecoveryNodeState.equals(Metadata.RecoveryNodeMetadata.RecoveryNodeState.ASSIGNED)) {
+        LOG.info("Recovery node - ASSIGNED received");
+        recoveryNodeReceivedAssignment.increment();
+        if (!recoveryNodePreviousState.equals(
+            Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE)) {
+          LOG.warn(
+              "Unexpected state transition from {} to {}",
+              recoveryNodePreviousState,
+              newRecoveryNodeState);
+        }
+        executorService.submit(() -> handleRecoveryTaskAssignment(recoveryNodeMetadata));
+      }
+      recoveryNodePreviousState = newRecoveryNodeState;
     };
+  }
+
+  private void handleRecoveryTaskAssignment(RecoveryNodeMetadata recoveryNodeMetadata) {
+    try {
+      setRecoveryNodeMetadataState(Metadata.RecoveryNodeMetadata.RecoveryNodeState.RECOVERING);
+
+      // todo - lookup task assignment, do work (once snapshot successful), delete the assignment
+
+      setRecoveryNodeMetadataState(Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE);
+      recoveryNodeCompletedAssignment.increment();
+    } catch (Exception e) {
+      LOG.error("Failed to complete recovery node task assignment", e);
+      recoveryNodeFailedAssignment.increment();
+    }
+  }
+
+  @VisibleForTesting
+  public void setRecoveryNodeMetadataState(
+      Metadata.RecoveryNodeMetadata.RecoveryNodeState newRecoveryNodeState) {
+    RecoveryNodeMetadata recoveryNodeMetadata =
+        recoveryNodeMetadataStore.getNodeSync(searchContext.hostname);
+    RecoveryNodeMetadata updatedRecoveryNodeMetadata =
+        new RecoveryNodeMetadata(
+            recoveryNodeMetadata.name,
+            newRecoveryNodeState,
+            newRecoveryNodeState.equals(Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE)
+                ? ""
+                : recoveryNodeMetadata.recoveryTaskName,
+            Instant.now().toEpochMilli());
+    recoveryNodeMetadataStore.updateSync(updatedRecoveryNodeMetadata);
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
@@ -45,7 +45,7 @@ public class RecoveryService extends AbstractIdleService {
   private RecoveryTaskMetadataStore recoveryTaskMetadataStore;
   private final ExecutorService executorService;
 
-  private Metadata.RecoveryNodeMetadata.RecoveryNodeState recoveryNodePreviousState;
+  private Metadata.RecoveryNodeMetadata.RecoveryNodeState recoveryNodeLastKnownState;
 
   public static final String RECOVERY_NODE_RECEIVED_ASSIGNMENT =
       "recovery_node_received_assignment";
@@ -94,7 +94,7 @@ public class RecoveryService extends AbstractIdleService {
             Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE,
             "",
             Instant.now().toEpochMilli()));
-    recoveryNodePreviousState = Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE;
+    recoveryNodeLastKnownState = Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE;
 
     recoveryNodeListenerMetadataStore =
         new RecoveryNodeMetadataStore(
@@ -126,16 +126,16 @@ public class RecoveryService extends AbstractIdleService {
       if (newRecoveryNodeState.equals(Metadata.RecoveryNodeMetadata.RecoveryNodeState.ASSIGNED)) {
         LOG.info("Recovery node - ASSIGNED received");
         recoveryNodeReceivedAssignment.increment();
-        if (!recoveryNodePreviousState.equals(
+        if (!recoveryNodeLastKnownState.equals(
             Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE)) {
           LOG.warn(
               "Unexpected state transition from {} to {}",
-              recoveryNodePreviousState,
+              recoveryNodeLastKnownState,
               newRecoveryNodeState);
         }
         executorService.submit(() -> handleRecoveryTaskAssignment(recoveryNodeMetadata));
       }
-      recoveryNodePreviousState = newRecoveryNodeState;
+      recoveryNodeLastKnownState = newRecoveryNodeState;
     };
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
@@ -1,0 +1,69 @@
+package com.slack.kaldb.recovery;
+
+import static com.slack.kaldb.config.KaldbConfig.DEFAULT_START_STOP_DURATION;
+
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.slack.kaldb.chunk.SearchContext;
+import com.slack.kaldb.config.KaldbConfig;
+import com.slack.kaldb.metadata.core.KaldbMetadataStoreChangeListener;
+import com.slack.kaldb.metadata.recovery.RecoveryNodeMetadata;
+import com.slack.kaldb.metadata.recovery.RecoveryNodeMetadataStore;
+import com.slack.kaldb.metadata.recovery.RecoveryTaskMetadataStore;
+import com.slack.kaldb.proto.metadata.Metadata;
+import com.slack.kaldb.server.MetadataStoreService;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RecoveryService extends AbstractIdleService {
+  private static final Logger LOG = LoggerFactory.getLogger(RecoveryService.class);
+
+  private final SearchContext searchContext;
+  private final MetadataStoreService metadataStoreService;
+  private final MeterRegistry meterRegistry;
+
+  private RecoveryNodeMetadataStore recoveryNodeMetadataStore;
+  private RecoveryNodeMetadataStore recoveryNodeListenerMetadataStore;
+  private RecoveryTaskMetadataStore recoveryTaskMetadataStore;
+
+  public RecoveryService(MetadataStoreService metadataStoreService, MeterRegistry meterRegistry) {
+    this.metadataStoreService = metadataStoreService;
+    this.meterRegistry = meterRegistry;
+
+    this.searchContext =
+        SearchContext.fromConfig(KaldbConfig.get().getRecoveryConfig().getServerConfig());
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    LOG.info("Starting recovery service");
+    metadataStoreService.awaitRunning(DEFAULT_START_STOP_DURATION);
+
+    recoveryNodeMetadataStore =
+        new RecoveryNodeMetadataStore(metadataStoreService.getMetadataStore(), false);
+    recoveryTaskMetadataStore =
+        new RecoveryTaskMetadataStore(metadataStoreService.getMetadataStore(), false);
+
+    recoveryNodeListenerMetadataStore =
+        new RecoveryNodeMetadataStore(
+            metadataStoreService.getMetadataStore(), searchContext.hostname, true);
+    recoveryNodeListenerMetadataStore.addListener(recoveryNodeListener());
+
+    recoveryNodeMetadataStore.createSync(
+        new RecoveryNodeMetadata(
+            searchContext.hostname, Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE));
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    LOG.info("Closed recovery service");
+  }
+
+  private KaldbMetadataStoreChangeListener recoveryNodeListener() {
+    return () -> {
+      // on assignment, do indexing between the assigned offsets
+      // once complete (created the snapshot successfully), delete the task and mark ourselves as
+      // free
+    };
+  }
+}

--- a/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
@@ -146,9 +146,9 @@ public class ArmeriaService extends AbstractIdleService {
 
   @Override
   protected void startUp() throws Exception {
+    LOG.info("Starting {} on port {}", serviceName, serverPort);
     CompletableFuture<Void> serverFuture = server.start();
     serverFuture.get(15, TimeUnit.SECONDS);
-    LOG.info("Started on port: {}", serverPort);
   }
 
   @Override

--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -152,14 +152,15 @@ public class Kaldb {
     }
 
     if (roles.contains(KaldbConfigs.NodeRole.RECOVERY)) {
-      final int serverPort =
-          KaldbConfig.get().getRecoveryConfig().getServerConfig().getServerPort();
+      final KaldbConfigs.RecoveryConfig recoveryConfig = KaldbConfig.get().getRecoveryConfig();
+      final int serverPort = recoveryConfig.getServerConfig().getServerPort();
+
       ArmeriaService armeriaService =
           new ArmeriaService(serverPort, prometheusMeterRegistry, "kaldbRecovery");
       services.add(armeriaService);
 
       RecoveryService recoveryService =
-          new RecoveryService(metadataStoreService, prometheusMeterRegistry);
+          new RecoveryService(recoveryConfig, metadataStoreService, prometheusMeterRegistry);
       services.add(recoveryService);
     }
 

--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -142,12 +142,20 @@ public class Kaldb {
     if (roles.contains(KaldbConfigs.NodeRole.MANAGER)) {
       final int serverPort = KaldbConfig.get().getManagerConfig().getServerConfig().getServerPort();
       ArmeriaService armeriaService =
-          new ArmeriaService(serverPort, prometheusMeterRegistry, "kaldbManager");
+          new ArmeriaService(serverPort, prometheusMeterRegistry, "kalDbManager");
       services.add(armeriaService);
 
       ReplicaCreatorService replicaCreatorService =
           new ReplicaCreatorService(metadataStoreService, prometheusMeterRegistry);
       services.add(replicaCreatorService);
+    }
+
+    if (roles.contains(KaldbConfigs.NodeRole.RECOVERY)) {
+      final int serverPort =
+          KaldbConfig.get().getRecoveryConfig().getServerConfig().getServerPort();
+      ArmeriaService armeriaService =
+          new ArmeriaService(serverPort, prometheusMeterRegistry, "kaldbRecovery");
+      services.add(armeriaService);
     }
 
     return services;

--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -12,6 +12,7 @@ import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.logstore.search.KaldbDistributedQueryService;
 import com.slack.kaldb.logstore.search.KaldbLocalQueryService;
 import com.slack.kaldb.proto.config.KaldbConfigs;
+import com.slack.kaldb.recovery.RecoveryService;
 import com.slack.kaldb.util.RuntimeHalterImpl;
 import com.slack.kaldb.writer.LogMessageTransformer;
 import com.slack.kaldb.writer.LogMessageWriterImpl;
@@ -156,6 +157,10 @@ public class Kaldb {
       ArmeriaService armeriaService =
           new ArmeriaService(serverPort, prometheusMeterRegistry, "kaldbRecovery");
       services.add(armeriaService);
+
+      RecoveryService recoveryService =
+          new RecoveryService(metadataStoreService, prometheusMeterRegistry);
+      services.add(recoveryService);
     }
 
     return services;

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -9,6 +9,7 @@ enum NodeRole {
     QUERY = 1;
     CACHE = 2;
     MANAGER = 3;
+    RECOVERY = 4;
 };
 
 message KaldbConfig {
@@ -21,6 +22,7 @@ message KaldbConfig {
     TracingConfig tracingConfig = 7;
     CacheConfig cacheConfig = 8;
     ManagerConfig managerConfig = 9;
+    RecoveryConfig recoveryConfig = 10;
 }
 
 message KafkaConfig {
@@ -85,5 +87,9 @@ message CacheConfig {
 }
 
 message ManagerConfig {
+    ServerConfig serverConfig = 1;
+}
+
+message RecoveryConfig {
     ServerConfig serverConfig = 1;
 }

--- a/kaldb/src/main/proto/metadata.proto
+++ b/kaldb/src/main/proto/metadata.proto
@@ -76,8 +76,14 @@ message RecoveryNodeMetadata {
   // Name of recovery node
   string name = 1;
 
+  // Name of the recovery task
+  string recoveryTaskName = 2;
+
   // State of the recovery node
-  RecoveryNodeState recoveryNodeState = 2;
+  RecoveryNodeState recoveryNodeState = 3;
+
+  // Last updated timestamp
+  int64 updatedTimeUtc = 4;
 }
 
 message RecoveryTaskMetadata {

--- a/kaldb/src/main/proto/metadata.proto
+++ b/kaldb/src/main/proto/metadata.proto
@@ -4,16 +4,16 @@ package slack.proto.kaldb;
 
 option java_package = "com.slack.kaldb.proto.metadata";
 
-enum CacheSlotState {
-  FREE = 0;
-  ASSIGNED = 1;
-  LOADING = 2;
-  LIVE = 3;
-  EVICT = 4;
-  EVICTING = 5;
-};
-
 message CacheSlotMetadata {
+  enum CacheSlotState {
+    FREE = 0;
+    ASSIGNED = 1;
+    LOADING = 2;
+    LIVE = 3;
+    EVICT = 4;
+    EVICTING = 5;
+  };
+
   // Name of the cache slot
   string name = 1;
 
@@ -64,4 +64,32 @@ message SearchMetadata {
 
   // url
   string url = 3;
+}
+
+message RecoveryNodeMetadata {
+  enum RecoveryNodeState {
+    FREE = 0;
+    ASSIGNED = 1;
+    RECOVERING = 2;
+  }
+
+  // Name of recovery node
+  string name = 1;
+
+  // State of the recovery node
+  RecoveryNodeState recoveryNodeState = 2;
+}
+
+message RecoveryTaskMetadata {
+  // Name of recovery node
+  string name = 1;
+
+  // Kafka partitionId.
+  string partitionId = 2;
+
+  // Kafka offset (inclusive) to start at
+  int64 startOffset = 3;
+
+  // Kafka offset (inclusive) to end at
+  int64 endOffset = 4;
 }

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/CachingChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/CachingChunkManagerTest.java
@@ -113,19 +113,19 @@ public class CachingChunkManagerTest {
             () ->
                 ((ReadOnlyChunkImpl) (readOnlyChunks.get(0)))
                     .getChunkMetadataState()
-                    .equals(Metadata.CacheSlotState.FREE));
+                    .equals(Metadata.CacheSlotMetadata.CacheSlotState.FREE));
     await()
         .until(
             () ->
                 ((ReadOnlyChunkImpl) (readOnlyChunks.get(1)))
                     .getChunkMetadataState()
-                    .equals(Metadata.CacheSlotState.FREE));
+                    .equals(Metadata.CacheSlotMetadata.CacheSlotState.FREE));
     await()
         .until(
             () ->
                 ((ReadOnlyChunkImpl) (readOnlyChunks.get(2)))
                     .getChunkMetadataState()
-                    .equals(Metadata.CacheSlotState.FREE));
+                    .equals(Metadata.CacheSlotMetadata.CacheSlotState.FREE));
 
     cachingChunkManager.stopAsync();
     metadataStoreService.stopAsync();

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -126,12 +126,20 @@ public class ReadOnlyChunkImplTest {
             searchMetadataStore);
 
     // wait for chunk to register
-    await().until(() -> readOnlyChunk.getChunkMetadataState() == Metadata.CacheSlotState.FREE);
+    await()
+        .until(
+            () ->
+                readOnlyChunk.getChunkMetadataState()
+                    == Metadata.CacheSlotMetadata.CacheSlotState.FREE);
 
     assignReplicaToChunk(cacheSlotMetadataStore, replicaId, readOnlyChunk);
 
     // ensure that the chunk was marked LIVE
-    await().until(() -> readOnlyChunk.getChunkMetadataState() == Metadata.CacheSlotState.LIVE);
+    await()
+        .until(
+            () ->
+                readOnlyChunk.getChunkMetadataState()
+                    == Metadata.CacheSlotMetadata.CacheSlotState.LIVE);
 
     SearchResult<LogMessage> logMessageSearchResult =
         readOnlyChunk.query(
@@ -152,10 +160,14 @@ public class ReadOnlyChunkImplTest {
     assertThat(searchMetadataStore.getCached().get(0).name).isEqualTo("localhost");
 
     // mark the chunk for eviction
-    readOnlyChunk.setChunkMetadataState(Metadata.CacheSlotState.EVICT);
+    readOnlyChunk.setChunkMetadataState(Metadata.CacheSlotMetadata.CacheSlotState.EVICT);
 
     // ensure that the evicted chunk was released
-    await().until(() -> readOnlyChunk.getChunkMetadataState() == Metadata.CacheSlotState.FREE);
+    await()
+        .until(
+            () ->
+                readOnlyChunk.getChunkMetadataState()
+                    == Metadata.CacheSlotMetadata.CacheSlotState.FREE);
 
     // ensure the search metadata node was unregistered
     await().until(() -> searchMetadataStore.getCached().size() == 0);
@@ -225,12 +237,20 @@ public class ReadOnlyChunkImplTest {
             searchMetadataStore);
 
     // wait for chunk to register
-    await().until(() -> readOnlyChunk.getChunkMetadataState() == Metadata.CacheSlotState.FREE);
+    await()
+        .until(
+            () ->
+                readOnlyChunk.getChunkMetadataState()
+                    == Metadata.CacheSlotMetadata.CacheSlotState.FREE);
 
     assignReplicaToChunk(cacheSlotMetadataStore, replicaId, readOnlyChunk);
 
     // assert that the chunk was released back to free
-    await().until(() -> readOnlyChunk.getChunkMetadataState() == Metadata.CacheSlotState.FREE);
+    await()
+        .until(
+            () ->
+                readOnlyChunk.getChunkMetadataState()
+                    == Metadata.CacheSlotMetadata.CacheSlotState.FREE);
 
     // ensure we did not register a search node
     assertThat(searchMetadataStore.getCached().size()).isEqualTo(0);
@@ -288,12 +308,20 @@ public class ReadOnlyChunkImplTest {
             searchMetadataStore);
 
     // wait for chunk to register
-    await().until(() -> readOnlyChunk.getChunkMetadataState() == Metadata.CacheSlotState.FREE);
+    await()
+        .until(
+            () ->
+                readOnlyChunk.getChunkMetadataState()
+                    == Metadata.CacheSlotMetadata.CacheSlotState.FREE);
 
     assignReplicaToChunk(cacheSlotMetadataStore, replicaId, readOnlyChunk);
 
     // assert that the chunk was released back to free
-    await().until(() -> readOnlyChunk.getChunkMetadataState() == Metadata.CacheSlotState.FREE);
+    await()
+        .until(
+            () ->
+                readOnlyChunk.getChunkMetadataState()
+                    == Metadata.CacheSlotMetadata.CacheSlotState.FREE);
 
     // ensure we did not register a search node
     assertThat(searchMetadataStore.getCached().size()).isEqualTo(0);
@@ -352,12 +380,20 @@ public class ReadOnlyChunkImplTest {
             searchMetadataStore);
 
     // wait for chunk to register
-    await().until(() -> readOnlyChunk.getChunkMetadataState() == Metadata.CacheSlotState.FREE);
+    await()
+        .until(
+            () ->
+                readOnlyChunk.getChunkMetadataState()
+                    == Metadata.CacheSlotMetadata.CacheSlotState.FREE);
 
     assignReplicaToChunk(cacheSlotMetadataStore, replicaId, readOnlyChunk);
 
     // ensure that the chunk was marked LIVE
-    await().until(() -> readOnlyChunk.getChunkMetadataState() == Metadata.CacheSlotState.LIVE);
+    await()
+        .until(
+            () ->
+                readOnlyChunk.getChunkMetadataState()
+                    == Metadata.CacheSlotMetadata.CacheSlotState.LIVE);
 
     SearchQuery query =
         new SearchQuery(
@@ -405,7 +441,7 @@ public class ReadOnlyChunkImplTest {
     CacheSlotMetadata updatedCacheSlotMetadata =
         new CacheSlotMetadata(
             readOnlyChunk.slotName,
-            Metadata.CacheSlotState.ASSIGNED,
+            Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
             replicaId,
             Instant.now().toEpochMilli());
     cacheSlotMetadataStore.update(updatedCacheSlotMetadata);

--- a/kaldb/src/test/java/com/slack/kaldb/config/KaldbConfigTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/config/KaldbConfigTest.java
@@ -206,6 +206,11 @@ public class KaldbConfigTest {
     final KaldbConfigs.ServerConfig managerServerConfig = managerConfig.getServerConfig();
     assertThat(managerServerConfig.getServerPort()).isEqualTo(8083);
     assertThat(managerServerConfig.getServerAddress()).isEqualTo("localhost");
+
+    final KaldbConfigs.RecoveryConfig recoveryConfig = config.getRecoveryConfig();
+    final KaldbConfigs.ServerConfig recoveryServerConfig = recoveryConfig.getServerConfig();
+    assertThat(recoveryServerConfig.getServerPort()).isEqualTo(8084);
+    assertThat(recoveryServerConfig.getServerAddress()).isEqualTo("localhost");
   }
 
   @Test
@@ -280,6 +285,11 @@ public class KaldbConfigTest {
     final KaldbConfigs.ServerConfig managerServerConfig = managerConfig.getServerConfig();
     assertThat(managerServerConfig.getServerPort()).isEqualTo(8083);
     assertThat(managerServerConfig.getServerAddress()).isEqualTo("localhost");
+
+    final KaldbConfigs.RecoveryConfig recoveryConfig = config.getRecoveryConfig();
+    final KaldbConfigs.ServerConfig recoveryServerConfig = recoveryConfig.getServerConfig();
+    assertThat(recoveryServerConfig.getServerPort()).isEqualTo(8084);
+    assertThat(recoveryServerConfig.getServerAddress()).isEqualTo("localhost");
   }
 
   @Test(expected = RuntimeException.class)
@@ -348,6 +358,11 @@ public class KaldbConfigTest {
     final KaldbConfigs.ServerConfig managerServerConfig = managerConfig.getServerConfig();
     assertThat(managerServerConfig.getServerPort()).isZero();
     assertThat(managerServerConfig.getServerAddress()).isEmpty();
+
+    final KaldbConfigs.RecoveryConfig recoveryConfig = config.getRecoveryConfig();
+    final KaldbConfigs.ServerConfig recoveryServerConfig = recoveryConfig.getServerConfig();
+    assertThat(recoveryServerConfig.getServerPort()).isZero();
+    assertThat(recoveryServerConfig.getServerAddress()).isEmpty();
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataTest.java
@@ -1,0 +1,55 @@
+package com.slack.kaldb.metadata.recovery;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.slack.kaldb.proto.metadata.Metadata;
+import java.time.Instant;
+import org.junit.Test;
+
+public class RecoveryNodeMetadataTest {
+
+  @Test
+  public void testRecoveryNodeMetadata() {
+    String name = "name";
+    Metadata.RecoveryNodeMetadata.RecoveryNodeState state =
+        Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE;
+    String task = "task";
+    long time = Instant.now().toEpochMilli();
+
+    RecoveryNodeMetadata recoveryNodeMetadata = new RecoveryNodeMetadata(name, state, task, time);
+
+    assertThat(recoveryNodeMetadata.name).isEqualTo(name);
+    assertThat(recoveryNodeMetadata.recoveryNodeState).isEqualTo(state);
+    assertThat(recoveryNodeMetadata.recoveryTaskName).isEqualTo(task);
+    assertThat(recoveryNodeMetadata.updatedTimeUtc).isEqualTo(time);
+  }
+
+  @Test
+  public void testRecoveryNodeEqualsHashcode() {
+    String name = "name";
+    Metadata.RecoveryNodeMetadata.RecoveryNodeState state =
+        Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE;
+    String task = "task";
+    long time = Instant.now().toEpochMilli();
+
+    RecoveryNodeMetadata recoveryNodeMetadataA = new RecoveryNodeMetadata(name, state, task, time);
+    RecoveryNodeMetadata recoveryNodeMetadataB = new RecoveryNodeMetadata(name, state, task, time);
+    RecoveryNodeMetadata recoveryNodeMetadataC =
+        new RecoveryNodeMetadata(
+            name, Metadata.RecoveryNodeMetadata.RecoveryNodeState.ASSIGNED, task, time);
+    RecoveryNodeMetadata recoveryNodeMetadataD =
+        new RecoveryNodeMetadata(name, state, "taskD", time);
+    RecoveryNodeMetadata recoveryNodeMetadataE =
+        new RecoveryNodeMetadata(name, state, task, time + 1);
+
+    assertThat(recoveryNodeMetadataA).isEqualTo(recoveryNodeMetadataB);
+    assertThat(recoveryNodeMetadataA).isNotEqualTo(recoveryNodeMetadataC);
+    assertThat(recoveryNodeMetadataA).isNotEqualTo(recoveryNodeMetadataD);
+    assertThat(recoveryNodeMetadataA).isNotEqualTo(recoveryNodeMetadataE);
+
+    assertThat(recoveryNodeMetadataA.hashCode()).isEqualTo(recoveryNodeMetadataB.hashCode());
+    assertThat(recoveryNodeMetadataA.hashCode()).isNotEqualTo(recoveryNodeMetadataC.hashCode());
+    assertThat(recoveryNodeMetadataA.hashCode()).isNotEqualTo(recoveryNodeMetadataD.hashCode());
+    assertThat(recoveryNodeMetadataA.hashCode()).isNotEqualTo(recoveryNodeMetadataE.hashCode());
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataTest.java
@@ -1,0 +1,53 @@
+package com.slack.kaldb.metadata.recovery;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.junit.Test;
+
+public class RecoveryTaskMetadataTest {
+
+  @Test
+  public void testRecoveryTaskMetadata() {
+    String name = "name";
+    String partitionId = "partitionId";
+    long startOffset = 1;
+    long endOffset = 2;
+
+    RecoveryTaskMetadata recoveryTaskMetadata =
+        new RecoveryTaskMetadata(name, partitionId, startOffset, endOffset);
+
+    assertThat(recoveryTaskMetadata.name).isEqualTo(name);
+    assertThat(recoveryTaskMetadata.partitionId).isEqualTo(partitionId);
+    assertThat(recoveryTaskMetadata.startOffset).isEqualTo(startOffset);
+    assertThat(recoveryTaskMetadata.endOffset).isEqualTo(endOffset);
+  }
+
+  @Test
+  public void testRecoveryTaskMetadataEqualsHashcode() {
+    String name = "name";
+    String partitionId = "partitionId";
+    long startOffset = 1;
+    long endOffset = 5;
+
+    RecoveryTaskMetadata recoveryTaskMetadataA =
+        new RecoveryTaskMetadata(name, partitionId, startOffset, endOffset);
+    RecoveryTaskMetadata recoveryTaskMetadataB =
+        new RecoveryTaskMetadata(name, partitionId, startOffset, endOffset);
+    RecoveryTaskMetadata recoveryTaskMetadataC =
+        new RecoveryTaskMetadata(name, "partitionIdC", startOffset, endOffset);
+    RecoveryTaskMetadata recoveryTaskMetadataD =
+        new RecoveryTaskMetadata(name, partitionId, 3, endOffset);
+    RecoveryTaskMetadata recoveryTaskMetadataE =
+        new RecoveryTaskMetadata(name, partitionId, startOffset, 8);
+
+    assertThat(recoveryTaskMetadataA).isEqualTo(recoveryTaskMetadataB);
+    assertThat(recoveryTaskMetadataA).isNotEqualTo(recoveryTaskMetadataC);
+    assertThat(recoveryTaskMetadataA).isNotEqualTo(recoveryTaskMetadataD);
+    assertThat(recoveryTaskMetadataA).isNotEqualTo(recoveryTaskMetadataE);
+
+    assertThat(recoveryTaskMetadataA.hashCode()).isEqualTo(recoveryTaskMetadataB.hashCode());
+    assertThat(recoveryTaskMetadataA.hashCode()).isNotEqualTo(recoveryTaskMetadataC.hashCode());
+    assertThat(recoveryTaskMetadataA.hashCode()).isNotEqualTo(recoveryTaskMetadataD.hashCode());
+    assertThat(recoveryTaskMetadataA.hashCode()).isNotEqualTo(recoveryTaskMetadataE.hashCode());
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataTest.java
@@ -1,0 +1,35 @@
+package com.slack.kaldb.metadata.replica;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.junit.Test;
+
+public class ReplicaMetadataTest {
+
+  @Test
+  public void testReplicaMetadata() {
+    String name = "name";
+    String snapshotId = "snapshotId";
+
+    ReplicaMetadata replicaMetadata = new ReplicaMetadata(name, snapshotId);
+
+    assertThat(replicaMetadata.name).isEqualTo(name);
+    assertThat(replicaMetadata.snapshotId).isEqualTo(snapshotId);
+  }
+
+  @Test
+  public void testReplicaMetadataEqualsHashcode() {
+    String name = "name";
+    String snapshotId = "snapshotId";
+
+    ReplicaMetadata replicaMetadataA = new ReplicaMetadata(name, snapshotId);
+    ReplicaMetadata replicaMetadataB = new ReplicaMetadata(name, snapshotId);
+    ReplicaMetadata replicaMetadataC = new ReplicaMetadata("nameC", snapshotId);
+
+    assertThat(replicaMetadataA).isEqualTo(replicaMetadataB);
+    assertThat(replicaMetadataA).isNotEqualTo(replicaMetadataC);
+
+    assertThat(replicaMetadataA.hashCode()).isEqualTo(replicaMetadataB.hashCode());
+    assertThat(replicaMetadataA.hashCode()).isNotEqualTo(replicaMetadataC.hashCode());
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
@@ -85,7 +85,8 @@ public class RecoveryServiceTest {
             Instant.now().toEpochMilli());
     recoveryNodeMetadataStore.updateSync(recoveryNodeAssignment);
 
-    // todo - verify it actually indexes here before it returns back to free
+    // todo - verify it actually indexes here before it returns back to free.
+    //  Recovery task should not exist at this point if it is complete
 
     await()
         .until(

--- a/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
@@ -1,0 +1,81 @@
+package com.slack.kaldb.recovery;
+
+import static com.slack.kaldb.config.KaldbConfig.DEFAULT_START_STOP_DURATION;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import brave.Tracing;
+import com.slack.kaldb.chunk.SearchContext;
+import com.slack.kaldb.metadata.recovery.RecoveryNodeMetadata;
+import com.slack.kaldb.metadata.recovery.RecoveryNodeMetadataStore;
+import com.slack.kaldb.proto.config.KaldbConfigs;
+import com.slack.kaldb.proto.metadata.Metadata;
+import com.slack.kaldb.server.MetadataStoreService;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RecoveryServiceTest {
+
+  private TestingServer testingServer;
+  private MeterRegistry meterRegistry;
+
+  @Before
+  public void setup() throws Exception {
+    Tracing.newBuilder().build();
+    meterRegistry = new SimpleMeterRegistry();
+    testingServer = new TestingServer();
+  }
+
+  @After
+  public void shutdown() throws IOException {
+    testingServer.close();
+    meterRegistry.close();
+  }
+
+  @Test
+  public void shouldRegisterAvailableRecoveryNode() throws Exception {
+    KaldbConfigs.ZookeeperConfig zkConfig =
+        KaldbConfigs.ZookeeperConfig.newBuilder()
+            .setZkConnectString(testingServer.getConnectString())
+            .setZkPathPrefix("shouldRegisterAvailableRecoveryNode")
+            .setZkSessionTimeoutMs(1000)
+            .setZkConnectionTimeoutMs(1000)
+            .setSleepBetweenRetriesMs(1000)
+            .build();
+
+    KaldbConfigs.ServerConfig serverConfig =
+        KaldbConfigs.ServerConfig.newBuilder()
+            .setServerPort(1234)
+            .setServerAddress("localhost")
+            .build();
+
+    KaldbConfigs.RecoveryConfig recoveryConfig =
+        KaldbConfigs.RecoveryConfig.newBuilder().setServerConfig(serverConfig).build();
+
+    SearchContext searchContext = SearchContext.fromConfig(serverConfig);
+
+    MetadataStoreService metadataStoreService = new MetadataStoreService(meterRegistry, zkConfig);
+    metadataStoreService.startAsync();
+    metadataStoreService.awaitRunning(DEFAULT_START_STOP_DURATION);
+
+    RecoveryService recoveryService =
+        new RecoveryService(recoveryConfig, metadataStoreService, meterRegistry);
+    recoveryService.startAsync();
+    recoveryService.awaitRunning(DEFAULT_START_STOP_DURATION);
+
+    RecoveryNodeMetadataStore recoveryNodeMetadataStore =
+        new RecoveryNodeMetadataStore(metadataStoreService.getMetadataStore(), false);
+
+    RecoveryNodeMetadata recoveryNodeMetadata =
+        recoveryNodeMetadataStore.getNodeSync(searchContext.hostname);
+    assertThat(recoveryNodeMetadata.recoveryNodeState)
+        .isEqualTo(Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE);
+
+    metadataStoreService.stopAsync();
+    metadataStoreService.awaitTerminated(DEFAULT_START_STOP_DURATION);
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/server/KalDbIntegrationTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KalDbIntegrationTest.java
@@ -33,7 +33,7 @@ public class KalDbIntegrationTest {
   private final ObjectMapper om = new ObjectMapper();
 
   @Before
-  public void start() throws IOException, Exception {
+  public void start() throws Exception {
     testingServer = new TestingServer(2181);
     broker = EphemeralKafkaBroker.create(9092);
     broker.start().get(10, TimeUnit.SECONDS);
@@ -88,6 +88,45 @@ public class KalDbIntegrationTest {
             String.format(
                 "http://localhost:%s/health",
                 KaldbConfig.get().getQueryConfig().getServerConfig().getServerPort()));
+    HashMap<String, Object> map = om.readValue(response, HashMap.class);
+
+    LOG.info(String.format("Response from healthcheck - '%s'", response));
+    assertThat(map.get("healthy")).isEqualTo(true);
+  }
+
+  @Test
+  public void testCacheStartupHealthcheck() throws JsonProcessingException {
+    String response =
+        getResponse(
+            String.format(
+                "http://localhost:%s/health",
+                KaldbConfig.get().getCacheConfig().getServerConfig().getServerPort()));
+    HashMap<String, Object> map = om.readValue(response, HashMap.class);
+
+    LOG.info(String.format("Response from healthcheck - '%s'", response));
+    assertThat(map.get("healthy")).isEqualTo(true);
+  }
+
+  @Test
+  public void testRecoveryStartupHealthcheck() throws JsonProcessingException {
+    String response =
+        getResponse(
+            String.format(
+                "http://localhost:%s/health",
+                KaldbConfig.get().getRecoveryConfig().getServerConfig().getServerPort()));
+    HashMap<String, Object> map = om.readValue(response, HashMap.class);
+
+    LOG.info(String.format("Response from healthcheck - '%s'", response));
+    assertThat(map.get("healthy")).isEqualTo(true);
+  }
+
+  @Test
+  public void testManagerStartupHealthcheck() throws JsonProcessingException {
+    String response =
+        getResponse(
+            String.format(
+                "http://localhost:%s/health",
+                KaldbConfig.get().getManagerConfig().getServerConfig().getServerPort()));
     HashMap<String, Object> map = om.readValue(response, HashMap.class);
 
     LOG.info(String.format("Response from healthcheck - '%s'", response));

--- a/kaldb/src/test/resources/test_config.json
+++ b/kaldb/src/test/resources/test_config.json
@@ -58,5 +58,11 @@
       "serverPort": 8083,
       "serverAddress": "localhost"
     }
+  },
+  "recoveryConfig": {
+    "serverConfig": {
+      "serverPort": 8084,
+      "serverAddress": "localhost"
+    }
   }
 }

--- a/kaldb/src/test/resources/test_config.yaml
+++ b/kaldb/src/test/resources/test_config.yaml
@@ -52,3 +52,8 @@ managerConfig:
   serverConfig:
     serverPort: 8083
     serverAddress: localhost
+
+recoveryConfig:
+  serverConfig:
+    serverPort: 8084
+    serverAddress: localhost


### PR DESCRIPTION
Adds functionality for registering recovery nodes. This will register nodes into ZK as available, and handle state transitions once assigned. Tests ensure that node is moved back to FREE once assigned, and we are matching the approach of the cache nodes for design and metadata store use.

Splitting offset indexing functionality into separate PR, as this is already quite large.