### PR TITLE
add toString in ArrmeriaService

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
@@ -59,6 +59,11 @@ public class ArmeriaService extends AbstractIdleService {
     this.server = sb.build();
   }
 
+  @Override
+  public String toString() {
+    return "ArmeriaService{" + "serviceName='" + serviceName + '\'' + '}';
+  }
+
   public ArmeriaService(
       int serverPort,
       PrometheusMeterRegistry prometheusMeterRegistry,


### PR DESCRIPTION
Prom metrics for armeria service shows up like this

```
grpc_service_total_duration_seconds_count{grpc_status="2",hostname_pattern="*",http_status="200",method="GET",service="com.slack.kaldb.server.ArmeriaService$$Lambda$490/0x0000000840562040",} 1102.0
grpc_service_total_duration_seconds_sum{grpc_status="2",hostname_pattern="*",http_status="200",method="GET",service="com.slack.kaldb.server.ArmeriaService$$Lambda$490/0x0000000840562040",} 2.850402313
```

So adding serviceName toString will help distinguish it