### PR TITLE
Add replica eviction service

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaEvictionService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaEvictionService.java
@@ -1,0 +1,164 @@
+package com.slack.kaldb.clusterManager;
+
+import static com.google.common.util.concurrent.Futures.addCallback;
+import static com.slack.kaldb.config.KaldbConfig.DEFAULT_ZK_TIMEOUT_SECS;
+import static com.slack.kaldb.util.FutureUtils.successCountingCallback;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.AbstractScheduledService;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.slack.kaldb.metadata.cache.CacheSlotMetadata;
+import com.slack.kaldb.metadata.cache.CacheSlotMetadataStore;
+import com.slack.kaldb.metadata.replica.ReplicaMetadata;
+import com.slack.kaldb.metadata.replica.ReplicaMetadataStore;
+import com.slack.kaldb.proto.config.KaldbConfigs;
+import com.slack.kaldb.proto.metadata.Metadata;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Marks expired replicas that are currently assigned to a cache slot for eviction. This service
+ * does not delete or mutate replicas, but only marks the cache slot as pending eviction. Once the
+ * cache node has evicted an expired replica, a separate service will delete expired, unassigned
+ * replicas.
+ */
+public class ReplicaEvictionService extends AbstractScheduledService {
+  private static final Logger LOG = LoggerFactory.getLogger(ReplicaEvictionService.class);
+
+  private final CacheSlotMetadataStore cacheSlotMetadataStore;
+  private final ReplicaMetadataStore replicaMetadataStore;
+  private final KaldbConfigs.ManagerConfig managerConfig;
+  private final MeterRegistry meterRegistry;
+
+  @VisibleForTesting protected int futuresListTimeoutSecs = DEFAULT_ZK_TIMEOUT_SECS;
+
+  public static final String REPLICA_MARK_EVICT_SUCCEEDED = "replica_mark_evict_succeeded";
+  public static final String REPLICA_MARK_EVICT_FAILED = "replica_mark_evict_failed";
+  public static final String REPLICA_MARK_EVICT_TIMER = "replica_mark_evict_timer";
+
+  protected final Counter replicaMarkEvictSucceeded;
+  protected final Counter replicaMarkEvictFailed;
+  private final Timer replicaMarkEvictTimer;
+
+  public ReplicaEvictionService(
+      CacheSlotMetadataStore cacheSlotMetadataStore,
+      ReplicaMetadataStore replicaMetadataStore,
+      KaldbConfigs.ManagerConfig managerConfig,
+      MeterRegistry meterRegistry) {
+    this.cacheSlotMetadataStore = cacheSlotMetadataStore;
+    this.replicaMetadataStore = replicaMetadataStore;
+    this.managerConfig = managerConfig;
+    this.meterRegistry = meterRegistry;
+
+    // schedule configs checked as part of the AbstractScheduledService
+
+    replicaMarkEvictSucceeded = meterRegistry.counter(REPLICA_MARK_EVICT_SUCCEEDED);
+    replicaMarkEvictFailed = meterRegistry.counter(REPLICA_MARK_EVICT_FAILED);
+    replicaMarkEvictTimer = meterRegistry.timer(REPLICA_MARK_EVICT_TIMER);
+  }
+
+  @Override
+  protected void runOneIteration() {
+    markReplicasForEviction();
+  }
+
+  @Override
+  protected Scheduler scheduler() {
+    return Scheduler.newFixedRateSchedule(
+        managerConfig.getScheduleInitialDelayMins(),
+        managerConfig.getReplicaEvictionServiceConfig().getSchedulePeriodMins(),
+        TimeUnit.MINUTES);
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    LOG.info("Starting replica eviction service");
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    LOG.info("Closed replica eviction service");
+  }
+
+  /**
+   * Marks cache slots that contain an expired replica as ready for eviction. Once eviction has
+   * started the cache node will further update the state indicating it has started evicting the
+   * replica from memory/disk.
+   */
+  protected int markReplicasForEviction() {
+    Timer.Sample evictionTimer = Timer.start(meterRegistry);
+
+    Map<String, ReplicaMetadata> replicaMetadataByReplicaId =
+        replicaMetadataStore
+            .getCached()
+            .stream()
+            .collect(Collectors.toUnmodifiableMap(ReplicaMetadata::getName, Function.identity()));
+
+    long expireAfterNow = Instant.now().toEpochMilli();
+    AtomicInteger successCounter = new AtomicInteger(0);
+    List<ListenableFuture<?>> replicaEvictions =
+        cacheSlotMetadataStore
+            .getCached()
+            .stream()
+            // get all the slots that are currently assigned, but have an expiration in the past
+            .filter(
+                cacheSlotMetadata ->
+                    cacheSlotMetadata.cacheSlotState.equals(
+                            Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED)
+                        && replicaMetadataByReplicaId.containsKey(cacheSlotMetadata.replicaId)
+                        && replicaMetadataByReplicaId.get(cacheSlotMetadata.replicaId)
+                                .expireAfterUtc
+                            < expireAfterNow)
+            .map(
+                (cacheSlotMetadata) -> {
+                  ListenableFuture<?> future =
+                      cacheSlotMetadataStore.update(
+                          new CacheSlotMetadata(
+                              cacheSlotMetadata.name,
+                              Metadata.CacheSlotMetadata.CacheSlotState.EVICT,
+                              cacheSlotMetadata.replicaId,
+                              Instant.now().toEpochMilli()));
+
+                  addCallback(
+                      future,
+                      successCountingCallback(successCounter),
+                      MoreExecutors.directExecutor());
+                  return future;
+                })
+            .collect(Collectors.toUnmodifiableList());
+
+    ListenableFuture<?> futureList = Futures.successfulAsList(replicaEvictions);
+    try {
+      futureList.get(futuresListTimeoutSecs, TimeUnit.SECONDS);
+    } catch (Exception e) {
+      futureList.cancel(true);
+    }
+
+    int successfulEvictions = successCounter.get();
+    int failedEvictions = replicaEvictions.size() - successfulEvictions;
+
+    replicaMarkEvictSucceeded.increment(successfulEvictions);
+    replicaMarkEvictFailed.increment(failedEvictions);
+
+    long evictionDuration = evictionTimer.stop(replicaMarkEvictTimer);
+    LOG.info(
+        "Completed replica evictions - successfully marked {} slots for eviction, failed to mark {} slots for eviction in {} ms",
+        successfulEvictions,
+        failedEvictions,
+        TimeUnit.MILLISECONDS.convert(evictionDuration, TimeUnit.NANOSECONDS));
+
+    return successfulEvictions;
+  }
+}

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbMetadata.java
@@ -10,6 +10,10 @@ public abstract class KaldbMetadata {
     this.name = name;
   }
 
