### PR TITLE
Update s3mock dependency

### DIFF
--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -351,7 +351,7 @@
         <dependency>
             <groupId>com.adobe.testing</groupId>
             <artifactId>s3mock-junit4</artifactId>
-            <version>2.1.24</version>
+            <version>2.2.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/kaldb/src/main/java/com/slack/kaldb/blobfs/s3/S3BlobFs.java
+++ b/kaldb/src/main/java/com/slack/kaldb/blobfs/s3/S3BlobFs.java
@@ -284,7 +284,7 @@ public class S3BlobFs extends BlobFs {
         }
         return deleteSucceeded;
       } else {
-        String prefix = sanitizePath(segmentUri.getPath());
+        String prefix = DELIMITER + sanitizePath(segmentUri.getPath());
         DeleteObjectRequest deleteObjectRequest =
             DeleteObjectRequest.builder().bucket(segmentUri.getHost()).key(prefix).build();
 

--- a/kaldb/src/test/java/com/slack/kaldb/blobfs/s3/S3BlobFsTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/blobfs/s3/S3BlobFsTest.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Assert;
@@ -27,21 +28,20 @@ public class S3BlobFsTest {
   @ClassRule public static final S3MockRule S3_MOCK_RULE = S3MockRule.builder().silent().build();
 
   final String DELIMITER = "/";
-  static final String BUCKET = "test-bucket";
   final String SCHEME = "s3";
   final String FILE_FORMAT = "%s://%s/%s";
   final String DIR_FORMAT = "%s://%s";
 
   private final S3Client s3Client = S3_MOCK_RULE.createS3ClientV2();
+  private String bucket;
   private S3BlobFs s3BlobFs;
-
-  // TODO: Make this before and after class to speed up the unit test runs like Pinot tests.
 
   @Before
   public void setUp() {
+    bucket = "test-bucket-" + UUID.randomUUID();
     s3BlobFs = new S3BlobFs();
     s3BlobFs.init(s3Client);
-    s3Client.createBucket(CreateBucketRequest.builder().bucket(BUCKET).build());
+    s3Client.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
   }
 
   @After
@@ -52,7 +52,7 @@ public class S3BlobFsTest {
   private void createEmptyFile(String folderName, String fileName) {
     String fileNameWithFolder = folderName + DELIMITER + fileName;
     s3Client.putObject(
-        S3TestUtils.getPutObjectRequest(BUCKET, fileNameWithFolder),
+        S3TestUtils.getPutObjectRequest(bucket, fileNameWithFolder),
         RequestBody.fromBytes(new byte[0]));
   }
 
@@ -62,10 +62,10 @@ public class S3BlobFsTest {
     String[] originalFiles = new String[] {"a-touch.txt", "b-touch.txt", "c-touch.txt"};
 
     for (String fileName : originalFiles) {
-      s3BlobFs.touch(URI.create(String.format(FILE_FORMAT, SCHEME, BUCKET, fileName)));
+      s3BlobFs.touch(URI.create(String.format(FILE_FORMAT, SCHEME, bucket, fileName)));
     }
     ListObjectsV2Response listObjectsV2Response =
-        s3Client.listObjectsV2(S3TestUtils.getListObjectRequest(BUCKET, "", true));
+        s3Client.listObjectsV2(S3TestUtils.getListObjectRequest(bucket, "", true));
 
     String[] response =
         listObjectsV2Response
@@ -87,10 +87,10 @@ public class S3BlobFsTest {
 
     for (String fileName : originalFiles) {
       String fileNameWithFolder = folder + DELIMITER + fileName;
-      s3BlobFs.touch(URI.create(String.format(FILE_FORMAT, SCHEME, BUCKET, fileNameWithFolder)));
+      s3BlobFs.touch(URI.create(String.format(FILE_FORMAT, SCHEME, bucket, fileNameWithFolder)));
     }
     ListObjectsV2Response listObjectsV2Response =
-        s3Client.listObjectsV2(S3TestUtils.getListObjectRequest(BUCKET, folder, false));
+        s3Client.listObjectsV2(S3TestUtils.getListObjectRequest(bucket, folder, false));
 
     String[] response =
         listObjectsV2Response
@@ -113,11 +113,11 @@ public class S3BlobFsTest {
 
     for (String fileName : originalFiles) {
       createEmptyFile("", fileName);
-      expectedFileNames.add(String.format(FILE_FORMAT, SCHEME, BUCKET, fileName));
+      expectedFileNames.add(String.format(FILE_FORMAT, SCHEME, bucket, fileName));
     }
 
     String[] actualFiles =
-        s3BlobFs.listFiles(URI.create(String.format(DIR_FORMAT, SCHEME, BUCKET)), false);
+        s3BlobFs.listFiles(URI.create(String.format(DIR_FORMAT, SCHEME, bucket)), false);
 
     actualFiles = Arrays.stream(actualFiles).filter(x -> x.contains("list")).toArray(String[]::new);
     Assert.assertEquals(actualFiles.length, originalFiles.length);
@@ -135,7 +135,7 @@ public class S3BlobFsTest {
     }
 
     String[] actualFiles =
-        s3BlobFs.listFiles(URI.create(String.format(FILE_FORMAT, SCHEME, BUCKET, folder)), false);
+        s3BlobFs.listFiles(URI.create(String.format(FILE_FORMAT, SCHEME, bucket, folder)), false);
 
     actualFiles =
         Arrays.stream(actualFiles).filter(x -> x.contains("list-2")).toArray(String[]::new);
@@ -146,7 +146,7 @@ public class S3BlobFsTest {
             Arrays.stream(originalFiles)
                 .map(
                     fileName ->
-                        String.format(FILE_FORMAT, SCHEME, BUCKET, folder + DELIMITER + fileName))
+                        String.format(FILE_FORMAT, SCHEME, bucket, folder + DELIMITER + fileName))
                 .toArray(),
             actualFiles));
   }
@@ -163,11 +163,11 @@ public class S3BlobFsTest {
       for (String fileName : originalFiles) {
         createEmptyFile(folderName, fileName);
         expectedResultList.add(
-            String.format(FILE_FORMAT, SCHEME, BUCKET, folderName + DELIMITER + fileName));
+            String.format(FILE_FORMAT, SCHEME, bucket, folderName + DELIMITER + fileName));
       }
     }
     String[] actualFiles =
-        s3BlobFs.listFiles(URI.create(String.format(FILE_FORMAT, SCHEME, BUCKET, folder)), true);
+        s3BlobFs.listFiles(URI.create(String.format(FILE_FORMAT, SCHEME, bucket, folder)), true);
 
     actualFiles =
         Arrays.stream(actualFiles).filter(x -> x.contains("list-3")).toArray(String[]::new);
@@ -188,10 +188,10 @@ public class S3BlobFsTest {
       }
     }
 
-    s3BlobFs.delete(URI.create(String.format(FILE_FORMAT, SCHEME, BUCKET, fileToDelete)), false);
+    s3BlobFs.delete(URI.create(String.format(FILE_FORMAT, SCHEME, bucket, fileToDelete)), false);
 
     ListObjectsV2Response listObjectsV2Response =
-        s3Client.listObjectsV2(S3TestUtils.getListObjectRequest(BUCKET, "", true));
+        s3Client.listObjectsV2(S3TestUtils.getListObjectRequest(bucket, "", true));
     String[] actualResponse =
         listObjectsV2Response
             .contents()
@@ -213,10 +213,10 @@ public class S3BlobFsTest {
       createEmptyFile(folderName, fileName);
     }
 
-    s3BlobFs.delete(URI.create(String.format(FILE_FORMAT, SCHEME, BUCKET, folderName)), true);
+    s3BlobFs.delete(URI.create(String.format(FILE_FORMAT, SCHEME, bucket, folderName)), true);
 
     ListObjectsV2Response listObjectsV2Response =
-        s3Client.listObjectsV2(S3TestUtils.getListObjectRequest(BUCKET, "", true));
+        s3Client.listObjectsV2(S3TestUtils.getListObjectRequest(bucket, "", true));
     String[] actualResponse =
         listObjectsV2Response
             .contents()
@@ -239,20 +239,20 @@ public class S3BlobFsTest {
     }
 
     boolean isBucketDir =
-        s3BlobFs.isDirectory(URI.create(String.format(DIR_FORMAT, SCHEME, BUCKET)));
+        s3BlobFs.isDirectory(URI.create(String.format(DIR_FORMAT, SCHEME, bucket)));
     boolean isDir =
-        s3BlobFs.isDirectory(URI.create(String.format(FILE_FORMAT, SCHEME, BUCKET, folder)));
+        s3BlobFs.isDirectory(URI.create(String.format(FILE_FORMAT, SCHEME, bucket, folder)));
     boolean isDirChild =
         s3BlobFs.isDirectory(
             URI.create(
-                String.format(FILE_FORMAT, SCHEME, BUCKET, folder + DELIMITER + childFolder)));
+                String.format(FILE_FORMAT, SCHEME, bucket, folder + DELIMITER + childFolder)));
     boolean notIsDir =
         s3BlobFs.isDirectory(
             URI.create(
                 String.format(
                     FILE_FORMAT,
                     SCHEME,
-                    BUCKET,
+                    bucket,
                     folder + DELIMITER + childFolder + DELIMITER + "a-delete.txt")));
 
     Assert.assertTrue(isBucketDir);
