### PR TITLE
add metadata store lifecycle manager

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/metadata/zookeeper/MetadataStoreLifecycleManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/zookeeper/MetadataStoreLifecycleManager.java
@@ -1,0 +1,36 @@
+package com.slack.kaldb.metadata.zookeeper;
+
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.slack.kaldb.metadata.core.CacheableMetadataStore;
+import com.slack.kaldb.proto.config.KaldbConfigs;
+import java.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Each instance of MetadataStoreLifecycleManager holds all the metadata stores required for each
+ * node role MetadataStoreLifecycleManager is a managed guava service. The caller needs to add the
+ * created instance to a service manager which would then take care of the object lifecycle
+ */
+public class MetadataStoreLifecycleManager extends AbstractIdleService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MetadataStoreLifecycleManager.class);
+
+  private final KaldbConfigs.NodeRole nodeRole;
+  private final List<CacheableMetadataStore<?>> metadataStores;
+
+  public MetadataStoreLifecycleManager(
+      KaldbConfigs.NodeRole role, List<CacheableMetadataStore<?>> metadataStores) {
+    this.metadataStores = metadataStores;
+    this.nodeRole = role;
+  }
+
+  @Override
+  protected void startUp() throws Exception {}
+
+  @Override
+  protected void shutDown() throws Exception {
+    LOG.info("shutting down MetadataStoreLifecycleManager for role=" + nodeRole.toString());
+    metadataStores.forEach(CacheableMetadataStore::close);
+  }
+}

--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -11,7 +11,9 @@ import com.slack.kaldb.config.KaldbConfig;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.logstore.search.KaldbDistributedQueryService;
 import com.slack.kaldb.logstore.search.KaldbLocalQueryService;
+import com.slack.kaldb.metadata.search.SearchMetadataStore;
 import com.slack.kaldb.metadata.zookeeper.MetadataStore;
+import com.slack.kaldb.metadata.zookeeper.MetadataStoreLifecycleManager;
 import com.slack.kaldb.metadata.zookeeper.ZookeeperMetadataStoreImpl;
 import com.slack.kaldb.proto.config.KaldbConfigs;
 import com.slack.kaldb.recovery.RecoveryService;
@@ -30,9 +32,7 @@ import io.micrometer.prometheus.PrometheusMeterRegistry;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.logging.log4j.LogManager;
@@ -121,6 +121,11 @@ public class Kaldb {
     }
 
     if (roles.contains(KaldbConfigs.NodeRole.QUERY)) {
+      SearchMetadataStore searchMetadataStore = new SearchMetadataStore(metadataStore, true);
+      services.add(
+          new MetadataStoreLifecycleManager(
+              KaldbConfigs.NodeRole.QUERY, Collections.singletonList(searchMetadataStore)));
+
       KaldbDistributedQueryService searcher = new KaldbDistributedQueryService();
       KaldbDistributedQueryService.servers =
           new ArrayList<>(KaldbConfig.get().getQueryConfig().getTmpIndexNodesList());


### PR DESCRIPTION
Add metadata store lifecycle manager. The code has example an example usage for the query service. 

in this design every service creates it's own MetadataStoreLifecycleManager and adds the list of stores that it needs. Then the current framework will do the job of closing the stores on shutdown