### PR TITLE
Exclude Log4j 1.2.17 (CVE-2022-23307 )

### DIFF
--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -22,7 +22,7 @@
         <!-- remove special databind version when jackson.version is the same -->
         <jackson.databind.version>${jackson.version}.1</jackson.databind.version>
         <lucene.version>8.4.1</lucene.version>
-        <curator.version>5.1.0</curator.version>
+        <curator.version>5.2.0</curator.version>
         <log4j.version>2.17.1</log4j.version>
         <aws.sdk.version>2.16.72</aws.sdk.version>
     </properties>
@@ -104,16 +104,34 @@
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-framework</artifactId>
             <version>${curator.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-client</artifactId>
             <version>${curator.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
             <version>${curator.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Lucene dependencies -->

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -22,7 +22,7 @@
         <!-- remove special databind version when jackson.version is the same -->
         <jackson.databind.version>${jackson.version}.1</jackson.databind.version>
         <lucene.version>8.4.1</lucene.version>
-        <curator.version>5.2.0</curator.version>
+        <curator.version>5.1.0</curator.version>
         <log4j.version>2.17.1</log4j.version>
         <aws.sdk.version>2.16.72</aws.sdk.version>
     </properties>
@@ -104,12 +104,6 @@
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-framework</artifactId>
             <version>${curator.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>
@@ -117,8 +111,8 @@
             <version>${curator.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -126,12 +120,6 @@
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
             <version>${curator.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Lucene dependencies -->


### PR DESCRIPTION
Exclude Log4j 1.2.17 (CVE-2022-23307 )

before
```
[INFO] +- org.apache.curator:curator-client:jar:5.2.0:compile
[INFO] |  \- org.apache.zookeeper:zookeeper:jar:3.6.3:compile
[INFO] |     +- org.apache.zookeeper:zookeeper-jute:jar:3.6.3:compile
[INFO] |     +- org.apache.yetus:audience-annotations:jar:0.5.0:compile
[INFO] |     +- io.netty:netty-transport-native-epoll:jar:4.1.63.Final:compile
[INFO] |     \- log4j:log4j:jar:1.2.17:compile
```

after
```
[INFO] +- org.apache.curator:curator-client:jar:5.2.0:compile
[INFO] |  \- org.apache.zookeeper:zookeeper:jar:3.6.3:compile
[INFO] |     +- org.apache.zookeeper:zookeeper-jute:jar:3.6.3:compile
[INFO] |     +- org.apache.yetus:audience-annotations:jar:0.5.0:compile
[INFO] |     \- io.netty:netty-transport-native-epoll:jar:4.1.63.Final:compile
```


If you see curator client ( https://mvnrepository.com/artifact/org.apache.curator/curator-client/5.2.0 ) it depends on zookeeper ( https://mvnrepository.com/artifact/org.apache.zookeeper/zookeeper/3.6.0 ) and if you click on the zookeeper dependency we pull in log4j 1.2.17 - So this PR removes that.