@@ -272,20 +272,20 @@ public class S3BlobFsTest {
       createEmptyFile(folderName, fileName);
     }
 
-    boolean bucketExists = s3BlobFs.exists(URI.create(String.format(DIR_FORMAT, SCHEME, BUCKET)));
+    boolean bucketExists = s3BlobFs.exists(URI.create(String.format(DIR_FORMAT, SCHEME, bucket)));
     boolean dirExists =
-        s3BlobFs.exists(URI.create(String.format(FILE_FORMAT, SCHEME, BUCKET, folder)));
+        s3BlobFs.exists(URI.create(String.format(FILE_FORMAT, SCHEME, bucket, folder)));
     boolean childDirExists =
         s3BlobFs.exists(
             URI.create(
-                String.format(FILE_FORMAT, SCHEME, BUCKET, folder + DELIMITER + childFolder)));
+                String.format(FILE_FORMAT, SCHEME, bucket, folder + DELIMITER + childFolder)));
     boolean fileExists =
         s3BlobFs.exists(
             URI.create(
                 String.format(
                     FILE_FORMAT,
                     SCHEME,
-                    BUCKET,
+                    bucket,
                     folder + DELIMITER + childFolder + DELIMITER + "a-ex.txt")));
     boolean fileNotExists =
         s3BlobFs.exists(
@@ -293,7 +293,7 @@ public class S3BlobFsTest {
                 String.format(
                     FILE_FORMAT,
                     SCHEME,
-                    BUCKET,
+                    bucket,
                     folder + DELIMITER + childFolder + DELIMITER + "d-ex.txt")));
 
     Assert.assertTrue(bucketExists);
