### PR TITLE
Distributed Query Service: Parallelize more work

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
@@ -340,7 +340,7 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
           query.howMany,
           query.bucketCount);
     } else {
-      return SearchResult.empty();
+      return (SearchResult<T>) SearchResult.empty();
     }
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResult.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResult.java
@@ -2,12 +2,15 @@ package com.slack.kaldb.logstore.search;
 
 import com.google.common.base.Objects;
 import com.slack.kaldb.histogram.HistogramBucket;
+import com.slack.kaldb.logstore.LogMessage;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class SearchResult<T> {
 
-  private static final SearchResult EMPTY = new SearchResult<>(null, 0, 0, null, 1, 1, 0, 0);
+  private static final SearchResult EMPTY =
+      new SearchResult<>(Collections.emptyList(), 0, 0, Collections.emptyList(), 1, 1, 0, 0);
 
   public final long totalCount;
 
@@ -84,7 +87,7 @@ public class SearchResult<T> {
         snapshotsWithReplicas);
   }
 
-  public static SearchResult empty() {
+  public static SearchResult<LogMessage> empty() {
     return EMPTY;
   }
 }


### PR DESCRIPTION
Parallelize the call to `SearchResultUtils::fromSearchResultProtoOrEmpty` by moving it right after the individual gRPC call finish instead of waiting for all gRPC calls to finish