### PR TITLE
Fix KaldbDistributedQueryServiceTest test failure

### DIFF
--- a/kaldb/src/test/java/com/slack/kaldb/util/LocalKafkaSeed.java
+++ b/kaldb/src/test/java/com/slack/kaldb/util/LocalKafkaSeed.java
@@ -1,6 +1,5 @@
 package com.slack.kaldb.util;
 
-import static com.slack.kaldb.testlib.TestKafkaServer.TEST_KAFKA_PARTITION;
 import static com.slack.kaldb.testlib.TestKafkaServer.TEST_KAFKA_TOPIC;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -90,10 +89,7 @@ public class LocalKafkaSeed {
               .build();
 
       return new ProducerRecord<>(
-          TEST_KAFKA_TOPIC,
-          TEST_KAFKA_PARTITION,
-          String.valueOf(offset),
-          testMurronMsg.toByteArray());
+          TEST_KAFKA_TOPIC, 0, String.valueOf(offset), testMurronMsg.toByteArray());
     } catch (Exception e) {
       System.out.println("skipping - cannot parse input" + e);
       return null;

--- a/kaldb/src/test/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumerTest.java
@@ -36,7 +36,7 @@ public class KaldbKafkaConsumerTest {
     public TestKaldbKafkaConsumer(String kafkaBootStrapServers, String testKafkaClientGroup) {
       super(
           TestKafkaServer.TEST_KAFKA_TOPIC,
-          String.valueOf(TestKafkaServer.TEST_KAFKA_PARTITION),
+          "0",
           kafkaBootStrapServers,
           testKafkaClientGroup,
           "true",


### PR DESCRIPTION
[1_build.txt](https://github.com/slackhq/kaldb/files/7621238/1_build.txt) - logs from the test run

The problem here was 
1. The service manager wasn't waiting for all the services to start
2. Even if the service manager ensures all services are running, the kafka consumer  ( within the indexer ) isn't attached to the service manager semantics ( it's okay since we want to back it up with ZK ) but to make sure the test setup works correctly we wait for the consumer group to also start up