@@ -310,16 +310,16 @@ public class S3BlobFsTest {
     File fileToCopy = new File(getClass().getClassLoader().getResource(fileName).getFile());
 
     s3BlobFs.copyFromLocalFile(
-        fileToCopy, URI.create(String.format(FILE_FORMAT, SCHEME, BUCKET, fileName)));
+        fileToCopy, URI.create(String.format(FILE_FORMAT, SCHEME, bucket, fileName)));
 
     HeadObjectResponse headObjectResponse =
-        s3Client.headObject(S3TestUtils.getHeadObjectRequest(BUCKET, fileName));
+        s3Client.headObject(S3TestUtils.getHeadObjectRequest(bucket, fileName));
 
     Assert.assertEquals(headObjectResponse.contentLength(), (Long) fileToCopy.length());
 
     File fileToDownload = new File("copyFile_download.txt").getAbsoluteFile();
     s3BlobFs.copyToLocalFile(
-        URI.create(String.format(FILE_FORMAT, SCHEME, BUCKET, fileName)), fileToDownload);
+        URI.create(String.format(FILE_FORMAT, SCHEME, bucket, fileName)), fileToDownload);
     Assert.assertEquals(fileToCopy.length(), fileToDownload.length());
 
     fileToDownload.deleteOnExit();
@@ -331,10 +331,10 @@ public class S3BlobFsTest {
     String fileContent = "Hello, World";
 
     s3Client.putObject(
-        S3TestUtils.getPutObjectRequest(BUCKET, fileName), RequestBody.fromString(fileContent));
+        S3TestUtils.getPutObjectRequest(bucket, fileName), RequestBody.fromString(fileContent));
 
     InputStream is =
-        s3BlobFs.open(URI.create(String.format(FILE_FORMAT, SCHEME, BUCKET, fileName)));
+        s3BlobFs.open(URI.create(String.format(FILE_FORMAT, SCHEME, bucket, fileName)));
     String actualContents = IOUtils.toString(is, StandardCharsets.UTF_8);
     Assert.assertEquals(actualContents, fileContent);
   }
@@ -343,10 +343,10 @@ public class S3BlobFsTest {
   public void testMkdir() throws Exception {
     String folderName = "my-test-folder";
 
-    s3BlobFs.mkdir(URI.create(String.format(FILE_FORMAT, SCHEME, BUCKET, folderName)));
+    s3BlobFs.mkdir(URI.create(String.format(FILE_FORMAT, SCHEME, bucket, folderName)));
 
     HeadObjectResponse headObjectResponse =
-        s3Client.headObject(S3TestUtils.getHeadObjectRequest(BUCKET, folderName));
+        s3Client.headObject(S3TestUtils.getHeadObjectRequest(bucket, folderName + DELIMITER));
     Assert.assertTrue(headObjectResponse.sdkHttpResponse().isSuccessful());
   }
 }


### PR DESCRIPTION
Updates s3mock to newer version. This was originally motivated out of https://github.com/slackhq/kaldb/pull/190#discussion_r774200759, as the currently used version has several mocks that do not function like the AWS api (getS3Object, prefixes, multipart uploads).