+  public String getName() {
+    return name;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;

--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -9,6 +9,7 @@ import com.slack.kaldb.chunkManager.IndexingChunkManager;
 import com.slack.kaldb.clusterManager.RecoveryTaskAssignmentService;
 import com.slack.kaldb.clusterManager.ReplicaAssignmentService;
 import com.slack.kaldb.clusterManager.ReplicaCreationService;
+import com.slack.kaldb.clusterManager.ReplicaEvictionService;
 import com.slack.kaldb.config.KaldbConfig;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.logstore.search.KaldbDistributedQueryService;
@@ -187,6 +188,11 @@ public class Kaldb {
           new ReplicaCreationService(
               replicaMetadataStore, snapshotMetadataStore, managerConfig, prometheusMeterRegistry);
       services.add(replicaCreationService);
+
+      ReplicaEvictionService replicaEvictionService =
+          new ReplicaEvictionService(
+              cacheSlotMetadataStore, replicaMetadataStore, managerConfig, prometheusMeterRegistry);
+      services.add(replicaEvictionService);
 
       RecoveryTaskAssignmentService recoveryTaskAssignmentService =
           new RecoveryTaskAssignmentService(

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
@@ -1,0 +1,814 @@
+package com.slack.kaldb.clusterManager;
+
+import static com.slack.kaldb.config.KaldbConfig.DEFAULT_START_STOP_DURATION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+import brave.Tracing;
+import com.google.common.util.concurrent.Futures;
+import com.slack.kaldb.metadata.cache.CacheSlotMetadata;
+import com.slack.kaldb.metadata.cache.CacheSlotMetadataStore;
+import com.slack.kaldb.metadata.replica.ReplicaMetadata;
+import com.slack.kaldb.metadata.replica.ReplicaMetadataStore;
+import com.slack.kaldb.metadata.zookeeper.MetadataStore;
+import com.slack.kaldb.metadata.zookeeper.ZookeeperMetadataStoreImpl;
+import com.slack.kaldb.proto.config.KaldbConfigs;
+import com.slack.kaldb.proto.metadata.Metadata;
+import com.slack.kaldb.testlib.MetricsUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeoutException;
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ReplicaEvictionServiceTest {
+
+  private TestingServer testingServer;
+  private MeterRegistry meterRegistry;
+
+  private MetadataStore metadataStore;
+  private CacheSlotMetadataStore cacheSlotMetadataStore;
+  private ReplicaMetadataStore replicaMetadataStore;
+
+  @Before
+  public void setup() throws Exception {
+    Tracing.newBuilder().build();
+    meterRegistry = new SimpleMeterRegistry();
+    testingServer = new TestingServer();
+
+    KaldbConfigs.ZookeeperConfig zkConfig =
+        KaldbConfigs.ZookeeperConfig.newBuilder()
+            .setZkConnectString(testingServer.getConnectString())
+            .setZkPathPrefix("ReplicaEvictionServiceTest")
+            .setZkSessionTimeoutMs(1000)
+            .setZkConnectionTimeoutMs(1000)
+            .setSleepBetweenRetriesMs(1000)
+            .build();
+
+    metadataStore = ZookeeperMetadataStoreImpl.fromConfig(meterRegistry, zkConfig);
+    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(metadataStore, true));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(metadataStore, true));
+  }
+
+  @After
+  public void shutdown() throws IOException {
+    cacheSlotMetadataStore.close();
+    replicaMetadataStore.close();
+    metadataStore.close();
+
+    testingServer.close();
+    meterRegistry.close();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowOnInvalidSchedulePeriodMins() {
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setSchedulePeriodMins(0)
+            .build();
+
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .setEventAggregationSecs(10)
+            .setScheduleInitialDelayMins(0)
+            .build();
+
+    new ReplicaEvictionService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry)
+        .scheduler();
+  }
+
+  @Test
+  public void shouldHandleNoReplicasOrAssignedSlots() {
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setSchedulePeriodMins(10)
+            .build();
+
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .setEventAggregationSecs(10)
+            .setScheduleInitialDelayMins(10)
+            .build();
+
+    ReplicaEvictionService replicaEvictionService =
+        new ReplicaEvictionService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+
+    int replicasMarked = replicaEvictionService.markReplicasForEviction();
+    assertThat(replicasMarked).isEqualTo(0);
+
+    assertThat(
+            MetricsUtil.getCount(
+                ReplicaEvictionService.REPLICA_MARK_EVICT_SUCCEEDED, meterRegistry))
+        .isEqualTo(0);
+    assertThat(
+            MetricsUtil.getCount(ReplicaEvictionService.REPLICA_MARK_EVICT_FAILED, meterRegistry))
+        .isEqualTo(0);
+    assertThat(
+            MetricsUtil.getTimerCount(
+                ReplicaEvictionService.REPLICA_MARK_EVICT_TIMER, meterRegistry))
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldHandleNoExpiredCacheSlots() {
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setSchedulePeriodMins(10)
+            .build();
+
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .setEventAggregationSecs(10)
+            .setScheduleInitialDelayMins(10)
+            .build();
+
+    ReplicaEvictionService replicaEvictionService =
+        new ReplicaEvictionService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+
+    List<ReplicaMetadata> replicas = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      ReplicaMetadata replicaMetadata =
+          new ReplicaMetadata(
+              UUID.randomUUID().toString(),
+              UUID.randomUUID().toString(),
+              Instant.now().toEpochMilli(),
+              Instant.now().plusSeconds(60).toEpochMilli());
+      replicas.add(replicaMetadata);
+      replicaMetadataStore.create(replicaMetadata);
+    }
+
+    List<CacheSlotMetadata> cacheSlots = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      CacheSlotMetadata cacheSlotMetadata =
+          new CacheSlotMetadata(
+              UUID.randomUUID().toString(),
+              Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
+              replicas.get(i).name,
+              Instant.now().toEpochMilli());
+      cacheSlots.add(cacheSlotMetadata);
+      cacheSlotMetadataStore.create(cacheSlotMetadata);
+    }
+
+    await().until(() -> replicaMetadataStore.getCached().size() == 5);
+    await().until(() -> cacheSlotMetadataStore.getCached().size() == 3);
+
+    int replicasMarked = replicaEvictionService.markReplicasForEviction();
+    assertThat(replicasMarked).isEqualTo(0);
+
+    assertThat(replicaMetadataStore.getCached()).containsExactlyInAnyOrderElementsOf(replicas);
+    assertThat(cacheSlotMetadataStore.getCached()).containsExactlyInAnyOrderElementsOf(cacheSlots);
+
+    assertThat(
+            MetricsUtil.getCount(
+                ReplicaEvictionService.REPLICA_MARK_EVICT_SUCCEEDED, meterRegistry))
+        .isEqualTo(0);
+    assertThat(
+            MetricsUtil.getCount(ReplicaEvictionService.REPLICA_MARK_EVICT_FAILED, meterRegistry))
+        .isEqualTo(0);
+    assertThat(
+            MetricsUtil.getTimerCount(
+                ReplicaEvictionService.REPLICA_MARK_EVICT_TIMER, meterRegistry))
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldEvictExpiredReplica() {
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setSchedulePeriodMins(10)
+            .build();
+
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .setEventAggregationSecs(10)
+            .setScheduleInitialDelayMins(10)
+            .build();
+
+    ReplicaEvictionService replicaEvictionService =
+        new ReplicaEvictionService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+
+    ReplicaMetadata replicaMetadata =
+        new ReplicaMetadata(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            Instant.now().toEpochMilli(),
+            Instant.now().minusSeconds(60).toEpochMilli());
+    replicaMetadataStore.create(replicaMetadata);
+
+    CacheSlotMetadata cacheSlotMetadata =
+        new CacheSlotMetadata(
+            UUID.randomUUID().toString(),
+            Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
+            replicaMetadata.name,
+            Instant.now().toEpochMilli());
+    cacheSlotMetadataStore.create(cacheSlotMetadata);
+
+    await().until(() -> replicaMetadataStore.getCached().size() == 1);
+    await().until(() -> cacheSlotMetadataStore.getCached().size() == 1);
+
+    int replicasMarked = replicaEvictionService.markReplicasForEviction();
+    assertThat(replicasMarked).isEqualTo(1);
+
+    assertThat(replicaMetadataStore.getCached()).containsExactly(replicaMetadata);
+    await()
+        .until(
+            () ->
+                cacheSlotMetadataStore
+                    .getCached()
+                    .stream()
+                    .allMatch(
+                        cacheSlot ->
+                            cacheSlot.cacheSlotState.equals(
+                                Metadata.CacheSlotMetadata.CacheSlotState.EVICT)));
+
+    CacheSlotMetadata updatedCacheSlot = cacheSlotMetadataStore.getCached().get(0);
+    assertThat(updatedCacheSlot.updatedTimeUtc).isGreaterThan(cacheSlotMetadata.updatedTimeUtc);
+    assertThat(updatedCacheSlot.cacheSlotState)
+        .isEqualTo(Metadata.CacheSlotMetadata.CacheSlotState.EVICT);
+    assertThat(updatedCacheSlot.name).isEqualTo(cacheSlotMetadata.name);
+    assertThat(updatedCacheSlot.replicaId).isEqualTo(cacheSlotMetadata.replicaId);
+
+    assertThat(
+            MetricsUtil.getCount(
+                ReplicaEvictionService.REPLICA_MARK_EVICT_SUCCEEDED, meterRegistry))
+        .isEqualTo(1);
+    assertThat(
+            MetricsUtil.getCount(ReplicaEvictionService.REPLICA_MARK_EVICT_FAILED, meterRegistry))
+        .isEqualTo(0);
+    assertThat(
+            MetricsUtil.getTimerCount(
+                ReplicaEvictionService.REPLICA_MARK_EVICT_TIMER, meterRegistry))
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldEvictReplicaWithEmptyExpiration() {
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setSchedulePeriodMins(10)
+            .build();
+
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .setEventAggregationSecs(10)
+            .setScheduleInitialDelayMins(10)
+            .build();
+
+    ReplicaEvictionService replicaEvictionService =
+        new ReplicaEvictionService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+
+    ReplicaMetadata replicaMetadata =
+        new ReplicaMetadata(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            Instant.now().toEpochMilli(),
+            0);
+    replicaMetadataStore.create(replicaMetadata);
+
+    CacheSlotMetadata cacheSlotMetadata =
+        new CacheSlotMetadata(
+            UUID.randomUUID().toString(),
+            Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
+            replicaMetadata.name,
+            Instant.now().toEpochMilli());
+    cacheSlotMetadataStore.create(cacheSlotMetadata);
+
+    await().until(() -> replicaMetadataStore.getCached().size() == 1);
+    await().until(() -> cacheSlotMetadataStore.getCached().size() == 1);
+
+    int replicasMarked = replicaEvictionService.markReplicasForEviction();
+    assertThat(replicasMarked).isEqualTo(1);
+
+    assertThat(replicaMetadataStore.getCached()).containsExactly(replicaMetadata);
+    await()
+        .until(
+            () ->
+                cacheSlotMetadataStore
+                    .getCached()
+                    .stream()
+                    .allMatch(
+                        cacheSlot ->
+                            cacheSlot.cacheSlotState.equals(
+                                Metadata.CacheSlotMetadata.CacheSlotState.EVICT)));
+
+    CacheSlotMetadata updatedCacheSlot = cacheSlotMetadataStore.getCached().get(0);
+    assertThat(updatedCacheSlot.updatedTimeUtc).isGreaterThan(cacheSlotMetadata.updatedTimeUtc);
+    assertThat(updatedCacheSlot.cacheSlotState)
+        .isEqualTo(Metadata.CacheSlotMetadata.CacheSlotState.EVICT);
+    assertThat(updatedCacheSlot.name).isEqualTo(cacheSlotMetadata.name);
+    assertThat(updatedCacheSlot.replicaId).isEqualTo(cacheSlotMetadata.replicaId);
+
+    assertThat(
+            MetricsUtil.getCount(
+                ReplicaEvictionService.REPLICA_MARK_EVICT_SUCCEEDED, meterRegistry))
+        .isEqualTo(1);
+    assertThat(
+            MetricsUtil.getCount(ReplicaEvictionService.REPLICA_MARK_EVICT_FAILED, meterRegistry))
+        .isEqualTo(0);
+    assertThat(
+            MetricsUtil.getTimerCount(
+                ReplicaEvictionService.REPLICA_MARK_EVICT_TIMER, meterRegistry))
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldNotMutateReplicaAlreadyMarkedForEviction() {
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setSchedulePeriodMins(10)
+            .build();
+
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .setEventAggregationSecs(10)
+            .setScheduleInitialDelayMins(10)
+            .build();
+
+    ReplicaEvictionService replicaEvictionService =
+        new ReplicaEvictionService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+
+    ReplicaMetadata replicaMetadata =
+        new ReplicaMetadata(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            Instant.now().toEpochMilli(),
+            Instant.now().minusSeconds(60).toEpochMilli());
+    replicaMetadataStore.create(replicaMetadata);
+
+    CacheSlotMetadata cacheSlotMetadata =
+        new CacheSlotMetadata(
+            UUID.randomUUID().toString(),
+            Metadata.CacheSlotMetadata.CacheSlotState.EVICT,
+            replicaMetadata.name,
+            Instant.now().toEpochMilli());
+    cacheSlotMetadataStore.create(cacheSlotMetadata);
+
+    await().until(() -> replicaMetadataStore.getCached().size() == 1);
+    await().until(() -> cacheSlotMetadataStore.getCached().size() == 1);
+
+    int replicasMarked = replicaEvictionService.markReplicasForEviction();
+    assertThat(replicasMarked).isEqualTo(0);
+
+    assertThat(replicaMetadataStore.getCached()).containsExactly(replicaMetadata);
+    assertThat(cacheSlotMetadataStore.getCached()).containsExactly(cacheSlotMetadata);
+
+    assertThat(
+            MetricsUtil.getCount(
+                ReplicaEvictionService.REPLICA_MARK_EVICT_SUCCEEDED, meterRegistry))
+        .isEqualTo(0);
+    assertThat(
+            MetricsUtil.getCount(ReplicaEvictionService.REPLICA_MARK_EVICT_FAILED, meterRegistry))
+        .isEqualTo(0);
+    assertThat(
+            MetricsUtil.getTimerCount(
+                ReplicaEvictionService.REPLICA_MARK_EVICT_TIMER, meterRegistry))
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldNotMutateReplicaAlreadyEvicting() {
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setSchedulePeriodMins(10)
+            .build();
+
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .setEventAggregationSecs(10)
+            .setScheduleInitialDelayMins(10)
+            .build();
+
+    ReplicaEvictionService replicaEvictionService =
+        new ReplicaEvictionService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+
+    ReplicaMetadata replicaMetadata =
+        new ReplicaMetadata(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            Instant.now().toEpochMilli(),
+            Instant.now().minusSeconds(60).toEpochMilli());
+    replicaMetadataStore.create(replicaMetadata);
+
+    CacheSlotMetadata cacheSlotMetadata =
+        new CacheSlotMetadata(
+            UUID.randomUUID().toString(),
+            Metadata.CacheSlotMetadata.CacheSlotState.EVICTING,
+            replicaMetadata.name,
+            Instant.now().toEpochMilli());
+    cacheSlotMetadataStore.create(cacheSlotMetadata);
+
+    await().until(() -> replicaMetadataStore.getCached().size() == 1);
+    await().until(() -> cacheSlotMetadataStore.getCached().size() == 1);
+
+    int replicasMarked = replicaEvictionService.markReplicasForEviction();
+    assertThat(replicasMarked).isEqualTo(0);
+
+    assertThat(replicaMetadataStore.getCached()).containsExactly(replicaMetadata);
+    assertThat(cacheSlotMetadataStore.getCached()).containsExactly(cacheSlotMetadata);
+
+    assertThat(
+            MetricsUtil.getCount(
+                ReplicaEvictionService.REPLICA_MARK_EVICT_SUCCEEDED, meterRegistry))
+        .isEqualTo(0);
+    assertThat(
+            MetricsUtil.getCount(ReplicaEvictionService.REPLICA_MARK_EVICT_FAILED, meterRegistry))
+        .isEqualTo(0);
+    assertThat(
+            MetricsUtil.getTimerCount(
+                ReplicaEvictionService.REPLICA_MARK_EVICT_TIMER, meterRegistry))
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldRetryFailedEvictionOnNextRun() {
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setSchedulePeriodMins(10)
+            .build();
+
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .setEventAggregationSecs(10)
+            .setScheduleInitialDelayMins(10)
+            .build();
+
+    ReplicaEvictionService replicaEvictionService =
+        new ReplicaEvictionService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+
+    ReplicaMetadata replicaMetadata =
+        new ReplicaMetadata(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            Instant.now().toEpochMilli(),
+            Instant.now().minusSeconds(60).toEpochMilli());
+    replicaMetadataStore.create(replicaMetadata);
+
+    CacheSlotMetadata cacheSlotMetadata =
+        new CacheSlotMetadata(
+            UUID.randomUUID().toString(),
+            Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
+            replicaMetadata.name,
+            Instant.now().toEpochMilli());
+    cacheSlotMetadataStore.create(cacheSlotMetadata);
+
+    await().until(() -> replicaMetadataStore.getCached().size() == 1);
+    await().until(() -> cacheSlotMetadataStore.getCached().size() == 1);
+
+    doReturn(Futures.immediateFailedFuture(new Exception()))
+        .when(cacheSlotMetadataStore)
+        .update(any());
+
+    int replicasMarkedFirstAttempt = replicaEvictionService.markReplicasForEviction();
+    assertThat(replicasMarkedFirstAttempt).isEqualTo(0);
+
+    assertThat(replicaMetadataStore.getCached()).containsExactly(replicaMetadata);
+    assertThat(cacheSlotMetadataStore.getCached()).containsExactly(cacheSlotMetadata);
+
+    assertThat(
+            MetricsUtil.getCount(
+                ReplicaEvictionService.REPLICA_MARK_EVICT_SUCCEEDED, meterRegistry))
+        .isEqualTo(0);
+    assertThat(
+            MetricsUtil.getCount(ReplicaEvictionService.REPLICA_MARK_EVICT_FAILED, meterRegistry))
+        .isEqualTo(1);
+    assertThat(
+            MetricsUtil.getTimerCount(
+                ReplicaEvictionService.REPLICA_MARK_EVICT_TIMER, meterRegistry))
+        .isEqualTo(1);
+
+    doCallRealMethod().when(cacheSlotMetadataStore).update(any());
+
+    int replicasMarkedSecondAttempt = replicaEvictionService.markReplicasForEviction();
+    assertThat(replicasMarkedSecondAttempt).isEqualTo(1);
+
+    assertThat(replicaMetadataStore.getCached()).containsExactly(replicaMetadata);
+
+    await()
+        .until(
+            () ->
+                cacheSlotMetadataStore
+                    .getCached()
+                    .stream()
+                    .allMatch(
+                        cacheSlot ->
+                            cacheSlot.cacheSlotState.equals(
+                                Metadata.CacheSlotMetadata.CacheSlotState.EVICT)));
+
+    CacheSlotMetadata updatedCacheSlot = cacheSlotMetadataStore.getCached().get(0);
+    assertThat(updatedCacheSlot.updatedTimeUtc).isGreaterThan(cacheSlotMetadata.updatedTimeUtc);
+    assertThat(updatedCacheSlot.cacheSlotState)
+        .isEqualTo(Metadata.CacheSlotMetadata.CacheSlotState.EVICT);
+    assertThat(updatedCacheSlot.name).isEqualTo(cacheSlotMetadata.name);
+    assertThat(updatedCacheSlot.replicaId).isEqualTo(cacheSlotMetadata.replicaId);
+
+    assertThat(
+            MetricsUtil.getCount(
+                ReplicaEvictionService.REPLICA_MARK_EVICT_SUCCEEDED, meterRegistry))
+        .isEqualTo(1);
+    assertThat(
+            MetricsUtil.getCount(ReplicaEvictionService.REPLICA_MARK_EVICT_FAILED, meterRegistry))
+        .isEqualTo(1);
+    assertThat(
+            MetricsUtil.getTimerCount(
+                ReplicaEvictionService.REPLICA_MARK_EVICT_TIMER, meterRegistry))
+        .isEqualTo(2);
+  }
+
+  @Test
+  public void shouldHandleMixOfZkSuccessFailures() {
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setSchedulePeriodMins(10)
+            .build();
+
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .setEventAggregationSecs(10)
+            .setScheduleInitialDelayMins(10)
+            .build();
+
+    ReplicaEvictionService replicaEvictionService =
+        new ReplicaEvictionService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+    replicaEvictionService.futuresListTimeoutSecs = 2;
+
+    List<ReplicaMetadata> replicas = new ArrayList<>();
+    for (int i = 0; i < 2; i++) {
+      ReplicaMetadata replicaMetadata =
+          new ReplicaMetadata(
+              UUID.randomUUID().toString(),
+              UUID.randomUUID().toString(),
+              Instant.now().toEpochMilli(),
+              Instant.now().minusSeconds(60).toEpochMilli());
+      replicas.add(replicaMetadata);
+      replicaMetadataStore.create(replicaMetadata);
+    }
+
+    for (int i = 0; i < 2; i++) {
+      CacheSlotMetadata cacheSlotMetadata =
+          new CacheSlotMetadata(
+              UUID.randomUUID().toString(),
+              Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
+              replicas.get(0).name,
+              Instant.now().toEpochMilli());
+      cacheSlotMetadataStore.create(cacheSlotMetadata);
+    }
+
+    await().until(() -> replicaMetadataStore.getCached().size() == 2);
+    await().until(() -> cacheSlotMetadataStore.getCached().size() == 2);
+
+    ExecutorService timeoutServiceExecutor = Executors.newSingleThreadExecutor();
+    // allow the first replica creation to work, and timeout the second one
+    doCallRealMethod()
+        .doReturn(
+            Futures.submit(
+                () -> {
+                  try {
+                    Thread.sleep(30 * 1000);
+                  } catch (InterruptedException ignored) {
+                  }
+                },
+                timeoutServiceExecutor))
+        .when(cacheSlotMetadataStore)
+        .update(any());
+
+    int replicasMarkedFirstAttempt = replicaEvictionService.markReplicasForEviction();
+    assertThat(replicasMarkedFirstAttempt).isEqualTo(1);
+
+    assertThat(replicaMetadataStore.getCached()).containsExactlyInAnyOrderElementsOf(replicas);
+    await()
+        .until(
+            () ->
+                cacheSlotMetadataStore
+                        .getCached()
+                        .stream()
+                        .filter(
+                            cacheSlotMetadata ->
+                                cacheSlotMetadata.cacheSlotState.equals(
+                                    Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED))
+                        .count()
+                    == 1);
+    await()
+        .until(
+            () ->
+                cacheSlotMetadataStore
+                        .getCached()
+                        .stream()
+                        .filter(
+                            cacheSlotMetadata ->
+                                cacheSlotMetadata.cacheSlotState.equals(
+                                    Metadata.CacheSlotMetadata.CacheSlotState.EVICT))
+                        .count()
+                    == 1);
+    assertThat(cacheSlotMetadataStore.getCached().size()).isEqualTo(2);
+
+    assertThat(
+            MetricsUtil.getCount(
+                ReplicaEvictionService.REPLICA_MARK_EVICT_SUCCEEDED, meterRegistry))
+        .isEqualTo(1);
+    assertThat(
+            MetricsUtil.getCount(ReplicaEvictionService.REPLICA_MARK_EVICT_FAILED, meterRegistry))
+        .isEqualTo(1);
+    assertThat(
+            MetricsUtil.getTimerCount(
+                ReplicaEvictionService.REPLICA_MARK_EVICT_TIMER, meterRegistry))
+        .isEqualTo(1);
+
+    doCallRealMethod().when(cacheSlotMetadataStore).update(any());
+
+    int replicasMarkedSecondAttempt = replicaEvictionService.markReplicasForEviction();
+    assertThat(replicasMarkedSecondAttempt).isEqualTo(1);
+
+    assertThat(replicaMetadataStore.getCached()).containsExactlyInAnyOrderElementsOf(replicas);
+    await()
+        .until(
+            () ->
+                cacheSlotMetadataStore
+                        .getCached()
+                        .stream()
+                        .filter(
+                            cacheSlotMetadata ->
+                                cacheSlotMetadata.cacheSlotState.equals(
+                                    Metadata.CacheSlotMetadata.CacheSlotState.EVICT))
+                        .count()
+                    == 2);
+    assertThat(cacheSlotMetadataStore.getCached().size()).isEqualTo(2);
+
+    assertThat(
+            MetricsUtil.getCount(
+                ReplicaEvictionService.REPLICA_MARK_EVICT_SUCCEEDED, meterRegistry))
+        .isEqualTo(2);
+    assertThat(
+            MetricsUtil.getCount(ReplicaEvictionService.REPLICA_MARK_EVICT_FAILED, meterRegistry))
+        .isEqualTo(1);
+    assertThat(
+            MetricsUtil.getTimerCount(
+                ReplicaEvictionService.REPLICA_MARK_EVICT_TIMER, meterRegistry))
+        .isEqualTo(2);
+
+    timeoutServiceExecutor.shutdown();
+  }
+
+  @Test
+  public void shouldHandleMixOfExpiredAndUnexpiredLifecycle() throws TimeoutException {
+    KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig replicaEvictionServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaEvictionServiceConfig.newBuilder()
+            .setSchedulePeriodMins(10)
+            .build();
+
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaEvictionServiceConfig(replicaEvictionServiceConfig)
+            .setEventAggregationSecs(10)
+            .setScheduleInitialDelayMins(0)
+            .build();
+
+    ReplicaMetadata replicaMetadataExpiredOne =
+        new ReplicaMetadata(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            Instant.now().toEpochMilli(),
+            Instant.now().minusSeconds(60).toEpochMilli());
+    replicaMetadataStore.create(replicaMetadataExpiredOne);
+    CacheSlotMetadata cacheSlotReplicaExpiredOne =
+        new CacheSlotMetadata(
+            UUID.randomUUID().toString(),
+            Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
+            replicaMetadataExpiredOne.name,
+            Instant.now().toEpochMilli());
+    cacheSlotMetadataStore.create(cacheSlotReplicaExpiredOne);
+
+    ReplicaMetadata replicaMetadataExpiredTwo =
+        new ReplicaMetadata(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            Instant.now().toEpochMilli(),
+            Instant.now().minusSeconds(60).toEpochMilli());
+    replicaMetadataStore.create(replicaMetadataExpiredTwo);
+    CacheSlotMetadata cacheSlotReplicaExpireTwo =
+        new CacheSlotMetadata(
+            UUID.randomUUID().toString(),
+            Metadata.CacheSlotMetadata.CacheSlotState.EVICT,
+            replicaMetadataExpiredTwo.name,
+            Instant.now().toEpochMilli());
+    cacheSlotMetadataStore.create(cacheSlotReplicaExpireTwo);
+
+    ReplicaMetadata replicaMetadataUnexpiredOne =
+        new ReplicaMetadata(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            Instant.now().toEpochMilli(),
+            Instant.now().plusSeconds(360).toEpochMilli());
+    replicaMetadataStore.create(replicaMetadataUnexpiredOne);
+    CacheSlotMetadata cacheSlotReplicaUnexpiredOne =
+        new CacheSlotMetadata(
+            UUID.randomUUID().toString(),
+            Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
+            replicaMetadataUnexpiredOne.name,
+            Instant.now().toEpochMilli());
+    cacheSlotMetadataStore.create(cacheSlotReplicaUnexpiredOne);
+
+    ReplicaMetadata replicaMetadataUnexpiredTwo =
+        new ReplicaMetadata(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            Instant.now().toEpochMilli(),
+            Instant.now().plusSeconds(360).toEpochMilli());
+    replicaMetadataStore.create(replicaMetadataUnexpiredTwo);
+    CacheSlotMetadata cacheSlotFree =
+        new CacheSlotMetadata(
+            UUID.randomUUID().toString(),
+            Metadata.CacheSlotMetadata.CacheSlotState.FREE,
+            "",
+            Instant.now().toEpochMilli());
+    cacheSlotMetadataStore.create(cacheSlotFree);
+
+    await().until(() -> replicaMetadataStore.getCached().size() == 4);
+    await().until(() -> cacheSlotMetadataStore.getCached().size() == 4);
+
+    ReplicaEvictionService replicaEvictionService =
+        new ReplicaEvictionService(
+            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+    replicaEvictionService.startAsync();
+    replicaEvictionService.awaitRunning(DEFAULT_START_STOP_DURATION);
+
+    await()
+        .until(
+            () ->
+                MetricsUtil.getTimerCount(
+                        ReplicaEvictionService.REPLICA_MARK_EVICT_TIMER, meterRegistry)
+                    == 1);
+    await()
+        .until(
+            () ->
+                cacheSlotMetadataStore
+                        .getCached()
+                        .stream()
+                        .filter(
+                            cacheSlotMetadata ->
+                                cacheSlotMetadata.cacheSlotState.equals(
+                                    Metadata.CacheSlotMetadata.CacheSlotState.EVICT))
+                        .count()
+                    == 2);
+
+    assertThat(replicaMetadataStore.getCached())
+        .containsExactlyInAnyOrder(
+            replicaMetadataExpiredOne,
+            replicaMetadataExpiredTwo,
+            replicaMetadataUnexpiredOne,
+            replicaMetadataUnexpiredTwo);
+    assertThat(cacheSlotMetadataStore.getCached())
+        .contains(cacheSlotReplicaExpireTwo, cacheSlotReplicaUnexpiredOne, cacheSlotFree);
+    assertThat(cacheSlotMetadataStore.getCached()).doesNotContain(cacheSlotReplicaExpiredOne);
+
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    CacheSlotMetadata updatedCacheSlot =
+        cacheSlotMetadataStore
+            .getCached()
+            .stream()
+            .filter(
+                cacheSlotMetadata ->
+                    Objects.equals(cacheSlotMetadata.name, cacheSlotReplicaExpiredOne.name))
+            .findFirst()
+            .get();
+    assertThat(updatedCacheSlot.replicaId).isEqualTo(cacheSlotReplicaExpiredOne.replicaId);
+    assertThat(updatedCacheSlot.cacheSlotState)
+        .isEqualTo(Metadata.CacheSlotMetadata.CacheSlotState.EVICT);
+    assertThat(updatedCacheSlot.updatedTimeUtc)
+        .isGreaterThan(cacheSlotReplicaExpiredOne.updatedTimeUtc);
+
+    replicaEvictionService.stopAsync();
+    replicaEvictionService.awaitTerminated(DEFAULT_START_STOP_DURATION);
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
@@ -111,7 +111,7 @@ public class ReplicaEvictionServiceTest {
         new ReplicaEvictionService(
             cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
 
-    int replicasMarked = replicaEvictionService.markReplicasForEviction();
+    int replicasMarked = replicaEvictionService.markReplicasForEviction(Instant.now());
     assertThat(replicasMarked).isEqualTo(0);
 
     assertThat(
@@ -158,21 +158,37 @@ public class ReplicaEvictionServiceTest {
     }
 
     List<CacheSlotMetadata> cacheSlots = new ArrayList<>();
-    for (int i = 0; i < 3; i++) {
-      CacheSlotMetadata cacheSlotMetadata =
-          new CacheSlotMetadata(
-              UUID.randomUUID().toString(),
-              Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
-              replicas.get(i).name,
-              Instant.now().toEpochMilli());
-      cacheSlots.add(cacheSlotMetadata);
-      cacheSlotMetadataStore.create(cacheSlotMetadata);
-    }
+    CacheSlotMetadata cacheSlotAssigned =
+        new CacheSlotMetadata(
+            UUID.randomUUID().toString(),
+            Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
+            replicas.get(0).name,
+            Instant.now().toEpochMilli());
+    cacheSlots.add(cacheSlotAssigned);
+    cacheSlotMetadataStore.create(cacheSlotAssigned);
+
+    CacheSlotMetadata cacheSlotLive =
+        new CacheSlotMetadata(
+            UUID.randomUUID().toString(),
+            Metadata.CacheSlotMetadata.CacheSlotState.LIVE,
+            replicas.get(1).name,
+            Instant.now().toEpochMilli());
+    cacheSlots.add(cacheSlotLive);
+    cacheSlotMetadataStore.create(cacheSlotLive);
+
+    CacheSlotMetadata cacheSlotLoading =
+        new CacheSlotMetadata(
+            UUID.randomUUID().toString(),
+            Metadata.CacheSlotMetadata.CacheSlotState.LOADING,
+            replicas.get(2).name,
+            Instant.now().toEpochMilli());
+    cacheSlots.add(cacheSlotLoading);
+    cacheSlotMetadataStore.create(cacheSlotLoading);
 
     await().until(() -> replicaMetadataStore.getCached().size() == 5);
     await().until(() -> cacheSlotMetadataStore.getCached().size() == 3);
 
-    int replicasMarked = replicaEvictionService.markReplicasForEviction();
+    int replicasMarked = replicaEvictionService.markReplicasForEviction(Instant.now());
     assertThat(replicasMarked).isEqualTo(0);
 
     assertThat(replicaMetadataStore.getCached()).containsExactlyInAnyOrderElementsOf(replicas);
@@ -220,7 +236,7 @@ public class ReplicaEvictionServiceTest {
     CacheSlotMetadata cacheSlotMetadata =
         new CacheSlotMetadata(
             UUID.randomUUID().toString(),
-            Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
+            Metadata.CacheSlotMetadata.CacheSlotState.LIVE,
             replicaMetadata.name,
             Instant.now().toEpochMilli());
     cacheSlotMetadataStore.create(cacheSlotMetadata);
@@ -228,7 +244,7 @@ public class ReplicaEvictionServiceTest {
     await().until(() -> replicaMetadataStore.getCached().size() == 1);
     await().until(() -> cacheSlotMetadataStore.getCached().size() == 1);
 
-    int replicasMarked = replicaEvictionService.markReplicasForEviction();
+    int replicasMarked = replicaEvictionService.markReplicasForEviction(Instant.now());
     assertThat(replicasMarked).isEqualTo(1);
 
     assertThat(replicaMetadataStore.getCached()).containsExactly(replicaMetadata);
@@ -292,7 +308,7 @@ public class ReplicaEvictionServiceTest {
     CacheSlotMetadata cacheSlotMetadata =
         new CacheSlotMetadata(
             UUID.randomUUID().toString(),
-            Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
+            Metadata.CacheSlotMetadata.CacheSlotState.LIVE,
             replicaMetadata.name,
             Instant.now().toEpochMilli());
     cacheSlotMetadataStore.create(cacheSlotMetadata);
@@ -300,7 +316,7 @@ public class ReplicaEvictionServiceTest {
     await().until(() -> replicaMetadataStore.getCached().size() == 1);
     await().until(() -> cacheSlotMetadataStore.getCached().size() == 1);
 
-    int replicasMarked = replicaEvictionService.markReplicasForEviction();
+    int replicasMarked = replicaEvictionService.markReplicasForEviction(Instant.now());
     assertThat(replicasMarked).isEqualTo(1);
 
     assertThat(replicaMetadataStore.getCached()).containsExactly(replicaMetadata);
@@ -372,7 +388,7 @@ public class ReplicaEvictionServiceTest {
     await().until(() -> replicaMetadataStore.getCached().size() == 1);
     await().until(() -> cacheSlotMetadataStore.getCached().size() == 1);
 
-    int replicasMarked = replicaEvictionService.markReplicasForEviction();
+    int replicasMarked = replicaEvictionService.markReplicasForEviction(Instant.now());
     assertThat(replicasMarked).isEqualTo(0);
 
     assertThat(replicaMetadataStore.getCached()).containsExactly(replicaMetadata);
@@ -428,7 +444,7 @@ public class ReplicaEvictionServiceTest {
     await().until(() -> replicaMetadataStore.getCached().size() == 1);
     await().until(() -> cacheSlotMetadataStore.getCached().size() == 1);
 
-    int replicasMarked = replicaEvictionService.markReplicasForEviction();
+    int replicasMarked = replicaEvictionService.markReplicasForEviction(Instant.now());
     assertThat(replicasMarked).isEqualTo(0);
 
     assertThat(replicaMetadataStore.getCached()).containsExactly(replicaMetadata);
@@ -476,7 +492,7 @@ public class ReplicaEvictionServiceTest {
     CacheSlotMetadata cacheSlotMetadata =
         new CacheSlotMetadata(
             UUID.randomUUID().toString(),
-            Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
+            Metadata.CacheSlotMetadata.CacheSlotState.LIVE,
             replicaMetadata.name,
             Instant.now().toEpochMilli());
     cacheSlotMetadataStore.create(cacheSlotMetadata);
@@ -488,7 +504,7 @@ public class ReplicaEvictionServiceTest {
         .when(cacheSlotMetadataStore)
         .update(any());
 
-    int replicasMarkedFirstAttempt = replicaEvictionService.markReplicasForEviction();
+    int replicasMarkedFirstAttempt = replicaEvictionService.markReplicasForEviction(Instant.now());
     assertThat(replicasMarkedFirstAttempt).isEqualTo(0);
 
     assertThat(replicaMetadataStore.getCached()).containsExactly(replicaMetadata);
@@ -508,7 +524,7 @@ public class ReplicaEvictionServiceTest {
 
     doCallRealMethod().when(cacheSlotMetadataStore).update(any());
 
-    int replicasMarkedSecondAttempt = replicaEvictionService.markReplicasForEviction();
+    int replicasMarkedSecondAttempt = replicaEvictionService.markReplicasForEviction(Instant.now());
     assertThat(replicasMarkedSecondAttempt).isEqualTo(1);
 
     assertThat(replicaMetadataStore.getCached()).containsExactly(replicaMetadata);
@@ -579,7 +595,7 @@ public class ReplicaEvictionServiceTest {
       CacheSlotMetadata cacheSlotMetadata =
           new CacheSlotMetadata(
               UUID.randomUUID().toString(),
-              Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
+              Metadata.CacheSlotMetadata.CacheSlotState.LIVE,
               replicas.get(0).name,
               Instant.now().toEpochMilli());
       cacheSlotMetadataStore.create(cacheSlotMetadata);
@@ -603,7 +619,7 @@ public class ReplicaEvictionServiceTest {
         .when(cacheSlotMetadataStore)
         .update(any());
 
-    int replicasMarkedFirstAttempt = replicaEvictionService.markReplicasForEviction();
+    int replicasMarkedFirstAttempt = replicaEvictionService.markReplicasForEviction(Instant.now());
     assertThat(replicasMarkedFirstAttempt).isEqualTo(1);
 
     assertThat(replicaMetadataStore.getCached()).containsExactlyInAnyOrderElementsOf(replicas);
@@ -616,7 +632,7 @@ public class ReplicaEvictionServiceTest {
                         .filter(
                             cacheSlotMetadata ->
                                 cacheSlotMetadata.cacheSlotState.equals(
-                                    Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED))
+                                    Metadata.CacheSlotMetadata.CacheSlotState.LIVE))
                         .count()
                     == 1);
     await()
@@ -647,7 +663,7 @@ public class ReplicaEvictionServiceTest {
 
     doCallRealMethod().when(cacheSlotMetadataStore).update(any());
 
-    int replicasMarkedSecondAttempt = replicaEvictionService.markReplicasForEviction();
+    int replicasMarkedSecondAttempt = replicaEvictionService.markReplicasForEviction(Instant.now());
     assertThat(replicasMarkedSecondAttempt).isEqualTo(1);
 
     assertThat(replicaMetadataStore.getCached()).containsExactlyInAnyOrderElementsOf(replicas);
@@ -704,7 +720,7 @@ public class ReplicaEvictionServiceTest {
     CacheSlotMetadata cacheSlotReplicaExpiredOne =
         new CacheSlotMetadata(
             UUID.randomUUID().toString(),
-            Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
+            Metadata.CacheSlotMetadata.CacheSlotState.LIVE,
             replicaMetadataExpiredOne.name,
             Instant.now().toEpochMilli());
     cacheSlotMetadataStore.create(cacheSlotReplicaExpiredOne);
@@ -734,7 +750,7 @@ public class ReplicaEvictionServiceTest {
     CacheSlotMetadata cacheSlotReplicaUnexpiredOne =
         new CacheSlotMetadata(
             UUID.randomUUID().toString(),
-            Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
+            Metadata.CacheSlotMetadata.CacheSlotState.LIVE,
             replicaMetadataUnexpiredOne.name,
             Instant.now().toEpochMilli());
     cacheSlotMetadataStore.create(cacheSlotReplicaUnexpiredOne);


### PR DESCRIPTION
Marks expired replicas that are currently assigned to a cache slot for eviction.