### PR TITLE
Fix JSON Logging Issues

### DIFF
--- a/kaldb/src/main/resources/KaldbLayout.json
+++ b/kaldb/src/main/resources/KaldbLayout.json
@@ -22,38 +22,40 @@
     "$resolver": "logger",
     "field": "name"
   },
-  "labels": {
+  "traceId": {
     "$resolver": "mdc",
-    "flatten": true,
+    "key": "traceId",
     "stringified": true
   },
-  "tags": {
-    "$resolver": "ndc"
+  "spanId": {
+    "$resolver": "mdc",
+    "key": "spanId",
+    "stringified": true
   },
-  "error.type": {
+  "error_type": {
     "$resolver": "exception",
     "field": "className"
   },
-  "error.message": {
+  "error_message": {
     "$resolver": "exception",
     "field": "message"
   },
-  "error.stack_trace": {
+  "error_stack_trace": {
     "$resolver": "exception",
     "field": "stackTrace",
     "stackTrace": {
       "stringified": true
     }
   },
-  "error.root_cause.class_name": {
+  "error_root_cause_class_name": {
     "$resolver": "exceptionRootCause",
     "field": "className"
   },
-  "error.root_cause.message": {
+  "error_root_cause_message": {
     "$resolver": "exceptionRootCause",
     "field": "message"
   },
-  "error.root_cause.stack_trace": {
+  "error_root_cause_stack_trace": {
     "$resolver": "exceptionRootCause",
     "field": "stackTrace",
     "stackTrace": {

--- a/kaldb/src/main/resources/log4j2.xml
+++ b/kaldb/src/main/resources/log4j2.xml
@@ -6,7 +6,7 @@
         <Console name="console" target="SYSTEM_OUT">
             <!-- https://github.com/apache/logging-log4j2/blob/master/log4j-layout-template-json/src/main/resources/EcsLayout.json -->
             <!-- maxStringLength - limit the length of the stack trace -->
-            <JsonTemplateLayout maxStringLength="2000" eventTemplateUri="classpath:KaldbLayout.json" />
+            <JsonTemplateLayout maxStringLength="2000" eventTemplateUri="classpath:KaldbLayout.json" truncatedStringSuffix="..."/>
         </Console>
     </Appenders>
 


### PR DESCRIPTION
- Explicitly add traceId/spanId to the logs. What was there currently wasn't working. Deployed and checked this works
- Don't rely on the explicit truncation symbol ( https://unicode-table.com/en/2026/ ) by explicitly setting it ( this wasn't causing any of the parse failures but still beneficial to set it ) 
- Rename the `error.foo` with underscores . `error.foo` was being interpreted as a nested object by ES and failing to get indexed