### PR TITLE
Add extra logging to the snapshot deletion

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/SnapshotDeletionService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/SnapshotDeletionService.java
@@ -187,6 +187,7 @@ public class SnapshotDeletionService extends AbstractScheduledService {
                               // the
                               // metadata and try again on the next run.
                               URI snapshotUri = URI.create(snapshotMetadata.snapshotPath);
+                              LOG.info("Starting delete of snapshot {}", snapshotMetadata);
                               if (s3BlobFs.exists(snapshotUri)) {
                                 // Ensure that the file exists before attempting to delete, in case
                                 // the previous run successfully deleted the object but failed the


### PR DESCRIPTION
This adds additional logging before attempting to delete snapshots of what will be attempted to be deleted, from both S3 and ZK.