### PR TITLE
shutdown log4j correctly

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/util/RuntimeHalterImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/util/RuntimeHalterImpl.java
@@ -8,7 +8,6 @@ public class RuntimeHalterImpl implements FatalErrorHandler {
 
   @Override
   public void handleFatal(Throwable t) {
-    t.printStackTrace();
     LOG.error("Runtime halter is called probably on an unrecoverable error. Stopping the VM.", t);
     // TODO: Make the exit more cleaner, once the system is more stable.
     System.exit(1);


### PR DESCRIPTION
shutdown log4j correctly

Make sure any exception is previous shutdown tasks doesn't skip log4j shutdown. Also since log4j 2.6 the correct way to shutdown is `LogManager.shutdown() `

This becomes a problem with JSON logging as the last few logs don't make it in JSON format since it doesn't go through log4j and just standard out

references
https://stackoverflow.com/questions/17400136/how-to-log-within-shutdown-hooks-with-log4j2
https://stackoverflow.com/questions/30657619/programmatically-disabling-shutdown-hook-in-log4j-2
https://stackoverflow.com/questions/25877102/how-to-properly-shutdown-log4j2