### PR TITLE
Snapshot deletion service

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -69,6 +69,10 @@ managerConfig:
     schedulePeriodMins: ${KALDB_MANAGER_REPLICA_DELETE_PERIOD_MINS:-15}
   recoveryTaskAssignmentServiceConfig:
     schedulePeriodMins: ${KALDB_MANAGER_RECOVERY_PERIOD_MINS:-15}
+  snapshotDeletionServiceConfig:
+    schedulePeriodMins: ${KALDB_MANAGER_SNAPSHOT_DELETE_PERIOD_MINS:-15}
+    snapshotLifespanMins: ${KALDB_MANAGER_SNAPSHOT_LIFESPAN_MINS:-10080}
+
 
 recoveryConfig:
   serverConfig:

--- a/kaldb/src/main/java/com/slack/kaldb/blobfs/s3/S3BlobFs.java
+++ b/kaldb/src/main/java/com/slack/kaldb/blobfs/s3/S3BlobFs.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.slack.kaldb.blobfs.BlobFs;
 import com.slack.kaldb.blobfs.BlobFsConfig;
+import com.slack.kaldb.proto.config.KaldbConfigs;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -519,5 +520,17 @@ public class S3BlobFs extends BlobFs {
   @Override
   public void close() throws IOException {
     super.close();
+  }
+
+  public static S3BlobFs getS3BlobFsClient(KaldbConfigs.S3Config s3Config) {
+    S3BlobFsConfig s3BlobFsConfig =
+        new S3BlobFsConfig(
+            s3Config.getS3AccessKey(),
+            s3Config.getS3SecretKey(),
+            s3Config.getS3Region(),
+            s3Config.getS3EndPoint());
+    S3BlobFs s3BlobFs = new S3BlobFs();
+    s3BlobFs.init(s3BlobFsConfig);
+    return s3BlobFs;
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/CachingChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/CachingChunkManager.java
@@ -1,5 +1,7 @@
 package com.slack.kaldb.chunkManager;
 
+import static com.slack.kaldb.blobfs.s3.S3BlobFs.getS3BlobFsClient;
+
 import com.slack.kaldb.blobfs.s3.S3BlobFs;
 import com.slack.kaldb.chunk.ReadOnlyChunkImpl;
 import com.slack.kaldb.chunk.SearchContext;
@@ -98,7 +100,7 @@ public class CachingChunkManager<T> extends ChunkManager<T> {
     return new CachingChunkManager<>(
         meterRegistry,
         metadataStore,
-        getS3BlobFsClient(KaldbConfig.get()),
+        getS3BlobFsClient(KaldbConfig.get().getS3Config()),
         SearchContext.fromConfig(serverConfig),
         KaldbConfig.get().getS3Config().getS3Bucket(),
         KaldbConfig.get().getCacheConfig().getDataDirectory(),

--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/ChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/ChunkManager.java
@@ -4,14 +4,11 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.linecorp.armeria.common.RequestContext;
-import com.slack.kaldb.blobfs.s3.S3BlobFs;
-import com.slack.kaldb.blobfs.s3.S3BlobFsConfig;
 import com.slack.kaldb.chunk.Chunk;
 import com.slack.kaldb.logstore.search.SearchQuery;
 import com.slack.kaldb.logstore.search.SearchResult;
 import com.slack.kaldb.logstore.search.SearchResultAggregator;
 import com.slack.kaldb.logstore.search.SearchResultAggregatorImpl;
-import com.slack.kaldb.proto.config.KaldbConfigs;
 import com.spotify.futures.CompletableFutures;
 import java.util.ArrayList;
 import java.util.List;
@@ -119,18 +116,5 @@ public abstract class ChunkManager<T> extends AbstractIdleService {
   @VisibleForTesting
   public List<Chunk<T>> getChunkList() {
     return chunkList;
-  }
-
-  protected static S3BlobFs getS3BlobFsClient(KaldbConfigs.KaldbConfig kaldbCfg) {
-    KaldbConfigs.S3Config s3Config = kaldbCfg.getS3Config();
-    S3BlobFsConfig s3BlobFsConfig =
-        new S3BlobFsConfig(
-            s3Config.getS3AccessKey(),
-            s3Config.getS3SecretKey(),
-            s3Config.getS3Region(),
-            s3Config.getS3EndPoint());
-    S3BlobFs s3BlobFs = new S3BlobFs();
-    s3BlobFs.init(s3BlobFsConfig);
-    return s3BlobFs;
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/IndexingChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/IndexingChunkManager.java
@@ -1,5 +1,6 @@
 package com.slack.kaldb.chunkManager;
 
+import static com.slack.kaldb.blobfs.s3.S3BlobFs.getS3BlobFsClient;
 import static com.slack.kaldb.util.ArgValidationUtils.ensureNonNullString;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -395,7 +396,7 @@ public class IndexingChunkManager<T> extends ChunkManager<T> {
         KaldbConfig.get().getIndexerConfig().getDataDirectory(),
         chunkRollOverStrategy,
         meterRegistry,
-        getS3BlobFsClient(KaldbConfig.get()),
+        getS3BlobFsClient(KaldbConfig.get().getS3Config()),
         KaldbConfig.get().getS3Config().getS3Bucket(),
         makeDefaultRollOverExecutor(),
         DEFAULT_ROLLOVER_FUTURE_TIMEOUT_MS,

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/SnapshotDeletionService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/SnapshotDeletionService.java
@@ -1,0 +1,212 @@
+package com.slack.kaldb.clusterManager;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.util.concurrent.Futures.addCallback;
+import static com.slack.kaldb.config.KaldbConfig.DEFAULT_ZK_TIMEOUT_SECS;
+import static com.slack.kaldb.util.FutureUtils.successCountingCallback;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.AbstractScheduledService;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.slack.kaldb.blobfs.s3.S3BlobFs;
+import com.slack.kaldb.metadata.replica.ReplicaMetadataStore;
+import com.slack.kaldb.metadata.snapshot.SnapshotMetadataStore;
+import com.slack.kaldb.proto.config.KaldbConfigs;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.io.IOException;
+import java.net.URI;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Deletes snapshots and their associated blob storage objects that both exceed their configured
+ * lifespan, and have no associated replicas configured. Snapshot lifespan is expected to be some
+ * value greater than the replica lifespan. This service only delete objects from blob storage that
+ * have a corresponding snapshot object - removal of orphaned objects will be removed by a separate
+ * service.
+ */
+public class SnapshotDeletionService extends AbstractScheduledService {
+  private static final Logger LOG = LoggerFactory.getLogger(SnapshotDeletionService.class);
+  private static final int THREAD_POOL_SIZE = 10;
+  private final KaldbConfigs.ManagerConfig managerConfig;
+
+  private final ReplicaMetadataStore replicaMetadataStore;
+  private final SnapshotMetadataStore snapshotMetadataStore;
+  private final MeterRegistry meterRegistry;
+  private final S3BlobFs s3BlobFs;
+
+  @VisibleForTesting protected int futuresListTimeoutSecs = DEFAULT_ZK_TIMEOUT_SECS;
+
+  public static final String SNAPSHOT_DELETE_SUCCESS = "snapshot_delete_success";
+  public static final String SNAPSHOT_DELETE_FAILED = "snapshot_delete_failed";
+  public static final String SNAPSHOT_DELETE_TIMER = "snapshot_delete_timer";
+
+  private final Counter snapshotDeleteSuccess;
+  private final Counter snapshotDeleteFailed;
+  private final Timer snapshotDeleteTimer;
+
+  private final ExecutorService executorService =
+      Executors.newFixedThreadPool(
+          THREAD_POOL_SIZE,
+          new ThreadFactoryBuilder().setNameFormat("snapshot-deletion-service-%d").build());
+
+  public SnapshotDeletionService(
+      ReplicaMetadataStore replicaMetadataStore,
+      SnapshotMetadataStore snapshotMetadataStore,
+      S3BlobFs s3BlobFs,
+      KaldbConfigs.ManagerConfig managerConfig,
+      MeterRegistry meterRegistry) {
+
+    checkArgument(
+        managerConfig.getSnapshotDeletionServiceConfig().getSnapshotLifespanMins()
+            > managerConfig.getReplicaCreationServiceConfig().getReplicaLifespanMins(),
+        "SnapshotLifespanMins must be greater than the ReplicaLifespanMins");
+    // schedule configs checked as part of the AbstractScheduledService
+
+    this.managerConfig = managerConfig;
+    this.replicaMetadataStore = replicaMetadataStore;
+    this.snapshotMetadataStore = snapshotMetadataStore;
+    this.s3BlobFs = s3BlobFs;
+    this.meterRegistry = meterRegistry;
+
+    this.snapshotDeleteSuccess = meterRegistry.counter(SNAPSHOT_DELETE_SUCCESS);
+    this.snapshotDeleteFailed = meterRegistry.counter(SNAPSHOT_DELETE_FAILED);
+    this.snapshotDeleteTimer = meterRegistry.timer(SNAPSHOT_DELETE_TIMER);
+  }
+
+  @Override
+  protected void runOneIteration() {
+    deleteExpiredSnapshotsWithoutReplicas();
+  }
+
+  @Override
+  protected Scheduler scheduler() {
+    return Scheduler.newFixedRateSchedule(
+        managerConfig.getScheduleInitialDelayMins(),
+        managerConfig.getSnapshotDeletionServiceConfig().getSchedulePeriodMins(),
+        TimeUnit.MINUTES);
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    LOG.info("Starting snapshot deletion service");
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    LOG.info("Closing snapshot deletion service");
+    executorService.shutdown();
+  }
+
+  /**
+   * Deletes snapshots and associated object storage data that have no corresponding replicas.
+   * Separate services are responsible for the eviction and deletion of expired replicas, and this
+   * service only is expected to remove snapshots that are not being currently served.
+   *
+   * <p>Consideration should be taken for when configs are changed, such as shortening the replica
+   * lifespan. The expectation is that previously created replicas that may have a longer expiration
+   * would see that respected throughout the duration of their lifespan.
+   *
+   * <p>Deletion of expired snapshots should gracefully handle the scenario where immediately prior
+   * to reaching the end of the configured snapshot lifespan, an on-demand request is received. In
+   * this scenario a new replica would have been created, and the object would be currently
+   * downloading for servicing the request. The expectation from the end user would be that the
+   * request would still be served, as when the request was made it was still "in compliance" with
+   * the lifespan configuration.
+   *
+   * <p>When creating on-demand replicas, care should be taken to not create replicas for snapshots
+   * that already exceed their maximum lifespan to prevent a race condition between on-demand
+   * creation and snapshot deletion.
+   */
+  protected int deleteExpiredSnapshotsWithoutReplicas() {
+    Timer.Sample deletionTimer = Timer.start(meterRegistry);
+
+    Set<String> snapshotIdsWithReplicas =
+        replicaMetadataStore
+            .getCached()
+            .stream()
+            .map(replicaMetadata -> replicaMetadata.snapshotId)
+            .filter(snapshotId -> snapshotId != null && !snapshotId.isEmpty())
+            .collect(Collectors.toUnmodifiableSet());
+
+    long expirationCutoff =
+        Instant.now()
+            .minus(
+                managerConfig.getSnapshotDeletionServiceConfig().getSnapshotLifespanMins(),
+                ChronoUnit.MINUTES)
+            .toEpochMilli();
+    AtomicInteger successCounter = new AtomicInteger(0);
+    List<ListenableFuture<?>> deletedSnapshotList =
+        snapshotMetadataStore
+            .getCached()
+            .stream()
+            // only snapshots that only contain data prior to our cutoff, and have no replicas
+            .filter(
+                snapshotMetadata ->
+                    snapshotMetadata.endTimeEpochMs < expirationCutoff
+                        && !snapshotIdsWithReplicas.contains(snapshotMetadata.name))
+            .map(
+                snapshotMetadata -> {
+                  ListenableFuture<?> future =
+                      Futures.submit(
+                          () -> {
+                            // we first delete the snapshot reference - if for some reason we fail
+                            // to delete the object from the object storage, the orphaned object
+                            // cleanup service will attempt to delete it later
+                            snapshotMetadataStore.deleteSync(snapshotMetadata);
+                            if (!s3BlobFs.delete(URI.create(snapshotMetadata.snapshotPath), true)) {
+                              throw new IOException(
+                                  String.format(
+                                      "Failed to delete '%s' from object store",
+                                      snapshotMetadata.snapshotPath));
+                            }
+                            return null;
+                          },
+                          executorService);
+
+                  addCallback(
+                      future,
+                      successCountingCallback(successCounter),
+                      MoreExecutors.directExecutor());
+                  return future;
+                })
+            .collect(Collectors.toUnmodifiableList());
+
+    ListenableFuture<?> futureList = Futures.successfulAsList(deletedSnapshotList);
+    try {
+      futureList.get(futuresListTimeoutSecs, TimeUnit.SECONDS);
+    } catch (Exception e) {
+      futureList.cancel(true);
+    }
+    int successfulDeletions = successCounter.get();
+
+    // failedDeletes = timed out futures
+    int failedDeletions = deletedSnapshotList.size() - successfulDeletions;
+
+    snapshotDeleteSuccess.increment(successfulDeletions);
+    snapshotDeleteFailed.increment(failedDeletions);
+
+    long deletionDuration = deletionTimer.stop(snapshotDeleteTimer);
+    LOG.info(
+        "Completed snapshot deletion - successfully deleted {} snapshots, failed to delete {} snapshots in {} ms",
+        successfulDeletions,
+        failedDeletions,
+        TimeUnit.MILLISECONDS.convert(deletionDuration, TimeUnit.NANOSECONDS));
+
+    return successfulDeletions;
+  }
+}

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -108,6 +108,11 @@ message ManagerConfig {
         int32 schedulePeriodMins = 1;
     }
 
+    message SnapshotDeletionServiceConfig {
+        int32 schedulePeriodMins = 1;
+        int32 snapshotLifespanMins = 2;
+    }
+
     int32 eventAggregationSecs = 1;
     int32 scheduleInitialDelayMins = 2;
     ServerConfig serverConfig = 3;
@@ -117,6 +122,7 @@ message ManagerConfig {
     ReplicaEvictionServiceConfig replicaEvictionServiceConfig = 6;
     ReplicaDeletionServiceConfig replicaDeletionServiceConfig = 7;
     RecoveryTaskAssignmentServiceConfig recoveryTaskAssignmentServiceConfig = 8;
+    SnapshotDeletionServiceConfig snapshotDeletionServiceConfig = 9;
 }
 
 message RecoveryConfig {

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/SnapshotDeletionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/SnapshotDeletionServiceTest.java
@@ -1,0 +1,798 @@
+package com.slack.kaldb.clusterManager;
+
+import static com.slack.kaldb.config.KaldbConfig.DEFAULT_START_STOP_DURATION;
+import static com.slack.kaldb.logstore.BlobFsUtils.createURI;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import brave.Tracing;
+import com.adobe.testing.s3mock.junit4.S3MockRule;
+import com.google.common.util.concurrent.Futures;
+import com.slack.kaldb.blobfs.s3.S3BlobFs;
+import com.slack.kaldb.metadata.replica.ReplicaMetadata;
+import com.slack.kaldb.metadata.replica.ReplicaMetadataStore;
+import com.slack.kaldb.metadata.snapshot.SnapshotMetadata;
+import com.slack.kaldb.metadata.snapshot.SnapshotMetadataStore;
+import com.slack.kaldb.metadata.zookeeper.InternalMetadataStoreException;
+import com.slack.kaldb.metadata.zookeeper.MetadataStore;
+import com.slack.kaldb.metadata.zookeeper.ZookeeperMetadataStoreImpl;
+import com.slack.kaldb.proto.config.KaldbConfigs;
+import com.slack.kaldb.testlib.MetricsUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+
+public class SnapshotDeletionServiceTest {
+
+  @ClassRule public static final S3MockRule S3_MOCK_RULE = S3MockRule.builder().silent().build();
+  private static final String S3_TEST_BUCKET = "snapshot-deletion-service-bucket";
+
+  private TestingServer testingServer;
+  private MeterRegistry meterRegistry;
+
+  private MetadataStore metadataStore;
+  private SnapshotMetadataStore snapshotMetadataStore;
+  private ReplicaMetadataStore replicaMetadataStore;
+  private S3Client s3Client;
+  private S3BlobFs s3BlobFs;
+
+  @Before
+  public void setup() throws Exception {
+    Tracing.newBuilder().build();
+    meterRegistry = new SimpleMeterRegistry();
+    testingServer = new TestingServer();
+
+    KaldbConfigs.ZookeeperConfig zkConfig =
+        KaldbConfigs.ZookeeperConfig.newBuilder()
+            .setZkConnectString(testingServer.getConnectString())
+            .setZkPathPrefix("SnapshotDeletionServiceTest")
+            .setZkSessionTimeoutMs(1000)
+            .setZkConnectionTimeoutMs(1000)
+            .setSleepBetweenRetriesMs(1000)
+            .build();
+
+    metadataStore = ZookeeperMetadataStoreImpl.fromConfig(meterRegistry, zkConfig);
+    snapshotMetadataStore = spy(new SnapshotMetadataStore(metadataStore, true));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(metadataStore, true));
+
+    s3Client = S3_MOCK_RULE.createS3ClientV2();
+    s3Client.createBucket(CreateBucketRequest.builder().bucket(S3_TEST_BUCKET).build());
+
+    s3BlobFs = spy(new S3BlobFs());
+    s3BlobFs.init(s3Client);
+  }
+
+  @After
+  public void shutdown() throws IOException {
+    snapshotMetadataStore.close();
+    replicaMetadataStore.close();
+    metadataStore.close();
+    s3Client.close();
+
+    testingServer.close();
+    meterRegistry.close();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowOnInvalidSnapshotLifespan() {
+    KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+
+    KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig snapshotDeletionServiceConfig =
+        KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig.newBuilder()
+            .setSchedulePeriodMins(10)
+            .setSnapshotLifespanMins(1440)
+            .build();
+
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaCreationServiceConfig(replicaCreationServiceConfig)
+            .setSnapshotDeletionServiceConfig(snapshotDeletionServiceConfig)
+            .setScheduleInitialDelayMins(0)
+            .build();
+
+    new SnapshotDeletionService(
+        replicaMetadataStore, snapshotMetadataStore, s3BlobFs, managerConfig, meterRegistry);
+  }
+
+  @Test
+  public void shouldDeleteExpiredSnapshotNoReplicas() throws Exception {
+    KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+
+    KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig snapshotDeletionServiceConfig =
+        KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig.newBuilder()
+            .setSchedulePeriodMins(10)
+            .setSnapshotLifespanMins(10080)
+            .build();
+
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaCreationServiceConfig(replicaCreationServiceConfig)
+            .setSnapshotDeletionServiceConfig(snapshotDeletionServiceConfig)
+            .setScheduleInitialDelayMins(0)
+            .build();
+
+    Path file = Files.createTempFile("", "");
+    URI path = createURI(S3_TEST_BUCKET, "foo", "bar");
+    s3BlobFs.copyFromLocalFile(file.toFile(), path);
+
+    SnapshotMetadata snapshotMetadata =
+        new SnapshotMetadata(
+            UUID.randomUUID().toString(),
+            path.toString(),
+            Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
+            Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
+            0,
+            "1");
+    snapshotMetadataStore.create(snapshotMetadata);
+    await().until(() -> snapshotMetadataStore.getCached().size() == 1);
+
+    SnapshotDeletionService snapshotDeletionService =
+        new SnapshotDeletionService(
+            replicaMetadataStore, snapshotMetadataStore, s3BlobFs, managerConfig, meterRegistry);
+
+    int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
+    assertThat(deletes).isEqualTo(1);
+
+    await().until(() -> snapshotMetadataStore.getCached().size() == 0);
+    verify(s3BlobFs, times(1)).delete(eq(path), eq(true));
+
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry))
+        .isEqualTo(1);
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_FAILED, meterRegistry))
+        .isEqualTo(0);
+    assertThat(
+            MetricsUtil.getTimerCount(SnapshotDeletionService.SNAPSHOT_DELETE_TIMER, meterRegistry))
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldNotDeleteExpiredSnapshotWithReplicas() throws Exception {
+    KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+
+    KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig snapshotDeletionServiceConfig =
+        KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig.newBuilder()
+            .setSchedulePeriodMins(10)
+            .setSnapshotLifespanMins(10080)
+            .build();
+
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaCreationServiceConfig(replicaCreationServiceConfig)
+            .setSnapshotDeletionServiceConfig(snapshotDeletionServiceConfig)
+            .setScheduleInitialDelayMins(0)
+            .build();
+
+    Path file = Files.createTempFile("", "");
+    URI path = createURI(S3_TEST_BUCKET, "foo", "bar");
+    s3BlobFs.copyFromLocalFile(file.toFile(), path);
+
+    SnapshotMetadata snapshotMetadata =
+        new SnapshotMetadata(
+            UUID.randomUUID().toString(),
+            path.toString(),
+            Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
+            Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
+            0,
+            "1");
+    snapshotMetadataStore.create(snapshotMetadata);
+
+    ReplicaMetadata replicaMetadata =
+        new ReplicaMetadata(
+            UUID.randomUUID().toString(),
+            snapshotMetadata.name,
+            Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
+            Instant.now().minus(500, ChronoUnit.MINUTES).toEpochMilli());
+    replicaMetadataStore.create(replicaMetadata);
+
+    await().until(() -> snapshotMetadataStore.getCached().size() == 1);
+    await().until(() -> replicaMetadataStore.getCached().size() == 1);
+
+    SnapshotDeletionService snapshotDeletionService =
+        new SnapshotDeletionService(
+            replicaMetadataStore, snapshotMetadataStore, s3BlobFs, managerConfig, meterRegistry);
+
+    int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
+    assertThat(deletes).isEqualTo(0);
+
+    assertThat(snapshotMetadataStore.getCached()).containsExactlyInAnyOrder(snapshotMetadata);
+    assertThat(replicaMetadataStore.getCached()).containsExactlyInAnyOrder(replicaMetadata);
+    verify(s3BlobFs, times(0)).delete(any(), anyBoolean());
+
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry))
+        .isEqualTo(0);
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_FAILED, meterRegistry))
+        .isEqualTo(0);
+    assertThat(
+            MetricsUtil.getTimerCount(SnapshotDeletionService.SNAPSHOT_DELETE_TIMER, meterRegistry))
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldHandleNoReplicasNoSnapshots() throws IOException {
+    KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+
+    KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig snapshotDeletionServiceConfig =
+        KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig.newBuilder()
+            .setSchedulePeriodMins(10)
+            .setSnapshotLifespanMins(10080)
+            .build();
+
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaCreationServiceConfig(replicaCreationServiceConfig)
+            .setSnapshotDeletionServiceConfig(snapshotDeletionServiceConfig)
+            .setScheduleInitialDelayMins(0)
+            .build();
+
+    SnapshotDeletionService snapshotDeletionService =
+        new SnapshotDeletionService(
+            replicaMetadataStore, snapshotMetadataStore, s3BlobFs, managerConfig, meterRegistry);
+
+    int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
+    assertThat(deletes).isEqualTo(0);
+
+    assertThat(snapshotMetadataStore.getCached().size()).isEqualTo(0);
+    assertThat(replicaMetadataStore.getCached().size()).isEqualTo(0);
+    verify(s3BlobFs, times(0)).delete(any(), anyBoolean());
+
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry))
+        .isEqualTo(0);
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_FAILED, meterRegistry))
+        .isEqualTo(0);
+    assertThat(
+            MetricsUtil.getTimerCount(SnapshotDeletionService.SNAPSHOT_DELETE_TIMER, meterRegistry))
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldHandleNoReplicasUnexpiredSnapshots() throws Exception {
+    KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+
+    KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig snapshotDeletionServiceConfig =
+        KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig.newBuilder()
+            .setSchedulePeriodMins(10)
+            .setSnapshotLifespanMins(10080)
+            .build();
+
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaCreationServiceConfig(replicaCreationServiceConfig)
+            .setSnapshotDeletionServiceConfig(snapshotDeletionServiceConfig)
+            .setScheduleInitialDelayMins(0)
+            .build();
+
+    Path file = Files.createTempFile("", "");
+    URI path = createURI(S3_TEST_BUCKET, "foo", "bar");
+    s3BlobFs.copyFromLocalFile(file.toFile(), path);
+
+    SnapshotMetadata snapshotMetadata =
+        new SnapshotMetadata(
+            UUID.randomUUID().toString(),
+            path.toString(),
+            Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
+            Instant.now().minus(500, ChronoUnit.MINUTES).toEpochMilli(),
+            0,
+            "1");
+    snapshotMetadataStore.create(snapshotMetadata);
+    await().until(() -> snapshotMetadataStore.getCached().size() == 1);
+
+    SnapshotDeletionService snapshotDeletionService =
+        new SnapshotDeletionService(
+            replicaMetadataStore, snapshotMetadataStore, s3BlobFs, managerConfig, meterRegistry);
+
+    int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
+    assertThat(deletes).isEqualTo(0);
+
+    assertThat(snapshotMetadataStore.getCached()).containsExactlyInAnyOrder(snapshotMetadata);
+    verify(s3BlobFs, times(0)).delete(any(), anyBoolean());
+
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry))
+        .isEqualTo(0);
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_FAILED, meterRegistry))
+        .isEqualTo(0);
+    assertThat(
+            MetricsUtil.getTimerCount(SnapshotDeletionService.SNAPSHOT_DELETE_TIMER, meterRegistry))
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldHandleReplicasWithLongerLifespanThanSnapshots() throws Exception {
+    KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+
+    KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig snapshotDeletionServiceConfig =
+        KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig.newBuilder()
+            .setSchedulePeriodMins(10)
+            .setSnapshotLifespanMins(10080)
+            .build();
+
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaCreationServiceConfig(replicaCreationServiceConfig)
+            .setSnapshotDeletionServiceConfig(snapshotDeletionServiceConfig)
+            .setScheduleInitialDelayMins(0)
+            .build();
+
+    Path file = Files.createTempFile("", "");
+    URI path = createURI(S3_TEST_BUCKET, "foo", "bar");
+    s3BlobFs.copyFromLocalFile(file.toFile(), path);
+
+    // snapshot is expired
+    SnapshotMetadata snapshotMetadata =
+        new SnapshotMetadata(
+            UUID.randomUUID().toString(),
+            path.toString(),
+            Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
+            Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
+            0,
+            "1");
+    snapshotMetadataStore.create(snapshotMetadata);
+
+    // replica is also expired
+    ReplicaMetadata replicaMetadata =
+        new ReplicaMetadata(
+            UUID.randomUUID().toString(),
+            snapshotMetadata.name,
+            Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
+            Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli());
+    replicaMetadataStore.create(replicaMetadata);
+
+    await().until(() -> snapshotMetadataStore.getCached().size() == 1);
+    await().until(() -> replicaMetadataStore.getCached().size() == 1);
+
+    SnapshotDeletionService snapshotDeletionService =
+        new SnapshotDeletionService(
+            replicaMetadataStore, snapshotMetadataStore, s3BlobFs, managerConfig, meterRegistry);
+
+    int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
+    assertThat(deletes).isEqualTo(0);
+
+    assertThat(snapshotMetadataStore.getCached()).containsExactlyInAnyOrder(snapshotMetadata);
+    assertThat(replicaMetadataStore.getCached()).containsExactlyInAnyOrder(replicaMetadata);
+    verify(s3BlobFs, times(0)).delete(any(), anyBoolean());
+
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry))
+        .isEqualTo(0);
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_FAILED, meterRegistry))
+        .isEqualTo(0);
+    assertThat(
+            MetricsUtil.getTimerCount(SnapshotDeletionService.SNAPSHOT_DELETE_TIMER, meterRegistry))
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldHandleExceptionalObjectStorageDelete() throws Exception {
+    KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+
+    KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig snapshotDeletionServiceConfig =
+        KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig.newBuilder()
+            .setSchedulePeriodMins(10)
+            .setSnapshotLifespanMins(10080)
+            .build();
+
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaCreationServiceConfig(replicaCreationServiceConfig)
+            .setSnapshotDeletionServiceConfig(snapshotDeletionServiceConfig)
+            .setScheduleInitialDelayMins(0)
+            .build();
+
+    Path file = Files.createTempFile("", "");
+    URI path = createURI(S3_TEST_BUCKET, "foo", "bar");
+    s3BlobFs.copyFromLocalFile(file.toFile(), path);
+
+    // snapshot is expired
+    SnapshotMetadata snapshotMetadata =
+        new SnapshotMetadata(
+            UUID.randomUUID().toString(),
+            path.toString(),
+            Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
+            Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
+            0,
+            "1");
+    snapshotMetadataStore.create(snapshotMetadata);
+
+    await().until(() -> snapshotMetadataStore.getCached().size() == 1);
+
+    SnapshotDeletionService snapshotDeletionService =
+        new SnapshotDeletionService(
+            replicaMetadataStore, snapshotMetadataStore, s3BlobFs, managerConfig, meterRegistry);
+    doThrow(new IOException()).when(s3BlobFs).delete(any(), anyBoolean());
+
+    int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
+    assertThat(deletes).isEqualTo(0);
+
+    await().until(() -> snapshotMetadataStore.getCached().size() == 0);
+    verify(s3BlobFs, times(1)).delete(any(), anyBoolean());
+
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry))
+        .isEqualTo(0);
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_FAILED, meterRegistry))
+        .isEqualTo(1);
+    assertThat(
+            MetricsUtil.getTimerCount(SnapshotDeletionService.SNAPSHOT_DELETE_TIMER, meterRegistry))
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldHandleFailedZkDelete() throws Exception {
+    KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+
+    KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig snapshotDeletionServiceConfig =
+        KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig.newBuilder()
+            .setSchedulePeriodMins(10)
+            .setSnapshotLifespanMins(10080)
+            .build();
+
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaCreationServiceConfig(replicaCreationServiceConfig)
+            .setSnapshotDeletionServiceConfig(snapshotDeletionServiceConfig)
+            .setScheduleInitialDelayMins(0)
+            .build();
+
+    Path file = Files.createTempFile("", "");
+    URI path = createURI(S3_TEST_BUCKET, "foo", "bar");
+    s3BlobFs.copyFromLocalFile(file.toFile(), path);
+
+    // snapshot is expired
+    SnapshotMetadata snapshotMetadata =
+        new SnapshotMetadata(
+            UUID.randomUUID().toString(),
+            path.toString(),
+            Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
+            Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
+            0,
+            "1");
+    snapshotMetadataStore.create(snapshotMetadata);
+    await().until(() -> snapshotMetadataStore.getCached().size() == 1);
+
+    SnapshotDeletionService snapshotDeletionService =
+        new SnapshotDeletionService(
+            replicaMetadataStore, snapshotMetadataStore, s3BlobFs, managerConfig, meterRegistry);
+    doReturn(Futures.immediateFailedFuture(new InternalMetadataStoreException("failed")))
+        .when(snapshotMetadataStore)
+        .delete(any(SnapshotMetadata.class));
+
+    int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
+    assertThat(deletes).isEqualTo(0);
+
+    assertThat(snapshotMetadataStore.getCached()).containsExactlyInAnyOrder(snapshotMetadata);
+    verify(s3BlobFs, times(0)).delete(any(), anyBoolean());
+
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry))
+        .isEqualTo(0);
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_FAILED, meterRegistry))
+        .isEqualTo(1);
+    assertThat(
+            MetricsUtil.getTimerCount(SnapshotDeletionService.SNAPSHOT_DELETE_TIMER, meterRegistry))
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldHandleFailedObjectDelete() throws Exception {
+    KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+
+    KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig snapshotDeletionServiceConfig =
+        KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig.newBuilder()
+            .setSchedulePeriodMins(10)
+            .setSnapshotLifespanMins(10080)
+            .build();
+
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaCreationServiceConfig(replicaCreationServiceConfig)
+            .setSnapshotDeletionServiceConfig(snapshotDeletionServiceConfig)
+            .setScheduleInitialDelayMins(0)
+            .build();
+
+    Path file = Files.createTempFile("", "");
+    URI path = createURI(S3_TEST_BUCKET, "foo", "bar");
+    s3BlobFs.copyFromLocalFile(file.toFile(), path);
+
+    // snapshot is expired
+    SnapshotMetadata snapshotMetadata =
+        new SnapshotMetadata(
+            UUID.randomUUID().toString(),
+            path.toString(),
+            Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
+            Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
+            0,
+            "1");
+    snapshotMetadataStore.create(snapshotMetadata);
+    await().until(() -> snapshotMetadataStore.getCached().size() == 1);
+
+    SnapshotDeletionService snapshotDeletionService =
+        new SnapshotDeletionService(
+            replicaMetadataStore, snapshotMetadataStore, s3BlobFs, managerConfig, meterRegistry);
+    doReturn(false).when(s3BlobFs).delete(any(), anyBoolean());
+
+    int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
+    assertThat(deletes).isEqualTo(0);
+
+    await().until(() -> snapshotMetadataStore.getCached().size() == 0);
+    verify(s3BlobFs, times(1)).delete(any(), anyBoolean());
+
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry))
+        .isEqualTo(0);
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_FAILED, meterRegistry))
+        .isEqualTo(1);
+    assertThat(
+            MetricsUtil.getTimerCount(SnapshotDeletionService.SNAPSHOT_DELETE_TIMER, meterRegistry))
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldRetryTimedOutZkDeleteNextRun() throws Exception {
+    KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+
+    KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig snapshotDeletionServiceConfig =
+        KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig.newBuilder()
+            .setSchedulePeriodMins(10)
+            .setSnapshotLifespanMins(10080)
+            .build();
+
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaCreationServiceConfig(replicaCreationServiceConfig)
+            .setSnapshotDeletionServiceConfig(snapshotDeletionServiceConfig)
+            .setScheduleInitialDelayMins(0)
+            .build();
+
+    Path file = Files.createTempFile("", "");
+    URI path = createURI(S3_TEST_BUCKET, "foo", "bar");
+    s3BlobFs.copyFromLocalFile(file.toFile(), path);
+
+    // snapshot is expired
+    SnapshotMetadata snapshotMetadata =
+        new SnapshotMetadata(
+            UUID.randomUUID().toString(),
+            path.toString(),
+            Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
+            Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
+            0,
+            "1");
+    snapshotMetadataStore.create(snapshotMetadata);
+    await().until(() -> snapshotMetadataStore.getCached().size() == 1);
+
+    SnapshotDeletionService snapshotDeletionService =
+        new SnapshotDeletionService(
+            replicaMetadataStore, snapshotMetadataStore, s3BlobFs, managerConfig, meterRegistry);
+    snapshotDeletionService.futuresListTimeoutSecs = 2;
+
+    ExecutorService timeoutServiceExecutor = Executors.newSingleThreadExecutor();
+    doReturn(
+            Futures.submit(
+                () -> {
+                  try {
+                    Thread.sleep(30 * 1000);
+                  } catch (InterruptedException ignored) {
+                  }
+                },
+                timeoutServiceExecutor))
+        .when(snapshotMetadataStore)
+        .delete(any(SnapshotMetadata.class));
+
+    int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
+    assertThat(deletes).isEqualTo(0);
+
+    assertThat(snapshotMetadataStore.getCached()).containsExactlyInAnyOrder(snapshotMetadata);
+    verify(s3BlobFs, times(0)).delete(any(), anyBoolean());
+
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry))
+        .isEqualTo(0);
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_FAILED, meterRegistry))
+        .isEqualTo(1);
+    assertThat(
+            MetricsUtil.getTimerCount(SnapshotDeletionService.SNAPSHOT_DELETE_TIMER, meterRegistry))
+        .isEqualTo(1);
+
+    doCallRealMethod().when(snapshotMetadataStore).delete(any(SnapshotMetadata.class));
+
+    int deletesRetry = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
+    assertThat(deletesRetry).isEqualTo(1);
+
+    assertThat(snapshotMetadataStore.getCached().size()).isEqualTo(0);
+    verify(s3BlobFs, times(1)).delete(any(), anyBoolean());
+
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry))
+        .isEqualTo(1);
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_FAILED, meterRegistry))
+        .isEqualTo(1);
+    assertThat(
+            MetricsUtil.getTimerCount(SnapshotDeletionService.SNAPSHOT_DELETE_TIMER, meterRegistry))
+        .isEqualTo(2);
+
+    timeoutServiceExecutor.shutdown();
+  }
+
+  @Test
+  public void shouldNotRetryFailedObjectStorageDeleteNextRun() throws Exception {
+    KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+
+    KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig snapshotDeletionServiceConfig =
+        KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig.newBuilder()
+            .setSchedulePeriodMins(10)
+            .setSnapshotLifespanMins(10080)
+            .build();
+
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaCreationServiceConfig(replicaCreationServiceConfig)
+            .setSnapshotDeletionServiceConfig(snapshotDeletionServiceConfig)
+            .setScheduleInitialDelayMins(0)
+            .build();
+
+    Path file = Files.createTempFile("", "");
+    URI path = createURI(S3_TEST_BUCKET, "foo", "bar");
+    s3BlobFs.copyFromLocalFile(file.toFile(), path);
+
+    // snapshot is expired
+    SnapshotMetadata snapshotMetadata =
+        new SnapshotMetadata(
+            UUID.randomUUID().toString(),
+            path.toString(),
+            Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
+            Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
+            0,
+            "1");
+    snapshotMetadataStore.create(snapshotMetadata);
+
+    await().until(() -> snapshotMetadataStore.getCached().size() == 1);
+
+    SnapshotDeletionService snapshotDeletionService =
+        new SnapshotDeletionService(
+            replicaMetadataStore, snapshotMetadataStore, s3BlobFs, managerConfig, meterRegistry);
+    doThrow(new IOException()).when(s3BlobFs).delete(any(), anyBoolean());
+
+    int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
+    assertThat(deletes).isEqualTo(0);
+
+    await().until(() -> snapshotMetadataStore.getCached().size() == 0);
+    verify(s3BlobFs, times(1)).delete(any(), anyBoolean());
+
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry))
+        .isEqualTo(0);
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_FAILED, meterRegistry))
+        .isEqualTo(1);
+    assertThat(
+            MetricsUtil.getTimerCount(SnapshotDeletionService.SNAPSHOT_DELETE_TIMER, meterRegistry))
+        .isEqualTo(1);
+
+    doCallRealMethod().when(s3BlobFs).delete(any(), anyBoolean());
+    int deleteRetry = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
+    assertThat(deleteRetry).isEqualTo(0);
+
+    // should be the same count as before
+    verify(s3BlobFs, times(1)).delete(any(), anyBoolean());
+
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry))
+        .isEqualTo(0);
+    assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_FAILED, meterRegistry))
+        .isEqualTo(1);
+    assertThat(
+            MetricsUtil.getTimerCount(SnapshotDeletionService.SNAPSHOT_DELETE_TIMER, meterRegistry))
+        .isEqualTo(2);
+  }
+
+  @Test
+  public void shouldHandleSnapshotDeleteLifecycle() throws Exception {
+    KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
+            .setReplicaLifespanMins(1440)
+            .build();
+
+    KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig snapshotDeletionServiceConfig =
+        KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig.newBuilder()
+            .setSchedulePeriodMins(10)
+            .setSnapshotLifespanMins(10080)
+            .build();
+
+    KaldbConfigs.ManagerConfig managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaCreationServiceConfig(replicaCreationServiceConfig)
+            .setSnapshotDeletionServiceConfig(snapshotDeletionServiceConfig)
+            .setScheduleInitialDelayMins(0)
+            .build();
+
+    Path file = Files.createTempFile("", "");
+    URI path = createURI(S3_TEST_BUCKET, "foo", "bar");
+    s3BlobFs.copyFromLocalFile(file.toFile(), path);
+
+    SnapshotMetadata snapshotMetadata =
+        new SnapshotMetadata(
+            UUID.randomUUID().toString(),
+            path.toString(),
+            Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
+            Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
+            0,
+            "1");
+    snapshotMetadataStore.create(snapshotMetadata);
+    await().until(() -> snapshotMetadataStore.getCached().size() == 1);
+
+    SnapshotDeletionService snapshotDeletionService =
+        new SnapshotDeletionService(
+            replicaMetadataStore, snapshotMetadataStore, s3BlobFs, managerConfig, meterRegistry);
+    snapshotDeletionService.startAsync();
+    snapshotDeletionService.awaitRunning(DEFAULT_START_STOP_DURATION);
+
+    await().until(() -> snapshotMetadataStore.getCached().size() == 0);
+    verify(s3BlobFs, times(1)).delete(eq(path), eq(true));
+
+    await()
+        .until(
+            () ->
+                MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry)
+                    == 1);
+    await()
+        .until(
+            () ->
+                MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_FAILED, meterRegistry)
+                    == 0);
+    await()
+        .until(
+            () ->
+                MetricsUtil.getTimerCount(
+                        SnapshotDeletionService.SNAPSHOT_DELETE_TIMER, meterRegistry)
+                    == 1);
+
+    snapshotDeletionService.stopAsync();
+    snapshotDeletionService.awaitTerminated(DEFAULT_START_STOP_DURATION);
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/SnapshotDeletionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/SnapshotDeletionServiceTest.java
@@ -223,6 +223,7 @@ public class SnapshotDeletionServiceTest {
     SnapshotDeletionService snapshotDeletionService =
         new SnapshotDeletionService(
             replicaMetadataStore, snapshotMetadataStore, s3BlobFs, managerConfig, meterRegistry);
+    String[] s3BlobFsFiles = s3BlobFs.listFiles(path, true);
 
     int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
     assertThat(deletes).isEqualTo(0);
@@ -230,6 +231,7 @@ public class SnapshotDeletionServiceTest {
     assertThat(snapshotMetadataStore.getCached()).containsExactlyInAnyOrder(snapshotMetadata);
     assertThat(replicaMetadataStore.getCached()).containsExactlyInAnyOrder(replicaMetadata);
     verify(s3BlobFs, times(0)).delete(any(), anyBoolean());
+    assertThat(s3BlobFs.listFiles(path, true)).isEqualTo(s3BlobFsFiles);
 
     assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry))
         .isEqualTo(0);
