### PR TITLE
add forbiddenapis

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,6 +28,8 @@ jobs:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
+    - name: Ensure no forbidden APIs are being used
+      run: mvn clean compile forbiddenapis:check --file kaldb/pom.xml
     - name: Ensure code is formatted
       run: mvn com.coveo:fmt-maven-plugin:check --file kaldb/pom.xml
     - name: Ensure jmh benchmark code is formatted

--- a/kaldb/forbiddenapis/com.google.guava.guava.all.txt
+++ b/kaldb/forbiddenapis/com.google.guava.guava.all.txt
@@ -1,0 +1,20 @@
+@defaultMessage Use corresponding Java 8 functional/streaming interfaces
+# KaldbMetadataStore uses this.
+# We can change the guava function to be java.util.function.Function
+# (it's even recommend in the guava docs) but Functions.transform lnly takes a guava Function
+# com.google.common.base.Function
+com.google.common.base.Joiner
+com.google.common.base.Predicate
+com.google.common.base.Supplier
+
+@defaultMessage Use java.nio.charset.StandardCharsets instead
+com.google.common.base.Charsets
+
+@defaultMessage Use methods in java.util.Objects instead
+com.google.common.base.Objects#equal(java.lang.Object,java.lang.Object)
+com.google.common.base.Objects#hashCode(java.lang.Object[])
+com.google.common.base.Preconditions#checkNotNull(java.lang.Object)
+com.google.common.base.Preconditions#checkNotNull(java.lang.Object,java.lang.Object)
+
+@defaultMessage Use methods in java.util.Comparator instead
+com.google.common.collect.Ordering

--- a/kaldb/forbiddenapis/commons-codec.commons-codec.all.txt
+++ b/kaldb/forbiddenapis/commons-codec.commons-codec.all.txt
@@ -1,0 +1,5 @@
+@defaultMessage Use java.nio.charset.StandardCharsets instead
+org.apache.commons.codec.Charsets
+
+@defaultMessage Use java.util.Base64 instead
+org.apache.commons.codec.binary.Base64

--- a/kaldb/forbiddenapis/defaults.logging.txt
+++ b/kaldb/forbiddenapis/defaults.logging.txt
@@ -1,0 +1,9 @@
+@defaultMessage Use slf4j classes instead
+java.util.logging.**
+org.apache.log4j.**
+# We depend on LogManager so not banning this one
+# org.apache.logging.log4j.**
+
+@defaultMessage Always include exception as the second parameter
+org.slf4j.Logger#error(java.lang.String)
+# org.apache.logging.slf4.Log4jLogger.**

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -11,6 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <javac.target>11</javac.target>
+        <maven.compiler.target>11</maven.compiler.target>
         <uberjar.name>kaldb</uberjar.name>
         <http.client.version>4.5.13</http.client.version>
         <http.core.version>4.4.14</http.core.version>
@@ -451,6 +452,45 @@
             </extension>
         </extensions>
         <plugins>
