### PR TITLE
Upgrade Armeria

### DIFF
--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -16,7 +16,7 @@
         <http.core.version>4.4.14</http.core.version>
         <protobuf.version>3.17.3</protobuf.version>
         <grpc.version>1.40.1</grpc.version>
-        <armeria.version>1.11.0</armeria.version>
+        <armeria.version>1.14.1</armeria.version>
         <micrometer.version>1.5.1</micrometer.version>
         <jackson.version>2.10.5</jackson.version>
         <!-- remove special databind version when jackson.version is the same -->


### PR DESCRIPTION
Upgrade armeria to update netty dependency which fixes https://github.com/netty/netty/security/advisories/GHSA-9vjp-v76f-g363 

```
[INFO] +- com.linecorp.armeria:armeria:jar:1.11.0:compile
[INFO] |  +- io.netty:netty-transport:jar:4.1.66.Final:compile
[INFO] |  |  +- io.netty:netty-common:jar:4.1.66.Final:compile
[INFO] |  |  +- io.netty:netty-buffer:jar:4.1.66.Final:compile
...
`

after
```
[INFO] +- com.linecorp.armeria:armeria:jar:1.14.1:compile
[INFO] |  +- io.netty:netty-transport:jar:4.1.73.Final:compile
[INFO] |  |  +- io.netty:netty-common:jar:4.1.73.Final:compile
...
```