### PR TITLE
KaldbDistributedQueryServiceTest potential fix - ensure grpc timeout is lower than global timeout

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
@@ -57,6 +57,8 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
   @VisibleForTesting
   public static long READ_TIMEOUT_MS = DISTRIBUTED_QUERY_TIMEOUT_DURATION.toMillis();
 
+  private static final long GRPC_TIMEOUT_BUFFER_MS = 100;
+
   // For now we will use SearchMetadataStore to populate servers
   // But this is wasteful since we add snapshots more often than we add/remove nodes ( hopefully )
   // So this should be replaced cache/index metadata store when that info is present in ZK
@@ -133,8 +135,10 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
     span.tag("queryServerCount", String.valueOf(stubs.size()));
 
     for (KaldbServiceGrpc.KaldbServiceFutureStub stub : stubs.values()) {
+      // make sure all underlying futures finish executing (successful/cancelled/failed/other)
+      // and cannot be pending when the successfulAsList.get(SAME_TIMEOUT_MS) runs
       ListenableFuture<KaldbSearch.SearchResult> searchRequest =
-          stub.withDeadlineAfter(READ_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+          stub.withDeadlineAfter(READ_TIMEOUT_MS - GRPC_TIMEOUT_BUFFER_MS, TimeUnit.MILLISECONDS)
               .withInterceptors(
                   GrpcTracing.newBuilder(Tracing.current()).build().newClientInterceptor())
               .search(request);
@@ -151,6 +155,8 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
     try {
       List<SearchResult<LogMessage>> searchResults =
           searchFuture.get(READ_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+      LOG.debug("searchResults.size={} searchResults={}", searchResults.size(), searchResults);
+
       return searchResults
           .stream()
           .map(searchResult -> searchResult == null ? SearchResult.empty() : searchResult)
@@ -175,6 +181,8 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
           ((SearchResultAggregator<LogMessage>)
                   new SearchResultAggregatorImpl<>(SearchResultUtils.fromSearchRequest(request)))
               .aggregate(searchResults);
+
+      LOG.debug("aggregatedResult={}", aggregatedResult);
       return SearchResultUtils.toSearchResultProto(aggregatedResult);
     } catch (Exception e) {
       LOG.error("Distributed search failed", e);

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResult.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResult.java
@@ -90,4 +90,26 @@ public class SearchResult<T> {
   public static SearchResult<LogMessage> empty() {
     return EMPTY;
   }
+
+  @Override
+  public String toString() {
+    return "SearchResult{"
+        + "totalCount="
+        + totalCount
+        + ", hits="
+        + hits
+        + ", tookMicros="
+        + tookMicros
+        + ", buckets="
+        + buckets
+        + ", failedNodes="
+        + failedNodes
+        + ", totalNodes="
+        + totalNodes
+        + ", totalSnapshots="
+        + totalSnapshots
+        + ", snapshotsWithReplicas="
+        + snapshotsWithReplicas
+        + '}';
+  }
 }


### PR DESCRIPTION
This PR is an attempt to fix the flaky `KaldbDistributedQueryServiceTest` test

`successfulAsList` is tolerant of failed futures - not pending futures. So `successfulAsList().get(TIMEOUT)` will throw a timeout exception if one of the component futures is still pending. This means we can run into a scenario in the test where 2/3 servers that succeeded also end up failing.