@@ -314,6 +316,7 @@ public class SnapshotDeletionServiceTest {
             "1");
     snapshotMetadataStore.create(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
+    String[] s3BlobFsFiles = s3BlobFs.listFiles(path, true);
 
     SnapshotDeletionService snapshotDeletionService =
         new SnapshotDeletionService(
@@ -324,6 +327,7 @@ public class SnapshotDeletionServiceTest {
 
     assertThat(snapshotMetadataStore.getCached()).containsExactlyInAnyOrder(snapshotMetadata);
     verify(s3BlobFs, times(0)).delete(any(), anyBoolean());
+    assertThat(s3BlobFs.listFiles(path, true)).isEqualTo(s3BlobFsFiles);
 
     assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry))
         .isEqualTo(0);
@@ -380,6 +384,7 @@ public class SnapshotDeletionServiceTest {
 
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
     await().until(() -> replicaMetadataStore.getCached().size() == 1);
+    String[] s3BlobFsFiles = s3BlobFs.listFiles(path, true);
 
     SnapshotDeletionService snapshotDeletionService =
         new SnapshotDeletionService(
@@ -391,6 +396,7 @@ public class SnapshotDeletionServiceTest {
     assertThat(snapshotMetadataStore.getCached()).containsExactlyInAnyOrder(snapshotMetadata);
     assertThat(replicaMetadataStore.getCached()).containsExactlyInAnyOrder(replicaMetadata);
     verify(s3BlobFs, times(0)).delete(any(), anyBoolean());
+    assertThat(s3BlobFs.listFiles(path, true)).isEqualTo(s3BlobFsFiles);
 
     assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry))
         .isEqualTo(0);
@@ -500,12 +506,14 @@ public class SnapshotDeletionServiceTest {
     doReturn(Futures.immediateFailedFuture(new InternalMetadataStoreException("failed")))
         .when(snapshotMetadataStore)
         .delete(any(SnapshotMetadata.class));
+    String[] s3BlobFsFiles = s3BlobFs.listFiles(path, true);
 
     int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
     assertThat(deletes).isEqualTo(0);
 
     assertThat(snapshotMetadataStore.getCached()).containsExactlyInAnyOrder(snapshotMetadata);
     verify(s3BlobFs, times(0)).delete(any(), anyBoolean());
+    assertThat(s3BlobFs.listFiles(path, true)).isEqualTo(s3BlobFsFiles);
 
     assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry))
         .isEqualTo(0);
@@ -612,6 +620,7 @@ public class SnapshotDeletionServiceTest {
         new SnapshotDeletionService(
             replicaMetadataStore, snapshotMetadataStore, s3BlobFs, managerConfig, meterRegistry);
     snapshotDeletionService.futuresListTimeoutSecs = 2;
+    String[] s3BlobFsFiles = s3BlobFs.listFiles(path, true);
 
     ExecutorService timeoutServiceExecutor = Executors.newSingleThreadExecutor();
     doReturn(
@@ -631,6 +640,7 @@ public class SnapshotDeletionServiceTest {
 
     assertThat(snapshotMetadataStore.getCached()).containsExactlyInAnyOrder(snapshotMetadata);
     verify(s3BlobFs, times(0)).delete(any(), anyBoolean());
+    assertThat(s3BlobFs.listFiles(path, true)).isEqualTo(s3BlobFsFiles);
 
     assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry))
         .isEqualTo(0);

--- a/kaldb/src/test/java/com/slack/kaldb/config/KaldbConfigTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/config/KaldbConfigTest.java
@@ -229,6 +229,11 @@ public class KaldbConfigTest {
         managerConfig.getReplicaAssignmentServiceConfig();
     assertThat(replicaAssignmentServiceConfig.getSchedulePeriodMins()).isEqualTo(10);
 
+    final KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig snapshotDeletionServiceConfig =
+        managerConfig.getSnapshotDeletionServiceConfig();
+    assertThat(snapshotDeletionServiceConfig.getSchedulePeriodMins()).isEqualTo(15);
+    assertThat(snapshotDeletionServiceConfig.getSnapshotLifespanMins()).isEqualTo(10080);
+
     final KaldbConfigs.ServerConfig managerServerConfig = managerConfig.getServerConfig();
     assertThat(managerServerConfig.getServerPort()).isEqualTo(8083);
     assertThat(managerServerConfig.getServerAddress()).isEqualTo("localhost");
@@ -334,6 +339,11 @@ public class KaldbConfigTest {
         managerConfig.getReplicaAssignmentServiceConfig();
     assertThat(replicaAssignmentServiceConfig.getSchedulePeriodMins()).isEqualTo(10);
 
+    final KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig snapshotDeletionServiceConfig =
+        managerConfig.getSnapshotDeletionServiceConfig();
+    assertThat(snapshotDeletionServiceConfig.getSchedulePeriodMins()).isEqualTo(15);
+    assertThat(snapshotDeletionServiceConfig.getSnapshotLifespanMins()).isEqualTo(10080);
+
     final KaldbConfigs.ServerConfig managerServerConfig = managerConfig.getServerConfig();
     assertThat(managerServerConfig.getServerPort()).isEqualTo(8083);
     assertThat(managerServerConfig.getServerAddress()).isEqualTo("localhost");
@@ -433,6 +443,11 @@ public class KaldbConfigTest {
         managerConfig.getReplicaAssignmentServiceConfig();
     assertThat(replicaAssignmentServiceConfig.getSchedulePeriodMins()).isZero();
 
+    final KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig snapshotDeletionServiceConfig =
+        managerConfig.getSnapshotDeletionServiceConfig();
+    assertThat(snapshotDeletionServiceConfig.getSchedulePeriodMins()).isZero();
+    assertThat(snapshotDeletionServiceConfig.getSnapshotLifespanMins()).isZero();
+
     final KaldbConfigs.ServerConfig managerServerConfig = managerConfig.getServerConfig();
     assertThat(managerServerConfig.getServerPort()).isZero();
     assertThat(managerServerConfig.getServerAddress()).isEmpty();
@@ -521,6 +536,11 @@ public class KaldbConfigTest {
     final KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig replicaAssignmentServiceConfig =
         managerConfig.getReplicaAssignmentServiceConfig();
     assertThat(replicaAssignmentServiceConfig.getSchedulePeriodMins()).isZero();
+
+    final KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig snapshotDeletionServiceConfig =
+        managerConfig.getSnapshotDeletionServiceConfig();
+    assertThat(snapshotDeletionServiceConfig.getSchedulePeriodMins()).isZero();
+    assertThat(snapshotDeletionServiceConfig.getSnapshotLifespanMins()).isZero();
 
     final KaldbConfigs.ServerConfig managerServerConfig = managerConfig.getServerConfig();
     assertThat(managerServerConfig.getServerPort()).isZero();

--- a/kaldb/src/test/resources/test_config.json
+++ b/kaldb/src/test/resources/test_config.json
@@ -80,6 +80,10 @@
     },
     "recoveryTaskAssignmentServiceConfig": {
       "schedulePeriodMins": 10
+    },
+    "snapshotDeletionServiceConfig": {
+      "schedulePeriodMins": 15,
+      "snapshotLifespanMins": 10080
     }
   },
   "recoveryConfig": {

--- a/kaldb/src/test/resources/test_config.yaml
+++ b/kaldb/src/test/resources/test_config.yaml
@@ -66,6 +66,9 @@ managerConfig:
     schedulePeriodMins: 90
   recoveryTaskAssignmentServiceConfig: 
     schedulePeriodMins: 10
+  snapshotDeletionServiceConfig:
+    schedulePeriodMins: 15
+    snapshotLifespanMins: 10080
 
 recoveryConfig:
   serverConfig:


### PR DESCRIPTION
Deletes snapshots and their associated blob storage objects that both exceed their configured lifespan, and have no associated replicas configured.