### PR TITLE
Refactory capacity reporting

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaAssignmentService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaAssignmentService.java
@@ -51,13 +51,13 @@ public class ReplicaAssignmentService extends AbstractScheduledService {
 
   public static final String REPLICA_ASSIGN_SUCCEEDED = "replica_assign_succeeded";
   public static final String REPLICA_ASSIGN_FAILED = "replica_assign_failed";
-  public static final String REPLICA_ASSIGN_INSUFFICIENT_CAPACITY =
-      "replica_assign_insufficient_capacity";
+  public static final String REPLICA_ASSIGN_AVAILABLE_CAPACITY =
+      "replica_assign_available_capacity";
   public static final String REPLICA_ASSIGN_TIMER = "replica_assign_timer";
 
   protected final Counter replicaAssignSucceeded;
   protected final Counter replicaAssignFailed;
-  protected final Counter replicaAssignInsufficientCapacity;
+  protected final AtomicInteger replicaAssignAvailableCapacity;
   private final Timer replicaAssignTimer;
 
   private final ScheduledExecutorService executorService =
@@ -79,7 +79,8 @@ public class ReplicaAssignmentService extends AbstractScheduledService {
 
     replicaAssignSucceeded = meterRegistry.counter(REPLICA_ASSIGN_SUCCEEDED);
     replicaAssignFailed = meterRegistry.counter(REPLICA_ASSIGN_FAILED);
-    replicaAssignInsufficientCapacity = meterRegistry.counter(REPLICA_ASSIGN_INSUFFICIENT_CAPACITY);
+    replicaAssignAvailableCapacity =
+        meterRegistry.gauge(REPLICA_ASSIGN_AVAILABLE_CAPACITY, new AtomicInteger(0));
     replicaAssignTimer = meterRegistry.timer(REPLICA_ASSIGN_TIMER);
   }
 
@@ -169,13 +170,14 @@ public class ReplicaAssignmentService extends AbstractScheduledService {
             .map(replicaMetadata -> replicaMetadata.name)
             .collect(Collectors.toUnmodifiableList());
 
+    // Report either a positive value (excess capacity) or a negative value (insufficient capacity)
+    replicaAssignAvailableCapacity.set(availableCacheSlots.size() - replicaIdsToAssign.size());
+
     if (replicaIdsToAssign.size() > availableCacheSlots.size()) {
       LOG.warn(
           "Insufficient cache slots to assign replicas, wanted {} slots but had {} replicas",
           replicaIdsToAssign.size(),
           availableCacheSlots.size());
-      replicaAssignInsufficientCapacity.increment(
-          replicaIdsToAssign.size() - availableCacheSlots.size());
     } else if (replicaIdsToAssign.size() == 0) {
       LOG.info("No replicas found requiring assignment");
       assignmentTimer.stop(replicaAssignTimer);

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
@@ -142,8 +142,8 @@ public class ReplicaAssignmentServiceTest {
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(0);
     Assertions.assertThat(
-            MetricsUtil.getCount(
-                ReplicaAssignmentService.REPLICA_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
+            MetricsUtil.getValue(
+                ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
         .isEqualTo(0);
     Assertions.assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
@@ -196,9 +196,9 @@ public class ReplicaAssignmentServiceTest {
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(0);
     Assertions.assertThat(
-            MetricsUtil.getCount(
-                ReplicaAssignmentService.REPLICA_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
-        .isEqualTo(3);
+            MetricsUtil.getValue(
+                ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
+        .isEqualTo(-3);
     Assertions.assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
         .isEqualTo(1);
@@ -250,9 +250,9 @@ public class ReplicaAssignmentServiceTest {
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(0);
     Assertions.assertThat(
-            MetricsUtil.getCount(
-                ReplicaAssignmentService.REPLICA_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
-        .isEqualTo(0);
+            MetricsUtil.getValue(
+                ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
+        .isEqualTo(3);
     Assertions.assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
         .isEqualTo(1);
@@ -328,9 +328,9 @@ public class ReplicaAssignmentServiceTest {
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(0);
     Assertions.assertThat(
-            MetricsUtil.getCount(
-                ReplicaAssignmentService.REPLICA_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
-        .isEqualTo(0);
+            MetricsUtil.getValue(
+                ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
+        .isEqualTo(2);
     Assertions.assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
         .isEqualTo(1);
@@ -430,8 +430,8 @@ public class ReplicaAssignmentServiceTest {
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(1);
     Assertions.assertThat(
-            MetricsUtil.getCount(
-                ReplicaAssignmentService.REPLICA_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
+            MetricsUtil.getValue(
+                ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
         .isEqualTo(0);
     Assertions.assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
@@ -497,9 +497,9 @@ public class ReplicaAssignmentServiceTest {
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(0);
     Assertions.assertThat(
-            MetricsUtil.getCount(
-                ReplicaAssignmentService.REPLICA_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
-        .isEqualTo(2);
+            MetricsUtil.getValue(
+                ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
+        .isEqualTo(-2);
     Assertions.assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
         .isEqualTo(1);
@@ -611,9 +611,9 @@ public class ReplicaAssignmentServiceTest {
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(3);
     Assertions.assertThat(
-            MetricsUtil.getCount(
-                ReplicaAssignmentService.REPLICA_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
-        .isEqualTo(0);
+            MetricsUtil.getValue(
+                ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
+        .isEqualTo(1);
     Assertions.assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
         .isEqualTo(1);
@@ -735,9 +735,9 @@ public class ReplicaAssignmentServiceTest {
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(2);
     Assertions.assertThat(
-            MetricsUtil.getCount(
-                ReplicaAssignmentService.REPLICA_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
-        .isEqualTo(0);
+            MetricsUtil.getValue(
+                ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
+        .isEqualTo(1);
     Assertions.assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
         .isEqualTo(2);
@@ -831,9 +831,9 @@ public class ReplicaAssignmentServiceTest {
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(1);
     Assertions.assertThat(
-            MetricsUtil.getCount(
-                ReplicaAssignmentService.REPLICA_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
-        .isEqualTo(0);
+            MetricsUtil.getValue(
+                ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
+        .isEqualTo(1);
     Assertions.assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
         .isEqualTo(1);
@@ -919,9 +919,9 @@ public class ReplicaAssignmentServiceTest {
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(1);
     Assertions.assertThat(
-            MetricsUtil.getCount(
-                ReplicaAssignmentService.REPLICA_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
-        .isEqualTo(0);
+            MetricsUtil.getValue(
+                ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
+        .isEqualTo(1);
     Assertions.assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
         .isEqualTo(1);
@@ -1013,9 +1013,9 @@ public class ReplicaAssignmentServiceTest {
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(2);
     Assertions.assertThat(
-            MetricsUtil.getCount(
-                ReplicaAssignmentService.REPLICA_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
-        .isEqualTo(0);
+            MetricsUtil.getValue(
+                ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
+        .isEqualTo(1);
     Assertions.assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
         .isEqualTo(1);
@@ -1090,9 +1090,9 @@ public class ReplicaAssignmentServiceTest {
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(2);
     Assertions.assertThat(
-            MetricsUtil.getCount(
-                ReplicaAssignmentService.REPLICA_ASSIGN_INSUFFICIENT_CAPACITY, meterRegistry))
-        .isEqualTo(1);
+            MetricsUtil.getValue(
+                ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
+        .isEqualTo(-1);
     Assertions.assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
         .isEqualTo(1);


### PR DESCRIPTION
Report available slot capacity as a guage instead of a counter. Combine reporting for excess/insuficient capacity.