### PR TITLE
Convert ArmeriaService to builder pattern

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -128,6 +128,7 @@ public class Kaldb {
       final int serverPort = KaldbConfig.get().getIndexerConfig().getServerConfig().getServerPort();
       ArmeriaService armeriaService =
           new ArmeriaService.Builder(serverPort, "kalDbIndex", prometheusMeterRegistry)
+              .withTracingEndpoint(KaldbConfig.get().getTracingConfig().getZipkinEndpoint())
               .withGrpcSearchApi(searcher)
               .build();
       services.add(armeriaService);
@@ -144,6 +145,7 @@ public class Kaldb {
       final int serverPort = KaldbConfig.get().getQueryConfig().getServerConfig().getServerPort();
       ArmeriaService armeriaService =
           new ArmeriaService.Builder(serverPort, "kalDbQuery", prometheusMeterRegistry)
+              .withTracingEndpoint(KaldbConfig.get().getTracingConfig().getZipkinEndpoint())
               .withElasticsearchApi(kaldbDistributedQueryService)
               .build();
       services.add(armeriaService);
@@ -161,6 +163,7 @@ public class Kaldb {
       final int serverPort = KaldbConfig.get().getCacheConfig().getServerConfig().getServerPort();
       ArmeriaService armeriaService =
           new ArmeriaService.Builder(serverPort, "kalDbCache", prometheusMeterRegistry)
+              .withTracingEndpoint(KaldbConfig.get().getTracingConfig().getZipkinEndpoint())
               .withGrpcSearchApi(searcher)
               .build();
       services.add(armeriaService);
@@ -171,7 +174,9 @@ public class Kaldb {
       final int serverPort = managerConfig.getServerConfig().getServerPort();
 
       ArmeriaService armeriaService =
-          new ArmeriaService.Builder(serverPort, "kalDbManager", prometheusMeterRegistry).build();
+          new ArmeriaService.Builder(serverPort, "kalDbManager", prometheusMeterRegistry)
+              .withTracingEndpoint(KaldbConfig.get().getTracingConfig().getZipkinEndpoint())
+              .build();
       services.add(armeriaService);
 
       ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(metadataStore, true);
@@ -237,7 +242,9 @@ public class Kaldb {
       final int serverPort = recoveryConfig.getServerConfig().getServerPort();
 
       ArmeriaService armeriaService =
-          new ArmeriaService.Builder(serverPort, "kalDbRecovery", prometheusMeterRegistry).build();
+          new ArmeriaService.Builder(serverPort, "kalDbRecovery", prometheusMeterRegistry)
+              .withTracingEndpoint(KaldbConfig.get().getTracingConfig().getZipkinEndpoint())
+              .build();
       services.add(armeriaService);
 
       RecoveryService recoveryService =


### PR DESCRIPTION
This allows for easily sharing a common set of configs, while still supporting specialized tweaks depending on the use case.