### PR TITLE
Cache slot assignment service

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -64,6 +64,8 @@ managerConfig:
     replicaLifespanMins: ${KALDB_MANAGER_REPLICA_LIFESPAN_MINS:-1440}
   recoveryTaskAssignmentServiceConfig:
     schedulePeriodMins: ${KALDB_MANAGER_RECOVERY_PERIOD_MINS:-15}
+  cacheSlotAssignmentServiceConfig:
+    schedulePeriodMins: ${KALDB_MANAGER_CACHE_SLOT_PERIOD_MINS:-15}
 
 recoveryConfig:
   serverConfig:

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/CacheSlotAssignmentService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/CacheSlotAssignmentService.java
@@ -1,0 +1,253 @@
+package com.slack.kaldb.clusterManager;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.util.concurrent.Futures.addCallback;
+import static com.slack.kaldb.config.KaldbConfig.DEFAULT_ZK_TIMEOUT_SECS;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Streams;
+import com.google.common.util.concurrent.AbstractScheduledService;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.slack.kaldb.metadata.cache.CacheSlotMetadata;
+import com.slack.kaldb.metadata.cache.CacheSlotMetadataStore;
+import com.slack.kaldb.metadata.replica.ReplicaMetadata;
+import com.slack.kaldb.metadata.replica.ReplicaMetadataStore;
+import com.slack.kaldb.proto.config.KaldbConfigs;
+import com.slack.kaldb.proto.metadata.Metadata;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The cache slot assignment service watches for changes in the available cache slots and replicas
+ * requiring assignments, and attempts to assign replicas to available slots. In the event there are
+ * no available slots a failure will be noted and the assignment will be retried on the following
+ * run.
+ */
+public class CacheSlotAssignmentService extends AbstractScheduledService {
+  private static final Logger LOG = LoggerFactory.getLogger(CacheSlotAssignmentService.class);
+
+  private final CacheSlotMetadataStore cacheSlotMetadataStore;
+  private final ReplicaMetadataStore replicaMetadataStore;
+  private final KaldbConfigs.ManagerConfig managerConfig;
+  private final MeterRegistry meterRegistry;
+
+  @VisibleForTesting protected int futuresListTimeoutSecs = DEFAULT_ZK_TIMEOUT_SECS;
+
+  public static final String SLOT_ASSIGN_SUCCEEDED = "cache_slot_assign_succeeded";
+  public static final String SLOT_ASSIGN_FAILED = "cache_slot_assign_failed";
+  public static final String SLOT_ASSIGN_INSUFFICIENT_CAPACITY =
+      "cache_slot_assign_insufficient_capacity";
+  public static final String SLOT_ASSIGN_TIMER = "cache_slot_assign_timer";
+
+  protected final Counter slotAssignSucceeded;
+  protected final Counter slotAssignFailed;
+  protected final Counter slotAssignInsufficientCapacity;
+  private final Timer slotAssignTimer;
+
+  private final ScheduledExecutorService executorService =
+      Executors.newSingleThreadScheduledExecutor();
+  private ScheduledFuture<?> pendingTask;
+
+  public CacheSlotAssignmentService(
+      CacheSlotMetadataStore cacheSlotMetadataStore,
+      ReplicaMetadataStore replicaMetadataStore,
+      KaldbConfigs.ManagerConfig managerConfig,
+      MeterRegistry meterRegistry) {
+    this.cacheSlotMetadataStore = cacheSlotMetadataStore;
+    this.replicaMetadataStore = replicaMetadataStore;
+    this.managerConfig = managerConfig;
+    this.meterRegistry = meterRegistry;
+
+    checkArgument(managerConfig.getEventAggregationSecs() > 0, "eventAggregationSecs must be > 0");
+    checkArgument(
+        managerConfig.getReplicaEvictionServiceConfig().getReplicaLifespanMins() > 0,
+        "replicaLifespanMins must be > 0");
+    // schedule configs checked as part of the AbstractScheduledService
+
+    slotAssignSucceeded = meterRegistry.counter(SLOT_ASSIGN_SUCCEEDED);
+    slotAssignFailed = meterRegistry.counter(SLOT_ASSIGN_FAILED);
+    slotAssignInsufficientCapacity = meterRegistry.counter(SLOT_ASSIGN_INSUFFICIENT_CAPACITY);
+    slotAssignTimer = meterRegistry.timer(SLOT_ASSIGN_TIMER);
+  }
+
+  @Override
+  protected synchronized void runOneIteration() {
+    if (pendingTask == null || pendingTask.getDelay(TimeUnit.SECONDS) <= 0) {
+      pendingTask =
+          executorService.schedule(
+              this::assignCacheSlotsToReplicas,
+              managerConfig.getEventAggregationSecs(),
+              TimeUnit.SECONDS);
+    } else {
+      LOG.debug(
+          "Cache slot assignment already queued for execution, will run in {} ms",
+          pendingTask.getDelay(TimeUnit.MILLISECONDS));
+    }
+  }
+
+  @Override
+  protected Scheduler scheduler() {
+    return Scheduler.newFixedRateSchedule(
+        managerConfig.getScheduleInitialDelayMins(),
+        managerConfig.getCacheSlotAssignmentServiceConfig().getSchedulePeriodMins(),
+        TimeUnit.MINUTES);
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    LOG.info("Starting cache slot assignment service");
+    cacheSlotMetadataStore.addListener(this::runOneIteration);
+    replicaMetadataStore.addListener(this::runOneIteration);
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    executorService.shutdown();
+    LOG.info("Closed cache assignment service");
+  }
+
+  /**
+   * Assigns replicas to available cache slots, up to the configured replica lifespan min
+   * configuration. Replicas will be assigned with the most recently created first in descending
+   * order. In the event that more replicas than slots exist this ensures the most recent replicas
+   * are preferred. No preference is given to specific cache slots, which may result in over/under
+   * utilization of specific cache slots.
+   *
+   * <p>If this method fails to successfully assign all the replicas needing slot assignment, the
+   * following iteration of this method would attempt to re-assign these until there are no more
+   * available replicas to assign.
+   *
+   * @return The count of successfully assigned cache slots
+   */
+  protected int assignCacheSlotsToReplicas() {
+    Timer.Sample assignmentTimer = Timer.start(meterRegistry);
+
+    List<CacheSlotMetadata> availableCacheSlots =
+        cacheSlotMetadataStore
+            .getCached()
+            .stream()
+            .filter(
+                cacheSlotMetadata ->
+                    cacheSlotMetadata.cacheSlotState.equals(
+                        Metadata.CacheSlotMetadata.CacheSlotState.FREE))
+            .collect(Collectors.toList());
+
+    List<String> assignedReplicaIds =
+        cacheSlotMetadataStore
+            .getCached()
+            .stream()
+            .map(cacheSlotMetadata -> cacheSlotMetadata.replicaId)
+            .filter(replicaId -> !replicaId.isEmpty())
+            .collect(Collectors.toList());
+
+    List<String> replicaIdsToAssign =
+        replicaMetadataStore
+            .getCached()
+            .stream()
+            // only replicas created in the last X mins
+            .filter(
+                replicaMetadata ->
+                    replicaMetadata.createdTimeUtc
+                        > Instant.now()
+                            .minus(
+                                managerConfig
+                                    .getReplicaEvictionServiceConfig()
+                                    .getReplicaLifespanMins(),
+                                ChronoUnit.MINUTES)
+                            .toEpochMilli())
+            // sort the list by the newest replicas first, in case we run out of available slots
+            .sorted(Comparator.comparingLong(ReplicaMetadata::getCreatedTimeUtc))
+            .map(replicaMetadata -> replicaMetadata.name)
+            .filter(replicaId -> !assignedReplicaIds.contains(replicaId))
+            .collect(Collectors.toList());
+
+    if (replicaIdsToAssign.size() > availableCacheSlots.size()) {
+      LOG.warn(
+          "Insufficient cache slots to assign replicas, wanted {} slots but had {} replicas",
+          replicaIdsToAssign.size(),
+          availableCacheSlots.size());
+      slotAssignInsufficientCapacity.increment(
+          replicaIdsToAssign.size() - availableCacheSlots.size());
+    } else if (replicaIdsToAssign.size() == 0) {
+      LOG.info("No replicas found requiring assignment");
+      assignmentTimer.stop(slotAssignTimer);
+      return 0;
+    }
+
+    AtomicInteger successCounter = new AtomicInteger(0);
+    List<ListenableFuture<?>> cacheSlotAssignments =
+        Streams.zip(
+                replicaIdsToAssign.stream(),
+                availableCacheSlots.stream(),
+                (replicaId, availableCacheSlot) -> {
+                  CacheSlotMetadata assignedCacheSlot =
+                      new CacheSlotMetadata(
+                          availableCacheSlot.name,
+                          Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
+                          replicaId,
+                          Instant.now().toEpochMilli());
+
+                  ListenableFuture<?> future = cacheSlotMetadataStore.update(assignedCacheSlot);
+                  addCallback(
+                      future,
+                      successCountingCallback(successCounter),
+                      MoreExecutors.directExecutor());
+                  return future;
+                })
+            .collect(Collectors.toList());
+
+    ListenableFuture<?> futureList = Futures.successfulAsList(cacheSlotAssignments);
+    try {
+      futureList.get(futuresListTimeoutSecs, TimeUnit.SECONDS);
+    } catch (Exception e) {
+      futureList.cancel(true);
+    }
+
+    int successfulAssignments = successCounter.get();
+    int failedAssignments = cacheSlotAssignments.size() - successfulAssignments;
+
+    slotAssignSucceeded.increment(successfulAssignments);
+    slotAssignFailed.increment(failedAssignments);
+
+    long assignmentDuration = assignmentTimer.stop(slotAssignTimer);
+    LOG.info(
+        "Completed cache slot assignment - successfully assigned {} replicas, failed to assign {} replicas in {} ms",
+        successfulAssignments,
+        failedAssignments,
+        TimeUnit.MILLISECONDS.convert(assignmentDuration, TimeUnit.NANOSECONDS));
+
+    return successfulAssignments;
+  }
+
+  /** Uses the provided atomic integer to keep track of FutureCallbacks that are successful */
+  private FutureCallback<Object> successCountingCallback(AtomicInteger counter) {
+    return new FutureCallback<>() {
+      @Override
+      public void onSuccess(@Nullable Object result) {
+        counter.incrementAndGet();
+      }
+
+      @Override
+      public void onFailure(Throwable t) {
+        // no-op
+      }
+    };
+  }
+}

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -99,6 +99,10 @@ message ManagerConfig {
         int32 schedulePeriodMins = 1;
     }
 
