### PR TITLE
upgrade to lucene 9

### DIFF
--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -21,7 +21,7 @@
         <jackson.version>2.10.5</jackson.version>
         <!-- remove special databind version when jackson.version is the same -->
         <jackson.databind.version>${jackson.version}.1</jackson.databind.version>
-        <lucene.version>8.4.1</lucene.version>
+        <lucene.version>9.0.0</lucene.version>
         <curator.version>5.1.0</curator.version>
         <log4j.version>2.17.1</log4j.version>
         <aws.sdk.version>2.16.72</aws.sdk.version>
@@ -134,7 +134,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-analyzers-common</artifactId>
+            <artifactId>lucene-analysis-common</artifactId>
             <version>${lucene.version}</version>
         </dependency>
         <dependency>

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
@@ -532,7 +532,7 @@ public class IndexingChunkImplTest {
       assertThat(chunk.snapshotToS3(bucket, "", s3BlobFs)).isTrue();
       assertThat(chunk.info().getSnapshotPath()).isNotEmpty();
 
-      assertThat(getCount(INDEX_FILES_UPLOAD, registry)).isEqualTo(15);
+      assertThat(getCount(INDEX_FILES_UPLOAD, registry)).isEqualTo(18);
       assertThat(getCount(INDEX_FILES_UPLOAD_FAILED, registry)).isEqualTo(0);
       assertThat(registry.get(SNAPSHOT_TIMER).timer().totalTime(TimeUnit.SECONDS)).isGreaterThan(0);
 


### PR DESCRIPTION
Lucene 9 is the next major version that released over a month ago. 

Right now our usage of lucene API is minimal so upgrading is much easier. Before we start working on more search improvements and use more of lucene APIs let's upgrade first 

complete list of changes are here - https://lucene.apache.org/core/9_0_0/changes/Changes.html