### PR TITLE
empty search metadata node will throw noisy excepetion

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbMetadata.java
@@ -1,12 +1,11 @@
 package com.slack.kaldb.metadata.core;
 
-import static com.google.common.base.Preconditions.checkState;
 
 public abstract class KaldbMetadata {
   public final String name;
 
   public KaldbMetadata(String name) {
-    checkState(name != null && !name.isEmpty(), "name can't be null or empty.");
+    //    checkState(name != null && !name.isEmpty(), "name can't be null or empty.");
     this.name = name;
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbMetadataStore.java
@@ -59,7 +59,7 @@ abstract class KaldbMetadataStore<T extends KaldbMetadata> {
     // Create the path to the store in ZK. However, since 2 different processes may create
     // a path at the same time, ignore the exception if node already exists.
     try {
-      metadataStore.create(storeFolder, "", true).get();
+      metadataStore.create(storeFolder, "{}", true).get();
     } catch (ExecutionException exception) {
       //noinspection StatementWithEmptyBody
       if (exception.getCause() instanceof NodeExistsException) {

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/search/SearchMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/search/SearchMetadata.java
@@ -1,6 +1,5 @@
 package com.slack.kaldb.metadata.search;
 
-import static com.google.common.base.Preconditions.checkState;
 
 import com.slack.kaldb.metadata.core.KaldbMetadata;
 
@@ -13,8 +12,9 @@ public class SearchMetadata extends KaldbMetadata {
 
   public SearchMetadata(String name, String snapshotName, String url) {
     super(name);
-    checkState(url != null && !url.isEmpty(), "Url shouldn't be empty");
-    checkState(snapshotName != null && !snapshotName.isEmpty(), "SnapshotName should not be empty");
+    //    checkState(url != null && !url.isEmpty(), "Url shouldn't be empty");
+    //    checkState(snapshotName != null && !snapshotName.isEmpty(), "SnapshotName should not be
+    // empty");
     this.snapshotName = snapshotName;
     this.url = url;
   }


### PR DESCRIPTION
Let's say you run `SearchMetadataStoreTest` you'll get a noisy exception in the log when we go to create the parent `/search` znode ( since the parent znode has no name, no url, no data )

```
RROR] 2021-11-11 14:17:20.375 [zk-metadata-runsafe-0] MappingListenerManager - Listener (org.apache.curator.framework.recipes.cache.CuratorCacheListenerBuilderImpl$2@19ae6bb) threw an exception
com.slack.kaldb.metadata.zookeeper.InternalMetadataStoreException: Error adding node at path /search
	at com.slack.kaldb.metadata.zookeeper.ZookeeperCachedMetadataStoreImpl.addInstance(ZookeeperCachedMetadataStoreImpl.java:205) ~[classes/:?]
	at com.slack.kaldb.metadata.zookeeper.ZookeeperCachedMetadataStoreImpl.nodeCreated(ZookeeperCachedMetadataStoreImpl.java:111) ~[classes/:?]
	at org.apache.curator.framework.recipes.cache.CuratorCacheListenerBuilderImpl.lambda$forCreates$0(CuratorCacheListenerBuilderImpl.java:45) ~[curator-recipes-5.1.0.jar:5.1.0]
	at org.apache.curator.framework.recipes.cache.CuratorCacheListenerBuilderImpl$2.lambda$event$0(CuratorCacheListenerBuilderImpl.java:149) ~[curator-recipes-5.1.0.jar:5.1.0]
	at java.util.ArrayList.forEach(ArrayList.java:1511) ~[?:?]
	at org.apache.curator.framework.recipes.cache.CuratorCacheListenerBuilderImpl$2.event(CuratorCacheListenerBuilderImpl.java:149) ~[curator-recipes-5.1.0.jar:5.1.0]
	at org.apache.curator.framework.recipes.cache.CuratorCacheImpl.lambda$putStorage$7(CuratorCacheImpl.java:279) ~[curator-recipes-5.1.0.jar:5.1.0]
	at org.apache.curator.framework.listen.MappingListenerManager.lambda$forEach$0(MappingListenerManager.java:92) ~[curator-framework-5.1.0.jar:5.1.0]
	at org.apache.curator.framework.listen.MappingListenerManager.forEach(MappingListenerManager.java:89) ~[curator-framework-5.1.0.jar:5.1.0]
	at org.apache.curator.framework.listen.StandardListenerManager.forEach(StandardListenerManager.java:89) ~[curator-framework-5.1.0.jar:5.1.0]
	at org.apache.curator.framework.recipes.cache.CuratorCacheImpl.lambda$callListeners$10(CuratorCacheImpl.java:293) ~[curator-recipes-5.1.0.jar:5.1.0]
	at java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1800) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630) ~[?:?]
	at java.lang.Thread.run(Thread.java:832) [?:?]
Caused by: com.google.protobuf.InvalidProtocolBufferException: Expect message object but got: null
	at com.google.protobuf.util.JsonFormat$ParserImpl.mergeMessage(JsonFormat.java:1479) ~[protobuf-java-util-3.17.3.jar:?]
	at com.google.protobuf.util.JsonFormat$ParserImpl.merge(JsonFormat.java:1456) ~[protobuf-java-util-3.17.3.jar:?]
	at com.google.protobuf.util.JsonFormat$ParserImpl.merge(JsonFormat.java:1338) ~[protobuf-java-util-3.17.3.jar:?]
	at com.google.protobuf.util.JsonFormat$Parser.merge(JsonFormat.java:476) ~[protobuf-java-util-3.17.3.jar:?]
	at com.slack.kaldb.metadata.search.SearchMetadataSerializer.fromJsonStr(SearchMetadataSerializer.java:35) ~[classes/:?]
	at com.slack.kaldb.metadata.search.SearchMetadataSerializer.fromJsonStr(SearchMetadataSerializer.java:8) ~[classes/:?]
	at com.slack.kaldb.metadata.zookeeper.ZookeeperCachedMetadataStoreImpl.addInstance(ZookeeperCachedMetadataStoreImpl.java:195) ~[classes/:?]
	... 14 more
```

After this fix we won't get the exception but we loose some checks. Thoughts if we should live with the noise or go down this route ( potentially for all the other metadata stores as well )

Personally I think we should not commit this after thinking about it.