### PR TITLE
Refactor query timeouts

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/ChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/ChunkManager.java
@@ -1,5 +1,7 @@
 package com.slack.kaldb.chunkManager;
 
+import static com.slack.kaldb.config.KaldbConfig.LOCAL_QUERY_TIMEOUT_DURATION;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -12,7 +14,11 @@ import com.slack.kaldb.logstore.search.SearchResultAggregatorImpl;
 import com.spotify.futures.CompletableFutures;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,10 +35,6 @@ public abstract class ChunkManager<T> extends AbstractIdleService {
   // we use a CopyOnWriteArrayList as we expect to have very few edits to this list compared
   // to the amount of reads, and it must be a threadsafe implementation
   protected final List<Chunk<T>> chunkList = new CopyOnWriteArrayList<>();
-
-  // TODO: Move this config to Kaldb config.
-  // Less than KaldbDistributedQueryService#READ_TIMEOUT_MS
-  public static final int QUERY_TIMEOUT_SECONDS = 10;
 
   private static final ExecutorService queryExecutorService = queryThreadPool();
 
@@ -70,7 +72,7 @@ public abstract class ChunkManager<T> extends AbstractIdleService {
                             RequestContext.makeContextPropagating(queryExecutorService))
                         // TODO: this will not cancel lucene query. Use ExitableDirectoryReader in
                         // the future and pass this timeout
-                        .orTimeout(QUERY_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                        .orTimeout(LOCAL_QUERY_TIMEOUT_DURATION.toMillis(), TimeUnit.MILLISECONDS))
             .map(
                 chunkFuture ->
                     chunkFuture.exceptionally(
@@ -91,16 +93,24 @@ public abstract class ChunkManager<T> extends AbstractIdleService {
     // Using the spotify library ( this method is much easier to operate then using
     // CompletableFuture.allOf and converting the CompletableFuture<Void> to
     // CompletableFuture<List<SearchResult>>
-    CompletableFuture<List<SearchResult<T>>> searchResults = CompletableFutures.allAsList(queries);
+    CompletableFuture<List<SearchResult<T>>> searchResultFuture =
+        CompletableFutures.allAsList(queries);
     try {
+      List<SearchResult<T>> searchResults =
+          searchResultFuture.get(LOCAL_QUERY_TIMEOUT_DURATION.toMillis(), TimeUnit.MILLISECONDS);
       //noinspection unchecked
       SearchResult<T> aggregatedResults =
           ((SearchResultAggregator<T>) new SearchResultAggregatorImpl<>(query))
-              .aggregate(searchResults.get(30, TimeUnit.SECONDS));
+              .aggregate(searchResults);
       return incrementNodeCount(aggregatedResults);
     } catch (Exception e) {
       LOG.error("Error searching across chunks ", e);
       throw new RuntimeException(e);
+    } finally {
+      // always request future cancellation. This won't interrupt I/O or downstream futures,
+      // but is good practice. Since this is backed by a CompletableFuture
+      // mayInterruptIfRunning has no effect
+      searchResultFuture.cancel(true);
     }
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/config/KaldbConfig.java
+++ b/kaldb/src/main/java/com/slack/kaldb/config/KaldbConfig.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 import org.apache.commons.text.StringSubstitutor;
 
@@ -24,6 +25,16 @@ public class KaldbConfig {
   // Default start/stop duration for guava services.
   public static Duration DEFAULT_START_STOP_DURATION = Duration.ofSeconds(15);
   public static final int DEFAULT_ZK_TIMEOUT_SECS = 15;
+
+  // Timeouts are structured such that we always attempt to return a successful response, as we
+  // include metadata that should always be present. The Armeria timeout is used at the top request,
+  // distributed query is used as a deadline for all nodes to return, and the local query timeout
+  // is used for controlling lucene future timeouts.
+  public static final Duration ARMERIA_TIMEOUT_DURATION = Duration.of(15, ChronoUnit.SECONDS);
+  public static Duration DISTRIBUTED_QUERY_TIMEOUT_DURATION =
+      ARMERIA_TIMEOUT_DURATION.minus(Duration.of(2, ChronoUnit.SECONDS));
+  public static Duration LOCAL_QUERY_TIMEOUT_DURATION =
+      DISTRIBUTED_QUERY_TIMEOUT_DURATION.minus(Duration.of(2, ChronoUnit.SECONDS));
 
   private static KaldbConfig _instance = null;
 

--- a/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
@@ -8,6 +8,7 @@ import com.google.protobuf.ByteString;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.annotation.Blocking;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Path;
@@ -57,6 +58,7 @@ public class ElasticsearchApiService {
    *     doc</a>
    */
   @Post
+  @Blocking
   @Path("/_msearch")
   public HttpResponse multiSearch(String postBody) throws IOException {
     List<EsSearchRequest> requests = EsSearchRequest.parse(postBody);

--- a/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
@@ -1,5 +1,7 @@
 package com.slack.kaldb.server;
 
+import static com.slack.kaldb.config.KaldbConfig.ARMERIA_TIMEOUT_DURATION;
+
 import brave.Tracing;
 import brave.context.log4j2.ThreadContextScopeDecorator;
 import brave.handler.SpanHandler;
@@ -77,6 +79,7 @@ public class ArmeriaService extends AbstractIdleService {
     addSearchServices(sb, searcher);
     initializeEventLoop(sb);
     addCompression(sb);
+    setTimeout(sb);
     addManagementEndpoints(sb);
     addTracing(sb);
     this.server = sb.build();
@@ -100,6 +103,13 @@ public class ArmeriaService extends AbstractIdleService {
 
   private void addCompression(ServerBuilder sb) {
     sb.decorator(EncodingService.builder().newDecorator());
+  }
+
+  private void setTimeout(ServerBuilder sb) {
+    sb.requestTimeout(ARMERIA_TIMEOUT_DURATION);
+    // todo - on timeout explore including a retry-after header via exception handler
+    //  https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/503
+    // sb.exceptionHandler()
   }
 
   private void addTracing(ServerBuilder sb) {


### PR DESCRIPTION
Refactors timeouts such that we always now attempt to return a successful response. Also introduces future cancellations when possible.