+    message CacheSlotAssignmentServiceConfig {
+        int32 schedulePeriodMins = 1;
+    }
+
     int32 eventAggregationSecs = 1;
     int32 scheduleInitialDelayMins = 2;
     ServerConfig serverConfig = 3;
@@ -106,6 +110,7 @@ message ManagerConfig {
     ReplicaCreationServiceConfig replicaCreationServiceConfig = 4;
     ReplicaEvictionServiceConfig replicaEvictionServiceConfig = 5;
     RecoveryTaskAssignmentServiceConfig recoveryTaskAssignmentServiceConfig = 6;
+    CacheSlotAssignmentServiceConfig cacheSlotAssignmentServiceConfig = 7;
 }
 
 message RecoveryConfig {

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/CacheSlotAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/CacheSlotAssignmentServiceTest.java
@@ -1,0 +1,1201 @@
+package com.slack.kaldb.clusterManager;
+
+import static com.slack.kaldb.config.KaldbConfig.DEFAULT_START_STOP_DURATION;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.spy;
+
+import brave.Tracing;
+import com.google.common.util.concurrent.Futures;
+import com.slack.kaldb.metadata.cache.CacheSlotMetadata;
+import com.slack.kaldb.metadata.cache.CacheSlotMetadataStore;
+import com.slack.kaldb.metadata.replica.ReplicaMetadata;
+import com.slack.kaldb.metadata.replica.ReplicaMetadataStore;
+import com.slack.kaldb.metadata.zookeeper.MetadataStore;
+import com.slack.kaldb.metadata.zookeeper.ZookeeperMetadataStoreImpl;
+import com.slack.kaldb.proto.config.KaldbConfigs;
+import com.slack.kaldb.proto.metadata.Metadata;
+import com.slack.kaldb.testlib.MetricsUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import org.apache.curator.test.TestingServer;
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CacheSlotAssignmentServiceTest {
+
+  private TestingServer testingServer;
+  private MeterRegistry meterRegistry;
+
+  private MetadataStore metadataStore;
+  private CacheSlotMetadataStore cacheSlotMetadataStore;
+  private ReplicaMetadataStore replicaMetadataStore;
+
+  @Before
+  public void setup() throws Exception {
+    Tracing.newBuilder().build();
+    meterRegistry = new SimpleMeterRegistry();
+    testingServer = new TestingServer();
+
+    KaldbConfigs.ZookeeperConfig zkConfig =
+        KaldbConfigs.ZookeeperConfig.newBuilder()
+            .setZkConnectString(testingServer.getConnectString())
+            .setZkPathPrefix("CacheSlotAssignmentServiceTest")
+            .setZkSessionTimeoutMs(1000)
+            .setZkConnectionTimeoutMs(1000)
+            .setSleepBetweenRetriesMs(1000)
+            .build();
+
+    metadataStore = ZookeeperMetadataStoreImpl.fromConfig(meterRegistry, zkConfig);
+    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(metadataStore, true));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(metadataStore, true));
+  }
+
+  @After
+  public void shutdown() throws IOException {
+    cacheSlotMetadataStore.close();
+    replicaMetadataStore.close();
+    metadataStore.close();
+
+    testingServer.close();
+    meterRegistry.close();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldCheckInvalidEventAggregation() {
+    KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig cacheSlotAssignmentServiceConfig =
+        KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig.newBuilder()
+            .setSchedulePeriodMins(1)
+            .build();
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setEventAggregationSecs(0)
+            .setScheduleInitialDelayMins(1)
+            .setCacheSlotAssignmentServiceConfig(cacheSlotAssignmentServiceConfig)
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .build();
+
+    new CacheSlotAssignmentService(
+        cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldCheckInvalidReplicaLifespanMins() {
+    KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig cacheSlotAssignmentServiceConfig =
+        KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig.newBuilder()
+            .setSchedulePeriodMins(1)
+            .build();
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setReplicaLifespanMins(0)
+            .build();
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setEventAggregationSecs(10)
+            .setScheduleInitialDelayMins(1)
+            .setCacheSlotAssignmentServiceConfig(cacheSlotAssignmentServiceConfig)
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .build();
+
+    new CacheSlotAssignmentService(
+        cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldCheckInvalidScheduleInitialDelay() {
+    KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig cacheSlotAssignmentServiceConfig =
+        KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig.newBuilder()
+            .setSchedulePeriodMins(1)
+            .build();
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setReplicaLifespanMins(0)
+            .build();
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setEventAggregationSecs(10)
+            .setScheduleInitialDelayMins(-1)
+            .setCacheSlotAssignmentServiceConfig(cacheSlotAssignmentServiceConfig)
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .build();
+
+    new CacheSlotAssignmentService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry)
+        .scheduler();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldCheckInvalidSchedulePeriod() {
+    KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig cacheSlotAssignmentServiceConfig =
+        KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig.newBuilder()
+            .setSchedulePeriodMins(-1)
+            .build();
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setReplicaLifespanMins(0)
+            .build();
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setEventAggregationSecs(10)
+            .setScheduleInitialDelayMins(1)
+            .setCacheSlotAssignmentServiceConfig(cacheSlotAssignmentServiceConfig)
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .build();
+
+    new CacheSlotAssignmentService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry)
+        .scheduler();
+  }
+
+  @Test
+  public void shouldHandleNoSlotsOrReplicas() {
+    KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig cacheSlotAssignmentServiceConfig =
+        KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig.newBuilder()
+            .setSchedulePeriodMins(1)
+            .build();
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setEventAggregationSecs(10)
+            .setScheduleInitialDelayMins(1)
+            .setCacheSlotAssignmentServiceConfig(cacheSlotAssignmentServiceConfig)
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .build();
+
+    CacheSlotAssignmentService cacheSlotAssignmentService =
+        new CacheSlotAssignmentService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+
+    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(0);
+    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(0);
+
+    int assignments = cacheSlotAssignmentService.assignCacheSlotsToReplicas();
+    assertThat(assignments).isEqualTo(0);
+
+    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(0);
+    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_FAILED, meterRegistry))
+        .isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_SUCCEEDED, meterRegistry))
+        .isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getCount(
+                CacheSlotAssignmentService.SLOT_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
+        .isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getTimerCount(CacheSlotAssignmentService.SLOT_ASSIGN_TIMER, meterRegistry))
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldHandleNoAvailableSlots() {
+    KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig cacheSlotAssignmentServiceConfig =
+        KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig.newBuilder()
+            .setSchedulePeriodMins(1)
+            .build();
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setEventAggregationSecs(10)
+            .setScheduleInitialDelayMins(1)
+            .setCacheSlotAssignmentServiceConfig(cacheSlotAssignmentServiceConfig)
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .build();
+
+    CacheSlotAssignmentService cacheSlotAssignmentService =
+        new CacheSlotAssignmentService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+
+    List<ReplicaMetadata> replicaMetadataList = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      ReplicaMetadata replicaMetadata =
+          new ReplicaMetadata(
+              UUID.randomUUID().toString(),
+              UUID.randomUUID().toString(),
+              Instant.now().toEpochMilli());
+      replicaMetadataList.add(replicaMetadata);
+      replicaMetadataStore.create(replicaMetadata);
+    }
+
+    await().until(() -> replicaMetadataStore.getCached().size() == 3);
+    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(0);
+
+    int assignments = cacheSlotAssignmentService.assignCacheSlotsToReplicas();
+    assertThat(assignments).isEqualTo(0);
+
+    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(0);
+    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(3);
+
+    assertTrue(replicaMetadataList.containsAll(replicaMetadataStore.listSync()));
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_FAILED, meterRegistry))
+        .isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_SUCCEEDED, meterRegistry))
+        .isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getCount(
+                CacheSlotAssignmentService.SLOT_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
+        .isEqualTo(3);
+    Assertions.assertThat(
+            MetricsUtil.getTimerCount(CacheSlotAssignmentService.SLOT_ASSIGN_TIMER, meterRegistry))
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldHandleNoAvailableReplicas() {
+    KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig cacheSlotAssignmentServiceConfig =
+        KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig.newBuilder()
+            .setSchedulePeriodMins(1)
+            .build();
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setEventAggregationSecs(10)
+            .setScheduleInitialDelayMins(1)
+            .setCacheSlotAssignmentServiceConfig(cacheSlotAssignmentServiceConfig)
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .build();
+
+    CacheSlotAssignmentService cacheSlotAssignmentService =
+        new CacheSlotAssignmentService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+
+    List<CacheSlotMetadata> cacheSlotMetadataList = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      CacheSlotMetadata cacheSlotMetadata =
+          new CacheSlotMetadata(
+              UUID.randomUUID().toString(),
+              Metadata.CacheSlotMetadata.CacheSlotState.FREE,
+              "",
+              Instant.now().toEpochMilli());
+      cacheSlotMetadataList.add(cacheSlotMetadata);
+      cacheSlotMetadataStore.create(cacheSlotMetadata);
+    }
+
+    await().until(() -> cacheSlotMetadataStore.getCached().size() == 3);
+    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(0);
+
+    int assignments = cacheSlotAssignmentService.assignCacheSlotsToReplicas();
+    assertThat(assignments).isEqualTo(0);
+
+    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(0);
+    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(3);
+
+    assertTrue(cacheSlotMetadataList.containsAll(cacheSlotMetadataStore.listSync()));
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_FAILED, meterRegistry))
+        .isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_SUCCEEDED, meterRegistry))
+        .isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getCount(
+                CacheSlotAssignmentService.SLOT_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
+        .isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getTimerCount(CacheSlotAssignmentService.SLOT_ASSIGN_TIMER, meterRegistry))
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldHandleAllReplicasAlreadyAssigned() {
+    KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig cacheSlotAssignmentServiceConfig =
+        KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig.newBuilder()
+            .setSchedulePeriodMins(1)
+            .build();
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setEventAggregationSecs(10)
+            .setScheduleInitialDelayMins(1)
+            .setCacheSlotAssignmentServiceConfig(cacheSlotAssignmentServiceConfig)
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .build();
+
+    CacheSlotAssignmentService cacheSlotAssignmentService =
+        new CacheSlotAssignmentService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+
+    List<ReplicaMetadata> replicaMetadataList = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      ReplicaMetadata replicaMetadata =
+          new ReplicaMetadata(
+              UUID.randomUUID().toString(),
+              UUID.randomUUID().toString(),
+              Instant.now().toEpochMilli());
+      replicaMetadataList.add(replicaMetadata);
+      replicaMetadataStore.create(replicaMetadata);
+    }
+
+    List<CacheSlotMetadata> cacheSlotMetadataList = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      CacheSlotMetadata cacheSlotMetadata =
+          new CacheSlotMetadata(
+              UUID.randomUUID().toString(),
+              Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
+              replicaMetadataList.get(i).name,
+              Instant.now().toEpochMilli());
+      cacheSlotMetadataList.add(cacheSlotMetadata);
+      cacheSlotMetadataStore.create(cacheSlotMetadata);
+    }
+
+    for (int i = 0; i < 2; i++) {
+      CacheSlotMetadata cacheSlotMetadata =
+          new CacheSlotMetadata(
+              UUID.randomUUID().toString(),
+              Metadata.CacheSlotMetadata.CacheSlotState.FREE,
+              "",
+              Instant.now().toEpochMilli());
+      cacheSlotMetadataList.add(cacheSlotMetadata);
+      cacheSlotMetadataStore.create(cacheSlotMetadata);
+    }
+
+    await().until(() -> cacheSlotMetadataStore.getCached().size() == 5);
+    await().until(() -> replicaMetadataStore.getCached().size() == 3);
+
+    int assignments = cacheSlotAssignmentService.assignCacheSlotsToReplicas();
+    assertThat(assignments).isEqualTo(0);
+
+    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(3);
+    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(5);
+
+    assertTrue(cacheSlotMetadataList.containsAll(cacheSlotMetadataStore.listSync()));
+    assertTrue(replicaMetadataList.containsAll(replicaMetadataStore.listSync()));
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_FAILED, meterRegistry))
+        .isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_SUCCEEDED, meterRegistry))
+        .isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getCount(
+                CacheSlotAssignmentService.SLOT_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
+        .isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getTimerCount(CacheSlotAssignmentService.SLOT_ASSIGN_TIMER, meterRegistry))
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldHandleMixOfSlotStates() {
+    KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig cacheSlotAssignmentServiceConfig =
+        KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig.newBuilder()
+            .setSchedulePeriodMins(1)
+            .build();
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setEventAggregationSecs(10)
+            .setScheduleInitialDelayMins(1)
+            .setCacheSlotAssignmentServiceConfig(cacheSlotAssignmentServiceConfig)
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .build();
+
+    CacheSlotAssignmentService cacheSlotAssignmentService =
+        new CacheSlotAssignmentService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+
+    List<ReplicaMetadata> replicaMetadataList = new ArrayList<>();
+    for (int i = 0; i < 4; i++) {
+      ReplicaMetadata replicaMetadata =
+          new ReplicaMetadata(
+              UUID.randomUUID().toString(),
+              UUID.randomUUID().toString(),
+              Instant.now().toEpochMilli());
+      replicaMetadataList.add(replicaMetadata);
+      replicaMetadataStore.create(replicaMetadata);
+    }
+
+    List<CacheSlotMetadata> unmutatedSlots = new ArrayList<>();
+    CacheSlotMetadata cacheSlotAssigned =
+        new CacheSlotMetadata(
+            UUID.randomUUID().toString(),
+            Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
+            replicaMetadataList.get(0).name,
+            Instant.now().toEpochMilli());
+    unmutatedSlots.add(cacheSlotAssigned);
+    cacheSlotMetadataStore.create(cacheSlotAssigned);
+
+    CacheSlotMetadata cacheSlotLive =
+        new CacheSlotMetadata(
+            UUID.randomUUID().toString(),
+            Metadata.CacheSlotMetadata.CacheSlotState.LIVE,
+            replicaMetadataList.get(1).name,
+            Instant.now().toEpochMilli());
+    unmutatedSlots.add(cacheSlotLive);
+    cacheSlotMetadataStore.create(cacheSlotLive);
+
+    CacheSlotMetadata cacheSlotEvicting =
+        new CacheSlotMetadata(
+            UUID.randomUUID().toString(),
+            Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
+            replicaMetadataList.get(2).name,
+            Instant.now().toEpochMilli());
+    unmutatedSlots.add(cacheSlotEvicting);
+    cacheSlotMetadataStore.create(cacheSlotEvicting);
+
+    CacheSlotMetadata cacheSlotFree =
+        new CacheSlotMetadata(
+            UUID.randomUUID().toString(),
+            Metadata.CacheSlotMetadata.CacheSlotState.FREE,
+            "",
+            Instant.now().toEpochMilli());
+    cacheSlotMetadataStore.create(cacheSlotFree);
+
+    await().until(() -> cacheSlotMetadataStore.getCached().size() == 4);
+    await().until(() -> replicaMetadataStore.getCached().size() == 4);
+
+    int assignments = cacheSlotAssignmentService.assignCacheSlotsToReplicas();
+    assertThat(assignments).isEqualTo(1);
+
+    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(4);
+    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(4);
+    assertTrue(cacheSlotMetadataStore.getCached().containsAll(unmutatedSlots));
+
+    List<CacheSlotMetadata> mutatedCacheSlots =
+        cacheSlotMetadataStore
+            .getCached()
+            .stream()
+            .filter(cacheSlotMetadata -> !unmutatedSlots.contains(cacheSlotMetadata))
+            .collect(Collectors.toList());
+    assertThat(mutatedCacheSlots.size()).isEqualTo(1);
+    assertThat(mutatedCacheSlots.get(0).name).isEqualTo(cacheSlotFree.name);
+    assertThat(mutatedCacheSlots.get(0).replicaId).isEqualTo(replicaMetadataList.get(3).name);
+
+    assertTrue(replicaMetadataList.containsAll(replicaMetadataStore.listSync()));
+
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_FAILED, meterRegistry))
+        .isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_SUCCEEDED, meterRegistry))
+        .isEqualTo(1);
+    Assertions.assertThat(
+            MetricsUtil.getCount(
+                CacheSlotAssignmentService.SLOT_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
+        .isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getTimerCount(CacheSlotAssignmentService.SLOT_ASSIGN_TIMER, meterRegistry))
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldHandleAllSlotsAlreadyAssigned() {
+    KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig cacheSlotAssignmentServiceConfig =
+        KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig.newBuilder()
+            .setSchedulePeriodMins(1)
+            .build();
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setEventAggregationSecs(10)
+            .setScheduleInitialDelayMins(1)
+            .setCacheSlotAssignmentServiceConfig(cacheSlotAssignmentServiceConfig)
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .build();
+
+    CacheSlotAssignmentService cacheSlotAssignmentService =
+        new CacheSlotAssignmentService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+
+    List<ReplicaMetadata> replicaMetadataList = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      ReplicaMetadata replicaMetadata =
+          new ReplicaMetadata(
+              UUID.randomUUID().toString(),
+              UUID.randomUUID().toString(),
+              Instant.now().toEpochMilli());
+      replicaMetadataList.add(replicaMetadata);
+      replicaMetadataStore.create(replicaMetadata);
+    }
+
+    List<CacheSlotMetadata> cacheSlotMetadataList = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      CacheSlotMetadata cacheSlotMetadata =
+          new CacheSlotMetadata(
+              UUID.randomUUID().toString(),
+              Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
+              replicaMetadataList.get(i).name,
+              Instant.now().toEpochMilli());
+      cacheSlotMetadataList.add(cacheSlotMetadata);
+      cacheSlotMetadataStore.create(cacheSlotMetadata);
+    }
+
+    await().until(() -> cacheSlotMetadataStore.getCached().size() == 3);
+    await().until(() -> replicaMetadataStore.getCached().size() == 5);
+
+    int assignments = cacheSlotAssignmentService.assignCacheSlotsToReplicas();
+    assertThat(assignments).isEqualTo(0);
+
+    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(5);
+    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(3);
+
+    assertTrue(cacheSlotMetadataList.containsAll(cacheSlotMetadataStore.listSync()));
+    assertTrue(replicaMetadataList.containsAll(replicaMetadataStore.listSync()));
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_FAILED, meterRegistry))
+        .isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_SUCCEEDED, meterRegistry))
+        .isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getCount(
+                CacheSlotAssignmentService.SLOT_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
+        .isEqualTo(2);
+    Assertions.assertThat(
+            MetricsUtil.getTimerCount(CacheSlotAssignmentService.SLOT_ASSIGN_TIMER, meterRegistry))
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldHandleExpiredReplicas() {
+    KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig cacheSlotAssignmentServiceConfig =
+        KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig.newBuilder()
+            .setSchedulePeriodMins(1)
+            .build();
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setEventAggregationSecs(10)
+            .setScheduleInitialDelayMins(1)
+            .setCacheSlotAssignmentServiceConfig(cacheSlotAssignmentServiceConfig)
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .build();
+
+    CacheSlotAssignmentService cacheSlotAssignmentService =
+        new CacheSlotAssignmentService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+
+    List<ReplicaMetadata> replicaMetadataExpiredList = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      ReplicaMetadata replicaMetadata =
+          new ReplicaMetadata(
+              UUID.randomUUID().toString(),
+              UUID.randomUUID().toString(),
+              Instant.now().minus(1500, ChronoUnit.MINUTES).toEpochMilli());
+      replicaMetadataExpiredList.add(replicaMetadata);
+      replicaMetadataStore.create(replicaMetadata);
+    }
+
+    List<ReplicaMetadata> replicaMetadataNonExpiredList = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      ReplicaMetadata replicaMetadata =
+          new ReplicaMetadata(
+              UUID.randomUUID().toString(),
+              UUID.randomUUID().toString(),
+              Instant.now().toEpochMilli());
+      replicaMetadataNonExpiredList.add(replicaMetadata);
+      replicaMetadataStore.create(replicaMetadata);
+    }
+
+    List<CacheSlotMetadata> cacheSlotMetadataList = new ArrayList<>();
+    for (int i = 0; i < 4; i++) {
+      CacheSlotMetadata cacheSlotMetadata =
+          new CacheSlotMetadata(
+              UUID.randomUUID().toString(),
+              Metadata.CacheSlotMetadata.CacheSlotState.FREE,
+              "",
+              Instant.now().toEpochMilli());
+      cacheSlotMetadataList.add(cacheSlotMetadata);
+      cacheSlotMetadataStore.create(cacheSlotMetadata);
+    }
+
+    await().until(() -> cacheSlotMetadataStore.getCached().size() == 4);
+    await().until(() -> replicaMetadataStore.getCached().size() == 6);
+
+    int assignments = cacheSlotAssignmentService.assignCacheSlotsToReplicas();
+    assertThat(assignments).isEqualTo(3);
+
+    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(6);
+    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(4);
+
+    assertThat(
+            cacheSlotMetadataStore
+                .listSync()
+                .stream()
+                .filter(
+                    cacheSlotMetadata ->
+                        cacheSlotMetadata.cacheSlotState.equals(
+                            Metadata.CacheSlotMetadata.CacheSlotState.FREE))
+                .count())
+        .isEqualTo(1);
+    assertThat(
+            cacheSlotMetadataStore
+                .listSync()
+                .stream()
+                .filter(
+                    cacheSlotMetadata ->
+                        cacheSlotMetadata.cacheSlotState.equals(
+                            Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED))
+                .count())
+        .isEqualTo(3);
+    assertTrue(
+        replicaMetadataExpiredList.containsAll(
+            replicaMetadataStore
+                .listSync()
+                .stream()
+                .filter(
+                    replicaMetadata ->
+                        replicaMetadata.createdTimeUtc
+                            < Instant.now().minus(1440, ChronoUnit.MINUTES).toEpochMilli())
+                .collect(Collectors.toList())));
+
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_FAILED, meterRegistry))
+        .isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_SUCCEEDED, meterRegistry))
+        .isEqualTo(3);
+    Assertions.assertThat(
+            MetricsUtil.getCount(
+                CacheSlotAssignmentService.SLOT_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
+        .isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getTimerCount(CacheSlotAssignmentService.SLOT_ASSIGN_TIMER, meterRegistry))
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldRetryFailedAssignmentOnFollowingRun() {
+    KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig cacheSlotAssignmentServiceConfig =
+        KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig.newBuilder()
+            .setSchedulePeriodMins(1)
+            .build();
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setEventAggregationSecs(10)
+            .setScheduleInitialDelayMins(1)
+            .setCacheSlotAssignmentServiceConfig(cacheSlotAssignmentServiceConfig)
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .build();
+
+    CacheSlotAssignmentService cacheSlotAssignmentService =
+        new CacheSlotAssignmentService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+
+    for (int i = 0; i < 2; i++) {
+      ReplicaMetadata replicaMetadata =
+          new ReplicaMetadata(
+              UUID.randomUUID().toString(),
+              UUID.randomUUID().toString(),
+              Instant.now().toEpochMilli());
+      replicaMetadataStore.create(replicaMetadata);
+    }
+
+    for (int i = 0; i < 3; i++) {
+      CacheSlotMetadata cacheSlotMetadata =
+          new CacheSlotMetadata(
+              UUID.randomUUID().toString(),
+              Metadata.CacheSlotMetadata.CacheSlotState.FREE,
+              "",
+              Instant.now().toEpochMilli());
+      cacheSlotMetadataStore.create(cacheSlotMetadata);
+    }
+
+    await().until(() -> cacheSlotMetadataStore.getCached().size() == 3);
+    await().until(() -> replicaMetadataStore.getCached().size() == 2);
+
+    doCallRealMethod()
+        .doReturn(Futures.immediateFailedFuture(new Exception()))
+        .when(cacheSlotMetadataStore)
+        .update(any());
+
+    int firstAssignment = cacheSlotAssignmentService.assignCacheSlotsToReplicas();
+    assertThat(firstAssignment).isEqualTo(1);
+
+    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(2);
+    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(3);
+    assertThat(
+            cacheSlotMetadataStore
+                .listSync()
+                .stream()
+                .filter(
+                    cacheSlotMetadata ->
+                        cacheSlotMetadata.cacheSlotState.equals(
+                            Metadata.CacheSlotMetadata.CacheSlotState.FREE))
+                .count())
+        .isEqualTo(2);
+    assertThat(
+            cacheSlotMetadataStore
+                .listSync()
+                .stream()
+                .filter(
+                    cacheSlotMetadata ->
+                        cacheSlotMetadata.cacheSlotState.equals(
+                            Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED))
+                .count())
+        .isEqualTo(1);
+
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_FAILED, meterRegistry))
+        .isEqualTo(1);
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_SUCCEEDED, meterRegistry))
+        .isEqualTo(1);
+    Assertions.assertThat(
+            MetricsUtil.getTimerCount(CacheSlotAssignmentService.SLOT_ASSIGN_TIMER, meterRegistry))
+        .isEqualTo(1);
+
+    doCallRealMethod().when(cacheSlotMetadataStore).update(any());
+
+    int secondAssignment = cacheSlotAssignmentService.assignCacheSlotsToReplicas();
+    assertThat(secondAssignment).isEqualTo(1);
+
+    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(2);
+    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(3);
+    assertThat(
+            cacheSlotMetadataStore
+                .listSync()
+                .stream()
+                .filter(
+                    cacheSlotMetadata ->
+                        cacheSlotMetadata.cacheSlotState.equals(
+                            Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED))
+                .count())
+        .isEqualTo(2);
+    assertThat(
+            cacheSlotMetadataStore
+                .listSync()
+                .stream()
+                .filter(
+                    cacheSlotMetadata ->
+                        cacheSlotMetadata.cacheSlotState.equals(
+                            Metadata.CacheSlotMetadata.CacheSlotState.FREE))
+                .count())
+        .isEqualTo(1);
+
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_FAILED, meterRegistry))
+        .isEqualTo(1);
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_SUCCEEDED, meterRegistry))
+        .isEqualTo(2);
+    Assertions.assertThat(
+            MetricsUtil.getCount(
+                CacheSlotAssignmentService.SLOT_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
+        .isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getTimerCount(CacheSlotAssignmentService.SLOT_ASSIGN_TIMER, meterRegistry))
+        .isEqualTo(2);
+  }
+
+  @Test
+  public void shouldHandleTimedOutFutures() {
+    KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig cacheSlotAssignmentServiceConfig =
+        KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig.newBuilder()
+            .setSchedulePeriodMins(1)
+            .build();
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setEventAggregationSecs(10)
+            .setScheduleInitialDelayMins(1)
+            .setCacheSlotAssignmentServiceConfig(cacheSlotAssignmentServiceConfig)
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .build();
+
+    CacheSlotAssignmentService cacheSlotAssignmentService =
+        new CacheSlotAssignmentService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+
+    for (int i = 0; i < 2; i++) {
+      ReplicaMetadata replicaMetadata =
+          new ReplicaMetadata(
+              UUID.randomUUID().toString(),
+              UUID.randomUUID().toString(),
+              Instant.now().toEpochMilli());
+      replicaMetadataStore.create(replicaMetadata);
+    }
+
+    for (int i = 0; i < 3; i++) {
+      CacheSlotMetadata cacheSlotMetadata =
+          new CacheSlotMetadata(
+              UUID.randomUUID().toString(),
+              Metadata.CacheSlotMetadata.CacheSlotState.FREE,
+              "",
+              Instant.now().toEpochMilli());
+      cacheSlotMetadataStore.create(cacheSlotMetadata);
+    }
+
+    await().until(() -> cacheSlotMetadataStore.getCached().size() == 3);
+    await().until(() -> replicaMetadataStore.getCached().size() == 2);
+
+    cacheSlotAssignmentService.futuresListTimeoutSecs = 2;
+    ExecutorService timeoutServiceExecutor = Executors.newSingleThreadExecutor();
+    doCallRealMethod()
+        .doReturn(
+            Futures.submit(
+                () -> {
+                  try {
+                    Thread.sleep(30 * 1000);
+                  } catch (InterruptedException ignored) {
+                  }
+                },
+                timeoutServiceExecutor))
+        .when(cacheSlotMetadataStore)
+        .update(any());
+
+    int firstAssignment = cacheSlotAssignmentService.assignCacheSlotsToReplicas();
+    assertThat(firstAssignment).isEqualTo(1);
+
+    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(2);
+    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(3);
+    assertThat(
+            cacheSlotMetadataStore
+                .listSync()
+                .stream()
+                .filter(
+                    cacheSlotMetadata ->
+                        cacheSlotMetadata.cacheSlotState.equals(
+                            Metadata.CacheSlotMetadata.CacheSlotState.FREE))
+                .count())
+        .isEqualTo(2);
+    assertThat(
+            cacheSlotMetadataStore
+                .listSync()
+                .stream()
+                .filter(
+                    cacheSlotMetadata ->
+                        cacheSlotMetadata.cacheSlotState.equals(
+                            Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED))
+                .count())
+        .isEqualTo(1);
+
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_FAILED, meterRegistry))
+        .isEqualTo(1);
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_SUCCEEDED, meterRegistry))
+        .isEqualTo(1);
+    Assertions.assertThat(
+            MetricsUtil.getCount(
+                CacheSlotAssignmentService.SLOT_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
+        .isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getTimerCount(CacheSlotAssignmentService.SLOT_ASSIGN_TIMER, meterRegistry))
+        .isEqualTo(1);
+
+    timeoutServiceExecutor.shutdown();
+  }
+
+  @Test
+  public void shouldHandleExceptionalFutures() {
+    KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig cacheSlotAssignmentServiceConfig =
+        KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig.newBuilder()
+            .setSchedulePeriodMins(1)
+            .build();
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setEventAggregationSecs(10)
+            .setScheduleInitialDelayMins(1)
+            .setCacheSlotAssignmentServiceConfig(cacheSlotAssignmentServiceConfig)
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .build();
+
+    CacheSlotAssignmentService cacheSlotAssignmentService =
+        new CacheSlotAssignmentService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+
+    for (int i = 0; i < 2; i++) {
+      ReplicaMetadata replicaMetadata =
+          new ReplicaMetadata(
+              UUID.randomUUID().toString(),
+              UUID.randomUUID().toString(),
+              Instant.now().toEpochMilli());
+      replicaMetadataStore.create(replicaMetadata);
+    }
+
+    for (int i = 0; i < 3; i++) {
+      CacheSlotMetadata cacheSlotMetadata =
+          new CacheSlotMetadata(
+              UUID.randomUUID().toString(),
+              Metadata.CacheSlotMetadata.CacheSlotState.FREE,
+              "",
+              Instant.now().toEpochMilli());
+      cacheSlotMetadataStore.create(cacheSlotMetadata);
+    }
+
+    await().until(() -> cacheSlotMetadataStore.getCached().size() == 3);
+    await().until(() -> replicaMetadataStore.getCached().size() == 2);
+
+    doCallRealMethod()
+        .doReturn(Futures.immediateFailedFuture(new Exception()))
+        .when(cacheSlotMetadataStore)
+        .update(any());
+
+    int firstAssignment = cacheSlotAssignmentService.assignCacheSlotsToReplicas();
+    assertThat(firstAssignment).isEqualTo(1);
+
+    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(2);
+    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(3);
+    assertThat(
+            cacheSlotMetadataStore
+                .listSync()
+                .stream()
+                .filter(
+                    cacheSlotMetadata ->
+                        cacheSlotMetadata.cacheSlotState.equals(
+                            Metadata.CacheSlotMetadata.CacheSlotState.FREE))
+                .count())
+        .isEqualTo(2);
+    assertThat(
+            cacheSlotMetadataStore
+                .listSync()
+                .stream()
+                .filter(
+                    cacheSlotMetadata ->
+                        cacheSlotMetadata.cacheSlotState.equals(
+                            Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED))
+                .count())
+        .isEqualTo(1);
+
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_FAILED, meterRegistry))
+        .isEqualTo(1);
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_SUCCEEDED, meterRegistry))
+        .isEqualTo(1);
+    Assertions.assertThat(
+            MetricsUtil.getCount(
+                CacheSlotAssignmentService.SLOT_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
+        .isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getTimerCount(CacheSlotAssignmentService.SLOT_ASSIGN_TIMER, meterRegistry))
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldHandleSlotsAvailableFirstLifecycle() throws Exception {
+    KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig cacheSlotAssignmentServiceConfig =
+        KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig.newBuilder()
+            .setSchedulePeriodMins(1)
+            .build();
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setEventAggregationSecs(2)
+            .setScheduleInitialDelayMins(1)
+            .setCacheSlotAssignmentServiceConfig(cacheSlotAssignmentServiceConfig)
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .build();
+
+    CacheSlotAssignmentService cacheSlotAssignmentService =
+        new CacheSlotAssignmentService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+
+    for (int i = 0; i < 3; i++) {
+      CacheSlotMetadata cacheSlotMetadata =
+          new CacheSlotMetadata(
+              UUID.randomUUID().toString(),
+              Metadata.CacheSlotMetadata.CacheSlotState.FREE,
+              "",
+              Instant.now().toEpochMilli());
+      cacheSlotMetadataStore.create(cacheSlotMetadata);
+    }
+
+    await().until(() -> cacheSlotMetadataStore.getCached().size() == 3);
+    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(0);
+    assertThat(
+            cacheSlotMetadataStore
+                .listSync()
+                .stream()
+                .filter(
+                    cacheSlotMetadata ->
+                        cacheSlotMetadata.cacheSlotState.equals(
+                            Metadata.CacheSlotMetadata.CacheSlotState.FREE))
+                .count())
+        .isEqualTo(3);
+
+    cacheSlotAssignmentService.startAsync();
+    cacheSlotAssignmentService.awaitRunning(DEFAULT_START_STOP_DURATION);
+
+    for (int i = 0; i < 2; i++) {
+      ReplicaMetadata replicaMetadata =
+          new ReplicaMetadata(
+              UUID.randomUUID().toString(),
+              UUID.randomUUID().toString(),
+              Instant.now().toEpochMilli());
+      replicaMetadataStore.create(replicaMetadata);
+    }
+
+    await().until(() -> replicaMetadataStore.getCached().size() == 2);
+    await()
+        .until(
+            () ->
+                cacheSlotMetadataStore
+                        .getCached()
+                        .stream()
+                        .filter(
+                            cacheSlotMetadata ->
+                                cacheSlotMetadata.cacheSlotState.equals(
+                                    Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED))
+                        .count()
+                    == 2);
+    await()
+        .until(
+            () ->
+                cacheSlotMetadataStore
+                        .getCached()
+                        .stream()
+                        .filter(
+                            cacheSlotMetadata ->
+                                cacheSlotMetadata.cacheSlotState.equals(
+                                    Metadata.CacheSlotMetadata.CacheSlotState.FREE))
+                        .count()
+                    == 1);
+
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_FAILED, meterRegistry))
+        .isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_SUCCEEDED, meterRegistry))
+        .isEqualTo(2);
+    Assertions.assertThat(
+            MetricsUtil.getCount(
+                CacheSlotAssignmentService.SLOT_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
+        .isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getTimerCount(CacheSlotAssignmentService.SLOT_ASSIGN_TIMER, meterRegistry))
+        .isEqualTo(1);
+
+    cacheSlotAssignmentService.stopAsync();
+    cacheSlotAssignmentService.awaitTerminated(DEFAULT_START_STOP_DURATION);
+  }
+
+  @Test
+  public void shouldHandleReplicasAvailableFirstLifecycle() throws Exception {
+    KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig cacheSlotAssignmentServiceConfig =
+        KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig.newBuilder()
+            .setSchedulePeriodMins(1)
+            .build();
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setEventAggregationSecs(2)
+            .setScheduleInitialDelayMins(1)
+            .setCacheSlotAssignmentServiceConfig(cacheSlotAssignmentServiceConfig)
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .build();
+
+    CacheSlotAssignmentService cacheSlotAssignmentService =
+        new CacheSlotAssignmentService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+
+    List<ReplicaMetadata> replicaMetadataList = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      ReplicaMetadata replicaMetadata =
+          new ReplicaMetadata(
+              UUID.randomUUID().toString(),
+              UUID.randomUUID().toString(),
+              Instant.now().toEpochMilli());
+      replicaMetadataList.add(replicaMetadata);
+      replicaMetadataStore.create(replicaMetadata);
+    }
+
+    await().until(() -> replicaMetadataStore.getCached().size() == 3);
+
+    cacheSlotAssignmentService.startAsync();
+    cacheSlotAssignmentService.awaitRunning(DEFAULT_START_STOP_DURATION);
+
+    for (int i = 0; i < 2; i++) {
+      CacheSlotMetadata cacheSlotMetadata =
+          new CacheSlotMetadata(
+              UUID.randomUUID().toString(),
+              Metadata.CacheSlotMetadata.CacheSlotState.FREE,
+              "",
+              Instant.now().toEpochMilli());
+      cacheSlotMetadataStore.create(cacheSlotMetadata);
+    }
+
+    await().until(() -> cacheSlotMetadataStore.getCached().size() == 2);
+    await()
+        .until(
+            () ->
+                cacheSlotMetadataStore
+                        .getCached()
+                        .stream()
+                        .filter(
+                            cacheSlotMetadata ->
+                                cacheSlotMetadata.cacheSlotState.equals(
+                                    Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED))
+                        .count()
+                    == 2);
+    assertTrue(replicaMetadataList.containsAll(replicaMetadataStore.listSync()));
+
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_FAILED, meterRegistry))
+        .isEqualTo(0);
+    Assertions.assertThat(
+            MetricsUtil.getCount(CacheSlotAssignmentService.SLOT_ASSIGN_SUCCEEDED, meterRegistry))
+        .isEqualTo(2);
+    Assertions.assertThat(
+            MetricsUtil.getCount(
+                CacheSlotAssignmentService.SLOT_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
+        .isEqualTo(1);
+    Assertions.assertThat(
+            MetricsUtil.getTimerCount(CacheSlotAssignmentService.SLOT_ASSIGN_TIMER, meterRegistry))
+        .isEqualTo(1);
+
+    cacheSlotAssignmentService.stopAsync();
+    cacheSlotAssignmentService.awaitTerminated(DEFAULT_START_STOP_DURATION);
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/config/KaldbConfigTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/config/KaldbConfigTest.java
@@ -220,6 +220,10 @@ public class KaldbConfigTest {
             managerConfig.getRecoveryTaskAssignmentServiceConfig();
     assertThat(recoveryTaskAssignmentServiceConfig.getSchedulePeriodMins()).isEqualTo(10);
 
+    final KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig
+        cacheSlotAssignmentServiceConfig = managerConfig.getCacheSlotAssignmentServiceConfig();
+    assertThat(cacheSlotAssignmentServiceConfig.getSchedulePeriodMins()).isEqualTo(10);
+
     final KaldbConfigs.ServerConfig managerServerConfig = managerConfig.getServerConfig();
     assertThat(managerServerConfig.getServerPort()).isEqualTo(8083);
     assertThat(managerServerConfig.getServerAddress()).isEqualTo("localhost");
@@ -316,6 +320,10 @@ public class KaldbConfigTest {
             managerConfig.getRecoveryTaskAssignmentServiceConfig();
     assertThat(recoveryTaskAssignmentServiceConfig.getSchedulePeriodMins()).isEqualTo(10);
 
+    final KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig
+        cacheSlotAssignmentServiceConfig = managerConfig.getCacheSlotAssignmentServiceConfig();
+    assertThat(cacheSlotAssignmentServiceConfig.getSchedulePeriodMins()).isEqualTo(10);
+
     final KaldbConfigs.ServerConfig managerServerConfig = managerConfig.getServerConfig();
     assertThat(managerServerConfig.getServerPort()).isEqualTo(8083);
     assertThat(managerServerConfig.getServerAddress()).isEqualTo("localhost");
@@ -406,6 +414,10 @@ public class KaldbConfigTest {
             managerConfig.getRecoveryTaskAssignmentServiceConfig();
     assertThat(recoveryTaskAssignmentServiceConfig.getSchedulePeriodMins()).isZero();
 
+    final KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig
+        cacheSlotAssignmentServiceConfig = managerConfig.getCacheSlotAssignmentServiceConfig();
+    assertThat(cacheSlotAssignmentServiceConfig.getSchedulePeriodMins()).isZero();
+
     final KaldbConfigs.ServerConfig managerServerConfig = managerConfig.getServerConfig();
     assertThat(managerServerConfig.getServerPort()).isZero();
     assertThat(managerServerConfig.getServerAddress()).isEmpty();
@@ -485,6 +497,10 @@ public class KaldbConfigTest {
         recoveryTaskAssignmentServiceConfig =
             managerConfig.getRecoveryTaskAssignmentServiceConfig();
     assertThat(recoveryTaskAssignmentServiceConfig.getSchedulePeriodMins()).isZero();
+
+    final KaldbConfigs.ManagerConfig.CacheSlotAssignmentServiceConfig
+        cacheSlotAssignmentServiceConfig = managerConfig.getCacheSlotAssignmentServiceConfig();
+    assertThat(cacheSlotAssignmentServiceConfig.getSchedulePeriodMins()).isZero();
 
     final KaldbConfigs.ServerConfig managerServerConfig = managerConfig.getServerConfig();
     assertThat(managerServerConfig.getServerPort()).isZero();

--- a/kaldb/src/test/resources/test_config.json
+++ b/kaldb/src/test/resources/test_config.json
@@ -1,13 +1,17 @@
 {
-  "nodeRoles": ["INDEX", "QUERY", "CACHE", "MANAGER"],
-
+  "nodeRoles": [
+    "INDEX",
+    "QUERY",
+    "CACHE",
+    "MANAGER"
+  ],
   "kafkaConfig": {
     "kafkaTopic": "testTopic",
     "kafkaTopicPartition": "1",
     "kafkaBootStrapServers": "kafka.us-east-1.consul:9092",
-    "kafkaClientGroup":  "kaldb-test",
-    "enableKafkaAutoCommit":  "true",
-    "kafkaAutoCommitInterval":  "5000",
+    "kafkaClientGroup": "kaldb-test",
+    "enableKafkaAutoCommit": "true",
+    "kafkaAutoCommitInterval": "5000",
     "kafkaSessionTimeout": "30000"
   },
   "s3Config": {
@@ -39,7 +43,7 @@
   "metadataStoreConfig": {
     "zookeeperConfig": {
       "zkConnectString": "1.2.3.4:9092",
-      "zkPathPrefix":  "zkPrefix",
+      "zkPathPrefix": "zkPrefix",
       "zkSessionTimeoutMs": 1000,
       "zkConnectionTimeoutMs": 1500,
       "sleepBetweenRetriesMs": 500
@@ -68,6 +72,9 @@
       "replicaLifespanMins": 1440
     },
     "recoveryTaskAssignmentServiceConfig": {
+      "schedulePeriodMins": 10
+    },
+    "cacheSlotAssignmentServiceConfig": {
       "schedulePeriodMins": 10
     }
   },

--- a/kaldb/src/test/resources/test_config.yaml
+++ b/kaldb/src/test/resources/test_config.yaml
@@ -1,4 +1,4 @@
-nodeRoles: [INDEX,QUERY,CACHE,MANAGER]
+nodeRoles: [ INDEX,QUERY,CACHE,MANAGER ]
 
 indexerConfig:
   maxMessagesPerChunk: 100
@@ -60,6 +60,8 @@ managerConfig:
   replicaEvictionServiceConfig:
     replicaLifespanMins: 1440
   recoveryTaskAssignmentServiceConfig:
+    schedulePeriodMins: 10
+  cacheSlotAssignmentServiceConfig:
     schedulePeriodMins: 10
 
 recoveryConfig:


### PR DESCRIPTION
Assigns available cache slots to replicas awaiting assignment. Also updates adds some missing metadata tests and asserts that are used by this code, and fixes a few incorrect asserts (state vs argument).