### PR TITLE
Chunk Assignment As Histogram

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
@@ -117,14 +117,31 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
     cacheSlotListenerMetadataStore.addListener(cacheNodeListener());
     cacheSlotLastKnownState = Metadata.CacheSlotMetadata.CacheSlotState.FREE;
 
+    // https://github.com/micrometer-metrics/micrometer-docs/blob/main/src/docs/concepts/histogram-quantiles.adoc
     chunkAssignmentTimerSuccess =
-        meterRegistry.timer(CHUNK_ASSIGNMENT_TIMER, "slotName", slotName, "successful", "true");
+        Timer.builder(CHUNK_ASSIGNMENT_TIMER)
+            .tags("slotName", slotName, "successful", "true")
+            .publishPercentiles(0.5, 0.9)
+            .publishPercentileHistogram()
+            .register(meterRegistry);
     chunkAssignmentTimerFailure =
-        meterRegistry.timer(CHUNK_ASSIGNMENT_TIMER, "slotName", slotName, "successful", "false");
+        Timer.builder(CHUNK_ASSIGNMENT_TIMER)
+            .tags("slotName", slotName, "successful", "false")
+            .publishPercentiles(0.5, 0.9)
+            .publishPercentileHistogram()
+            .register(meterRegistry);
     chunkEvictionTimerSuccess =
-        meterRegistry.timer(CHUNK_EVICTION_TIMER, "slotName", slotName, "successful", "true");
+        Timer.builder(CHUNK_EVICTION_TIMER)
+            .tags("slotName", slotName, "successful", "true")
+            .publishPercentiles(0.5, 0.9)
+            .publishPercentileHistogram()
+            .register(meterRegistry);
     chunkEvictionTimerFailure =
-        meterRegistry.timer(CHUNK_EVICTION_TIMER, "slotName", slotName, "successful", "false");
+        Timer.builder(CHUNK_EVICTION_TIMER)
+            .tags("slotName", slotName, "successful", "false")
+            .publishPercentiles(0.5, 0.9)
+            .publishPercentileHistogram()
+            .register(meterRegistry);
 
     LOG.info("Created a new read only chunk - zkSlotId: {}", slotId);
   }


### PR DESCRIPTION
<img width="1151" alt="image" src="https://user-images.githubusercontent.com/158041/151430145-29b186bd-d8cd-4aeb-88ae-c83cb9b38a75.png">

If we implement this we'll see data like this. For now no need for this PR so I will close it out but I was experimenting with this to learn more

Prom Query - `histogram_quantile(0.99, sum by (replicaset, successful, le) (rate(chunk_assignment_timer_seconds_bucket[10m])))`