### PR TITLE
LuceneIndexStoreImpl log level

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadWriteChunk.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadWriteChunk.java
@@ -8,6 +8,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.slack.kaldb.blobfs.s3.S3BlobFs;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.logstore.LogStore;
+import com.slack.kaldb.logstore.LuceneIndexStoreImpl;
 import com.slack.kaldb.logstore.search.LogIndexSearcher;
 import com.slack.kaldb.logstore.search.LogIndexSearcherImpl;
 import com.slack.kaldb.logstore.search.SearchQuery;
@@ -23,7 +24,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collection;
-import java.util.UUID;
 import org.apache.lucene.index.IndexCommit;
 import org.slf4j.Logger;
 
@@ -90,6 +90,7 @@ public abstract class ReadWriteChunk<T> implements Chunk<T> {
       String kafkaPartitionId,
       Logger logger) {
     this.logStore = logStore;
+    String logStoreId = ((LuceneIndexStoreImpl) logStore).getId();
     this.logSearcher =
         (LogIndexSearcher<T>) new LogIndexSearcherImpl(logStore.getSearcherManager());
 
@@ -98,7 +99,7 @@ public abstract class ReadWriteChunk<T> implements Chunk<T> {
     this.kafkaPartitionId = kafkaPartitionId;
     chunkInfo =
         new ChunkInfo(
-            chunkDataPrefix + "_" + chunkCreationTime.getEpochSecond() + "_" + UUID.randomUUID(),
+            chunkDataPrefix + "_" + chunkCreationTime.getEpochSecond() + "_" + logStoreId,
             chunkCreationTime.toEpochMilli(),
             kafkaPartitionId,
             SnapshotMetadata.LIVE_SNAPSHOT_PATH);

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreImpl.java
@@ -187,8 +187,8 @@ public class LuceneIndexStoreImpl implements LogStore<LogMessage> {
       if (indexWriter.isPresent()) {
         indexWriter.get().addDocument(documentBuilder.fromMessage(message));
       } else {
-        LOG.warn("IndexWriter should never be null when adding a message");
-        throw new IllegalStateException("Index writer should never be null when adding a message");
+        LOG.error("IndexWriter should never be null when adding a message");
+        throw new IllegalStateException("IndexWriter should never be null when adding a message");
       }
     } catch (PropertyTypeMismatchException
         | UnSupportedPropertyTypeException
@@ -304,5 +304,9 @@ public class LuceneIndexStoreImpl implements LogStore<LogMessage> {
   @Override
   public SearcherManager getSearcherManager() {
     return searcherManager;
+  }
+
+  public String getId() {
+    return id;
   }
 }


### PR DESCRIPTION
This log entry should definitely be an ERROR since it causes an application restart.

Being ERROR means it's easier to query log search applications when debugging for issues 

Secondly this log line is confusing,
```
[INFO ] 2021-12-13 23:53:40.600 [KaldbKafkaWriter] IndexingChunkImpl - Created a new index LuceneIndexStoreImpl{id='13ca528d-19f0-43e5-94c4-c0867a68c642', at=/mnt/kaldb/data/indices/13ca528d-19f0-43e5-94c4-c0867a68c642} and chunk ChunkInfo{chunkId='log_1639439620_9e0ccea1-ca49-46f3-895d-781056d9d9cf, chunkCreationTimeEpochMs=1639439620574, kafkaPartitionId='0, maxOffset=0, chunkLastUpdatedTimeEpochMs=1639439620574, dataStartTimeEpochMs=1639439620574, dataEndTimeEpochMs=9223372036854775807, chunkSnapshotTimeEpochMs=0, snapshotPath='LIVE}
```

There are two UUIDs which make grepping for things tougher