### PR TITLE
Include time unit in metadata proto fields.

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ChunkInfo.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ChunkInfo.java
@@ -23,11 +23,11 @@ public class ChunkInfo {
   public static ChunkInfo fromSnapshotMetadata(SnapshotMetadata snapshotMetadata) {
     return new ChunkInfo(
         snapshotMetadata.snapshotId,
-        snapshotMetadata.startTimeUtc,
-        snapshotMetadata.endTimeUtc,
-        snapshotMetadata.startTimeUtc,
-        snapshotMetadata.endTimeUtc,
-        snapshotMetadata.endTimeUtc,
+        snapshotMetadata.startTimeEpochMsUtc,
+        snapshotMetadata.endTimeEpochMsUtc,
+        snapshotMetadata.startTimeEpochMsUtc,
+        snapshotMetadata.endTimeEpochMsUtc,
+        snapshotMetadata.endTimeEpochMsUtc,
         snapshotMetadata.maxOffset,
         snapshotMetadata.partitionId,
         snapshotMetadata.snapshotPath);

--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ChunkInfo.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ChunkInfo.java
@@ -23,11 +23,11 @@ public class ChunkInfo {
   public static ChunkInfo fromSnapshotMetadata(SnapshotMetadata snapshotMetadata) {
     return new ChunkInfo(
         snapshotMetadata.snapshotId,
-        snapshotMetadata.startTimeEpochMsUtc,
-        snapshotMetadata.endTimeEpochMsUtc,
-        snapshotMetadata.startTimeEpochMsUtc,
-        snapshotMetadata.endTimeEpochMsUtc,
-        snapshotMetadata.endTimeEpochMsUtc,
+        snapshotMetadata.startTimeEpochMs,
+        snapshotMetadata.endTimeEpochMs,
+        snapshotMetadata.startTimeEpochMs,
+        snapshotMetadata.endTimeEpochMs,
+        snapshotMetadata.endTimeEpochMs,
         snapshotMetadata.maxOffset,
         snapshotMetadata.partitionId,
         snapshotMetadata.snapshotPath);

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentService.java
@@ -151,7 +151,7 @@ public class RecoveryTaskAssignmentService extends AbstractScheduledService {
             // want when running KalDb as a logging solution. If newest recovery tasks were
             // preferred, under heavy lag you would have higher-value logs available sooner,
             // at the increased chance of losing old logs.
-            .sorted(Comparator.comparingLong(RecoveryTaskMetadata::getCreatedTimeUtc))
+            .sorted(Comparator.comparingLong(RecoveryTaskMetadata::getCreatedTimeEpochMsUtc))
             .collect(Collectors.toUnmodifiableList());
 
     List<RecoveryNodeMetadata> availableRecoveryNodes =

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentService.java
@@ -151,7 +151,7 @@ public class RecoveryTaskAssignmentService extends AbstractScheduledService {
             // want when running KalDb as a logging solution. If newest recovery tasks were
             // preferred, under heavy lag you would have higher-value logs available sooner,
             // at the increased chance of losing old logs.
-            .sorted(Comparator.comparingLong(RecoveryTaskMetadata::getCreatedTimeEpochMsUtc))
+            .sorted(Comparator.comparingLong(RecoveryTaskMetadata::getCreatedTimeEpochMs))
             .collect(Collectors.toUnmodifiableList());
 
     List<RecoveryNodeMetadata> availableRecoveryNodes =

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaAssignmentService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaAssignmentService.java
@@ -163,10 +163,10 @@ public class ReplicaAssignmentService extends AbstractScheduledService {
             // only assign replicas that are not expired, and not already assigned
             .filter(
                 replicaMetadata ->
-                    replicaMetadata.expireAfterUtc > nowMilli
+                    replicaMetadata.expireAfterEpochMsUtc > nowMilli
                         && !assignedReplicaIds.contains(replicaMetadata.name))
             // sort the list by the newest replicas first, in case we run out of available slots
-            .sorted(Comparator.comparingLong(ReplicaMetadata::getCreatedTimeUtc))
+            .sorted(Comparator.comparingLong(ReplicaMetadata::getCreatedTimeEpochMsUtc))
             .map(replicaMetadata -> replicaMetadata.name)
             .collect(Collectors.toUnmodifiableList());
 

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaAssignmentService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaAssignmentService.java
@@ -163,10 +163,10 @@ public class ReplicaAssignmentService extends AbstractScheduledService {
             // only assign replicas that are not expired, and not already assigned
             .filter(
                 replicaMetadata ->
-                    replicaMetadata.expireAfterEpochMsUtc > nowMilli
+                    replicaMetadata.expireAfterEpochMs > nowMilli
                         && !assignedReplicaIds.contains(replicaMetadata.name))
             // sort the list by the newest replicas first, in case we run out of available slots
-            .sorted(Comparator.comparingLong(ReplicaMetadata::getCreatedTimeEpochMsUtc))
+            .sorted(Comparator.comparingLong(ReplicaMetadata::getCreatedTimeEpochMs))
             .map(replicaMetadata -> replicaMetadata.name)
             .collect(Collectors.toUnmodifiableList());
 

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaCreationService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaCreationService.java
@@ -171,7 +171,7 @@ public class ReplicaCreationService extends AbstractScheduledService {
             // only attempt to create replicas for snapshots that have not expired, and are not live
             .filter(
                 snapshotMetadata ->
-                    snapshotMetadata.endTimeUtc > snapshotExpiration
+                    snapshotMetadata.endTimeEpochMsUtc > snapshotExpiration
                         && !SnapshotMetadata.isLive(snapshotMetadata))
             .map(
                 (snapshotMetadata) ->
@@ -186,7 +186,7 @@ public class ReplicaCreationService extends AbstractScheduledService {
                                   replicaMetadataStore.create(
                                       replicaMetadataFromSnapshotId(
                                           snapshotMetadata.snapshotId,
-                                          Instant.ofEpochMilli(snapshotMetadata.endTimeUtc)
+                                          Instant.ofEpochMilli(snapshotMetadata.endTimeEpochMsUtc)
                                               .plus(
                                                   managerConfig
                                                       .getReplicaCreationServiceConfig()

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaCreationService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaCreationService.java
@@ -171,7 +171,7 @@ public class ReplicaCreationService extends AbstractScheduledService {
             // only attempt to create replicas for snapshots that have not expired, and are not live
             .filter(
                 snapshotMetadata ->
-                    snapshotMetadata.endTimeEpochMsUtc > snapshotExpiration
+                    snapshotMetadata.endTimeEpochMs > snapshotExpiration
                         && !SnapshotMetadata.isLive(snapshotMetadata))
             .map(
                 (snapshotMetadata) ->
@@ -186,7 +186,7 @@ public class ReplicaCreationService extends AbstractScheduledService {
                                   replicaMetadataStore.create(
                                       replicaMetadataFromSnapshotId(
                                           snapshotMetadata.snapshotId,
-                                          Instant.ofEpochMilli(snapshotMetadata.endTimeEpochMsUtc)
+                                          Instant.ofEpochMilli(snapshotMetadata.endTimeEpochMs)
                                               .plus(
                                                   managerConfig
                                                       .getReplicaCreationServiceConfig()

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaDeletionService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaDeletionService.java
@@ -110,7 +110,7 @@ public class ReplicaDeletionService extends AbstractScheduledService {
             .stream()
             .filter(
                 replicaMetadata ->
-                    replicaMetadata.expireAfterUtc < deleteOlderThan.toEpochMilli()
+                    replicaMetadata.expireAfterEpochMsUtc < deleteOlderThan.toEpochMilli()
                         && !replicaIdsWithAssignments.contains(replicaMetadata.name))
             .map(
                 (replicaMetadata) -> {

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaDeletionService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaDeletionService.java
@@ -110,7 +110,7 @@ public class ReplicaDeletionService extends AbstractScheduledService {
             .stream()
             .filter(
                 replicaMetadata ->
-                    replicaMetadata.expireAfterEpochMsUtc < deleteOlderThan.toEpochMilli()
+                    replicaMetadata.expireAfterEpochMs < deleteOlderThan.toEpochMilli()
                         && !replicaIdsWithAssignments.contains(replicaMetadata.name))
             .map(
                 (replicaMetadata) -> {

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaEvictionService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaEvictionService.java
@@ -167,7 +167,7 @@ public class ReplicaEvictionService extends AbstractScheduledService {
       CacheSlotMetadata cacheSlotMetadata) {
     return cacheSlotMetadata.cacheSlotState.equals(Metadata.CacheSlotMetadata.CacheSlotState.LIVE)
         && replicaMetadataByReplicaId.containsKey(cacheSlotMetadata.replicaId)
-        && replicaMetadataByReplicaId.get(cacheSlotMetadata.replicaId).expireAfterEpochMsUtc
+        && replicaMetadataByReplicaId.get(cacheSlotMetadata.replicaId).expireAfterEpochMs
             < expireOlderThan.toEpochMilli();
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaEvictionService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaEvictionService.java
@@ -167,7 +167,7 @@ public class ReplicaEvictionService extends AbstractScheduledService {
       CacheSlotMetadata cacheSlotMetadata) {
     return cacheSlotMetadata.cacheSlotState.equals(Metadata.CacheSlotMetadata.CacheSlotState.LIVE)
         && replicaMetadataByReplicaId.containsKey(cacheSlotMetadata.replicaId)
-        && replicaMetadataByReplicaId.get(cacheSlotMetadata.replicaId).expireAfterUtc
+        && replicaMetadataByReplicaId.get(cacheSlotMetadata.replicaId).expireAfterEpochMsUtc
             < expireOlderThan.toEpochMilli();
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadata.java
@@ -8,7 +8,7 @@ import com.slack.kaldb.proto.metadata.Metadata;
 public class CacheSlotMetadata extends KaldbMetadata {
   public final Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState;
   public final String replicaId;
-  public final long updatedTimeUtc;
+  public final long updatedTimeEpochMsUtc;
 
   public CacheSlotMetadata(
       String name,
@@ -30,7 +30,7 @@ public class CacheSlotMetadata extends KaldbMetadata {
 
     this.cacheSlotState = cacheSlotState;
     this.replicaId = replicaId;
-    this.updatedTimeUtc = updatedTimeUtc;
+    this.updatedTimeEpochMsUtc = updatedTimeUtc;
   }
 
   @Override
@@ -42,7 +42,7 @@ public class CacheSlotMetadata extends KaldbMetadata {
     CacheSlotMetadata that = (CacheSlotMetadata) o;
 
     if (!cacheSlotState.equals(that.cacheSlotState)) return false;
-    if (updatedTimeUtc != that.updatedTimeUtc) return false;
+    if (updatedTimeEpochMsUtc != that.updatedTimeEpochMsUtc) return false;
     return replicaId.equals(that.replicaId);
   }
 
@@ -51,7 +51,7 @@ public class CacheSlotMetadata extends KaldbMetadata {
     int result = super.hashCode();
     result = 31 * result + cacheSlotState.hashCode();
     result = 31 * result + replicaId.hashCode();
-    result = 31 * result + (int) (updatedTimeUtc ^ (updatedTimeUtc >>> 32));
+    result = 31 * result + (int) (updatedTimeEpochMsUtc ^ (updatedTimeEpochMsUtc >>> 32));
     return result;
   }
 
@@ -64,7 +64,7 @@ public class CacheSlotMetadata extends KaldbMetadata {
         + replicaId
         + '\''
         + ", updatedTimeUtc='"
-        + updatedTimeUtc
+        + updatedTimeEpochMsUtc
         + ", name='"
         + name
         + '\''

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadata.java
@@ -14,10 +14,10 @@ public class CacheSlotMetadata extends KaldbMetadata {
       String name,
       Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState,
       String replicaId,
-      long updatedTimeUtc) {
+      long updatedTimeEpochMsUtc) {
     super(name);
     checkArgument(cacheSlotState != null, "Cache slot state cannot be null");
-    checkArgument(updatedTimeUtc > 0, "Updated time must be greater than 0");
+    checkArgument(updatedTimeEpochMsUtc > 0, "Updated time must be greater than 0");
     if (cacheSlotState.equals(Metadata.CacheSlotMetadata.CacheSlotState.FREE)) {
       checkArgument(
           replicaId != null && replicaId.isEmpty(),
@@ -30,7 +30,7 @@ public class CacheSlotMetadata extends KaldbMetadata {
 
     this.cacheSlotState = cacheSlotState;
     this.replicaId = replicaId;
-    this.updatedTimeEpochMsUtc = updatedTimeUtc;
+    this.updatedTimeEpochMsUtc = updatedTimeEpochMsUtc;
   }
 
   @Override
@@ -63,7 +63,7 @@ public class CacheSlotMetadata extends KaldbMetadata {
         + ", replicaId='"
         + replicaId
         + '\''
-        + ", updatedTimeUtc='"
+        + ", updatedTimeEpochMsUtc='"
         + updatedTimeEpochMsUtc
         + ", name='"
         + name

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadata.java
@@ -8,16 +8,16 @@ import com.slack.kaldb.proto.metadata.Metadata;
 public class CacheSlotMetadata extends KaldbMetadata {
   public final Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState;
   public final String replicaId;
-  public final long updatedTimeEpochMsUtc;
+  public final long updatedTimeEpochMs;
 
   public CacheSlotMetadata(
       String name,
       Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState,
       String replicaId,
-      long updatedTimeEpochMsUtc) {
+      long updatedTimeEpochMs) {
     super(name);
     checkArgument(cacheSlotState != null, "Cache slot state cannot be null");
-    checkArgument(updatedTimeEpochMsUtc > 0, "Updated time must be greater than 0");
+    checkArgument(updatedTimeEpochMs > 0, "Updated time must be greater than 0");
     if (cacheSlotState.equals(Metadata.CacheSlotMetadata.CacheSlotState.FREE)) {
       checkArgument(
           replicaId != null && replicaId.isEmpty(),
@@ -30,7 +30,7 @@ public class CacheSlotMetadata extends KaldbMetadata {
 
     this.cacheSlotState = cacheSlotState;
     this.replicaId = replicaId;
-    this.updatedTimeEpochMsUtc = updatedTimeEpochMsUtc;
+    this.updatedTimeEpochMs = updatedTimeEpochMs;
   }
 
   @Override
@@ -42,7 +42,7 @@ public class CacheSlotMetadata extends KaldbMetadata {
     CacheSlotMetadata that = (CacheSlotMetadata) o;
 
     if (!cacheSlotState.equals(that.cacheSlotState)) return false;
-    if (updatedTimeEpochMsUtc != that.updatedTimeEpochMsUtc) return false;
+    if (updatedTimeEpochMs != that.updatedTimeEpochMs) return false;
     return replicaId.equals(that.replicaId);
   }
 
@@ -51,7 +51,7 @@ public class CacheSlotMetadata extends KaldbMetadata {
     int result = super.hashCode();
     result = 31 * result + cacheSlotState.hashCode();
     result = 31 * result + replicaId.hashCode();
-    result = 31 * result + (int) (updatedTimeEpochMsUtc ^ (updatedTimeEpochMsUtc >>> 32));
+    result = 31 * result + (int) (updatedTimeEpochMs ^ (updatedTimeEpochMs >>> 32));
     return result;
   }
 
@@ -63,8 +63,8 @@ public class CacheSlotMetadata extends KaldbMetadata {
         + ", replicaId='"
         + replicaId
         + '\''
-        + ", updatedTimeEpochMsUtc='"
-        + updatedTimeEpochMsUtc
+        + ", updatedTimeEpochMs='"
+        + updatedTimeEpochMs
         + ", name='"
         + name
         + '\''

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializer.java
@@ -21,7 +21,7 @@ public class CacheSlotMetadataSerializer implements MetadataSerializer<CacheSlot
         .setName(metadata.name)
         .setReplicaId(metadata.replicaId)
         .setCacheSlotState(metadata.cacheSlotState)
-        .setUpdatedTimeEpochMsUtc(metadata.updatedTimeUtc)
+        .setUpdatedTimeEpochMsUtc(metadata.updatedTimeEpochMsUtc)
         .build();
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializer.java
@@ -13,7 +13,7 @@ public class CacheSlotMetadataSerializer implements MetadataSerializer<CacheSlot
         Metadata.CacheSlotMetadata.CacheSlotState.valueOf(
             cacheSlotMetadataProto.getCacheSlotState().name()),
         cacheSlotMetadataProto.getReplicaId(),
-        cacheSlotMetadataProto.getUpdatedTimeUtc());
+        cacheSlotMetadataProto.getUpdatedTimeEpochMsUtc());
   }
 
   private static Metadata.CacheSlotMetadata toCacheSlotMetadataProto(CacheSlotMetadata metadata) {
@@ -21,7 +21,7 @@ public class CacheSlotMetadataSerializer implements MetadataSerializer<CacheSlot
         .setName(metadata.name)
         .setReplicaId(metadata.replicaId)
         .setCacheSlotState(metadata.cacheSlotState)
-        .setUpdatedTimeUtc(metadata.updatedTimeUtc)
+        .setUpdatedTimeEpochMsUtc(metadata.updatedTimeUtc)
         .build();
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializer.java
@@ -13,7 +13,7 @@ public class CacheSlotMetadataSerializer implements MetadataSerializer<CacheSlot
         Metadata.CacheSlotMetadata.CacheSlotState.valueOf(
             cacheSlotMetadataProto.getCacheSlotState().name()),
         cacheSlotMetadataProto.getReplicaId(),
-        cacheSlotMetadataProto.getUpdatedTimeEpochMsUtc());
+        cacheSlotMetadataProto.getUpdatedTimeEpochMs());
   }
 
   private static Metadata.CacheSlotMetadata toCacheSlotMetadataProto(CacheSlotMetadata metadata) {
@@ -21,7 +21,7 @@ public class CacheSlotMetadataSerializer implements MetadataSerializer<CacheSlot
         .setName(metadata.name)
         .setReplicaId(metadata.replicaId)
         .setCacheSlotState(metadata.cacheSlotState)
-        .setUpdatedTimeEpochMsUtc(metadata.updatedTimeEpochMsUtc)
+        .setUpdatedTimeEpochMs(metadata.updatedTimeEpochMs)
         .build();
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadata.java
@@ -14,16 +14,16 @@ public class RecoveryNodeMetadata extends KaldbMetadata {
 
   public final Metadata.RecoveryNodeMetadata.RecoveryNodeState recoveryNodeState;
   public final String recoveryTaskName;
-  public final long updatedTimeUtc;
+  public final long updatedTimeEpochMs;
 
   public RecoveryNodeMetadata(
       String name,
       Metadata.RecoveryNodeMetadata.RecoveryNodeState recoveryNodeState,
       String recoveryTaskName,
-      long updatedTimeUtc) {
+      long updatedTimeEpochMs) {
     super(name);
 
-    checkArgument(updatedTimeUtc > 0, "Updated time must be greater than 0");
+    checkArgument(updatedTimeEpochMs > 0, "Updated time must be greater than 0");
     if (recoveryNodeState.equals(Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE)) {
       checkArgument(
           recoveryTaskName != null && recoveryTaskName.isEmpty(),
@@ -36,7 +36,7 @@ public class RecoveryNodeMetadata extends KaldbMetadata {
 
     this.recoveryNodeState = recoveryNodeState;
     this.recoveryTaskName = recoveryTaskName;
-    this.updatedTimeUtc = updatedTimeUtc;
+    this.updatedTimeEpochMs = updatedTimeEpochMs;
   }
 
   @Override
@@ -45,14 +45,14 @@ public class RecoveryNodeMetadata extends KaldbMetadata {
     if (o == null || getClass() != o.getClass()) return false;
     if (!super.equals(o)) return false;
     RecoveryNodeMetadata that = (RecoveryNodeMetadata) o;
-    return updatedTimeUtc == that.updatedTimeUtc
+    return updatedTimeEpochMs == that.updatedTimeEpochMs
         && recoveryNodeState == that.recoveryNodeState
         && recoveryTaskName.equals(that.recoveryTaskName);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), recoveryNodeState, recoveryTaskName, updatedTimeUtc);
+    return Objects.hash(super.hashCode(), recoveryNodeState, recoveryTaskName, updatedTimeEpochMs);
   }
 
   @Override
@@ -67,7 +67,7 @@ public class RecoveryNodeMetadata extends KaldbMetadata {
         + recoveryTaskName
         + '\''
         + ", updatedTimeUtc="
-        + updatedTimeUtc
+        + updatedTimeEpochMs
         + '}';
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadata.java
@@ -66,7 +66,7 @@ public class RecoveryNodeMetadata extends KaldbMetadata {
         + ", recoveryTaskName='"
         + recoveryTaskName
         + '\''
-        + ", updatedTimeUtc="
+        + ", updatedTimeEpchMs="
         + updatedTimeEpochMs
         + '}';
   }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataSerializer.java
@@ -13,7 +13,7 @@ public class RecoveryNodeMetadataSerializer implements MetadataSerializer<Recove
         recoveryNodeMetadataProto.getName(),
         recoveryNodeMetadataProto.getRecoveryNodeState(),
         recoveryNodeMetadataProto.getRecoveryTaskName(),
-        recoveryNodeMetadataProto.getUpdatedTimeUtc());
+        recoveryNodeMetadataProto.getUpdatedTimeEpochMsUtc());
   }
 
   private static Metadata.RecoveryNodeMetadata toRecoveryNodeMetadataProto(
@@ -22,7 +22,7 @@ public class RecoveryNodeMetadataSerializer implements MetadataSerializer<Recove
         .setName(metadata.name)
         .setRecoveryNodeState(metadata.recoveryNodeState)
         .setRecoveryTaskName(metadata.recoveryTaskName)
-        .setUpdatedTimeUtc(metadata.updatedTimeUtc)
+        .setUpdatedTimeEpochMsUtc(metadata.updatedTimeUtc)
         .build();
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataSerializer.java
@@ -13,7 +13,7 @@ public class RecoveryNodeMetadataSerializer implements MetadataSerializer<Recove
         recoveryNodeMetadataProto.getName(),
         recoveryNodeMetadataProto.getRecoveryNodeState(),
         recoveryNodeMetadataProto.getRecoveryTaskName(),
-        recoveryNodeMetadataProto.getUpdatedTimeEpochMsUtc());
+        recoveryNodeMetadataProto.getUpdatedTimeEpochMs());
   }
 
   private static Metadata.RecoveryNodeMetadata toRecoveryNodeMetadataProto(
@@ -22,7 +22,7 @@ public class RecoveryNodeMetadataSerializer implements MetadataSerializer<Recove
         .setName(metadata.name)
         .setRecoveryNodeState(metadata.recoveryNodeState)
         .setRecoveryTaskName(metadata.recoveryTaskName)
-        .setUpdatedTimeEpochMsUtc(metadata.updatedTimeUtc)
+        .setUpdatedTimeEpochMs(metadata.updatedTimeEpochMs)
         .build();
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadata.java
@@ -23,7 +23,7 @@ public class RecoveryTaskMetadata extends KaldbMetadata {
         partitionId != null && !partitionId.isEmpty(), "partitionId can't be null or empty");
     checkArgument(startOffset >= 0, "startOffset must greater than 0");
     checkArgument(endOffset > startOffset, "endOffset must be greater than the startOffset");
-    checkArgument(createdTimeEpochMs > 0, "createdTimeEpochMsUtc must be greater than 0");
+    checkArgument(createdTimeEpochMs > 0, "createdTimeEpochMs must be greater than 0");
 
     this.partitionId = partitionId;
     this.startOffset = startOffset;
@@ -65,7 +65,7 @@ public class RecoveryTaskMetadata extends KaldbMetadata {
         + startOffset
         + ", endOffset="
         + endOffset
-        + ", createdTimeUtc="
+        + ", createdTimeEpochMs="
         + createdTimeEpochMs
         + '}';
   }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadata.java
@@ -13,30 +13,26 @@ public class RecoveryTaskMetadata extends KaldbMetadata {
   public final String partitionId;
   public final long startOffset;
   public final long endOffset;
-  public final long createdTimeEpochMsUtc;
+  public final long createdTimeEpochMs;
 
   public RecoveryTaskMetadata(
-      String name,
-      String partitionId,
-      long startOffset,
-      long endOffset,
-      long createdTimeEpochMsUtc) {
+      String name, String partitionId, long startOffset, long endOffset, long createdTimeEpochMs) {
     super(name);
 
     checkArgument(
         partitionId != null && !partitionId.isEmpty(), "partitionId can't be null or empty");
     checkArgument(startOffset >= 0, "startOffset must greater than 0");
     checkArgument(endOffset > startOffset, "endOffset must be greater than the startOffset");
-    checkArgument(createdTimeEpochMsUtc > 0, "createdTimeEpochMsUtc must be greater than 0");
+    checkArgument(createdTimeEpochMs > 0, "createdTimeEpochMsUtc must be greater than 0");
 
     this.partitionId = partitionId;
     this.startOffset = startOffset;
     this.endOffset = endOffset;
-    this.createdTimeEpochMsUtc = createdTimeEpochMsUtc;
+    this.createdTimeEpochMs = createdTimeEpochMs;
   }
 
-  public long getCreatedTimeEpochMsUtc() {
-    return createdTimeEpochMsUtc;
+  public long getCreatedTimeEpochMs() {
+    return createdTimeEpochMs;
   }
 
   @Override
@@ -47,14 +43,13 @@ public class RecoveryTaskMetadata extends KaldbMetadata {
     RecoveryTaskMetadata that = (RecoveryTaskMetadata) o;
     return startOffset == that.startOffset
         && endOffset == that.endOffset
-        && createdTimeEpochMsUtc == that.createdTimeEpochMsUtc
+        && createdTimeEpochMs == that.createdTimeEpochMs
         && partitionId.equals(that.partitionId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(
-        super.hashCode(), partitionId, startOffset, endOffset, createdTimeEpochMsUtc);
+    return Objects.hash(super.hashCode(), partitionId, startOffset, endOffset, createdTimeEpochMs);
   }
 
   @Override
@@ -71,7 +66,7 @@ public class RecoveryTaskMetadata extends KaldbMetadata {
         + ", endOffset="
         + endOffset
         + ", createdTimeUtc="
-        + createdTimeEpochMsUtc
+        + createdTimeEpochMs
         + '}';
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadata.java
@@ -13,26 +13,30 @@ public class RecoveryTaskMetadata extends KaldbMetadata {
   public final String partitionId;
   public final long startOffset;
   public final long endOffset;
-  public final long createdTimeUtc;
+  public final long createdTimeEpochMsUtc;
 
   public RecoveryTaskMetadata(
-      String name, String partitionId, long startOffset, long endOffset, long createdTimeUtc) {
+      String name,
+      String partitionId,
+      long startOffset,
+      long endOffset,
+      long createdTimeEpochMsUtc) {
     super(name);
 
     checkArgument(
         partitionId != null && !partitionId.isEmpty(), "partitionId can't be null or empty");
     checkArgument(startOffset >= 0, "startOffset must greater than 0");
     checkArgument(endOffset > startOffset, "endOffset must be greater than the startOffset");
-    checkArgument(createdTimeUtc > 0, "createdTimeUtc must be greater than 0");
+    checkArgument(createdTimeEpochMsUtc > 0, "createdTimeEpochMsUtc must be greater than 0");
 
     this.partitionId = partitionId;
     this.startOffset = startOffset;
     this.endOffset = endOffset;
-    this.createdTimeUtc = createdTimeUtc;
+    this.createdTimeEpochMsUtc = createdTimeEpochMsUtc;
   }
 
-  public long getCreatedTimeUtc() {
-    return createdTimeUtc;
+  public long getCreatedTimeEpochMsUtc() {
+    return createdTimeEpochMsUtc;
   }
 
   @Override
@@ -43,13 +47,14 @@ public class RecoveryTaskMetadata extends KaldbMetadata {
     RecoveryTaskMetadata that = (RecoveryTaskMetadata) o;
     return startOffset == that.startOffset
         && endOffset == that.endOffset
-        && createdTimeUtc == that.createdTimeUtc
+        && createdTimeEpochMsUtc == that.createdTimeEpochMsUtc
         && partitionId.equals(that.partitionId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), partitionId, startOffset, endOffset, createdTimeUtc);
+    return Objects.hash(
+        super.hashCode(), partitionId, startOffset, endOffset, createdTimeEpochMsUtc);
   }
 
   @Override
@@ -66,7 +71,7 @@ public class RecoveryTaskMetadata extends KaldbMetadata {
         + ", endOffset="
         + endOffset
         + ", createdTimeUtc="
-        + createdTimeUtc
+        + createdTimeEpochMsUtc
         + '}';
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataSerializer.java
@@ -24,7 +24,7 @@ public class RecoveryTaskMetadataSerializer implements MetadataSerializer<Recove
         .setPartitionId(metadata.partitionId)
         .setStartOffset(metadata.startOffset)
         .setEndOffset(metadata.endOffset)
-        .setCreatedTimeEpochMsUtc(metadata.createdTimeUtc)
+        .setCreatedTimeEpochMsUtc(metadata.createdTimeEpochMsUtc)
         .build();
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataSerializer.java
@@ -14,7 +14,7 @@ public class RecoveryTaskMetadataSerializer implements MetadataSerializer<Recove
         recoveryTaskMetadataProto.getPartitionId(),
         recoveryTaskMetadataProto.getStartOffset(),
         recoveryTaskMetadataProto.getEndOffset(),
-        recoveryTaskMetadataProto.getCreatedTimeEpochMsUtc());
+        recoveryTaskMetadataProto.getCreatedTimeEpochMs());
   }
 
   private static Metadata.RecoveryTaskMetadata toRecoveryTaskMetadataProto(
@@ -24,7 +24,7 @@ public class RecoveryTaskMetadataSerializer implements MetadataSerializer<Recove
         .setPartitionId(metadata.partitionId)
         .setStartOffset(metadata.startOffset)
         .setEndOffset(metadata.endOffset)
-        .setCreatedTimeEpochMsUtc(metadata.createdTimeEpochMsUtc)
+        .setCreatedTimeEpochMs(metadata.createdTimeEpochMs)
         .build();
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataSerializer.java
@@ -14,7 +14,7 @@ public class RecoveryTaskMetadataSerializer implements MetadataSerializer<Recove
         recoveryTaskMetadataProto.getPartitionId(),
         recoveryTaskMetadataProto.getStartOffset(),
         recoveryTaskMetadataProto.getEndOffset(),
-        recoveryTaskMetadataProto.getCreatedTimeUtc());
+        recoveryTaskMetadataProto.getCreatedTimeEpochMsUtc());
   }
 
   private static Metadata.RecoveryTaskMetadata toRecoveryTaskMetadataProto(
@@ -24,7 +24,7 @@ public class RecoveryTaskMetadataSerializer implements MetadataSerializer<Recove
         .setPartitionId(metadata.partitionId)
         .setStartOffset(metadata.startOffset)
         .setEndOffset(metadata.endOffset)
-        .setCreatedTimeUtc(metadata.createdTimeUtc)
+        .setCreatedTimeEpochMsUtc(metadata.createdTimeUtc)
         .build();
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadata.java
@@ -13,8 +13,8 @@ import java.util.Objects;
 public class ReplicaMetadata extends KaldbMetadata {
 
   public final String snapshotId;
-  public final long createdTimeUtc;
-  public final long expireAfterUtc;
+  public final long createdTimeEpochMsUtc;
+  public final long expireAfterEpochMsUtc;
 
   public ReplicaMetadata(String name, String snapshotId, long createdTimeUtc, long expireAfterUtc) {
     super(name);
@@ -24,20 +24,20 @@ public class ReplicaMetadata extends KaldbMetadata {
         snapshotId != null && !snapshotId.isEmpty(), "SnapshotId must not be null or empty");
 
     this.snapshotId = snapshotId;
-    this.createdTimeUtc = createdTimeUtc;
-    this.expireAfterUtc = expireAfterUtc;
+    this.createdTimeEpochMsUtc = createdTimeUtc;
+    this.expireAfterEpochMsUtc = expireAfterUtc;
   }
 
   public String getSnapshotId() {
     return snapshotId;
   }
 
-  public long getCreatedTimeUtc() {
-    return createdTimeUtc;
+  public long getCreatedTimeEpochMsUtc() {
+    return createdTimeEpochMsUtc;
   }
 
-  public long getExpireAfterUtc() {
-    return expireAfterUtc;
+  public long getExpireAfterEpochMsUtc() {
+    return expireAfterEpochMsUtc;
   }
 
   @Override
@@ -46,14 +46,14 @@ public class ReplicaMetadata extends KaldbMetadata {
     if (o == null || getClass() != o.getClass()) return false;
     if (!super.equals(o)) return false;
     ReplicaMetadata that = (ReplicaMetadata) o;
-    return createdTimeUtc == that.createdTimeUtc
-        && expireAfterUtc == that.expireAfterUtc
+    return createdTimeEpochMsUtc == that.createdTimeEpochMsUtc
+        && expireAfterEpochMsUtc == that.expireAfterEpochMsUtc
         && snapshotId.equals(that.snapshotId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), snapshotId, createdTimeUtc, expireAfterUtc);
+    return Objects.hash(super.hashCode(), snapshotId, createdTimeEpochMsUtc, expireAfterEpochMsUtc);
   }
 
   @Override
@@ -66,9 +66,9 @@ public class ReplicaMetadata extends KaldbMetadata {
         + snapshotId
         + '\''
         + ", createdTimeUtc="
-        + createdTimeUtc
+        + createdTimeEpochMsUtc
         + ", expireAfterUtc="
-        + expireAfterUtc
+        + expireAfterEpochMsUtc
         + '}';
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadata.java
@@ -13,31 +13,32 @@ import java.util.Objects;
 public class ReplicaMetadata extends KaldbMetadata {
 
   public final String snapshotId;
-  public final long createdTimeEpochMsUtc;
-  public final long expireAfterEpochMsUtc;
+  public final long createdTimeEpochMs;
+  public final long expireAfterEpochMs;
 
-  public ReplicaMetadata(String name, String snapshotId, long createdTimeUtc, long expireAfterUtc) {
+  public ReplicaMetadata(
+      String name, String snapshotId, long createdTimeEpochMs, long expireAfterEpochMs) {
     super(name);
-    checkArgument(createdTimeUtc > 0, "Created time must be greater than 0");
-    checkArgument(expireAfterUtc >= 0, "Expiration time must be greater than or equal to 0");
+    checkArgument(createdTimeEpochMs > 0, "Created time must be greater than 0");
+    checkArgument(expireAfterEpochMs >= 0, "Expiration time must be greater than or equal to 0");
     checkArgument(
         snapshotId != null && !snapshotId.isEmpty(), "SnapshotId must not be null or empty");
 
     this.snapshotId = snapshotId;
-    this.createdTimeEpochMsUtc = createdTimeUtc;
-    this.expireAfterEpochMsUtc = expireAfterUtc;
+    this.createdTimeEpochMs = createdTimeEpochMs;
+    this.expireAfterEpochMs = expireAfterEpochMs;
   }
 
   public String getSnapshotId() {
     return snapshotId;
   }
 
-  public long getCreatedTimeEpochMsUtc() {
-    return createdTimeEpochMsUtc;
+  public long getCreatedTimeEpochMs() {
+    return createdTimeEpochMs;
   }
 
-  public long getExpireAfterEpochMsUtc() {
-    return expireAfterEpochMsUtc;
+  public long getExpireAfterEpochMs() {
+    return expireAfterEpochMs;
   }
 
   @Override
@@ -46,14 +47,14 @@ public class ReplicaMetadata extends KaldbMetadata {
     if (o == null || getClass() != o.getClass()) return false;
     if (!super.equals(o)) return false;
     ReplicaMetadata that = (ReplicaMetadata) o;
-    return createdTimeEpochMsUtc == that.createdTimeEpochMsUtc
-        && expireAfterEpochMsUtc == that.expireAfterEpochMsUtc
+    return createdTimeEpochMs == that.createdTimeEpochMs
+        && expireAfterEpochMs == that.expireAfterEpochMs
         && snapshotId.equals(that.snapshotId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), snapshotId, createdTimeEpochMsUtc, expireAfterEpochMsUtc);
+    return Objects.hash(super.hashCode(), snapshotId, createdTimeEpochMs, expireAfterEpochMs);
   }
 
   @Override
@@ -65,10 +66,10 @@ public class ReplicaMetadata extends KaldbMetadata {
         + ", snapshotId='"
         + snapshotId
         + '\''
-        + ", createdTimeEpochMsUtc="
-        + createdTimeEpochMsUtc
-        + ", expireAfterEpochMsUtc="
-        + expireAfterEpochMsUtc
+        + ", createdTimeEpochMs="
+        + createdTimeEpochMs
+        + ", expireAfterEpochMs="
+        + expireAfterEpochMs
         + '}';
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadata.java
@@ -65,9 +65,9 @@ public class ReplicaMetadata extends KaldbMetadata {
         + ", snapshotId='"
         + snapshotId
         + '\''
-        + ", createdTimeUtc="
+        + ", createdTimeEpochMsUtc="
         + createdTimeEpochMsUtc
-        + ", expireAfterUtc="
+        + ", expireAfterEpochMsUtc="
         + expireAfterEpochMsUtc
         + '}';
   }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializer.java
@@ -19,8 +19,8 @@ public class ReplicaMetadataSerializer implements MetadataSerializer<ReplicaMeta
     return Metadata.ReplicaMetadata.newBuilder()
         .setName(metadata.name)
         .setSnapshotId(metadata.snapshotId)
-        .setCreatedTimeEpochMsUtc(metadata.createdTimeUtc)
-        .setExpireAfterEpochMsUtc(metadata.expireAfterUtc)
+        .setCreatedTimeEpochMsUtc(metadata.createdTimeEpochMsUtc)
+        .setExpireAfterEpochMsUtc(metadata.expireAfterEpochMsUtc)
         .build();
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializer.java
@@ -11,16 +11,16 @@ public class ReplicaMetadataSerializer implements MetadataSerializer<ReplicaMeta
     return new ReplicaMetadata(
         replicaMetadataProto.getName(),
         replicaMetadataProto.getSnapshotId(),
-        replicaMetadataProto.getCreatedTimeEpochMsUtc(),
-        replicaMetadataProto.getExpireAfterEpochMsUtc());
+        replicaMetadataProto.getCreatedTimeEpochMs(),
+        replicaMetadataProto.getExpireAfterEpochMs());
   }
 
   private static Metadata.ReplicaMetadata toReplicaMetadataProto(ReplicaMetadata metadata) {
     return Metadata.ReplicaMetadata.newBuilder()
         .setName(metadata.name)
         .setSnapshotId(metadata.snapshotId)
-        .setCreatedTimeEpochMsUtc(metadata.createdTimeEpochMsUtc)
-        .setExpireAfterEpochMsUtc(metadata.expireAfterEpochMsUtc)
+        .setCreatedTimeEpochMs(metadata.createdTimeEpochMs)
+        .setExpireAfterEpochMs(metadata.expireAfterEpochMs)
         .build();
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializer.java
@@ -11,16 +11,16 @@ public class ReplicaMetadataSerializer implements MetadataSerializer<ReplicaMeta
     return new ReplicaMetadata(
         replicaMetadataProto.getName(),
         replicaMetadataProto.getSnapshotId(),
-        replicaMetadataProto.getCreatedTimeUtc(),
-        replicaMetadataProto.getExpireAfterUtc());
+        replicaMetadataProto.getCreatedTimeEpochMsUtc(),
+        replicaMetadataProto.getExpireAfterEpochMsUtc());
   }
 
   private static Metadata.ReplicaMetadata toReplicaMetadataProto(ReplicaMetadata metadata) {
     return Metadata.ReplicaMetadata.newBuilder()
         .setName(metadata.name)
         .setSnapshotId(metadata.snapshotId)
-        .setCreatedTimeUtc(metadata.createdTimeUtc)
-        .setExpireAfterUtc(metadata.expireAfterUtc)
+        .setCreatedTimeEpochMsUtc(metadata.createdTimeUtc)
+        .setExpireAfterEpochMsUtc(metadata.expireAfterUtc)
         .build();
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadata.java
@@ -26,24 +26,24 @@ public class SnapshotMetadata extends KaldbMetadata {
 
   public final String snapshotPath;
   public final String snapshotId;
-  public final long startTimeEpochMsUtc;
-  public final long endTimeEpochMsUtc;
+  public final long startTimeEpochMs;
+  public final long endTimeEpochMs;
   public final long maxOffset;
   public final String partitionId;
 
   public SnapshotMetadata(
       String snapshotId,
       String snapshotPath,
-      long startTimeEpochMsUtc,
-      long endTimeEpochMsUtc,
+      long startTimeEpochMs,
+      long endTimeEpochMs,
       long maxOffset,
       String partitionId) {
     this(
         snapshotId,
         snapshotPath,
         snapshotId,
-        startTimeEpochMsUtc,
-        endTimeEpochMsUtc,
+        startTimeEpochMs,
+        endTimeEpochMs,
         maxOffset,
         partitionId);
   }
@@ -52,16 +52,16 @@ public class SnapshotMetadata extends KaldbMetadata {
       String name,
       String snapshotPath,
       String snapshotId,
-      long startTimeEpochMsUtc,
-      long endTimeEpochMsUtc,
+      long startTimeEpochMs,
+      long endTimeEpochMs,
       long maxOffset,
       String partitionId) {
     super(name);
     checkArgument(snapshotId != null && !snapshotId.isEmpty(), "snapshotId can't be null or empty");
-    checkArgument(startTimeEpochMsUtc > 0, "start time should be greater than zero.");
-    checkArgument(endTimeEpochMsUtc > 0, "end time should be greater than zero.");
+    checkArgument(startTimeEpochMs > 0, "start time should be greater than zero.");
+    checkArgument(endTimeEpochMs > 0, "end time should be greater than zero.");
     checkArgument(
-        endTimeEpochMsUtc >= startTimeEpochMsUtc,
+        endTimeEpochMs >= startTimeEpochMs,
         "start time should be greater than or equal to endtime");
     checkArgument(maxOffset >= 0, "max offset should be greater than or equal to zero.");
     checkArgument(
@@ -71,8 +71,8 @@ public class SnapshotMetadata extends KaldbMetadata {
 
     this.snapshotPath = snapshotPath;
     this.snapshotId = snapshotId;
-    this.startTimeEpochMsUtc = startTimeEpochMsUtc;
-    this.endTimeEpochMsUtc = endTimeEpochMsUtc;
+    this.startTimeEpochMs = startTimeEpochMs;
+    this.endTimeEpochMs = endTimeEpochMs;
     this.maxOffset = maxOffset;
     this.partitionId = partitionId;
   }
@@ -85,8 +85,8 @@ public class SnapshotMetadata extends KaldbMetadata {
 
     SnapshotMetadata that = (SnapshotMetadata) o;
 
-    if (startTimeEpochMsUtc != that.startTimeEpochMsUtc) return false;
-    if (endTimeEpochMsUtc != that.endTimeEpochMsUtc) return false;
+    if (startTimeEpochMs != that.startTimeEpochMs) return false;
+    if (endTimeEpochMs != that.endTimeEpochMs) return false;
     if (maxOffset != that.maxOffset) return false;
     if (!snapshotPath.equals(that.snapshotPath)) return false;
     if (!snapshotId.equals(that.snapshotId)) return false;
@@ -98,8 +98,8 @@ public class SnapshotMetadata extends KaldbMetadata {
     int result = super.hashCode();
     result = 31 * result + snapshotPath.hashCode();
     result = 31 * result + snapshotId.hashCode();
-    result = 31 * result + (int) (startTimeEpochMsUtc ^ (startTimeEpochMsUtc >>> 32));
-    result = 31 * result + (int) (endTimeEpochMsUtc ^ (endTimeEpochMsUtc >>> 32));
+    result = 31 * result + (int) (startTimeEpochMs ^ (startTimeEpochMs >>> 32));
+    result = 31 * result + (int) (endTimeEpochMs ^ (endTimeEpochMs >>> 32));
     result = 31 * result + (int) (maxOffset ^ (maxOffset >>> 32));
     result = 31 * result + partitionId.hashCode();
     return result;
@@ -119,9 +119,9 @@ public class SnapshotMetadata extends KaldbMetadata {
         + snapshotId
         + '\''
         + ", startTimeEpochMsUtc="
-        + startTimeEpochMsUtc
+        + startTimeEpochMs
         + ", endTimeEpochMsUtc="
-        + endTimeEpochMsUtc
+        + endTimeEpochMs
         + ", maxOffset="
         + maxOffset
         + ", partitionId='"

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadata.java
@@ -26,35 +26,43 @@ public class SnapshotMetadata extends KaldbMetadata {
 
   public final String snapshotPath;
   public final String snapshotId;
-  public final long startTimeUtc;
-  public final long endTimeUtc;
+  public final long startTimeEpochMsUtc;
+  public final long endTimeEpochMsUtc;
   public final long maxOffset;
   public final String partitionId;
 
   public SnapshotMetadata(
       String snapshotId,
       String snapshotPath,
-      long startTimeUtc,
-      long endTimeUtc,
+      long startTimeEpochMsUtc,
+      long endTimeEpochMsUtc,
       long maxOffset,
       String partitionId) {
-    this(snapshotId, snapshotPath, snapshotId, startTimeUtc, endTimeUtc, maxOffset, partitionId);
+    this(
+        snapshotId,
+        snapshotPath,
+        snapshotId,
+        startTimeEpochMsUtc,
+        endTimeEpochMsUtc,
+        maxOffset,
+        partitionId);
   }
 
   private SnapshotMetadata(
       String name,
       String snapshotPath,
       String snapshotId,
-      long startTimeUtc,
-      long endTimeUtc,
+      long startTimeEpochMsUtc,
+      long endTimeEpochMsUtc,
       long maxOffset,
       String partitionId) {
     super(name);
     checkArgument(snapshotId != null && !snapshotId.isEmpty(), "snapshotId can't be null or empty");
-    checkArgument(startTimeUtc > 0, "start time should be greater than zero.");
-    checkArgument(endTimeUtc > 0, "end time should be greater than zero.");
+    checkArgument(startTimeEpochMsUtc > 0, "start time should be greater than zero.");
+    checkArgument(endTimeEpochMsUtc > 0, "end time should be greater than zero.");
     checkArgument(
-        endTimeUtc >= startTimeUtc, "start time should be greater than or equal to endtime");
+        endTimeEpochMsUtc >= startTimeEpochMsUtc,
+        "start time should be greater than or equal to endtime");
     checkArgument(maxOffset >= 0, "max offset should be greater than or equal to zero.");
     checkArgument(
         partitionId != null && !partitionId.isEmpty(), "partitionId can't be null or empty");
@@ -63,8 +71,8 @@ public class SnapshotMetadata extends KaldbMetadata {
 
     this.snapshotPath = snapshotPath;
     this.snapshotId = snapshotId;
-    this.startTimeUtc = startTimeUtc;
-    this.endTimeUtc = endTimeUtc;
+    this.startTimeEpochMsUtc = startTimeEpochMsUtc;
+    this.endTimeEpochMsUtc = endTimeEpochMsUtc;
     this.maxOffset = maxOffset;
     this.partitionId = partitionId;
   }
@@ -77,8 +85,8 @@ public class SnapshotMetadata extends KaldbMetadata {
 
     SnapshotMetadata that = (SnapshotMetadata) o;
 
-    if (startTimeUtc != that.startTimeUtc) return false;
-    if (endTimeUtc != that.endTimeUtc) return false;
+    if (startTimeEpochMsUtc != that.startTimeEpochMsUtc) return false;
+    if (endTimeEpochMsUtc != that.endTimeEpochMsUtc) return false;
     if (maxOffset != that.maxOffset) return false;
     if (!snapshotPath.equals(that.snapshotPath)) return false;
     if (!snapshotId.equals(that.snapshotId)) return false;
@@ -90,8 +98,8 @@ public class SnapshotMetadata extends KaldbMetadata {
     int result = super.hashCode();
     result = 31 * result + snapshotPath.hashCode();
     result = 31 * result + snapshotId.hashCode();
-    result = 31 * result + (int) (startTimeUtc ^ (startTimeUtc >>> 32));
-    result = 31 * result + (int) (endTimeUtc ^ (endTimeUtc >>> 32));
+    result = 31 * result + (int) (startTimeEpochMsUtc ^ (startTimeEpochMsUtc >>> 32));
+    result = 31 * result + (int) (endTimeEpochMsUtc ^ (endTimeEpochMsUtc >>> 32));
     result = 31 * result + (int) (maxOffset ^ (maxOffset >>> 32));
     result = 31 * result + partitionId.hashCode();
     return result;
@@ -110,10 +118,10 @@ public class SnapshotMetadata extends KaldbMetadata {
         + ", snapshotId='"
         + snapshotId
         + '\''
-        + ", startTimeUtc="
-        + startTimeUtc
-        + ", endTimeUtc="
-        + endTimeUtc
+        + ", startTimeEpochMsUtc="
+        + startTimeEpochMsUtc
+        + ", endTimeEpochMsUtc="
+        + endTimeEpochMsUtc
         + ", maxOffset="
         + maxOffset
         + ", partitionId='"

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadata.java
@@ -118,9 +118,9 @@ public class SnapshotMetadata extends KaldbMetadata {
         + ", snapshotId='"
         + snapshotId
         + '\''
-        + ", startTimeEpochMsUtc="
+        + ", startTimeEpochMs="
         + startTimeEpochMs
-        + ", endTimeEpochMsUtc="
+        + ", endTimeEpochMs="
         + endTimeEpochMs
         + ", maxOffset="
         + maxOffset

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataSerializer.java
@@ -12,8 +12,8 @@ public class SnapshotMetadataSerializer implements MetadataSerializer<SnapshotMe
         .setName(snapshotMetadata.name)
         .setSnapshotId(snapshotMetadata.snapshotId)
         .setSnapshotPath(snapshotMetadata.snapshotPath)
-        .setStartTimeEpochMsUtc(snapshotMetadata.startTimeEpochMsUtc)
-        .setEndTimeEpochMsUtc(snapshotMetadata.endTimeEpochMsUtc)
+        .setStartTimeEpochMs(snapshotMetadata.startTimeEpochMs)
+        .setEndTimeEpochMs(snapshotMetadata.endTimeEpochMs)
         .setPartitionId(snapshotMetadata.partitionId)
         .setMaxOffset(snapshotMetadata.maxOffset)
         .build();
@@ -24,8 +24,8 @@ public class SnapshotMetadataSerializer implements MetadataSerializer<SnapshotMe
     return new SnapshotMetadata(
         protoSnapshotMetadata.getSnapshotId(),
         protoSnapshotMetadata.getSnapshotPath(),
-        protoSnapshotMetadata.getStartTimeEpochMsUtc(),
-        protoSnapshotMetadata.getEndTimeEpochMsUtc(),
+        protoSnapshotMetadata.getStartTimeEpochMs(),
+        protoSnapshotMetadata.getEndTimeEpochMs(),
         protoSnapshotMetadata.getMaxOffset(),
         protoSnapshotMetadata.getPartitionId());
   }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataSerializer.java
@@ -12,8 +12,8 @@ public class SnapshotMetadataSerializer implements MetadataSerializer<SnapshotMe
         .setName(snapshotMetadata.name)
         .setSnapshotId(snapshotMetadata.snapshotId)
         .setSnapshotPath(snapshotMetadata.snapshotPath)
-        .setStartTimeEpochMsUtc(snapshotMetadata.startTimeUtc)
-        .setEndTimeEpochMsUtc(snapshotMetadata.endTimeUtc)
+        .setStartTimeEpochMsUtc(snapshotMetadata.startTimeEpochMsUtc)
+        .setEndTimeEpochMsUtc(snapshotMetadata.endTimeEpochMsUtc)
         .setPartitionId(snapshotMetadata.partitionId)
         .setMaxOffset(snapshotMetadata.maxOffset)
         .build();

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataSerializer.java
@@ -12,8 +12,8 @@ public class SnapshotMetadataSerializer implements MetadataSerializer<SnapshotMe
         .setName(snapshotMetadata.name)
         .setSnapshotId(snapshotMetadata.snapshotId)
         .setSnapshotPath(snapshotMetadata.snapshotPath)
-        .setStartTimeUtc(snapshotMetadata.startTimeUtc)
-        .setEndTimeUtc(snapshotMetadata.endTimeUtc)
+        .setStartTimeEpochMsUtc(snapshotMetadata.startTimeUtc)
+        .setEndTimeEpochMsUtc(snapshotMetadata.endTimeUtc)
         .setPartitionId(snapshotMetadata.partitionId)
         .setMaxOffset(snapshotMetadata.maxOffset)
         .build();
@@ -24,8 +24,8 @@ public class SnapshotMetadataSerializer implements MetadataSerializer<SnapshotMe
     return new SnapshotMetadata(
         protoSnapshotMetadata.getSnapshotId(),
         protoSnapshotMetadata.getSnapshotPath(),
-        protoSnapshotMetadata.getStartTimeUtc(),
-        protoSnapshotMetadata.getEndTimeUtc(),
+        protoSnapshotMetadata.getStartTimeEpochMsUtc(),
+        protoSnapshotMetadata.getEndTimeEpochMsUtc(),
         protoSnapshotMetadata.getMaxOffset(),
         protoSnapshotMetadata.getPartitionId());
   }

--- a/kaldb/src/main/proto/metadata.proto
+++ b/kaldb/src/main/proto/metadata.proto
@@ -24,7 +24,7 @@ message CacheSlotMetadata {
   CacheSlotState cacheSlotState = 3;
 
   // Last updated timestamp
-  int64 updatedTimeEpochMsUtc = 4;
+  int64 updatedTimeEpochMs = 4;
 }
 
 message ReplicaMetadata {
@@ -35,10 +35,10 @@ message ReplicaMetadata {
   string snapshotId = 2;
 
   // Last updated timestamp
-  int64 createdTimeEpochMsUtc = 4;
+  int64 createdTimeEpochMs = 4;
 
   // Timestamp after which this replica can be deleted
-  int64 expireAfterEpochMsUtc = 5;
+  int64 expireAfterEpochMs = 5;
 }
 
 message SnapshotMetadata {
@@ -51,9 +51,9 @@ message SnapshotMetadata {
   // Path of the file stored in blobstore.
   string snapshotPath = 3;
   // earliest timestamp of the event in the snapshot file.
-  int64 startTimeEpochMsUtc = 4;
+  int64 startTimeEpochMs = 4;
   // End or latest timestamp of the event in the snapshot file.
-  int64 endTimeEpochMsUtc = 5;
+  int64 endTimeEpochMs = 5;
 
   // Kafka partitionId.
   string partitionId = 7;
@@ -89,7 +89,7 @@ message RecoveryNodeMetadata {
   RecoveryNodeState recoveryNodeState = 3;
 
   // Last updated timestamp
-  int64 updatedTimeEpochMsUtc = 4;
+  int64 updatedTimeEpochMs = 4;
 }
 
 message RecoveryTaskMetadata {
@@ -106,5 +106,5 @@ message RecoveryTaskMetadata {
   int64 endOffset = 4;
 
   // Created timestamp
-  int64 createdTimeEpochMsUtc = 5;
+  int64 createdTimeEpochMs = 5;
 }

--- a/kaldb/src/main/proto/metadata.proto
+++ b/kaldb/src/main/proto/metadata.proto
@@ -24,7 +24,7 @@ message CacheSlotMetadata {
   CacheSlotState cacheSlotState = 3;
 
   // Last updated timestamp
-  int64 updatedTimeUtc = 4;
+  int64 updatedTimeEpochMsUtc = 4;
 }
 
 message ReplicaMetadata {
@@ -35,10 +35,10 @@ message ReplicaMetadata {
   string snapshotId = 2;
 
   // Last updated timestamp
-  int64 createdTimeUtc = 4;
+  int64 createdTimeEpochMsUtc = 4;
 
   // Timestamp after which this replica can be deleted
-  int64 expireAfterUtc = 5;
+  int64 expireAfterEpochMsUtc = 5;
 }
 
 message SnapshotMetadata {
@@ -51,9 +51,9 @@ message SnapshotMetadata {
   // Path of the file stored in blobstore.
   string snapshotPath = 3;
   // earliest timestamp of the event in the snapshot file.
-  int64 startTimeUtc = 4;
+  int64 startTimeEpochMsUtc = 4;
   // End or latest timestamp of the event in the snapshot file.
-  int64 endTimeUtc = 5;
+  int64 endTimeEpochMsUtc = 5;
 
   // Kafka partitionId.
   string partitionId = 7;
@@ -89,7 +89,7 @@ message RecoveryNodeMetadata {
   RecoveryNodeState recoveryNodeState = 3;
 
   // Last updated timestamp
-  int64 updatedTimeUtc = 4;
+  int64 updatedTimeEpochMsUtc = 4;
 }
 
 message RecoveryTaskMetadata {
@@ -106,5 +106,5 @@ message RecoveryTaskMetadata {
   int64 endOffset = 4;
 
   // Created timestamp
-  int64 createdTimeUtc = 5;
+  int64 createdTimeEpochMsUtc = 5;
 }

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ChunkCleanerServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ChunkCleanerServiceTest.java
@@ -116,8 +116,8 @@ public class ChunkCleanerServiceTest {
     assertThat(liveSnapshot.maxOffset).isEqualTo(9);
     assertThat(liveSnapshot.snapshotPath).isEqualTo(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
     assertThat(liveSnapshot.snapshotId).startsWith(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
-    assertThat(liveSnapshot.startTimeUtc).isEqualTo(startTime.toEpochMilli());
-    assertThat(liveSnapshot.endTimeUtc).isEqualTo(startTime.plusSeconds(8).toEpochMilli());
+    assertThat(liveSnapshot.startTimeEpochMsUtc).isEqualTo(startTime.toEpochMilli());
+    assertThat(liveSnapshot.endTimeEpochMsUtc).isEqualTo(startTime.plusSeconds(8).toEpochMilli());
     SnapshotMetadata nonLiveSnapshot = fetchNonLiveSnapshot(afterSnapshots).get(0);
     assertThat(nonLiveSnapshot.partitionId).isEqualTo(TEST_KAFKA_PARTITION_ID);
     assertThat(nonLiveSnapshot.maxOffset).isEqualTo(9);
@@ -126,8 +126,9 @@ public class ChunkCleanerServiceTest {
                 && nonLiveSnapshot.snapshotPath.contains(nonLiveSnapshot.name))
         .isTrue();
     assertThat(nonLiveSnapshot.snapshotId).isEqualTo(nonLiveSnapshot.name);
-    assertThat(nonLiveSnapshot.startTimeUtc).isEqualTo(startTime.toEpochMilli());
-    assertThat(nonLiveSnapshot.endTimeUtc).isEqualTo(startTime.plusSeconds(8).toEpochMilli());
+    assertThat(nonLiveSnapshot.startTimeEpochMsUtc).isEqualTo(startTime.toEpochMilli());
+    assertThat(nonLiveSnapshot.endTimeEpochMsUtc)
+        .isEqualTo(startTime.plusSeconds(8).toEpochMilli());
 
     List<SearchMetadata> afterSearchNodes = fetchSearchNodes(chunkManager);
     assertThat(afterSearchNodes.size()).isEqualTo(1);
@@ -171,8 +172,9 @@ public class ChunkCleanerServiceTest {
         .isTrue();
     assertThat(nonLiveSnapshotAfterChunkDelete.snapshotId)
         .isEqualTo(nonLiveSnapshotAfterChunkDelete.name);
-    assertThat(nonLiveSnapshotAfterChunkDelete.startTimeUtc).isEqualTo(startTime.toEpochMilli());
-    assertThat(nonLiveSnapshotAfterChunkDelete.endTimeUtc)
+    assertThat(nonLiveSnapshotAfterChunkDelete.startTimeEpochMsUtc)
+        .isEqualTo(startTime.toEpochMilli());
+    assertThat(nonLiveSnapshotAfterChunkDelete.endTimeEpochMsUtc)
         .isEqualTo(startTime.plusSeconds(8).toEpochMilli());
     assertThat(fetchSearchNodes(chunkManager)).isEmpty();
   }
@@ -186,9 +188,9 @@ public class ChunkCleanerServiceTest {
     assertThat(snapshotNodes.get(0).maxOffset).isEqualTo(0);
     assertThat(snapshotNodes.get(0).partitionId).isEqualTo(TEST_KAFKA_PARTITION_ID);
     assertThat(snapshotNodes.get(0).snapshotId).startsWith(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
-    assertThat(snapshotNodes.get(0).startTimeUtc)
+    assertThat(snapshotNodes.get(0).startTimeEpochMsUtc)
         .isCloseTo(creationTime.toEpochMilli(), Offset.offset(1000L));
-    assertThat(snapshotNodes.get(0).endTimeUtc).isEqualTo(MAX_FUTURE_TIME);
+    assertThat(snapshotNodes.get(0).endTimeEpochMsUtc).isEqualTo(MAX_FUTURE_TIME);
     final List<SearchMetadata> searchNodes = fetchSearchNodes(chunkManager);
     assertThat(searchNodes.size()).isEqualTo(1);
     assertThat(searchNodes.get(0).url).contains(TEST_HOST);
@@ -334,7 +336,7 @@ public class ChunkCleanerServiceTest {
     assertThat(liveSnapshots.stream().map(s -> s.snapshotId).collect(Collectors.toList()))
         .containsExactlyInAnyOrderElementsOf(
             searchNodes.stream().map(s -> s.snapshotName).collect(Collectors.toList()));
-    assertThat(snapshots.stream().filter(s -> s.endTimeUtc == MAX_FUTURE_TIME).count())
+    assertThat(snapshots.stream().filter(s -> s.endTimeEpochMsUtc == MAX_FUTURE_TIME).count())
         .isEqualTo(expectedInfinitySnapshotSize);
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ChunkCleanerServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ChunkCleanerServiceTest.java
@@ -116,8 +116,8 @@ public class ChunkCleanerServiceTest {
     assertThat(liveSnapshot.maxOffset).isEqualTo(9);
     assertThat(liveSnapshot.snapshotPath).isEqualTo(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
     assertThat(liveSnapshot.snapshotId).startsWith(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
-    assertThat(liveSnapshot.startTimeEpochMsUtc).isEqualTo(startTime.toEpochMilli());
-    assertThat(liveSnapshot.endTimeEpochMsUtc).isEqualTo(startTime.plusSeconds(8).toEpochMilli());
+    assertThat(liveSnapshot.startTimeEpochMs).isEqualTo(startTime.toEpochMilli());
+    assertThat(liveSnapshot.endTimeEpochMs).isEqualTo(startTime.plusSeconds(8).toEpochMilli());
     SnapshotMetadata nonLiveSnapshot = fetchNonLiveSnapshot(afterSnapshots).get(0);
     assertThat(nonLiveSnapshot.partitionId).isEqualTo(TEST_KAFKA_PARTITION_ID);
     assertThat(nonLiveSnapshot.maxOffset).isEqualTo(9);
@@ -126,9 +126,8 @@ public class ChunkCleanerServiceTest {
                 && nonLiveSnapshot.snapshotPath.contains(nonLiveSnapshot.name))
         .isTrue();
     assertThat(nonLiveSnapshot.snapshotId).isEqualTo(nonLiveSnapshot.name);
-    assertThat(nonLiveSnapshot.startTimeEpochMsUtc).isEqualTo(startTime.toEpochMilli());
-    assertThat(nonLiveSnapshot.endTimeEpochMsUtc)
-        .isEqualTo(startTime.plusSeconds(8).toEpochMilli());
+    assertThat(nonLiveSnapshot.startTimeEpochMs).isEqualTo(startTime.toEpochMilli());
+    assertThat(nonLiveSnapshot.endTimeEpochMs).isEqualTo(startTime.plusSeconds(8).toEpochMilli());
 
     List<SearchMetadata> afterSearchNodes = fetchSearchNodes(chunkManager);
     assertThat(afterSearchNodes.size()).isEqualTo(1);
@@ -172,9 +171,9 @@ public class ChunkCleanerServiceTest {
         .isTrue();
     assertThat(nonLiveSnapshotAfterChunkDelete.snapshotId)
         .isEqualTo(nonLiveSnapshotAfterChunkDelete.name);
-    assertThat(nonLiveSnapshotAfterChunkDelete.startTimeEpochMsUtc)
+    assertThat(nonLiveSnapshotAfterChunkDelete.startTimeEpochMs)
         .isEqualTo(startTime.toEpochMilli());
-    assertThat(nonLiveSnapshotAfterChunkDelete.endTimeEpochMsUtc)
+    assertThat(nonLiveSnapshotAfterChunkDelete.endTimeEpochMs)
         .isEqualTo(startTime.plusSeconds(8).toEpochMilli());
     assertThat(fetchSearchNodes(chunkManager)).isEmpty();
   }
@@ -188,9 +187,9 @@ public class ChunkCleanerServiceTest {
     assertThat(snapshotNodes.get(0).maxOffset).isEqualTo(0);
     assertThat(snapshotNodes.get(0).partitionId).isEqualTo(TEST_KAFKA_PARTITION_ID);
     assertThat(snapshotNodes.get(0).snapshotId).startsWith(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
-    assertThat(snapshotNodes.get(0).startTimeEpochMsUtc)
+    assertThat(snapshotNodes.get(0).startTimeEpochMs)
         .isCloseTo(creationTime.toEpochMilli(), Offset.offset(1000L));
-    assertThat(snapshotNodes.get(0).endTimeEpochMsUtc).isEqualTo(MAX_FUTURE_TIME);
+    assertThat(snapshotNodes.get(0).endTimeEpochMs).isEqualTo(MAX_FUTURE_TIME);
     final List<SearchMetadata> searchNodes = fetchSearchNodes(chunkManager);
     assertThat(searchNodes.size()).isEqualTo(1);
     assertThat(searchNodes.get(0).url).contains(TEST_HOST);
@@ -336,7 +335,7 @@ public class ChunkCleanerServiceTest {
     assertThat(liveSnapshots.stream().map(s -> s.snapshotId).collect(Collectors.toList()))
         .containsExactlyInAnyOrderElementsOf(
             searchNodes.stream().map(s -> s.snapshotName).collect(Collectors.toList()));
-    assertThat(snapshots.stream().filter(s -> s.endTimeEpochMsUtc == MAX_FUTURE_TIME).count())
+    assertThat(snapshots.stream().filter(s -> s.endTimeEpochMs == MAX_FUTURE_TIME).count())
         .isEqualTo(expectedInfinitySnapshotSize);
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkManagerTest.java
@@ -256,9 +256,9 @@ public class IndexingChunkManagerTest {
     assertThat(snapshots.get(0).maxOffset).isEqualTo(0);
     assertThat(snapshots.get(0).partitionId).isEqualTo(TEST_KAFKA_PARTITION_ID);
     assertThat(snapshots.get(0).snapshotId).startsWith(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
-    assertThat(snapshots.get(0).startTimeUtc)
+    assertThat(snapshots.get(0).startTimeEpochMsUtc)
         .isCloseTo(creationTime.toEpochMilli(), Offset.offset(1000L));
-    assertThat(snapshots.get(0).endTimeUtc).isEqualTo(MAX_FUTURE_TIME);
+    assertThat(snapshots.get(0).endTimeEpochMsUtc).isEqualTo(MAX_FUTURE_TIME);
 
     List<SearchMetadata> searchNodes = fetchSearchNodes(chunkManager);
     assertThat(searchNodes.size()).isEqualTo(1);
@@ -435,7 +435,7 @@ public class IndexingChunkManagerTest {
     assertThat(liveSnapshots.stream().map(s -> s.snapshotId).collect(Collectors.toList()))
         .containsExactlyInAnyOrderElementsOf(
             searchNodes.stream().map(s -> s.snapshotName).collect(Collectors.toList()));
-    assertThat(snapshots.stream().filter(s -> s.endTimeUtc == MAX_FUTURE_TIME).count())
+    assertThat(snapshots.stream().filter(s -> s.endTimeEpochMsUtc == MAX_FUTURE_TIME).count())
         .isEqualTo(expectedInfinitySnapshotsCount);
   }
 
@@ -893,7 +893,7 @@ public class IndexingChunkManagerTest {
     assertThat(liveSnapshots.stream().map(s -> s.snapshotId).collect(Collectors.toList()))
         .containsExactlyInAnyOrderElementsOf(
             searchNodes.stream().map(s -> s.snapshotName).collect(Collectors.toList()));
-    assertThat(snapshots.stream().filter(s -> s.endTimeUtc == MAX_FUTURE_TIME).count())
+    assertThat(snapshots.stream().filter(s -> s.endTimeEpochMsUtc == MAX_FUTURE_TIME).count())
         .isEqualTo(2);
   }
 
@@ -942,7 +942,7 @@ public class IndexingChunkManagerTest {
     assertThat(fetchNonLiveSnapshot(snapshots).size()).isEqualTo(1);
     assertThat(fetchLiveSnapshot(snapshots)).isEmpty();
     assertThat(snapshots.get(0).maxOffset).isEqualTo(offset - 1);
-    assertThat(snapshots.get(0).endTimeUtc).isLessThan(MAX_FUTURE_TIME);
+    assertThat(snapshots.get(0).endTimeEpochMsUtc).isLessThan(MAX_FUTURE_TIME);
     assertThat(snapshots.get(0).snapshotId).doesNotContain(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
     searchMetadataStore.close();
     snapshotMetadataStore.close();

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkManagerTest.java
@@ -256,9 +256,9 @@ public class IndexingChunkManagerTest {
     assertThat(snapshots.get(0).maxOffset).isEqualTo(0);
     assertThat(snapshots.get(0).partitionId).isEqualTo(TEST_KAFKA_PARTITION_ID);
     assertThat(snapshots.get(0).snapshotId).startsWith(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
-    assertThat(snapshots.get(0).startTimeEpochMsUtc)
+    assertThat(snapshots.get(0).startTimeEpochMs)
         .isCloseTo(creationTime.toEpochMilli(), Offset.offset(1000L));
-    assertThat(snapshots.get(0).endTimeEpochMsUtc).isEqualTo(MAX_FUTURE_TIME);
+    assertThat(snapshots.get(0).endTimeEpochMs).isEqualTo(MAX_FUTURE_TIME);
 
     List<SearchMetadata> searchNodes = fetchSearchNodes(chunkManager);
     assertThat(searchNodes.size()).isEqualTo(1);
@@ -435,7 +435,7 @@ public class IndexingChunkManagerTest {
     assertThat(liveSnapshots.stream().map(s -> s.snapshotId).collect(Collectors.toList()))
         .containsExactlyInAnyOrderElementsOf(
             searchNodes.stream().map(s -> s.snapshotName).collect(Collectors.toList()));
-    assertThat(snapshots.stream().filter(s -> s.endTimeEpochMsUtc == MAX_FUTURE_TIME).count())
+    assertThat(snapshots.stream().filter(s -> s.endTimeEpochMs == MAX_FUTURE_TIME).count())
         .isEqualTo(expectedInfinitySnapshotsCount);
   }
 
@@ -893,7 +893,7 @@ public class IndexingChunkManagerTest {
     assertThat(liveSnapshots.stream().map(s -> s.snapshotId).collect(Collectors.toList()))
         .containsExactlyInAnyOrderElementsOf(
             searchNodes.stream().map(s -> s.snapshotName).collect(Collectors.toList()));
-    assertThat(snapshots.stream().filter(s -> s.endTimeEpochMsUtc == MAX_FUTURE_TIME).count())
+    assertThat(snapshots.stream().filter(s -> s.endTimeEpochMs == MAX_FUTURE_TIME).count())
         .isEqualTo(2);
   }
 
@@ -942,7 +942,7 @@ public class IndexingChunkManagerTest {
     assertThat(fetchNonLiveSnapshot(snapshots).size()).isEqualTo(1);
     assertThat(fetchLiveSnapshot(snapshots)).isEmpty();
     assertThat(snapshots.get(0).maxOffset).isEqualTo(offset - 1);
-    assertThat(snapshots.get(0).endTimeEpochMsUtc).isLessThan(MAX_FUTURE_TIME);
+    assertThat(snapshots.get(0).endTimeEpochMs).isLessThan(MAX_FUTURE_TIME);
     assertThat(snapshots.get(0).snapshotId).doesNotContain(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
     searchMetadataStore.close();
     snapshotMetadataStore.close();

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentServiceTest.java
@@ -824,7 +824,7 @@ public class RecoveryTaskAssignmentServiceTest {
                     .stream()
                     .allMatch(
                         (recoveryNodeMetadata ->
-                            recoveryNodeMetadata.updatedTimeUtc > before.toEpochMilli()
+                            recoveryNodeMetadata.updatedTimeEpochMs > before.toEpochMilli()
                                 && recoveryNodeMetadata.recoveryNodeState.equals(
                                     Metadata.RecoveryNodeMetadata.RecoveryNodeState.ASSIGNED))));
     assertThat(recoveryTaskMetadataStore.getCached().size()).isEqualTo(7);
@@ -938,7 +938,7 @@ public class RecoveryTaskAssignmentServiceTest {
                     .stream()
                     .allMatch(
                         (recoveryNodeMetadata ->
-                            recoveryNodeMetadata.updatedTimeUtc > before.toEpochMilli()
+                            recoveryNodeMetadata.updatedTimeEpochMs > before.toEpochMilli()
                                 && recoveryNodeMetadata.recoveryNodeState.equals(
                                     Metadata.RecoveryNodeMetadata.RecoveryNodeState.ASSIGNED))));
     assertThat(recoveryTaskMetadataStore.getCached().size()).isEqualTo(7);

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
@@ -600,7 +600,7 @@ public class ReplicaAssignmentServiceTest {
                 .stream()
                 .filter(
                     replicaMetadata ->
-                        replicaMetadata.createdTimeUtc
+                        replicaMetadata.createdTimeEpochMsUtc
                             < Instant.now().minus(1440, ChronoUnit.MINUTES).toEpochMilli())
                 .collect(Collectors.toList())));
 

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
@@ -600,7 +600,7 @@ public class ReplicaAssignmentServiceTest {
                 .stream()
                 .filter(
                     replicaMetadata ->
-                        replicaMetadata.createdTimeEpochMsUtc
+                        replicaMetadata.createdTimeEpochMs
                             < Instant.now().minus(1440, ChronoUnit.MINUTES).toEpochMilli())
                 .collect(Collectors.toList())));
 

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
@@ -260,7 +260,8 @@ public class ReplicaEvictionServiceTest {
                                 Metadata.CacheSlotMetadata.CacheSlotState.EVICT)));
 
     CacheSlotMetadata updatedCacheSlot = cacheSlotMetadataStore.getCached().get(0);
-    assertThat(updatedCacheSlot.updatedTimeUtc).isGreaterThan(cacheSlotMetadata.updatedTimeUtc);
+    assertThat(updatedCacheSlot.updatedTimeEpochMsUtc)
+        .isGreaterThan(cacheSlotMetadata.updatedTimeEpochMsUtc);
     assertThat(updatedCacheSlot.cacheSlotState)
         .isEqualTo(Metadata.CacheSlotMetadata.CacheSlotState.EVICT);
     assertThat(updatedCacheSlot.name).isEqualTo(cacheSlotMetadata.name);
@@ -332,7 +333,8 @@ public class ReplicaEvictionServiceTest {
                                 Metadata.CacheSlotMetadata.CacheSlotState.EVICT)));
 
     CacheSlotMetadata updatedCacheSlot = cacheSlotMetadataStore.getCached().get(0);
-    assertThat(updatedCacheSlot.updatedTimeUtc).isGreaterThan(cacheSlotMetadata.updatedTimeUtc);
+    assertThat(updatedCacheSlot.updatedTimeEpochMsUtc)
+        .isGreaterThan(cacheSlotMetadata.updatedTimeEpochMsUtc);
     assertThat(updatedCacheSlot.cacheSlotState)
         .isEqualTo(Metadata.CacheSlotMetadata.CacheSlotState.EVICT);
     assertThat(updatedCacheSlot.name).isEqualTo(cacheSlotMetadata.name);
@@ -541,7 +543,8 @@ public class ReplicaEvictionServiceTest {
                                 Metadata.CacheSlotMetadata.CacheSlotState.EVICT)));
 
     CacheSlotMetadata updatedCacheSlot = cacheSlotMetadataStore.getCached().get(0);
-    assertThat(updatedCacheSlot.updatedTimeUtc).isGreaterThan(cacheSlotMetadata.updatedTimeUtc);
+    assertThat(updatedCacheSlot.updatedTimeEpochMsUtc)
+        .isGreaterThan(cacheSlotMetadata.updatedTimeEpochMsUtc);
     assertThat(updatedCacheSlot.cacheSlotState)
         .isEqualTo(Metadata.CacheSlotMetadata.CacheSlotState.EVICT);
     assertThat(updatedCacheSlot.name).isEqualTo(cacheSlotMetadata.name);
@@ -821,8 +824,8 @@ public class ReplicaEvictionServiceTest {
     assertThat(updatedCacheSlot.replicaId).isEqualTo(cacheSlotReplicaExpiredOne.replicaId);
     assertThat(updatedCacheSlot.cacheSlotState)
         .isEqualTo(Metadata.CacheSlotMetadata.CacheSlotState.EVICT);
-    assertThat(updatedCacheSlot.updatedTimeUtc)
-        .isGreaterThan(cacheSlotReplicaExpiredOne.updatedTimeUtc);
+    assertThat(updatedCacheSlot.updatedTimeEpochMsUtc)
+        .isGreaterThan(cacheSlotReplicaExpiredOne.updatedTimeEpochMsUtc);
 
     replicaEvictionService.stopAsync();
     replicaEvictionService.awaitTerminated(DEFAULT_START_STOP_DURATION);

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
@@ -260,8 +260,8 @@ public class ReplicaEvictionServiceTest {
                                 Metadata.CacheSlotMetadata.CacheSlotState.EVICT)));
 
     CacheSlotMetadata updatedCacheSlot = cacheSlotMetadataStore.getCached().get(0);
-    assertThat(updatedCacheSlot.updatedTimeEpochMsUtc)
-        .isGreaterThan(cacheSlotMetadata.updatedTimeEpochMsUtc);
+    assertThat(updatedCacheSlot.updatedTimeEpochMs)
+        .isGreaterThan(cacheSlotMetadata.updatedTimeEpochMs);
     assertThat(updatedCacheSlot.cacheSlotState)
         .isEqualTo(Metadata.CacheSlotMetadata.CacheSlotState.EVICT);
     assertThat(updatedCacheSlot.name).isEqualTo(cacheSlotMetadata.name);
@@ -333,8 +333,8 @@ public class ReplicaEvictionServiceTest {
                                 Metadata.CacheSlotMetadata.CacheSlotState.EVICT)));
 
     CacheSlotMetadata updatedCacheSlot = cacheSlotMetadataStore.getCached().get(0);
-    assertThat(updatedCacheSlot.updatedTimeEpochMsUtc)
-        .isGreaterThan(cacheSlotMetadata.updatedTimeEpochMsUtc);
+    assertThat(updatedCacheSlot.updatedTimeEpochMs)
+        .isGreaterThan(cacheSlotMetadata.updatedTimeEpochMs);
     assertThat(updatedCacheSlot.cacheSlotState)
         .isEqualTo(Metadata.CacheSlotMetadata.CacheSlotState.EVICT);
     assertThat(updatedCacheSlot.name).isEqualTo(cacheSlotMetadata.name);
@@ -543,8 +543,8 @@ public class ReplicaEvictionServiceTest {
                                 Metadata.CacheSlotMetadata.CacheSlotState.EVICT)));
 
     CacheSlotMetadata updatedCacheSlot = cacheSlotMetadataStore.getCached().get(0);
-    assertThat(updatedCacheSlot.updatedTimeEpochMsUtc)
-        .isGreaterThan(cacheSlotMetadata.updatedTimeEpochMsUtc);
+    assertThat(updatedCacheSlot.updatedTimeEpochMs)
+        .isGreaterThan(cacheSlotMetadata.updatedTimeEpochMs);
     assertThat(updatedCacheSlot.cacheSlotState)
         .isEqualTo(Metadata.CacheSlotMetadata.CacheSlotState.EVICT);
     assertThat(updatedCacheSlot.name).isEqualTo(cacheSlotMetadata.name);
@@ -824,8 +824,8 @@ public class ReplicaEvictionServiceTest {
     assertThat(updatedCacheSlot.replicaId).isEqualTo(cacheSlotReplicaExpiredOne.replicaId);
     assertThat(updatedCacheSlot.cacheSlotState)
         .isEqualTo(Metadata.CacheSlotMetadata.CacheSlotState.EVICT);
-    assertThat(updatedCacheSlot.updatedTimeEpochMsUtc)
-        .isGreaterThan(cacheSlotReplicaExpiredOne.updatedTimeEpochMsUtc);
+    assertThat(updatedCacheSlot.updatedTimeEpochMs)
+        .isGreaterThan(cacheSlotReplicaExpiredOne.updatedTimeEpochMs);
 
     replicaEvictionService.stopAsync();
     replicaEvictionService.awaitTerminated(DEFAULT_START_STOP_DURATION);

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializerTest.java
@@ -32,7 +32,7 @@ public class CacheSlotMetadataSerializerTest {
     assertThat(deserializedCacheSlotMetadata.name).isEqualTo(name);
     assertThat(deserializedCacheSlotMetadata.cacheSlotState).isEqualTo(cacheSlotState);
     assertThat(deserializedCacheSlotMetadata.replicaId).isEqualTo(replicaId);
-    assertThat(deserializedCacheSlotMetadata.updatedTimeUtc).isEqualTo(updatedTimeUtc);
+    assertThat(deserializedCacheSlotMetadata.updatedTimeEpochMsUtc).isEqualTo(updatedTimeUtc);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializerTest.java
@@ -17,10 +17,10 @@ public class CacheSlotMetadataSerializerTest {
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState =
         Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED;
     String replicaId = "123";
-    long updatedTimeUtc = Instant.now().toEpochMilli();
+    long updatedTimeEpochMs = Instant.now().toEpochMilli();
 
     CacheSlotMetadata cacheSlotMetadata =
-        new CacheSlotMetadata(name, cacheSlotState, replicaId, updatedTimeUtc);
+        new CacheSlotMetadata(name, cacheSlotState, replicaId, updatedTimeEpochMs);
 
     String serializedCacheSlotMetadata = serDe.toJsonStr(cacheSlotMetadata);
     assertThat(serializedCacheSlotMetadata).isNotEmpty();
@@ -32,7 +32,7 @@ public class CacheSlotMetadataSerializerTest {
     assertThat(deserializedCacheSlotMetadata.name).isEqualTo(name);
     assertThat(deserializedCacheSlotMetadata.cacheSlotState).isEqualTo(cacheSlotState);
     assertThat(deserializedCacheSlotMetadata.replicaId).isEqualTo(replicaId);
-    assertThat(deserializedCacheSlotMetadata.updatedTimeEpochMs).isEqualTo(updatedTimeUtc);
+    assertThat(deserializedCacheSlotMetadata.updatedTimeEpochMs).isEqualTo(updatedTimeEpochMs);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializerTest.java
@@ -32,7 +32,7 @@ public class CacheSlotMetadataSerializerTest {
     assertThat(deserializedCacheSlotMetadata.name).isEqualTo(name);
     assertThat(deserializedCacheSlotMetadata.cacheSlotState).isEqualTo(cacheSlotState);
     assertThat(deserializedCacheSlotMetadata.replicaId).isEqualTo(replicaId);
-    assertThat(deserializedCacheSlotMetadata.updatedTimeEpochMsUtc).isEqualTo(updatedTimeUtc);
+    assertThat(deserializedCacheSlotMetadata.updatedTimeEpochMs).isEqualTo(updatedTimeUtc);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataTest.java
@@ -15,14 +15,14 @@ public class CacheSlotMetadataTest {
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState =
         Metadata.CacheSlotMetadata.CacheSlotState.FREE;
     String replicaId = "";
-    long updatedTimeUtc = Instant.now().toEpochMilli();
+    long updatedTimeEpochMs = Instant.now().toEpochMilli();
 
     CacheSlotMetadata cacheSlotMetadata =
-        new CacheSlotMetadata(name, cacheSlotState, replicaId, updatedTimeUtc);
+        new CacheSlotMetadata(name, cacheSlotState, replicaId, updatedTimeEpochMs);
     assertThat(cacheSlotMetadata.name).isEqualTo(name);
     assertThat(cacheSlotMetadata.cacheSlotState).isEqualTo(cacheSlotState);
     assertThat(cacheSlotMetadata.replicaId).isEqualTo(replicaId);
-    assertThat(cacheSlotMetadata.updatedTimeEpochMs).isEqualTo(updatedTimeUtc);
+    assertThat(cacheSlotMetadata.updatedTimeEpochMs).isEqualTo(updatedTimeEpochMs);
   }
 
   @Test
@@ -31,19 +31,19 @@ public class CacheSlotMetadataTest {
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState =
         Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED;
     String replicaId = "123";
-    long updatedTimeUtc = Instant.now().toEpochMilli();
+    long updatedTimeEpochMs = Instant.now().toEpochMilli();
 
     CacheSlotMetadata cacheSlot =
-        new CacheSlotMetadata(name, cacheSlotState, replicaId, updatedTimeUtc);
+        new CacheSlotMetadata(name, cacheSlotState, replicaId, updatedTimeEpochMs);
     CacheSlotMetadata cacheSlotDuplicate =
-        new CacheSlotMetadata(name, cacheSlotState, replicaId, updatedTimeUtc);
+        new CacheSlotMetadata(name, cacheSlotState, replicaId, updatedTimeEpochMs);
     CacheSlotMetadata cacheSlotDifferentState =
         new CacheSlotMetadata(
-            name, Metadata.CacheSlotMetadata.CacheSlotState.EVICT, replicaId, updatedTimeUtc);
+            name, Metadata.CacheSlotMetadata.CacheSlotState.EVICT, replicaId, updatedTimeEpochMs);
     CacheSlotMetadata cacheSlotDifferentReplicaId =
-        new CacheSlotMetadata(name, cacheSlotState, "321", updatedTimeUtc);
+        new CacheSlotMetadata(name, cacheSlotState, "321", updatedTimeEpochMs);
     CacheSlotMetadata cacheSlotDifferentUpdatedTime =
-        new CacheSlotMetadata(name, cacheSlotState, replicaId, updatedTimeUtc + 1);
+        new CacheSlotMetadata(name, cacheSlotState, replicaId, updatedTimeEpochMs + 1);
 
     assertThat(cacheSlot.hashCode()).isEqualTo(cacheSlotDuplicate.hashCode());
     assertThat(cacheSlot).isEqualTo(cacheSlotDuplicate);

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataTest.java
@@ -22,7 +22,7 @@ public class CacheSlotMetadataTest {
     assertThat(cacheSlotMetadata.name).isEqualTo(name);
     assertThat(cacheSlotMetadata.cacheSlotState).isEqualTo(cacheSlotState);
     assertThat(cacheSlotMetadata.replicaId).isEqualTo(replicaId);
-    assertThat(cacheSlotMetadata.updatedTimeEpochMsUtc).isEqualTo(updatedTimeUtc);
+    assertThat(cacheSlotMetadata.updatedTimeEpochMs).isEqualTo(updatedTimeUtc);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataTest.java
@@ -22,7 +22,7 @@ public class CacheSlotMetadataTest {
     assertThat(cacheSlotMetadata.name).isEqualTo(name);
     assertThat(cacheSlotMetadata.cacheSlotState).isEqualTo(cacheSlotState);
     assertThat(cacheSlotMetadata.replicaId).isEqualTo(replicaId);
-    assertThat(cacheSlotMetadata.updatedTimeUtc).isEqualTo(updatedTimeUtc);
+    assertThat(cacheSlotMetadata.updatedTimeEpochMsUtc).isEqualTo(updatedTimeUtc);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
@@ -141,8 +141,8 @@ public class KaldbMetadataStoreTest {
       assertThat(metadata.name).isEqualTo(name);
       assertThat(metadata.snapshotPath).isEqualTo(snapshotPath);
       assertThat(metadata.snapshotId).isEqualTo(name);
-      assertThat(metadata.startTimeEpochMsUtc).isEqualTo(startTimeUtc);
-      assertThat(metadata.endTimeEpochMsUtc).isEqualTo(endTimeUtc);
+      assertThat(metadata.startTimeEpochMs).isEqualTo(startTimeUtc);
+      assertThat(metadata.endTimeEpochMs).isEqualTo(endTimeUtc);
       assertThat(metadata.maxOffset).isEqualTo(maxOffset);
       assertThat(metadata.partitionId).isEqualTo(partitionId);
 
@@ -156,8 +156,8 @@ public class KaldbMetadataStoreTest {
       assertThat(newMetadata.name).isEqualTo(name);
       assertThat(newMetadata.snapshotPath).isEqualTo(snapshotPath);
       assertThat(newMetadata.snapshotId).isEqualTo(name);
-      assertThat(newMetadata.startTimeEpochMsUtc).isEqualTo(startTimeUtc + 1);
-      assertThat(newMetadata.endTimeEpochMsUtc).isEqualTo(endTimeUtc + 1);
+      assertThat(newMetadata.startTimeEpochMs).isEqualTo(startTimeUtc + 1);
+      assertThat(newMetadata.endTimeEpochMs).isEqualTo(endTimeUtc + 1);
       assertThat(newMetadata.maxOffset).isEqualTo(maxOffset + 100);
       assertThat(newMetadata.partitionId).isEqualTo(partitionId);
 
@@ -217,8 +217,8 @@ public class KaldbMetadataStoreTest {
       assertThat(metadata.name).isEqualTo(name);
       assertThat(metadata.snapshotPath).isEqualTo(snapshotPath);
       assertThat(metadata.snapshotId).isEqualTo(name);
-      assertThat(metadata.startTimeEpochMsUtc).isEqualTo(startTimeUtc);
-      assertThat(metadata.endTimeEpochMsUtc).isEqualTo(endTimeUtc);
+      assertThat(metadata.startTimeEpochMs).isEqualTo(startTimeUtc);
+      assertThat(metadata.endTimeEpochMs).isEqualTo(endTimeUtc);
       assertThat(metadata.maxOffset).isEqualTo(maxOffset);
       assertThat(metadata.partitionId).isEqualTo(partitionId);
 
@@ -879,8 +879,8 @@ public class KaldbMetadataStoreTest {
       assertThat(metadata.name).isEqualTo(name);
       assertThat(metadata.snapshotPath).isEqualTo(snapshotPath);
       assertThat(metadata.snapshotId).isEqualTo(name);
-      assertThat(metadata.startTimeEpochMsUtc).isEqualTo(startTimeUtc);
-      assertThat(metadata.endTimeEpochMsUtc).isEqualTo(endTimeUtc);
+      assertThat(metadata.startTimeEpochMs).isEqualTo(startTimeUtc);
+      assertThat(metadata.endTimeEpochMs).isEqualTo(endTimeUtc);
       assertThat(metadata.maxOffset).isEqualTo(maxOffset);
       assertThat(metadata.partitionId).isEqualTo(partitionId);
 
@@ -894,8 +894,8 @@ public class KaldbMetadataStoreTest {
       assertThat(newMetadata.name).isEqualTo(name);
       assertThat(newMetadata.snapshotPath).isEqualTo(snapshotPath);
       assertThat(newMetadata.snapshotId).isEqualTo(name);
-      assertThat(newMetadata.startTimeEpochMsUtc).isEqualTo(startTimeUtc + 1);
-      assertThat(newMetadata.endTimeEpochMsUtc).isEqualTo(endTimeUtc + 1);
+      assertThat(newMetadata.startTimeEpochMs).isEqualTo(startTimeUtc + 1);
+      assertThat(newMetadata.endTimeEpochMs).isEqualTo(endTimeUtc + 1);
       assertThat(newMetadata.maxOffset).isEqualTo(maxOffset + 100);
       assertThat(newMetadata.partitionId).isEqualTo(partitionId);
 
@@ -955,8 +955,8 @@ public class KaldbMetadataStoreTest {
       assertThat(metadata.name).isEqualTo(name);
       assertThat(metadata.snapshotPath).isEqualTo(snapshotPath);
       assertThat(metadata.snapshotId).isEqualTo(name);
-      assertThat(metadata.startTimeEpochMsUtc).isEqualTo(startTimeUtc);
-      assertThat(metadata.endTimeEpochMsUtc).isEqualTo(endTimeUtc);
+      assertThat(metadata.startTimeEpochMs).isEqualTo(startTimeUtc);
+      assertThat(metadata.endTimeEpochMs).isEqualTo(endTimeUtc);
       assertThat(metadata.maxOffset).isEqualTo(maxOffset);
       assertThat(metadata.partitionId).isEqualTo(partitionId);
 

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
@@ -141,8 +141,8 @@ public class KaldbMetadataStoreTest {
       assertThat(metadata.name).isEqualTo(name);
       assertThat(metadata.snapshotPath).isEqualTo(snapshotPath);
       assertThat(metadata.snapshotId).isEqualTo(name);
-      assertThat(metadata.startTimeUtc).isEqualTo(startTimeUtc);
-      assertThat(metadata.endTimeUtc).isEqualTo(endTimeUtc);
+      assertThat(metadata.startTimeEpochMsUtc).isEqualTo(startTimeUtc);
+      assertThat(metadata.endTimeEpochMsUtc).isEqualTo(endTimeUtc);
       assertThat(metadata.maxOffset).isEqualTo(maxOffset);
       assertThat(metadata.partitionId).isEqualTo(partitionId);
 
@@ -156,8 +156,8 @@ public class KaldbMetadataStoreTest {
       assertThat(newMetadata.name).isEqualTo(name);
       assertThat(newMetadata.snapshotPath).isEqualTo(snapshotPath);
       assertThat(newMetadata.snapshotId).isEqualTo(name);
-      assertThat(newMetadata.startTimeUtc).isEqualTo(startTimeUtc + 1);
-      assertThat(newMetadata.endTimeUtc).isEqualTo(endTimeUtc + 1);
+      assertThat(newMetadata.startTimeEpochMsUtc).isEqualTo(startTimeUtc + 1);
+      assertThat(newMetadata.endTimeEpochMsUtc).isEqualTo(endTimeUtc + 1);
       assertThat(newMetadata.maxOffset).isEqualTo(maxOffset + 100);
       assertThat(newMetadata.partitionId).isEqualTo(partitionId);
 
@@ -217,8 +217,8 @@ public class KaldbMetadataStoreTest {
       assertThat(metadata.name).isEqualTo(name);
       assertThat(metadata.snapshotPath).isEqualTo(snapshotPath);
       assertThat(metadata.snapshotId).isEqualTo(name);
-      assertThat(metadata.startTimeUtc).isEqualTo(startTimeUtc);
-      assertThat(metadata.endTimeUtc).isEqualTo(endTimeUtc);
+      assertThat(metadata.startTimeEpochMsUtc).isEqualTo(startTimeUtc);
+      assertThat(metadata.endTimeEpochMsUtc).isEqualTo(endTimeUtc);
       assertThat(metadata.maxOffset).isEqualTo(maxOffset);
       assertThat(metadata.partitionId).isEqualTo(partitionId);
 
@@ -879,8 +879,8 @@ public class KaldbMetadataStoreTest {
       assertThat(metadata.name).isEqualTo(name);
       assertThat(metadata.snapshotPath).isEqualTo(snapshotPath);
       assertThat(metadata.snapshotId).isEqualTo(name);
-      assertThat(metadata.startTimeUtc).isEqualTo(startTimeUtc);
-      assertThat(metadata.endTimeUtc).isEqualTo(endTimeUtc);
+      assertThat(metadata.startTimeEpochMsUtc).isEqualTo(startTimeUtc);
+      assertThat(metadata.endTimeEpochMsUtc).isEqualTo(endTimeUtc);
       assertThat(metadata.maxOffset).isEqualTo(maxOffset);
       assertThat(metadata.partitionId).isEqualTo(partitionId);
 
@@ -894,8 +894,8 @@ public class KaldbMetadataStoreTest {
       assertThat(newMetadata.name).isEqualTo(name);
       assertThat(newMetadata.snapshotPath).isEqualTo(snapshotPath);
       assertThat(newMetadata.snapshotId).isEqualTo(name);
-      assertThat(newMetadata.startTimeUtc).isEqualTo(startTimeUtc + 1);
-      assertThat(newMetadata.endTimeUtc).isEqualTo(endTimeUtc + 1);
+      assertThat(newMetadata.startTimeEpochMsUtc).isEqualTo(startTimeUtc + 1);
+      assertThat(newMetadata.endTimeEpochMsUtc).isEqualTo(endTimeUtc + 1);
       assertThat(newMetadata.maxOffset).isEqualTo(maxOffset + 100);
       assertThat(newMetadata.partitionId).isEqualTo(partitionId);
 
@@ -955,8 +955,8 @@ public class KaldbMetadataStoreTest {
       assertThat(metadata.name).isEqualTo(name);
       assertThat(metadata.snapshotPath).isEqualTo(snapshotPath);
       assertThat(metadata.snapshotId).isEqualTo(name);
-      assertThat(metadata.startTimeUtc).isEqualTo(startTimeUtc);
-      assertThat(metadata.endTimeUtc).isEqualTo(endTimeUtc);
+      assertThat(metadata.startTimeEpochMsUtc).isEqualTo(startTimeUtc);
+      assertThat(metadata.endTimeEpochMsUtc).isEqualTo(endTimeUtc);
       assertThat(metadata.maxOffset).isEqualTo(maxOffset);
       assertThat(metadata.partitionId).isEqualTo(partitionId);
 

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataSerializerTest.java
@@ -17,10 +17,10 @@ public class RecoveryNodeMetadataSerializerTest {
     Metadata.RecoveryNodeMetadata.RecoveryNodeState recoveryNodeState =
         Metadata.RecoveryNodeMetadata.RecoveryNodeState.ASSIGNED;
     String recoveryTaskName = "taskName";
-    long updatedTimeUtc = Instant.now().toEpochMilli();
+    long updatedTimeEpochMs = Instant.now().toEpochMilli();
 
     RecoveryNodeMetadata recoveryNodeMetadata =
-        new RecoveryNodeMetadata(name, recoveryNodeState, recoveryTaskName, updatedTimeUtc);
+        new RecoveryNodeMetadata(name, recoveryNodeState, recoveryTaskName, updatedTimeEpochMs);
 
     String serializedCacheSlotMetadata = serDe.toJsonStr(recoveryNodeMetadata);
     assertThat(serializedCacheSlotMetadata).isNotEmpty();
@@ -32,7 +32,7 @@ public class RecoveryNodeMetadataSerializerTest {
     assertThat(deserializedRecoveryNodeMetadata.name).isEqualTo(name);
     assertThat(deserializedRecoveryNodeMetadata.recoveryNodeState).isEqualTo(recoveryNodeState);
     assertThat(deserializedRecoveryNodeMetadata.recoveryTaskName).isEqualTo(recoveryTaskName);
-    assertThat(deserializedRecoveryNodeMetadata.updatedTimeEpochMs).isEqualTo(updatedTimeUtc);
+    assertThat(deserializedRecoveryNodeMetadata.updatedTimeEpochMs).isEqualTo(updatedTimeEpochMs);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataSerializerTest.java
@@ -32,7 +32,7 @@ public class RecoveryNodeMetadataSerializerTest {
     assertThat(deserializedRecoveryNodeMetadata.name).isEqualTo(name);
     assertThat(deserializedRecoveryNodeMetadata.recoveryNodeState).isEqualTo(recoveryNodeState);
     assertThat(deserializedRecoveryNodeMetadata.recoveryTaskName).isEqualTo(recoveryTaskName);
-    assertThat(deserializedRecoveryNodeMetadata.updatedTimeUtc).isEqualTo(updatedTimeUtc);
+    assertThat(deserializedRecoveryNodeMetadata.updatedTimeEpochMs).isEqualTo(updatedTimeUtc);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataTest.java
@@ -22,7 +22,7 @@ public class RecoveryNodeMetadataTest {
     assertThat(recoveryNodeMetadata.name).isEqualTo(name);
     assertThat(recoveryNodeMetadata.recoveryNodeState).isEqualTo(state);
     assertThat(recoveryNodeMetadata.recoveryTaskName).isEqualTo(task);
-    assertThat(recoveryNodeMetadata.updatedTimeUtc).isEqualTo(time);
+    assertThat(recoveryNodeMetadata.updatedTimeEpochMs).isEqualTo(time);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataSerializerTest.java
@@ -32,7 +32,7 @@ public class RecoveryTaskMetadataSerializerTest {
     assertThat(deserializedRecoveryTaskMetadata.partitionId).isEqualTo(partitionId);
     assertThat(deserializedRecoveryTaskMetadata.startOffset).isEqualTo(startOffset);
     assertThat(deserializedRecoveryTaskMetadata.endOffset).isEqualTo(endOffset);
-    assertThat(deserializedRecoveryTaskMetadata.createdTimeEpochMsUtc).isEqualTo(createdTimeUtc);
+    assertThat(deserializedRecoveryTaskMetadata.createdTimeEpochMs).isEqualTo(createdTimeUtc);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataSerializerTest.java
@@ -32,7 +32,7 @@ public class RecoveryTaskMetadataSerializerTest {
     assertThat(deserializedRecoveryTaskMetadata.partitionId).isEqualTo(partitionId);
     assertThat(deserializedRecoveryTaskMetadata.startOffset).isEqualTo(startOffset);
     assertThat(deserializedRecoveryTaskMetadata.endOffset).isEqualTo(endOffset);
-    assertThat(deserializedRecoveryTaskMetadata.createdTimeUtc).isEqualTo(createdTimeUtc);
+    assertThat(deserializedRecoveryTaskMetadata.createdTimeEpochMsUtc).isEqualTo(createdTimeUtc);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataSerializerTest.java
@@ -16,10 +16,10 @@ public class RecoveryTaskMetadataSerializerTest {
     String partitionId = "partitionId";
     long startOffset = 0;
     long endOffset = 1;
-    long createdTimeUtc = Instant.now().toEpochMilli();
+    long createdTimeEpochMs = Instant.now().toEpochMilli();
 
     RecoveryTaskMetadata recoveryTaskMetadata =
-        new RecoveryTaskMetadata(name, partitionId, startOffset, endOffset, createdTimeUtc);
+        new RecoveryTaskMetadata(name, partitionId, startOffset, endOffset, createdTimeEpochMs);
 
     String serializedRecoveryTaskMetadata = serDe.toJsonStr(recoveryTaskMetadata);
     assertThat(serializedRecoveryTaskMetadata).isNotEmpty();
@@ -32,7 +32,7 @@ public class RecoveryTaskMetadataSerializerTest {
     assertThat(deserializedRecoveryTaskMetadata.partitionId).isEqualTo(partitionId);
     assertThat(deserializedRecoveryTaskMetadata.startOffset).isEqualTo(startOffset);
     assertThat(deserializedRecoveryTaskMetadata.endOffset).isEqualTo(endOffset);
-    assertThat(deserializedRecoveryTaskMetadata.createdTimeEpochMs).isEqualTo(createdTimeUtc);
+    assertThat(deserializedRecoveryTaskMetadata.createdTimeEpochMs).isEqualTo(createdTimeEpochMs);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataTest.java
@@ -23,7 +23,7 @@ public class RecoveryTaskMetadataTest {
     assertThat(recoveryTaskMetadata.partitionId).isEqualTo(partitionId);
     assertThat(recoveryTaskMetadata.startOffset).isEqualTo(startOffset);
     assertThat(recoveryTaskMetadata.endOffset).isEqualTo(endOffset);
-    assertThat(recoveryTaskMetadata.createdTimeEpochMsUtc).isEqualTo(createdTimeUtc);
+    assertThat(recoveryTaskMetadata.createdTimeEpochMs).isEqualTo(createdTimeUtc);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataTest.java
@@ -14,16 +14,16 @@ public class RecoveryTaskMetadataTest {
     String partitionId = "partitionId";
     long startOffset = 1;
     long endOffset = 2;
-    long createdTimeUtc = 3;
+    long createdTimeEpochMs = 3;
 
     RecoveryTaskMetadata recoveryTaskMetadata =
-        new RecoveryTaskMetadata(name, partitionId, startOffset, endOffset, createdTimeUtc);
+        new RecoveryTaskMetadata(name, partitionId, startOffset, endOffset, createdTimeEpochMs);
 
     assertThat(recoveryTaskMetadata.name).isEqualTo(name);
     assertThat(recoveryTaskMetadata.partitionId).isEqualTo(partitionId);
     assertThat(recoveryTaskMetadata.startOffset).isEqualTo(startOffset);
     assertThat(recoveryTaskMetadata.endOffset).isEqualTo(endOffset);
-    assertThat(recoveryTaskMetadata.createdTimeEpochMs).isEqualTo(createdTimeUtc);
+    assertThat(recoveryTaskMetadata.createdTimeEpochMs).isEqualTo(createdTimeEpochMs);
   }
 
   @Test
@@ -32,18 +32,18 @@ public class RecoveryTaskMetadataTest {
     String partitionId = "partitionId";
     long startOffset = 1;
     long endOffset = 5;
-    long createdTimeUtc = 9;
+    long createdTimeEpochMs = 9;
 
     RecoveryTaskMetadata recoveryTaskMetadataA =
-        new RecoveryTaskMetadata(name, partitionId, startOffset, endOffset, createdTimeUtc);
+        new RecoveryTaskMetadata(name, partitionId, startOffset, endOffset, createdTimeEpochMs);
     RecoveryTaskMetadata recoveryTaskMetadataB =
-        new RecoveryTaskMetadata(name, partitionId, startOffset, endOffset, createdTimeUtc);
+        new RecoveryTaskMetadata(name, partitionId, startOffset, endOffset, createdTimeEpochMs);
     RecoveryTaskMetadata recoveryTaskMetadataC =
-        new RecoveryTaskMetadata(name, "partitionIdC", startOffset, endOffset, createdTimeUtc);
+        new RecoveryTaskMetadata(name, "partitionIdC", startOffset, endOffset, createdTimeEpochMs);
     RecoveryTaskMetadata recoveryTaskMetadataD =
-        new RecoveryTaskMetadata(name, partitionId, 3, endOffset, createdTimeUtc);
+        new RecoveryTaskMetadata(name, partitionId, 3, endOffset, createdTimeEpochMs);
     RecoveryTaskMetadata recoveryTaskMetadataE =
-        new RecoveryTaskMetadata(name, partitionId, startOffset, 8, createdTimeUtc);
+        new RecoveryTaskMetadata(name, partitionId, startOffset, 8, createdTimeEpochMs);
 
     assertThat(recoveryTaskMetadataA).isEqualTo(recoveryTaskMetadataB);
     assertThat(recoveryTaskMetadataA).isNotEqualTo(recoveryTaskMetadataC);

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataTest.java
@@ -23,7 +23,7 @@ public class RecoveryTaskMetadataTest {
     assertThat(recoveryTaskMetadata.partitionId).isEqualTo(partitionId);
     assertThat(recoveryTaskMetadata.startOffset).isEqualTo(startOffset);
     assertThat(recoveryTaskMetadata.endOffset).isEqualTo(endOffset);
-    assertThat(recoveryTaskMetadata.createdTimeUtc).isEqualTo(createdTimeUtc);
+    assertThat(recoveryTaskMetadata.createdTimeEpochMsUtc).isEqualTo(createdTimeUtc);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializerTest.java
@@ -14,11 +14,11 @@ public class ReplicaMetadataSerializerTest {
   public void testReplicaMetadataSerializer() throws InvalidProtocolBufferException {
     String name = "name";
     String snapshotId = "snapshotId";
-    long createdTimeUtc = Instant.now().toEpochMilli();
-    long expireAfterUtc = Instant.now().plusSeconds(60).toEpochMilli();
+    long createdTimeEpochMs = Instant.now().toEpochMilli();
+    long expireAfterEpochMs = Instant.now().plusSeconds(60).toEpochMilli();
 
     ReplicaMetadata replicaMetadata =
-        new ReplicaMetadata(name, snapshotId, createdTimeUtc, expireAfterUtc);
+        new ReplicaMetadata(name, snapshotId, createdTimeEpochMs, expireAfterEpochMs);
 
     String serializedReplicaMetadata = serDe.toJsonStr(replicaMetadata);
     assertThat(serializedReplicaMetadata).isNotEmpty();
@@ -28,8 +28,8 @@ public class ReplicaMetadataSerializerTest {
 
     assertThat(deserializedReplicaMetadata.name).isEqualTo(name);
     assertThat(deserializedReplicaMetadata.snapshotId).isEqualTo(snapshotId);
-    assertThat(deserializedReplicaMetadata.createdTimeEpochMs).isEqualTo(createdTimeUtc);
-    assertThat(deserializedReplicaMetadata.expireAfterEpochMs).isEqualTo(expireAfterUtc);
+    assertThat(deserializedReplicaMetadata.createdTimeEpochMs).isEqualTo(createdTimeEpochMs);
+    assertThat(deserializedReplicaMetadata.expireAfterEpochMs).isEqualTo(expireAfterEpochMs);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializerTest.java
@@ -41,7 +41,7 @@ public class ReplicaMetadataSerializerTest {
         "{\n"
             + "  \"name\": \"name\",\n"
             + "  \"snapshotId\": \"snapshotId\",\n"
-            + "  \"createdTimeUtc\": \"1639677020380\"\n"
+            + "  \"createdTimeEpochMsUtc\": \"1639677020380\"\n"
             + "}";
     ReplicaMetadata deserializedReplicaMetadata = serDe.fromJsonStr(emptyExpiration);
 

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializerTest.java
@@ -2,7 +2,6 @@ package com.slack.kaldb.metadata.replica;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.junit.Assert.*;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.time.Instant;
@@ -29,8 +28,8 @@ public class ReplicaMetadataSerializerTest {
 
     assertThat(deserializedReplicaMetadata.name).isEqualTo(name);
     assertThat(deserializedReplicaMetadata.snapshotId).isEqualTo(snapshotId);
-    assertThat(deserializedReplicaMetadata.createdTimeUtc).isEqualTo(createdTimeUtc);
-    assertThat(deserializedReplicaMetadata.expireAfterUtc).isEqualTo(expireAfterUtc);
+    assertThat(deserializedReplicaMetadata.createdTimeEpochMsUtc).isEqualTo(createdTimeUtc);
+    assertThat(deserializedReplicaMetadata.expireAfterEpochMsUtc).isEqualTo(expireAfterUtc);
   }
 
   @Test
@@ -47,8 +46,8 @@ public class ReplicaMetadataSerializerTest {
 
     assertThat(deserializedReplicaMetadata.name).isEqualTo("name");
     assertThat(deserializedReplicaMetadata.snapshotId).isEqualTo("snapshotId");
-    assertThat(deserializedReplicaMetadata.createdTimeUtc).isEqualTo(1639677020380L);
-    assertThat(deserializedReplicaMetadata.expireAfterUtc).isEqualTo(0L);
+    assertThat(deserializedReplicaMetadata.createdTimeEpochMsUtc).isEqualTo(1639677020380L);
+    assertThat(deserializedReplicaMetadata.expireAfterEpochMsUtc).isEqualTo(0L);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializerTest.java
@@ -28,8 +28,8 @@ public class ReplicaMetadataSerializerTest {
 
     assertThat(deserializedReplicaMetadata.name).isEqualTo(name);
     assertThat(deserializedReplicaMetadata.snapshotId).isEqualTo(snapshotId);
-    assertThat(deserializedReplicaMetadata.createdTimeEpochMsUtc).isEqualTo(createdTimeUtc);
-    assertThat(deserializedReplicaMetadata.expireAfterEpochMsUtc).isEqualTo(expireAfterUtc);
+    assertThat(deserializedReplicaMetadata.createdTimeEpochMs).isEqualTo(createdTimeUtc);
+    assertThat(deserializedReplicaMetadata.expireAfterEpochMs).isEqualTo(expireAfterUtc);
   }
 
   @Test
@@ -40,14 +40,14 @@ public class ReplicaMetadataSerializerTest {
         "{\n"
             + "  \"name\": \"name\",\n"
             + "  \"snapshotId\": \"snapshotId\",\n"
-            + "  \"createdTimeEpochMsUtc\": \"1639677020380\"\n"
+            + "  \"createdTimeEpochMs\": \"1639677020380\"\n"
             + "}";
     ReplicaMetadata deserializedReplicaMetadata = serDe.fromJsonStr(emptyExpiration);
 
     assertThat(deserializedReplicaMetadata.name).isEqualTo("name");
     assertThat(deserializedReplicaMetadata.snapshotId).isEqualTo("snapshotId");
-    assertThat(deserializedReplicaMetadata.createdTimeEpochMsUtc).isEqualTo(1639677020380L);
-    assertThat(deserializedReplicaMetadata.expireAfterEpochMsUtc).isEqualTo(0L);
+    assertThat(deserializedReplicaMetadata.createdTimeEpochMs).isEqualTo(1639677020380L);
+    assertThat(deserializedReplicaMetadata.expireAfterEpochMs).isEqualTo(0L);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataTest.java
@@ -12,34 +12,34 @@ public class ReplicaMetadataTest {
   public void testReplicaMetadata() {
     String name = "name";
     String snapshotId = "snapshotId";
-    long createdTimeUtc = Instant.now().toEpochMilli();
-    long expireAfterUtc = Instant.now().toEpochMilli();
+    long createdTimeEpochMs = Instant.now().toEpochMilli();
+    long expireAfterEpochMs = Instant.now().toEpochMilli();
 
     ReplicaMetadata replicaMetadata =
-        new ReplicaMetadata(name, snapshotId, createdTimeUtc, expireAfterUtc);
+        new ReplicaMetadata(name, snapshotId, createdTimeEpochMs, expireAfterEpochMs);
 
     assertThat(replicaMetadata.name).isEqualTo(name);
     assertThat(replicaMetadata.snapshotId).isEqualTo(snapshotId);
-    assertThat(replicaMetadata.createdTimeEpochMs).isEqualTo(createdTimeUtc);
+    assertThat(replicaMetadata.createdTimeEpochMs).isEqualTo(createdTimeEpochMs);
   }
 
   @Test
   public void testReplicaMetadataEqualsHashcode() {
     String name = "name";
     String snapshotId = "snapshotId";
-    long createdTimeUtc = Instant.now().toEpochMilli();
-    long expireAfterUtc = Instant.now().toEpochMilli();
+    long createdTimeEpochMs = Instant.now().toEpochMilli();
+    long expireAfterEpochMs = Instant.now().toEpochMilli();
 
     ReplicaMetadata replicaMetadataA =
-        new ReplicaMetadata(name, snapshotId, createdTimeUtc, expireAfterUtc);
+        new ReplicaMetadata(name, snapshotId, createdTimeEpochMs, expireAfterEpochMs);
     ReplicaMetadata replicaMetadataB =
-        new ReplicaMetadata(name, snapshotId, createdTimeUtc, expireAfterUtc);
+        new ReplicaMetadata(name, snapshotId, createdTimeEpochMs, expireAfterEpochMs);
     ReplicaMetadata replicaMetadataC =
-        new ReplicaMetadata("nameC", snapshotId, createdTimeUtc, expireAfterUtc);
+        new ReplicaMetadata("nameC", snapshotId, createdTimeEpochMs, expireAfterEpochMs);
     ReplicaMetadata replicaMetadataD =
-        new ReplicaMetadata(name, snapshotId, createdTimeUtc + 1, expireAfterUtc);
+        new ReplicaMetadata(name, snapshotId, createdTimeEpochMs + 1, expireAfterEpochMs);
     ReplicaMetadata replicaMetadataE =
-        new ReplicaMetadata(name, snapshotId, createdTimeUtc, expireAfterUtc + 1);
+        new ReplicaMetadata(name, snapshotId, createdTimeEpochMs, expireAfterEpochMs + 1);
 
     assertThat(replicaMetadataA).isEqualTo(replicaMetadataB);
     assertThat(replicaMetadataA).isNotEqualTo(replicaMetadataC);

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataTest.java
@@ -20,7 +20,7 @@ public class ReplicaMetadataTest {
 
     assertThat(replicaMetadata.name).isEqualTo(name);
     assertThat(replicaMetadata.snapshotId).isEqualTo(snapshotId);
-    assertThat(replicaMetadata.createdTimeUtc).isEqualTo(createdTimeUtc);
+    assertThat(replicaMetadata.createdTimeEpochMsUtc).isEqualTo(createdTimeUtc);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataTest.java
@@ -20,7 +20,7 @@ public class ReplicaMetadataTest {
 
     assertThat(replicaMetadata.name).isEqualTo(name);
     assertThat(replicaMetadata.snapshotId).isEqualTo(snapshotId);
-    assertThat(replicaMetadata.createdTimeEpochMsUtc).isEqualTo(createdTimeUtc);
+    assertThat(replicaMetadata.createdTimeEpochMs).isEqualTo(createdTimeUtc);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataSerializerTest.java
@@ -29,8 +29,8 @@ public class SnapshotMetadataSerializerTest {
     assertThat(deserializedSnapshotMetadata.name).isEqualTo(name);
     assertThat(deserializedSnapshotMetadata.snapshotPath).isEqualTo(path);
     assertThat(deserializedSnapshotMetadata.snapshotId).isEqualTo(name);
-    assertThat(deserializedSnapshotMetadata.startTimeUtc).isEqualTo(startTime);
-    assertThat(deserializedSnapshotMetadata.endTimeUtc).isEqualTo(endTime);
+    assertThat(deserializedSnapshotMetadata.startTimeEpochMsUtc).isEqualTo(startTime);
+    assertThat(deserializedSnapshotMetadata.endTimeEpochMsUtc).isEqualTo(endTime);
     assertThat(deserializedSnapshotMetadata.maxOffset).isEqualTo(maxOffset);
     assertThat(deserializedSnapshotMetadata.partitionId).isEqualTo(partitionId);
   }

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataSerializerTest.java
@@ -29,8 +29,8 @@ public class SnapshotMetadataSerializerTest {
     assertThat(deserializedSnapshotMetadata.name).isEqualTo(name);
     assertThat(deserializedSnapshotMetadata.snapshotPath).isEqualTo(path);
     assertThat(deserializedSnapshotMetadata.snapshotId).isEqualTo(name);
-    assertThat(deserializedSnapshotMetadata.startTimeEpochMsUtc).isEqualTo(startTime);
-    assertThat(deserializedSnapshotMetadata.endTimeEpochMsUtc).isEqualTo(endTime);
+    assertThat(deserializedSnapshotMetadata.startTimeEpochMs).isEqualTo(startTime);
+    assertThat(deserializedSnapshotMetadata.endTimeEpochMs).isEqualTo(endTime);
     assertThat(deserializedSnapshotMetadata.maxOffset).isEqualTo(maxOffset);
     assertThat(deserializedSnapshotMetadata.partitionId).isEqualTo(partitionId);
   }

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataTest.java
@@ -24,8 +24,8 @@ public class SnapshotMetadataTest {
     assertThat(snapshotMetadata.name).isEqualTo(name);
     assertThat(snapshotMetadata.snapshotPath).isEqualTo(path);
     assertThat(snapshotMetadata.snapshotId).isEqualTo(name);
-    assertThat(snapshotMetadata.startTimeEpochMsUtc).isEqualTo(startTime);
-    assertThat(snapshotMetadata.endTimeEpochMsUtc).isEqualTo(endTime);
+    assertThat(snapshotMetadata.startTimeEpochMs).isEqualTo(startTime);
+    assertThat(snapshotMetadata.endTimeEpochMs).isEqualTo(endTime);
     assertThat(snapshotMetadata.maxOffset).isEqualTo(maxOffset);
     assertThat(snapshotMetadata.partitionId).isEqualTo(partitionId);
   }
@@ -85,7 +85,7 @@ public class SnapshotMetadataTest {
     // Start time same as end time.
     assertThat(
             new SnapshotMetadata(name, path, startTime, startTime, maxOffset, partitionId)
-                .endTimeEpochMsUtc)
+                .endTimeEpochMs)
         .isEqualTo(startTime);
 
     assertThatIllegalArgumentException()

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataTest.java
@@ -24,8 +24,8 @@ public class SnapshotMetadataTest {
     assertThat(snapshotMetadata.name).isEqualTo(name);
     assertThat(snapshotMetadata.snapshotPath).isEqualTo(path);
     assertThat(snapshotMetadata.snapshotId).isEqualTo(name);
-    assertThat(snapshotMetadata.startTimeUtc).isEqualTo(startTime);
-    assertThat(snapshotMetadata.endTimeUtc).isEqualTo(endTime);
+    assertThat(snapshotMetadata.startTimeEpochMsUtc).isEqualTo(startTime);
+    assertThat(snapshotMetadata.endTimeEpochMsUtc).isEqualTo(endTime);
     assertThat(snapshotMetadata.maxOffset).isEqualTo(maxOffset);
     assertThat(snapshotMetadata.partitionId).isEqualTo(partitionId);
   }
@@ -85,7 +85,7 @@ public class SnapshotMetadataTest {
     // Start time same as end time.
     assertThat(
             new SnapshotMetadata(name, path, startTime, startTime, maxOffset, partitionId)
-                .endTimeUtc)
+                .endTimeEpochMsUtc)
         .isEqualTo(startTime);
 
     assertThatIllegalArgumentException()


### PR DESCRIPTION
Include time unit in metadata proto fields so it's easier to add time in a consistent format everywhere.