+            <plugin>
+                <groupId>de.thetaphi</groupId>
+                <artifactId>forbiddenapis</artifactId>
+                <version>3.2</version>
+                <configuration>
+                    <!--
+                      if the used Java version is too new,
+                      don't fail, just do nothing:
+                    -->
+                    <failOnUnsupportedJava>false</failOnUnsupportedJava>
+                    <bundledSignatures>
+                        <!--
+                          This will automatically choose the right
+                          signatures based on 'maven.compiler.target':
+                        -->
+                        <bundledSignature>jdk-unsafe</bundledSignature>
+                        <bundledSignature>jdk-deprecated</bundledSignature>
+                        <!-- disallow undocumented classes like sun.misc.Unsafe: -->
+                        <bundledSignature>jdk-non-portable</bundledSignature>
+                        <!-- don't allow unsafe reflective access: -->
+                        <bundledSignature>jdk-reflection</bundledSignature>
+                        <bundledSignature>jdk-system-out</bundledSignature>
+                    </bundledSignatures>
+                    <signaturesFiles>
+                        <signaturesFile>./forbiddenapis/defaults.kaldb.txt</signaturesFile>
+                        <signaturesFile>./forbiddenapis/com.google.guava.guava.all.txt</signaturesFile>
+                        <signaturesFile>./forbiddenapis/commons-codec.commons-codec.all.txt</signaturesFile>
+                        <signaturesFile>./forbiddenapis/defaults.logging.txt</signaturesFile>
+                    </signaturesFiles>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                            <goal>testCheck</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/kaldb/src/main/java/com/slack/kaldb/blobfs/s3/S3BlobFs.java
+++ b/kaldb/src/main/java/com/slack/kaldb/blobfs/s3/S3BlobFs.java
@@ -17,6 +17,7 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -118,7 +119,7 @@ public class S3BlobFs extends BlobFs {
   }
 
   private String normalizeToDirectoryPrefix(URI uri) throws IOException {
-    Preconditions.checkNotNull(uri, "uri is null");
+    Objects.requireNonNull(uri, "uri is null");
     URI strippedUri = getBase(uri).relativize(uri);
     if (isPathTerminatedByDelimiter(strippedUri)) {
       return sanitizePath(strippedUri.getPath());
@@ -227,7 +228,7 @@ public class S3BlobFs extends BlobFs {
   public boolean mkdir(URI uri) throws IOException {
     LOG.info("mkdir {}", uri);
     try {
-      Preconditions.checkNotNull(uri, "uri is null");
+      Objects.requireNonNull(uri, "uri is null");
       String path = normalizeToDirectoryPrefix(uri);
       // Bucket root directory already exists and cannot be created
       if (path.equals(DELIMITER)) {

--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ChunkInfo.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ChunkInfo.java
@@ -3,6 +3,7 @@ package com.slack.kaldb.chunk;
 import static com.slack.kaldb.util.ArgValidationUtils.ensureTrue;
 
 import com.slack.kaldb.metadata.snapshot.SnapshotMetadata;
+import java.util.Locale;
 import java.util.Objects;
 
 /**
@@ -173,7 +174,10 @@ public class ChunkInfo {
     ensureTrue(
         endTimeMs - startTimeMs >= 0,
         String.format(
-            "end timestamp %d can't be less than the start timestamp %d.", endTimeMs, startTimeMs));
+            Locale.ROOT,
+            "end timestamp %d can't be less than the start timestamp %d.",
+            endTimeMs,
+            startTimeMs));
     return (dataStartTimeEpochMs <= startTimeMs && dataEndTimeEpochMs >= startTimeMs)
         || (dataStartTimeEpochMs <= endTimeMs && dataEndTimeEpochMs >= endTimeMs)
         || (dataStartTimeEpochMs >= startTimeMs && dataEndTimeEpochMs <= endTimeMs);

--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
@@ -29,6 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.Locale;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -99,7 +100,7 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
         Executors.newSingleThreadExecutor(
             new ThreadFactoryBuilder().setNameFormat("readonly-chunk-%d").build());
     this.searchContext = searchContext;
-    this.slotName = String.format("%s-%s", searchContext.hostname, slotId);
+    this.slotName = String.format(Locale.ROOT, "%s-%s", searchContext.hostname, slotId);
 
     this.cacheSlotMetadataStore = cacheSlotMetadataStore;
     this.replicaMetadataStore = replicaMetadataStore;
@@ -180,7 +181,11 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
 
       dataDirectory =
           Path.of(
-              String.format("%s/kaldb-slot-%s", dataDirectoryPrefix, cacheSlotMetadata.replicaId));
+              String.format(
+                  Locale.ROOT,
+                  "%s/kaldb-slot-%s",
+                  dataDirectoryPrefix,
+                  cacheSlotMetadata.replicaId));
       if (Files.isDirectory(dataDirectory) && Files.list(dataDirectory).findFirst().isPresent()) {
         LOG.warn("Existing files found in slot directory, clearing directory");
         cleanDirectory();
@@ -279,7 +284,7 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
       cacheSlotMetadataStore.update(updatedChunkMetadata).get(TIMEOUT_MS, TimeUnit.MILLISECONDS);
       return true;
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      LOG.error("Error setting chunk metadata state");
+      LOG.error("Error setting chunk metadata state", e);
       return false;
     }
   }

--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadWriteChunk.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadWriteChunk.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.Locale;
 import org.apache.lucene.index.IndexCommit;
 import org.slf4j.Logger;
 
@@ -148,7 +149,8 @@ public abstract class ReadWriteChunk<T> implements Chunk<T> {
         chunkInfo.updateMaxOffset(offset);
       }
     } else {
-      throw new IllegalStateException(String.format("Chunk %s is read only", chunkInfo));
+      throw new IllegalStateException(
+          String.format(Locale.ROOT, "Chunk %s is read only", chunkInfo));
     }
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/IndexingChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/IndexingChunkManager.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -225,6 +226,7 @@ public class IndexingChunkManager<T> extends ChunkManager<T> {
     } else {
       throw new ChunkRollOverException(
           String.format(
+              Locale.ROOT,
               "The chunk roll over %s is already in progress."
                   + "It is not recommended to index faster than we can roll over, since we may not be able to keep up",
               currentChunk.info()));

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaCreationService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaCreationService.java
@@ -21,6 +21,7 @@ import io.micrometer.core.instrument.Timer;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Executors;
@@ -228,7 +229,7 @@ public class ReplicaCreationService extends AbstractScheduledService {
   public static ReplicaMetadata replicaMetadataFromSnapshotId(
       String snapshotId, Instant expireAfter) {
     return new ReplicaMetadata(
-        String.format("%s-%s", snapshotId, UUID.randomUUID()),
+        String.format(Locale.ROOT, "%s-%s", snapshotId, UUID.randomUUID()),
         snapshotId,
         Instant.now().toEpochMilli(),
         expireAfter.toEpochMilli());

--- a/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/searchRequest/SearchRequestSort.java
+++ b/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/searchRequest/SearchRequestSort.java
@@ -1,6 +1,7 @@
 package com.slack.kaldb.elasticsearchApi.searchRequest;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Locale;
 
 public enum SearchRequestSort {
   ASC,
@@ -8,7 +9,7 @@ public enum SearchRequestSort {
 
   public static SearchRequestSort parse(JsonNode sort) {
     if (sort != null) {
-      return SearchRequestSort.valueOf(sort.findValue("order").asText().toUpperCase());
+      return SearchRequestSort.valueOf(sort.findValue("order").asText().toUpperCase(Locale.ROOT));
     }
     return SearchRequestSort.DESC;
   }

--- a/kaldb/src/main/java/com/slack/kaldb/histogram/FixedIntervalHistogramImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/histogram/FixedIntervalHistogramImpl.java
@@ -4,6 +4,7 @@ import static com.slack.kaldb.util.ArgValidationUtils.ensureTrue;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 /** This class contains an implementation of the histogram with fixed interval buckets. */
@@ -103,7 +104,8 @@ public class FixedIntervalHistogramImpl implements Histogram {
       ArrayList<HistogramBucket> buckets, int start, int end, double value) {
     if (start == end) {
       throw new IllegalStateException(
-          String.format("Value out of bounds for histogram (%f %f %f)", value, low, high));
+          String.format(
+              Locale.ROOT, "Value out of bounds for histogram (%f %f %f)", value, low, high));
     } else {
       int mid = start + ((end - start - 1) / 2);
       int valueComparator = buckets.get(mid).compareTo(value);

--- a/kaldb/src/main/java/com/slack/kaldb/histogram/HistogramBucket.java
+++ b/kaldb/src/main/java/com/slack/kaldb/histogram/HistogramBucket.java
@@ -1,6 +1,7 @@
 package com.slack.kaldb.histogram;
 
-import com.google.common.base.Objects;
+import java.util.Locale;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 
 /**
@@ -16,7 +17,7 @@ public class HistogramBucket implements Comparable<HistogramBucket> {
   public HistogramBucket(double low, double high, double count) {
     if (low >= high) {
       throw new IllegalArgumentException(
-          String.format("The low %s should be higher than high %s", low, high));
+          String.format(Locale.ROOT, "The low %s should be higher than high %s", low, high));
     }
     this.low = low;
     this.high = high;
@@ -65,7 +66,8 @@ public class HistogramBucket implements Comparable<HistogramBucket> {
   }
 
   public String toString() {
-    return String.format("HistogramBucket low:%f, high:%f, count:%f", low, high, count);
+    return String.format(
+        Locale.ROOT, "HistogramBucket low:%f, high:%f, count:%f", low, high, count);
   }
   // TODO: Consider adding "overlap" projection for merge?
 
@@ -81,6 +83,6 @@ public class HistogramBucket implements Comparable<HistogramBucket> {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(low, high, count);
+    return Objects.hash(low, high, count);
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/BlobFsUtils.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/BlobFsUtils.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.Locale;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,8 +38,9 @@ public class BlobFsUtils {
 
   public static URI createURI(String bucket, String prefix, String fileName) {
     return (prefix != null && !prefix.isEmpty())
-        ? URI.create(String.format(FILE_FORMAT, SCHEME, bucket + DELIMITER + prefix, fileName))
-        : URI.create(String.format(FILE_FORMAT, SCHEME, bucket, fileName));
+        ? URI.create(
+            String.format(Locale.ROOT, FILE_FORMAT, SCHEME, bucket + DELIMITER + prefix, fileName))
+        : URI.create(String.format(Locale.ROOT, FILE_FORMAT, SCHEME, bucket, fileName));
   }
 
   // TODO: Can we copy files without list files and a prefix only?

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LogDocumentBuilderImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LogDocumentBuilderImpl.java
@@ -3,6 +3,7 @@ package com.slack.kaldb.logstore;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableMap;
 import com.slack.kaldb.util.JsonUtil;
+import java.util.Locale;
 import java.util.Map;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.DoubleDocValuesField;
@@ -187,11 +188,15 @@ public class LogDocumentBuilderImpl implements DocumentBuilder<LogMessage> {
       if (!(desc.propertyType.equals(PropertyType.ANY)
           || desc.propertyType.equals(PropertyType.TEXT))) {
         throw new PropertyTypeMismatchException(
-            String.format("Found string but property %s was not configured as TextProperty", name));
+            String.format(
+                Locale.ROOT,
+                "Found string but property %s was not configured as TextProperty",
+                name));
       }
       if (desc.storeNumericDocValue) {
         throw new PropertyTypeMismatchException(
             String.format(
+                Locale.ROOT,
                 "Found string but property %s was configured with storeNumericDocValue=true.",
                 name));
       }
@@ -220,7 +225,9 @@ public class LogDocumentBuilderImpl implements DocumentBuilder<LogMessage> {
       } else {
         throw new PropertyTypeMismatchException(
             String.format(
-                "Found int but property %s was not configured to be an int property.", name));
+                Locale.ROOT,
+                "Found int but property %s was not configured to be an int property.",
+                name));
       }
       return;
     }
@@ -244,7 +251,8 @@ public class LogDocumentBuilderImpl implements DocumentBuilder<LogMessage> {
         addStringProperty(doc, name, String.valueOf(longValue), desc);
       } else {
         throw new PropertyTypeMismatchException(
-            String.format("Found long but property %s was not configured to be a Long.", name));
+            String.format(
+                Locale.ROOT, "Found long but property %s was not configured to be a Long.", name));
       }
       return;
     }
@@ -268,7 +276,10 @@ public class LogDocumentBuilderImpl implements DocumentBuilder<LogMessage> {
         addStringProperty(doc, name, String.valueOf(floatValue), desc);
       } else {
         throw new PropertyTypeMismatchException(
-            String.format("Found float but property %s was not configured to be a Float.", name));
+            String.format(
+                Locale.ROOT,
+                "Found float but property %s was not configured to be a Float.",
+                name));
       }
       return;
     }
@@ -292,7 +303,10 @@ public class LogDocumentBuilderImpl implements DocumentBuilder<LogMessage> {
         addStringProperty(doc, name, String.valueOf(doubleValue), desc);
       } else {
         throw new PropertyTypeMismatchException(
-            String.format("Found double but property %s was not configured to be a Double.", name));
+            String.format(
+                Locale.ROOT,
+                "Found double but property %s was not configured to be a Double.",
+                name));
       }
       return;
     }
@@ -312,7 +326,10 @@ public class LogDocumentBuilderImpl implements DocumentBuilder<LogMessage> {
         } else {
           throw new PropertyTypeMismatchException(
               String.format(
-                  "Property %s,%s has an non-string type which is unsupported", name, value));
+                  Locale.ROOT,
+                  "Property %s,%s has an non-string type which is unsupported",
+                  name,
+                  value));
         }
       }
       return;
@@ -320,7 +337,7 @@ public class LogDocumentBuilderImpl implements DocumentBuilder<LogMessage> {
 
     // Unknown type.
     throw new UnSupportedPropertyTypeException(
-        String.format("Property %s, %s has unsupported type.", name, value));
+        String.format(Locale.ROOT, "Property %s, %s has unsupported type.", name, value));
   }
 
   private void addPropertyHandleExceptions(Document doc, String name, Object value) {

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LogMessage.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LogMessage.java
@@ -166,6 +166,7 @@ public class LogMessage extends LogWireMessage {
     if (id == null || that.id == null) {
       LOG.warn("id missing - equals comparison won't be accurate");
     }
+    LOG.info("TEST:: timeSinceEpochMilli=" + timeSinceEpochMilli + " that.timeSinceEpochMilli=" + that.timeSinceEpochMilli);
     return timeSinceEpochMilli == that.timeSinceEpochMilli
         && Objects.equals(getIndex(), that.getIndex())
         && Objects.equals(getType(), that.getType())

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LogMessage.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LogMessage.java
@@ -174,6 +174,6 @@ public class LogMessage extends LogWireMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hash(timeSinceEpochMilli, getIndex(), getMillisecondsSinceEpoch(), id);
+    return Objects.hash(timeSinceEpochMilli, getIndex(), id);
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LogMessage.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LogMessage.java
@@ -1,12 +1,8 @@
 package com.slack.kaldb.logstore;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import java.time.*;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -116,7 +112,12 @@ public class LogMessage extends LogWireMessage {
   private BadMessageFormatException raiseException(Throwable t) {
     throw new BadMessageFormatException(
         String.format(
-            "Index:%s, Type: %s, Id: %s, Source: %s".format(getIndex(), getType(), id, source)),
+            Locale.ROOT,
+            "Index:%s, Type: %s, Id: %s, Source: %s",
+            getIndex(),
+            getType(),
+            id,
+            source),
         t);
   }
 
@@ -127,7 +128,8 @@ public class LogMessage extends LogWireMessage {
     super(index, type, messageId, source);
     if (!isValid()) {
       throw new BadMessageFormatException(
-          String.format("Index:%s, Type: %s, Id: %s, Source: %s".format(index, type, id, source)));
+          String.format(
+              Locale.ROOT, "Index:%s, Type: %s, Id: %s, Source: %s", index, type, id, source));
     }
     this.timeSinceEpochMilli = getMillisecondsSinceEpoch();
   }
@@ -165,13 +167,13 @@ public class LogMessage extends LogWireMessage {
       LOG.warn("id missing - equals comparison won't be accurate");
     }
     return timeSinceEpochMilli == that.timeSinceEpochMilli
-        && Objects.equal(getIndex(), that.getIndex())
-        && Objects.equal(getType(), that.getType())
-        && Objects.equal(id, that.id);
+        && Objects.equals(getIndex(), that.getIndex())
+        && Objects.equals(getType(), that.getType())
+        && Objects.equals(id, that.id);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(timeSinceEpochMilli, getIndex(), getMillisecondsSinceEpoch(), id);
+    return Objects.hash(timeSinceEpochMilli, getIndex(), getMillisecondsSinceEpoch(), id);
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LogMessage.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LogMessage.java
@@ -166,7 +166,6 @@ public class LogMessage extends LogWireMessage {
     if (id == null || that.id == null) {
       LOG.warn("id missing - equals comparison won't be accurate");
     }
-    LOG.info("TEST:: timeSinceEpochMilli=" + timeSinceEpochMilli + " that.timeSinceEpochMilli=" + that.timeSinceEpochMilli);
     return timeSinceEpochMilli == that.timeSinceEpochMilli
         && Objects.equals(getIndex(), that.getIndex())
         && Objects.equals(getType(), that.getType())

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LoggingInfoStream.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LoggingInfoStream.java
@@ -6,7 +6,11 @@ import org.apache.lucene.util.InfoStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** An {@link InfoStream} implementation which passes messages on to Kaldb's logging */
+/**
+ * LoggingInfoStream ( inspired by Solr ) is an {@link InfoStream} implementation passes messages on
+ * to Kaldb's logging mechanism (Log4J) instead of writing to system out. Writing via Log4J means
+ * logs will respect JSON logging, file rotations etc.
+ */
 public class LoggingInfoStream extends InfoStream {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LoggingInfoStream.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LoggingInfoStream.java
@@ -1,0 +1,28 @@
+package com.slack.kaldb.logstore;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import org.apache.lucene.util.InfoStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** An {@link InfoStream} implementation which passes messages on to Kaldb's logging */
+public class LoggingInfoStream extends InfoStream {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @Override
+  public void message(String component, String message) {
+    if (log.isInfoEnabled()) {
+      log.info("[{}][{}]: {}", component, Thread.currentThread().getName(), message);
+    }
+  }
+
+  @Override
+  public boolean isEnabled(String component) {
+    // ignore testpoints so this can be used with tests without flooding logs with verbose messages
+    return !"TP".equals(component) && log.isInfoEnabled();
+  }
+
+  @Override
+  public void close() throws IOException {}
+}

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
@@ -105,7 +105,7 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
           addedStubs.get(),
           removedStubs.get());
     } catch (Exception e) {
-      LOG.error("Cannot update SearchMetadata cache on the query service" + e);
+      LOG.error("Cannot update SearchMetadata cache on the query service", e);
       throw new RuntimeException("Cannot update SearchMetadata cache on the query service ", e);
     }
   }
@@ -151,7 +151,7 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
         span.finish();
       }
     } catch (Exception e) {
-      LOG.error("SearchMetadata failed with " + e);
+      LOG.error("SearchMetadata failed with ", e);
       List<CompletableFuture<SearchResult<LogMessage>>> emptyResultList =
           Collections.singletonList(CompletableFuture.supplyAsync(SearchResult::empty));
       return CompletableFutures.allAsList(emptyResultList);

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResult.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResult.java
@@ -1,11 +1,11 @@
 package com.slack.kaldb.logstore.search;
 
-import com.google.common.base.Objects;
 import com.slack.kaldb.histogram.HistogramBucket;
 import com.slack.kaldb.logstore.LogMessage;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class SearchResult<T> {
 
@@ -70,13 +70,13 @@ public class SearchResult<T> {
         && totalNodes == that.totalNodes
         && totalSnapshots == that.totalSnapshots
         && snapshotsWithReplicas == that.snapshotsWithReplicas
-        && Objects.equal(hits, that.hits)
-        && Objects.equal(buckets, that.buckets);
+        && Objects.equals(hits, that.hits)
+        && Objects.equals(buckets, that.buckets);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(
+    return Objects.hash(
         totalCount,
         hits,
         tookMicros,

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStore.java
@@ -2,6 +2,7 @@ package com.slack.kaldb.metadata.cache;
 
 import com.slack.kaldb.metadata.core.EphemeralMutableMetadataStore;
 import com.slack.kaldb.metadata.zookeeper.MetadataStore;
+import java.util.Locale;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +34,7 @@ public class CacheSlotMetadataStore extends EphemeralMutableMetadataStore<CacheS
     super(
         shouldCache,
         false,
-        String.format("%s/%s", CACHE_SLOT_ZK_PATH, cacheSlotName),
+        String.format(Locale.ROOT, "%s/%s", CACHE_SLOT_ZK_PATH, cacheSlotName),
         metadataStore,
         new CacheSlotMetadataSerializer(),
         LOG);

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/core/EphemeralMutableMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/core/EphemeralMutableMetadataStore.java
@@ -7,6 +7,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.slack.kaldb.metadata.zookeeper.InternalMetadataStoreException;
 import com.slack.kaldb.metadata.zookeeper.MetadataStore;
+import java.util.Locale;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -35,7 +36,8 @@ public abstract class EphemeralMutableMetadataStore<T extends KaldbMetadata>
     try {
       return metadataStore.createEphemeralNode(path, metadataSerializer.toJsonStr(metadataNode));
     } catch (InvalidProtocolBufferException e) {
-      String msg = String.format("Error serializing node %s at path %s", metadataNode, path);
+      String msg =
+          String.format(Locale.ROOT, "Error serializing node %s at path %s", metadataNode, path);
       logger.error(msg, e);
       return Futures.immediateFailedFuture(e);
     }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbMetadataStore.java
@@ -1,6 +1,5 @@
 package com.slack.kaldb.metadata.core;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.slack.kaldb.config.KaldbConfig.DEFAULT_ZK_TIMEOUT_SECS;
 
@@ -12,9 +11,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.slack.kaldb.metadata.zookeeper.InternalMetadataStoreException;
 import com.slack.kaldb.metadata.zookeeper.MetadataStore;
 import com.slack.kaldb.metadata.zookeeper.NodeExistsException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -45,11 +42,11 @@ abstract class KaldbMetadataStore<T extends KaldbMetadata> {
       MetadataSerializer<T> metadataSerializer,
       Logger logger)
       throws ExecutionException, InterruptedException {
-    checkNotNull(metadataStore, "MetadataStore can't be null");
+    Objects.requireNonNull(metadataStore, "MetadataStore can't be null");
     checkState(
         storeFolder != null && !storeFolder.isEmpty(),
         "SnapshotStoreFolder can't be null or empty.");
-    checkNotNull(logger, "Logger can't be null or empty");
+    Objects.requireNonNull(logger, "Logger can't be null or empty");
 
     this.metadataStore = metadataStore;
     this.storeFolder = storeFolder;
@@ -88,8 +85,10 @@ abstract class KaldbMetadataStore<T extends KaldbMetadata> {
             } catch (InvalidProtocolBufferException e) {
               final String msg =
                   String.format(
+                      Locale.ROOT,
                       "Unable to de-serialize data %s at path %s into a protobuf message.",
-                      data, path);
+                      data,
+                      path);
               logger.error(msg, e);
               throw new IllegalStateException(msg, e);
             }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/core/PersistentMutableMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/core/PersistentMutableMetadataStore.java
@@ -7,6 +7,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.slack.kaldb.metadata.zookeeper.InternalMetadataStoreException;
 import com.slack.kaldb.metadata.zookeeper.MetadataStore;
+import java.util.Locale;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -35,7 +36,8 @@ public abstract class PersistentMutableMetadataStore<T extends KaldbMetadata>
     try {
       return metadataStore.create(path, metadataSerializer.toJsonStr(metadataNode), true);
     } catch (InvalidProtocolBufferException e) {
-      String msg = String.format("Error serializing node %s at path %s", metadataNode, path);
+      String msg =
+          String.format(Locale.ROOT, "Error serializing node %s at path %s", metadataNode, path);
       logger.error(msg, e);
       return Futures.immediateFailedFuture(e);
     }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/core/UpdatableCacheableMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/core/UpdatableCacheableMetadataStore.java
@@ -6,6 +6,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.slack.kaldb.config.KaldbConfig;
 import com.slack.kaldb.metadata.zookeeper.InternalMetadataStoreException;
 import com.slack.kaldb.metadata.zookeeper.MetadataStore;
+import java.util.Locale;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -30,7 +31,8 @@ public abstract class UpdatableCacheableMetadataStore<T extends KaldbMetadata>
     try {
       return metadataStore.put(path, metadataSerializer.toJsonStr(metadataNode));
     } catch (InvalidProtocolBufferException e) {
-      String msg = String.format("Error serializing node %s at path %s", metadataNode, path);
+      String msg =
+          String.format(Locale.ROOT, "Error serializing node %s at path %s", metadataNode, path);
       logger.error(msg, e);
       return Futures.immediateFailedFuture(e);
     }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataStore.java
@@ -2,6 +2,7 @@ package com.slack.kaldb.metadata.recovery;
 
 import com.slack.kaldb.metadata.core.EphemeralMutableMetadataStore;
 import com.slack.kaldb.metadata.zookeeper.MetadataStore;
+import java.util.Locale;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +35,7 @@ public class RecoveryNodeMetadataStore extends EphemeralMutableMetadataStore<Rec
     super(
         shouldCache,
         false,
-        String.format("%s/%s", RECOVERY_NODE_ZK_PATH, recoveryNodeName),
+        String.format(Locale.ROOT, "%s/%s", RECOVERY_NODE_ZK_PATH, recoveryNodeName),
         metadataStore,
         new RecoveryNodeMetadataSerializer(),
         LOG);

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/zookeeper/ZookeeperCachedMetadataStoreImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/zookeeper/ZookeeperCachedMetadataStoreImpl.java
@@ -9,7 +9,9 @@ import com.slack.kaldb.metadata.core.KaldbMetadata;
 import com.slack.kaldb.metadata.core.MetadataSerializer;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
@@ -73,9 +75,9 @@ public class ZookeeperCachedMetadataStoreImpl<T extends KaldbMetadata>
       MetadataSerializer<T> metadataSerde,
       CuratorFramework curator,
       MeterRegistry meterRegistry) {
-    Preconditions.checkNotNull(path, "name cannot be null");
-    Preconditions.checkNotNull(metadataSerde, "metadata serializer cannot be null");
-    Preconditions.checkNotNull(curator, "curator framework cannot be null");
+    Objects.requireNonNull(path, "name cannot be null");
+    Objects.requireNonNull(metadataSerde, "metadata serializer cannot be null");
+    Objects.requireNonNull(curator, "curator framework cannot be null");
     this.metadataSerde = metadataSerde;
     this.pathPrefix = path.endsWith(ZKPaths.PATH_SEPARATOR) ? path : path + ZKPaths.PATH_SEPARATOR;
     /*
@@ -192,7 +194,8 @@ public class ZookeeperCachedMetadataStoreImpl<T extends KaldbMetadata>
     String instanceId = "";
     try {
       instanceId = instanceIdFromData(childData);
-      T serviceInstance = metadataSerde.fromJsonStr(new String(childData.getData()));
+      T serviceInstance =
+          metadataSerde.fromJsonStr(new String(childData.getData(), StandardCharsets.UTF_8));
       instances.put(instanceId, serviceInstance);
     } catch (InvalidProtocolBufferException e) {
       // If we are unable to add the updated value to the cache, invalidate the key so cache is

--- a/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
@@ -27,6 +27,7 @@ import com.slack.kaldb.proto.service.KaldbServiceGrpc;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
+import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
@@ -107,7 +108,7 @@ public class ArmeriaService extends AbstractIdleService {
     SpanHandler spanHandler = new SpanHandler() {};
 
     if (!endpoint.isBlank()) {
-      LOG.info(String.format("Trace reporting enabled: %s", endpoint));
+      LOG.info(String.format(Locale.ROOT, "Trace reporting enabled: %s", endpoint));
       Sender sender = URLConnectionSender.create(endpoint);
       spanHandler = AsyncZipkinSpanHandler.create(sender);
     } else {

--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -41,10 +41,7 @@ import io.micrometer.prometheus.PrometheusMeterRegistry;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.slf4j.Logger;
@@ -235,7 +232,8 @@ public class Kaldb {
       @Override
       public void failure(Service service) {
         LOG.error(
-            String.format("Service %s failed with cause ", service.getClass().toString()),
+            String.format(
+                Locale.ROOT, "Service %s failed with cause ", service.getClass().toString()),
             service.failureCause());
 
         // shutdown if any services enters failure state
@@ -257,8 +255,17 @@ public class Kaldb {
     } catch (Exception e) {
       LOG.error("Error while calling metadataStore.close() ", e);
     }
-    LOG.info("Shutting down LogManager");
-    LogManager.shutdown();
+
+    // this call assumes that the logging impl is Log4J
+    // all logging calls implement the SLF4J API so technically one can decide to use a different
+    // logging impl
+    // so let's wrap it in try-catch
+    try {
+      LOG.info("Shutting down LogManager");
+      LogManager.shutdown();
+    } catch (Exception e) {
+      // do nothing
+    }
   }
 
   private void addShutdownHook() {

--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -256,10 +256,9 @@ public class Kaldb {
       LOG.error("Error while calling metadataStore.close() ", e);
     }
 
-    // this call assumes that the logging impl is Log4J
-    // all logging calls implement the SLF4J API so technically one can decide to use a different
-    // logging impl
-    // so let's wrap it in try-catch
+    // This call assumes that the logging impl is Log4J
+    // All logging calls implement the SLF4J API so technically one can decide to use a different
+    // logging impl so let's wrap it in try-catch
     try {
       LOG.info("Shutting down LogManager");
       LogManager.shutdown();

--- a/kaldb/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
@@ -1,6 +1,5 @@
 package com.slack.kaldb.server;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.slack.kaldb.config.KaldbConfig.DEFAULT_START_STOP_DURATION;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -13,6 +12,7 @@ import com.slack.kaldb.writer.LogMessageTransformer;
 import com.slack.kaldb.writer.LogMessageWriterImpl;
 import com.slack.kaldb.writer.kafka.KaldbKafkaWriter;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
@@ -92,7 +92,7 @@ public class KaldbIndexer extends AbstractIdleService {
    * chunkManager and then the consumer,
    */
   public KaldbIndexer(IndexingChunkManager<LogMessage> chunkManager, KaldbKafkaWriter kafkaWriter) {
-    checkNotNull(chunkManager, "Chunk manager can't be null");
+    Objects.requireNonNull(chunkManager, "Chunk manager can't be null");
     this.chunkManager = chunkManager;
     this.kafkaWriter = kafkaWriter;
   }

--- a/kaldb/src/main/java/com/slack/kaldb/server/KaldbQueryServiceBase.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/KaldbQueryServiceBase.java
@@ -3,6 +3,7 @@ package com.slack.kaldb.server;
 import com.slack.kaldb.proto.service.KaldbSearch;
 import com.slack.kaldb.proto.service.KaldbServiceGrpc;
 import io.grpc.stub.StreamObserver;
+import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,7 +18,8 @@ public abstract class KaldbQueryServiceBase extends KaldbServiceGrpc.KaldbServic
       StreamObserver<KaldbSearch.SearchResult> responseObserver) {
 
     LOG.info(
-        String.format("Search request received: '%s'", request.toString().replace("\n", ", ")));
+        String.format(
+            Locale.ROOT, "Search request received: '%s'", request.toString().replace("\n", ", ")));
 
     // There is a nuance between handle vs handleAsync/whenCompleteAsync
     // handleAsync/whenCompleteAsync will cause the callback to be invoked from Java's default

--- a/kaldb/src/main/java/com/slack/kaldb/util/JsonUtil.java
+++ b/kaldb/src/main/java/com/slack/kaldb/util/JsonUtil.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 public class JsonUtil {
   private static JsonUtil ourInstance = new JsonUtil();
@@ -16,7 +17,7 @@ public class JsonUtil {
   }
 
   public static <T> ByteBuffer toByteBuffer(T obj) throws JsonProcessingException {
-    return ByteBuffer.wrap(writeAsString(obj).getBytes());
+    return ByteBuffer.wrap(writeAsString(obj).getBytes(StandardCharsets.UTF_8));
   }
 
   public static <T> String writeAsString(T obj) throws JsonProcessingException {

--- a/kaldb/src/main/java/com/slack/kaldb/writer/ApiLogFormatter.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/ApiLogFormatter.java
@@ -8,6 +8,7 @@ import com.google.protobuf.ByteString;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.service.murron.Murron;
 import com.slack.service.murron.trace.Trace;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -50,11 +51,11 @@ public class ApiLogFormatter {
 
     String parentId =
         (String) jsonMsgMap.getOrDefault(LogMessage.ReservedField.PARENT_ID.fieldName, "");
-    spanBuilder.setParentId(ByteString.copyFrom(parentId.getBytes()));
+    spanBuilder.setParentId(ByteString.copyFrom(parentId.getBytes(StandardCharsets.UTF_8)));
 
     String traceId =
         (String) jsonMsgMap.getOrDefault(LogMessage.ReservedField.TRACE_ID.fieldName, "");
-    spanBuilder.setTraceId(ByteString.copyFrom(traceId.getBytes()));
+    spanBuilder.setTraceId(ByteString.copyFrom(traceId.getBytes(StandardCharsets.UTF_8)));
 
     spanBuilder.setStartTimestampMicros(murronMsg.getTimestamp() / 1000);
     spanBuilder.setDurationMicros((int) jsonMsgMap.getOrDefault(API_LOG_DURATION_FIELD, 1));
@@ -84,7 +85,8 @@ public class ApiLogFormatter {
         tagBuilder.setVFloat64((double) entry.getValue());
       } else if (entry.getValue() != null) {
         tagBuilder.setVType(Trace.ValueType.BINARY);
-        tagBuilder.setVBinary(ByteString.copyFrom(entry.getValue().toString().getBytes()));
+        tagBuilder.setVBinary(
+            ByteString.copyFrom(entry.getValue().toString().getBytes(StandardCharsets.UTF_8)));
       }
       tags.add(tagBuilder.build());
     }
@@ -99,7 +101,7 @@ public class ApiLogFormatter {
 
     // Create a message id.
     String msgId = murronMsg.getHost() + ":" + murronMsg.getPid() + ":" + murronMsg.getOffset();
-    spanBuilder.setId(ByteString.copyFrom(msgId.getBytes()));
+    spanBuilder.setId(ByteString.copyFrom(msgId.getBytes(StandardCharsets.UTF_8)));
 
     // Replace hyphens with underscore since lucene doesn't like it.
     tags.add(

--- a/kaldb/src/main/java/com/slack/kaldb/writer/LogMessageWriterImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/LogMessageWriterImpl.java
@@ -121,7 +121,10 @@ public class LogMessageWriterImpl implements MessageWriter {
     try {
       murronMsg = Murron.MurronMessage.parseFrom(recordStr);
     } catch (InvalidProtocolBufferException e) {
-      LOG.info("Error parsing byte string into MurronMessage: {}", new String(recordStr), e);
+      LOG.info(
+          "Error parsing byte string into MurronMessage: {}",
+          new String(recordStr, StandardCharsets.UTF_8),
+          e);
     }
     return murronMsg;
   }

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/FieldConflictsTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/FieldConflictsTest.java
@@ -8,6 +8,7 @@ import brave.Tracing;
 import com.slack.kaldb.testlib.MessageUtil;
 import com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Map;
 import org.junit.BeforeClass;
@@ -28,7 +29,10 @@ public class FieldConflictsTest {
 
   @Test
   public void testMessageEquality() {
-    String ts = MessageUtil.getCurrentLogDate();
+    Instant time = Instant.now();
+    Instant time2 = Instant.ofEpochSecond(time.getEpochSecond() + 1);
+
+    String ts = time.toString();
     LogMessage msg1 =
         new LogMessage(
             MessageUtil.TEST_INDEX_NAME,
@@ -65,7 +69,7 @@ public class FieldConflictsTest {
             "1",
             Map.of(
                 LogMessage.ReservedField.TIMESTAMP.fieldName,
-                MessageUtil.getCurrentLogDate(),
+                time2.toString(),
                 LogMessage.ReservedField.MESSAGE.fieldName,
                 "Test message",
                 LogMessage.ReservedField.HOSTNAME.fieldName,

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/FieldConflictsTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/FieldConflictsTest.java
@@ -27,6 +27,54 @@ public class FieldConflictsTest {
   public FieldConflictsTest() throws IOException {}
 
   @Test
+  public void testMessageEquality() {
+    String ts = MessageUtil.getCurrentLogDate();
+    LogMessage msg1 =
+        new LogMessage(
+            MessageUtil.TEST_INDEX_NAME,
+            "INFO",
+            "1",
+            Map.of(
+                LogMessage.ReservedField.TIMESTAMP.fieldName,
+                ts,
+                LogMessage.ReservedField.MESSAGE.fieldName,
+                "Test message",
+                LogMessage.ReservedField.HOSTNAME.fieldName,
+                "host1-dc2.abc.com"));
+
+    LogMessage msg2 =
+        new LogMessage(
+            MessageUtil.TEST_INDEX_NAME,
+            "INFO",
+            "1",
+            Map.of(
+                LogMessage.ReservedField.TIMESTAMP.fieldName,
+                ts,
+                LogMessage.ReservedField.MESSAGE.fieldName,
+                "Test message",
+                LogMessage.ReservedField.HOSTNAME.fieldName,
+                "host1-dc2.abc.com"));
+
+    assertThat(msg1).isEqualTo(msg2);
+
+    // change the timestamp
+    msg2 =
+        new LogMessage(
+            MessageUtil.TEST_INDEX_NAME,
+            "INFO",
+            "1",
+            Map.of(
+                LogMessage.ReservedField.TIMESTAMP.fieldName,
+                MessageUtil.getCurrentLogDate(),
+                LogMessage.ReservedField.MESSAGE.fieldName,
+                "Test message",
+                LogMessage.ReservedField.HOSTNAME.fieldName,
+                "host1-dc2.abc.com"));
+
+    assertThat(msg1).isNotEqualTo(msg2);
+  }
+
+  @Test
   public void testFieldConflictingFieldTypeWithSameValue() throws InterruptedException {
     final String conflictingFieldName = "conflictingField";
 


### PR DESCRIPTION
https://github.com/policeman-tools/forbidden-apis will help us ban APIs that we consider error prone.

For example ban `LOG.error(String)` since every error log should propagate an exception

A lot of APIs are copied from lucene/solr codebase
see https://github.com/apache/lucene/tree/main/gradle/validation/forbidden-apis
and https://github.com/apache/solr/tree/main/gradle/validation/forbidden-apis

LoggingInfoStream was also added ( copied from Solr ) since we were currently printing to sys out without a logger which means it won't respect JSON logging, file rotations etc