### PR TITLE
Disable index filtering at query layer

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/LogIndexSearcherImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/LogIndexSearcherImpl.java
@@ -26,7 +26,6 @@ import java.util.stream.Stream;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.Term;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.BooleanClause.Occur;
@@ -40,7 +39,6 @@ import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortField.Type;
-import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopFieldCollector;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.slf4j.Logger;
@@ -194,7 +192,12 @@ public class LogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
       String indexName, String queryStr, long startTimeMsEpoch, long endTimeMsEpoch)
       throws ParseException {
     Builder queryBuilder = new Builder();
-    queryBuilder.add(new TermQuery(new Term(SystemField.INDEX.fieldName, indexName)), Occur.MUST);
+
+    // todo - we currently do not enforce searching against an index name, as we do not support
+    //  multi-tenancy yet - see https://github.com/slackhq/kaldb/issues/223. Once index filtering
+    //  is support at snapshot/query layer this should be re-enabled as appropriate.
+    // queryBuilder.add(new TermQuery(new Term(SystemField.INDEX.fieldName, indexName)),
+    // Occur.MUST);
     queryBuilder.add(
         LongPoint.newRangeQuery(
             SystemField.TIME_SINCE_EPOCH.fieldName, startTimeMsEpoch, endTimeMsEpoch),

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
@@ -1,6 +1,9 @@
 package com.slack.kaldb.logstore.search;
 
-import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.*;
+import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.COMMITS_COUNTER;
+import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_FAILED_COUNTER;
+import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_RECEIVED_COUNTER;
+import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.REFRESHES_COUNTER;
 import static com.slack.kaldb.testlib.MessageUtil.TEST_INDEX_NAME;
 import static com.slack.kaldb.testlib.MessageUtil.makeMessageWithIndexAndTimestamp;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
@@ -18,6 +21,7 @@ import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -37,8 +41,10 @@ public class LogIndexSearcherImplTest {
   private void loadTestData(Instant time) {
     strictLogStore.logStore.addMessage(
         makeMessageWithIndexAndTimestamp(1, "apple", TEST_INDEX_NAME, time));
-    strictLogStore.logStore.addMessage(
-        makeMessageWithIndexAndTimestamp(2, "baby", "new" + TEST_INDEX_NAME, time.plusSeconds(1)));
+
+    // todo - re-enable when multi-tenancy is supported - slackhq/kaldb/issues/223
+    // strictLogStore.logStore.addMessage(
+    // makeMessageWithIndexAndTimestamp(2, "baby", "new" + TEST_INDEX_NAME, time.plusSeconds(1)));
     strictLogStore.logStore.addMessage(
         makeMessageWithIndexAndTimestamp(3, "apple baby", TEST_INDEX_NAME, time.plusSeconds(2)));
     strictLogStore.logStore.addMessage(
@@ -128,6 +134,7 @@ public class LogIndexSearcherImplTest {
   }
 
   @Test
+  @Ignore // todo - re-enable when multi-tenancy is supported - slackhq/kaldb/issues/223
   public void testIndexBoundSearch() {
     Instant time = Instant.ofEpochSecond(1593365471);
     strictLogStore.logStore.addMessage(makeMessageWithIndexAndTimestamp(1, "test1", "idx", time));
@@ -357,6 +364,7 @@ public class LogIndexSearcherImplTest {
   }
 
   @Test
+  @Ignore // todo - re-enable when multi-tenancy is supported - slackhq/kaldb/issues/223
   public void testMissingIndexSearch() {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);


### PR DESCRIPTION
Until support is added at the snapshot/query layer this should be removed so that multiple indexes can be searched at once.