### PR TITLE
Kaldb Preprocessor

### DIFF
--- a/.run/KalDb_preprocessor.run.xml
+++ b/.run/KalDb_preprocessor.run.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="KalDb Preprocessor Node" type="Application" factoryName="Application">
+    <envs>
+      <env name="NODE_ROLES" value="PREPROCESSOR" />
+    </envs>
+    <option name="MAIN_CLASS_NAME" value="com.slack.kaldb.server.Kaldb" />
+    <module name="kaldb" />
+    <option name="PROGRAM_PARAMETERS" value="config/config.yaml" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,4 +1,4 @@
-nodeRoles: [${NODE_ROLES:-QUERY,INDEX,CACHE,MANAGER,RECOVERY}]
+nodeRoles: [${NODE_ROLES:-QUERY,INDEX,CACHE,MANAGER,RECOVERY,PREPROCESSOR}]
 
 indexerConfig:
   maxMessagesPerChunk: ${INDEXER_MAX_MESSAGES_PER_CHUNK:-100000}
@@ -75,8 +75,19 @@ managerConfig:
     schedulePeriodMins: ${KALDB_MANAGER_SNAPSHOT_DELETE_PERIOD_MINS:-15}
     snapshotLifespanMins: ${KALDB_MANAGER_SNAPSHOT_LIFESPAN_MINS:-10080}
 
-
 recoveryConfig:
   serverConfig:
     serverPort: ${KALDB_RECOVERY_SERVER_PORT:-8085}
     serverAddress: ${KALDB_RECOVERY_SERVER_ADDRESS:-localhost}
+
+preprocessorConfig:
+  kafkaStreamConfig:
+    downstreamTopic: ${KAKFA_DOWNSTREAM_TOPIC:-test-topic-out}
+    bootstrapServers: ${KAFKA_BOOTSTRAP_SERVERS:-localhost:9092}
+    applicationId: ${KAFKA_APPLICATION_ID:-kaldb_preprocessor}
+    numStreamThreads: ${KAFKA_STREAM_THREADS:-2}
+  serverConfig:
+    serverPort: ${KALDB_PREPROCESSOR_SERVER_PORT:-8086}
+    serverAddress: ${KALDB_PREPROCESSOR_SERVER_ADDRESS:-localhost}
+  preprocessorInstanceCount: ${PREPROCESSOR_INSTANCE_COUNT:-1}
+  dataTransformer: ${PREPROCESSOR_TRANSFORMER:-api_log}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -82,12 +82,14 @@ recoveryConfig:
 
 preprocessorConfig:
   kafkaStreamConfig:
-    downstreamTopic: ${KAKFA_DOWNSTREAM_TOPIC:-test-topic-out}
     bootstrapServers: ${KAFKA_BOOTSTRAP_SERVERS:-localhost:9092}
     applicationId: ${KAFKA_APPLICATION_ID:-kaldb_preprocessor}
     numStreamThreads: ${KAFKA_STREAM_THREADS:-2}
+    processingGuarantee: ${KAFKA_STREAM_PROCESSING_GUARANTEE:-at_least_once}
   serverConfig:
     serverPort: ${KALDB_PREPROCESSOR_SERVER_PORT:-8086}
     serverAddress: ${KALDB_PREPROCESSOR_SERVER_ADDRESS:-localhost}
+  upstreamTopics: [${KAKFA_UPSTREAM_TOPICS:-test-topic}]
+  downstreamTopic: ${KAKFA_DOWNSTREAM_TOPIC:-test-topic-out}
   preprocessorInstanceCount: ${PREPROCESSOR_INSTANCE_COUNT:-1}
   dataTransformer: ${PREPROCESSOR_TRANSFORMER:-api_log}

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -18,6 +18,7 @@
         <grpc.version>1.40.1</grpc.version>
         <armeria.version>1.14.1</armeria.version>
         <micrometer.version>1.5.1</micrometer.version>
+        <kafka.version>2.5.1</kafka.version>
         <jackson.version>2.10.5</jackson.version>
         <!-- remove special databind version when jackson.version is the same -->
         <jackson.databind.version>${jackson.version}.1</jackson.databind.version>
@@ -153,7 +154,13 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>2.5.1</version>
+            <version>${kafka.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-streams</artifactId>
+            <version>${kafka.version}</version>
         </dependency>
 
         <!-- Jackson JSON parser dependencies -->

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LogWireMessage.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LogWireMessage.java
@@ -18,6 +18,12 @@ public class LogWireMessage extends Message {
   private String index;
   private String type;
 
+  /**
+   * Move all Kafka message serializers to common class
+   *
+   * @see com.slack.kaldb.preprocessor.KaldbSerdes
+   */
+  @Deprecated
   static Optional<LogWireMessage> fromJson(String jsonStr) {
     try {
       ObjectMapper objectMapper = new ObjectMapper();

--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/KaldbSerdes.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/KaldbSerdes.java
@@ -45,6 +45,35 @@ public class KaldbSerdes {
     };
   }
 
+  public static Serde<Trace.Span> TraceSpan() {
+    return new Serde<>() {
+      @Override
+      public Serializer<Trace.Span> serializer() {
+        return (topic, data) -> {
+          if (data == null) {
+            return null;
+          }
+          return data.toByteArray();
+        };
+      }
+
+      @Override
+      public Deserializer<Trace.Span> deserializer() {
+        return (topic, data) -> {
+          Trace.Span span = null;
+          if (data == null || data.length == 0) return null;
+
+          try {
+            span = Trace.Span.parseFrom(data);
+          } catch (InvalidProtocolBufferException e) {
+            LOG.error("Error parsing byte string into Trace.Span: {}", new String(data), e);
+          }
+          return span;
+        };
+      }
+    };
+  }
+
   public static Serde<Trace.ListOfSpans> TraceListOfSpans() {
     return new Serde<>() {
       @Override

--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/KaldbSerdes.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/KaldbSerdes.java
@@ -1,0 +1,76 @@
+package com.slack.kaldb.preprocessor;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.slack.service.murron.Murron;
+import com.slack.service.murron.trace.Trace;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Factory for creating Kaldb specific serializers / deserializers. Based off of
+ * org.apache.kafka.common.serialization.Serdes
+ */
+public class KaldbSerdes {
+  private static final Logger LOG = LoggerFactory.getLogger(KaldbSerdes.class);
+
+  public static Serde<Murron.MurronMessage> MurronMurronMessage() {
+    return new Serde<>() {
+      @Override
+      public Serializer<Murron.MurronMessage> serializer() {
+        return (topic, data) -> {
+          if (data == null) {
+            return null;
+          }
+          return data.toByteArray();
+        };
+      }
+
+      @Override
+      public Deserializer<Murron.MurronMessage> deserializer() {
+        return (topic, data) -> {
+          Murron.MurronMessage murronMsg = null;
+          if (data == null || data.length == 0) return null;
+
+          try {
+            murronMsg = Murron.MurronMessage.parseFrom(data);
+          } catch (InvalidProtocolBufferException e) {
+            LOG.error("Error parsing byte string into MurronMessage: {}", new String(data), e);
+          }
+          return murronMsg;
+        };
+      }
+    };
+  }
+
+  public static Serde<Trace.ListOfSpans> TraceListOfSpans() {
+    return new Serde<>() {
+      @Override
+      public Serializer<Trace.ListOfSpans> serializer() {
+        return (topic, data) -> {
+          if (data == null) {
+            return null;
+          }
+          return data.toByteArray();
+        };
+      }
+
+      @Override
+      public Deserializer<Trace.ListOfSpans> deserializer() {
+        return (topic, data) -> {
+          Trace.ListOfSpans listOfSpans = null;
+          if (data == null || data.length == 0) return null;
+
+          try {
+            listOfSpans = Trace.ListOfSpans.parseFrom(data);
+          } catch (InvalidProtocolBufferException e) {
+            LOG.error("Error parsing byte string into Trace.ListOfSpans: {}", new String(data), e);
+          }
+          return listOfSpans;
+        };
+      }
+    };
+  }
+}

--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiter.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiter.java
@@ -1,0 +1,69 @@
+package com.slack.kaldb.preprocessor;
+
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.RateLimiter;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import java.util.List;
+import javax.annotation.concurrent.ThreadSafe;
+import org.apache.kafka.streams.kstream.Predicate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The PreprocessorRateLimiter provides a thread-safe Kafka streams predicate for determining if a
+ * Kafka message should be filtered or not. Metrics are provided for visibility when a rate limiter
+ * is dropping messages.
+ */
+@ThreadSafe
+@SuppressWarnings("UnstableApiUsage")
+public class PreprocessorRateLimiter {
+  private static final Logger LOG = LoggerFactory.getLogger(PreprocessorRateLimiter.class);
+
+  private final MeterRegistry meterRegistry;
+  private final int preprocessorCount;
+
+  public static final String MESSAGES_DROPPED = "preprocessor_rate_limit_messages_dropped";
+  public static final String BYTES_DROPPED = "preprocessor_rate_limit_bytes_dropped";
+
+  public PreprocessorRateLimiter(final MeterRegistry meterRegistry, final int preprocessorCount) {
+    Preconditions.checkArgument(preprocessorCount > 0, "Preprocessor count must be greater than 0");
+
+    this.meterRegistry = meterRegistry;
+    this.preprocessorCount = preprocessorCount;
+  }
+
+  public Predicate<String, byte[]> createRateLimiter(
+      final String name, final long throughputBytes) {
+    double permitsPerSecond = (double) throughputBytes / preprocessorCount;
+    LOG.info(
+        "Rate limiter initialized for {} at {} bytes per second (target throughput {} / processorCount {})",
+        name,
+        permitsPerSecond,
+        throughputBytes,
+        preprocessorCount);
+    RateLimiter rateLimiter = RateLimiter.create(permitsPerSecond);
+
+    Iterable<Tag> tags = List.of(Tag.of("service", name));
+    Counter messagesDropped = meterRegistry.counter(MESSAGES_DROPPED, tags);
+    Counter bytesDropped = meterRegistry.counter(BYTES_DROPPED, tags);
+
+    return (String key, byte[] value) -> {
+      if (value == null || value.length == 0) {
+        return true;
+      } else if (rateLimiter.tryAcquire(value.length)) {
+        return true;
+      } else {
+        messagesDropped.increment();
+        bytesDropped.increment(value.length);
+        LOG.warn(
+            "Message was dropped from topic {} due to rate limiting ({} bytes per second), wanted {} bytes",
+            name,
+            permitsPerSecond,
+            value.length);
+        return false;
+      }
+    };
+  }
+}

--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorService.java
@@ -1,0 +1,249 @@
+package com.slack.kaldb.preprocessor;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
+
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.slack.kaldb.metadata.service.ServiceMetadata;
+import com.slack.kaldb.metadata.service.ServiceMetadataStore;
+import com.slack.kaldb.metadata.service.ServicePartitionMetadata;
+import com.slack.kaldb.proto.config.KaldbConfigs;
+import com.slack.service.murron.trace.Trace;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.kafka.KafkaStreamsMetrics;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.ValueMapper;
+import org.apache.kafka.streams.processor.StreamPartitioner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The PreprocessorService consumes from multiple upstream topics, applies rate limiting, transforms
+ * the data format, and then writes out the new message to a common downstream topic targeting
+ * specific partitions. The upstream topic information, rate limits, and target partitions are read
+ * in via the ServiceMetadataStore, and the common output topic and transforms are stored via a
+ * service config.
+ */
+public class PreprocessorService extends AbstractIdleService {
+  private static final Logger LOG = LoggerFactory.getLogger(PreprocessorService.class);
+  private static final long MAX_TIME = Long.MAX_VALUE;
+
+  private final ServiceMetadataStore serviceMetadataStore;
+  private final PreprocessorRateLimiter rateLimiter;
+  private final Properties kafkaProperties;
+  private final String downstreamTopic;
+  private final String dataTransformer;
+  private final MeterRegistry meterRegistry;
+
+  private KafkaStreams kafkaStreams;
+  private KafkaStreamsMetrics kafkaStreamsMetrics;
+
+  private final Counter configReloadCounter;
+  public static final String CONFIG_RELOAD_COUNTER = "preprocessor_config_reload_counter";
+
+  public PreprocessorService(
+      ServiceMetadataStore serviceMetadataStore,
+      KaldbConfigs.PreprocessorConfig preprocessorConfig,
+      MeterRegistry meterRegistry) {
+    this.serviceMetadataStore = serviceMetadataStore;
+    this.meterRegistry = meterRegistry;
+    this.configReloadCounter = meterRegistry.counter(CONFIG_RELOAD_COUNTER);
+
+    this.kafkaProperties = makeKafkaStreamsProps(preprocessorConfig.getKafkaStreamConfig());
+    this.downstreamTopic = preprocessorConfig.getKafkaStreamConfig().getDownstreamTopic();
+    this.dataTransformer = preprocessorConfig.getDataTransformer();
+    this.rateLimiter =
+        new PreprocessorRateLimiter(
+            meterRegistry, preprocessorConfig.getPreprocessorInstanceCount());
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    LOG.info("Starting preprocessor service");
+    load();
+    serviceMetadataStore.addListener(this::load);
+    LOG.info("Preprocessor service started");
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    LOG.info("Stopping preprocessor service");
+    if (kafkaStreams != null) {
+      kafkaStreams.close(DEFAULT_START_STOP_DURATION);
+    }
+    if (kafkaStreamsMetrics != null) {
+      kafkaStreamsMetrics.close();
+    }
+    serviceMetadataStore.removeListener(this::load);
+    LOG.info("Preprocessor service closed");
+  }
+
+  /**
+   * Configures and starts a KafkaStream processor, based off of the cached ServiceMetadataStore.
+   * This method is reentrant, and will restart any existing KafkaStream processors. Access to this
+   * must be synchronized if using this method as part of a listener.
+   */
+  public synchronized void load() {
+    configReloadCounter.increment();
+    LOG.info("Loading new Kafka stream processor config");
+    if (kafkaStreams != null) {
+      LOG.info("Closing existing Kafka stream processor");
+      kafkaStreams.close();
+      kafkaStreams.cleanUp();
+    }
+    if (kafkaStreamsMetrics != null) {
+      kafkaStreamsMetrics.close();
+    }
+
+    // only attempt to register stream processing on valid service configurations
+    List<ServiceMetadata> serviceMetadataToProcess =
+        filterValidServiceMetadata(serviceMetadataStore.listSync());
+
+    if (serviceMetadataToProcess.size() > 0) {
+      Topology topology =
+          buildTopology(serviceMetadataToProcess, rateLimiter, downstreamTopic, dataTransformer);
+      kafkaStreams = new KafkaStreams(topology, kafkaProperties);
+      kafkaStreamsMetrics = new KafkaStreamsMetrics(kafkaStreams);
+      kafkaStreamsMetrics.bindTo(meterRegistry);
+      kafkaStreams.start();
+      LOG.info("Kafka stream processor config loaded successfully");
+    } else {
+      LOG.info(
+          "No valid service configurations found to process - will retry on next service configuration update");
+    }
+  }
+
+  /**
+   * Builds a KafkaStream Topology with multiple source topics, targeting a single sink. Applies
+   * rate limits per-service if required, and uses the service configured target topic sink and data
+   * transformer.
+   */
+  protected static Topology buildTopology(
+      List<ServiceMetadata> serviceMetadataList,
+      PreprocessorRateLimiter rateLimiter,
+      String downstreamTopic,
+      String dataTransformer) {
+    Preconditions.checkArgument(
+        !serviceMetadataList.isEmpty(), "service metadata list must not be empty");
+    Preconditions.checkArgument(!downstreamTopic.isEmpty(), "downstream topic must not be empty");
+    Preconditions.checkArgument(!dataTransformer.isEmpty(), "data transformer must not be empty");
+
+    StreamsBuilder builder = new StreamsBuilder();
+    ValueMapper<byte[], Trace.ListOfSpans> valueMapper =
+        PreprocessorValueMapper.byteArrayToTraceListOfSpans(dataTransformer);
+    serviceMetadataList.forEach(
+        (serviceMetadata ->
+            builder
+                .stream(
+                    serviceMetadata.getName(), Consumed.with(Serdes.String(), Serdes.ByteArray()))
+                .filter(
+                    rateLimiter.createRateLimiter(
+                        serviceMetadata.getName(), serviceMetadata.getThroughputBytes()))
+                .mapValues(valueMapper)
+                .filter((key, listOfSpans) -> listOfSpans != null)
+                .peek(
+                    (key, listOfSpans) ->
+                        LOG.debug(
+                            "Processed key/record {}/{} from topic {} to topic {}",
+                            key,
+                            listOfSpans.toString(),
+                            serviceMetadata.getName(),
+                            downstreamTopic))
+                .to(
+                    downstreamTopic,
+                    Produced.with(
+                        Serdes.String(),
+                        KaldbSerdes.TraceListOfSpans(),
+                        streamPartitioner(getActivePartitionList(serviceMetadata))))));
+
+    return builder.build();
+  }
+
+  /**
+   * Filters the provided list of service metadata to those that are valid. This includes correctly
+   * defined throughput and partition configurations.
+   */
+  protected static List<ServiceMetadata> filterValidServiceMetadata(
+      List<ServiceMetadata> serviceMetadataList) {
+    return serviceMetadataList
+        .stream()
+        .filter(serviceMetadata -> serviceMetadata.getThroughputBytes() > 0)
+        .filter(serviceMetadata -> getActivePartitionList(serviceMetadata).size() > 0)
+        .collect(Collectors.toList());
+  }
+
+  /** Gets the active list of partitions from the provided service metadata */
+  protected static List<Integer> getActivePartitionList(ServiceMetadata serviceMetadata) {
+    Optional<ServicePartitionMetadata> servicePartitionMetadata =
+        serviceMetadata
+            .getPartitionConfigs()
+            .stream()
+            .filter(partitionMetadata -> partitionMetadata.getEndTimeEpochMs() == MAX_TIME)
+            .findFirst();
+
+    if (servicePartitionMetadata.isEmpty()) {
+      return Collections.emptyList();
+    }
+    return servicePartitionMetadata
+        .get()
+        .getPartitions()
+        .stream()
+        .map(java.lang.Integer::parseInt)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Returns a StreamPartitioner that selects from the provided list of partitions. If no valid
+   * partitions are provided throws an exception.
+   */
+  protected static StreamPartitioner<Object, Object> streamPartitioner(List<Integer> partitions) {
+    checkArgument(partitions.size() > 0, "Invalid partition list provided, had no partitions");
+    checkArgument(
+        partitions.stream().noneMatch(integer -> integer < 0),
+        "All partitions must be positive, non-null values");
+    return (topic, key, value, partitionCount) ->
+        partitions.get(ThreadLocalRandom.current().nextInt(partitions.size()));
+  }
+
+  /** Builds a Properties hashtable using the provided config, and sensible defaults */
+  protected static Properties makeKafkaStreamsProps(
+      KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig) {
+    Preconditions.checkArgument(
+        !kafkaStreamConfig.getApplicationId().isEmpty(),
+        "Kafka stream applicationId must be provided");
+    Preconditions.checkArgument(
+        !kafkaStreamConfig.getBootstrapServers().isEmpty(),
+        "Kafka stream bootstrapServers must be provided");
+    Preconditions.checkArgument(
+        kafkaStreamConfig.getNumStreamThreads() > 0,
+        "Kafka stream numStreamThreads must be greater than 0");
+
+    Properties props = new Properties();
+
+    props.put(StreamsConfig.APPLICATION_ID_CONFIG, kafkaStreamConfig.getApplicationId());
+    props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaStreamConfig.getBootstrapServers());
+    props.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, kafkaStreamConfig.getNumStreamThreads());
+
+    // todo - expose this as an option for users to configure?
+    // This will allow parallel processing up to the amount of upstream partitions. You cannot have
+    // more threads than you have upstreams due to how the work is partitioned
+    // @see StreamsConfig.EXACTLY_ONCE
+    props.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.AT_LEAST_ONCE);
+
+    return props;
+  }
+}

--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorValueMapper.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorValueMapper.java
@@ -1,0 +1,63 @@
+package com.slack.kaldb.preprocessor;
+
+import static com.slack.kaldb.writer.LogMessageWriterImpl.toMurronMessage;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.slack.kaldb.writer.ApiLogFormatter;
+import com.slack.kaldb.writer.SpanFormatter;
+import com.slack.service.murron.Murron;
+import com.slack.service.murron.trace.Trace;
+import java.util.Map;
+import org.apache.kafka.streams.kstream.ValueMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * KafkaStream value mappers for transforming upstream byte array messages into Trace.ListOfSpans.
+ */
+public class PreprocessorValueMapper {
+  private static final Logger LOG = LoggerFactory.getLogger(PreprocessorValueMapper.class);
+
+  @FunctionalInterface
+  private interface MessageTransformer {
+    Trace.ListOfSpans toTraceSpan(byte[] record) throws Exception;
+  }
+
+  // An apiLog message is a json blob wrapped in a murron message.
+  public static final MessageTransformer apiLogTransformer =
+      record -> {
+        final Murron.MurronMessage murronMsg = toMurronMessage(record);
+        Trace.Span apiSpan = ApiLogFormatter.toSpan(murronMsg);
+        return Trace.ListOfSpans.newBuilder().addSpans(apiSpan).build();
+      };
+
+  // A single trace record consists of a list of spans wrapped in a murron message.
+  public static final MessageTransformer spanTransformer =
+      record -> {
+        Murron.MurronMessage murronMsg = toMurronMessage(record);
+        return SpanFormatter.fromMurronMessage(murronMsg);
+      };
+
+  // todo - add a json blob transformer, ie LogMessageWriterImpl.jsonLogMessageTransformer
+
+  private static final Map<String, MessageTransformer> DATA_TRANSFORMER_MAP =
+      ImmutableMap.of("api_log", apiLogTransformer, "spans", spanTransformer);
+
+  /** KafkaStream ValueMapper for transforming upstream sources to target Trace.ListOfSpans */
+  public static ValueMapper<byte[], Trace.ListOfSpans> byteArrayToTraceListOfSpans(
+      String dataTransformer) {
+    Preconditions.checkArgument(
+        DATA_TRANSFORMER_MAP.containsKey(dataTransformer),
+        "Invalid data transformer provided, must be one of {}",
+        DATA_TRANSFORMER_MAP.toString());
+    return messageBytes -> {
+      try {
+        return DATA_TRANSFORMER_MAP.get(dataTransformer).toTraceSpan(messageBytes);
+      } catch (Exception e) {
+        LOG.error("Error converting byte array to Trace.ListOfSpans", e);
+        return null;
+      }
+    };
+  }
+}

--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorValueMapper.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorValueMapper.java
@@ -8,35 +8,36 @@ import com.slack.kaldb.writer.ApiLogFormatter;
 import com.slack.kaldb.writer.SpanFormatter;
 import com.slack.service.murron.Murron;
 import com.slack.service.murron.trace.Trace;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.apache.kafka.streams.kstream.ValueMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * KafkaStream value mappers for transforming upstream byte array messages into Trace.ListOfSpans.
+ * KafkaStream value mappers for transforming upstream byte array messages into Iterable<Trace.Span>
  */
 public class PreprocessorValueMapper {
   private static final Logger LOG = LoggerFactory.getLogger(PreprocessorValueMapper.class);
 
   @FunctionalInterface
   private interface MessageTransformer {
-    Trace.ListOfSpans toTraceSpan(byte[] record) throws Exception;
+    List<Trace.Span> toTraceSpans(byte[] record) throws Exception;
   }
 
   // An apiLog message is a json blob wrapped in a murron message.
   public static final MessageTransformer apiLogTransformer =
       record -> {
         final Murron.MurronMessage murronMsg = toMurronMessage(record);
-        Trace.Span apiSpan = ApiLogFormatter.toSpan(murronMsg);
-        return Trace.ListOfSpans.newBuilder().addSpans(apiSpan).build();
+        return List.of(ApiLogFormatter.toSpan(murronMsg));
       };
 
   // A single trace record consists of a list of spans wrapped in a murron message.
   public static final MessageTransformer spanTransformer =
       record -> {
         Murron.MurronMessage murronMsg = toMurronMessage(record);
-        return SpanFormatter.fromMurronMessage(murronMsg);
+        return SpanFormatter.fromMurronMessage(murronMsg).getSpansList();
       };
 
   // todo - add a json blob transformer, ie LogMessageWriterImpl.jsonLogMessageTransformer
@@ -44,8 +45,25 @@ public class PreprocessorValueMapper {
   private static final Map<String, MessageTransformer> DATA_TRANSFORMER_MAP =
       ImmutableMap.of("api_log", apiLogTransformer, "spans", spanTransformer);
 
+  /** Span key for KeyValue pair to use as the service name */
+  public static String SERVICE_NAME_KEY = "service_name";
+
+  /**
+   * Helper method to extract the service name from a Span
+   *
+   * <p>todo - consider putting the service name into a top-level Trace.Span property
+   */
+  public static String getServiceName(Trace.Span span) {
+    return span.getTagsList()
+        .stream()
+        .filter(tag -> tag.getKey().equals(SERVICE_NAME_KEY))
+        .map(Trace.KeyValue::getVStr)
+        .findFirst()
+        .orElse(null);
+  }
+
   /** KafkaStream ValueMapper for transforming upstream sources to target Trace.ListOfSpans */
-  public static ValueMapper<byte[], Trace.ListOfSpans> byteArrayToTraceListOfSpans(
+  public static ValueMapper<byte[], Iterable<Trace.Span>> byteArrayToTraceSpans(
       String dataTransformer) {
     Preconditions.checkArgument(
         DATA_TRANSFORMER_MAP.containsKey(dataTransformer),
@@ -53,10 +71,10 @@ public class PreprocessorValueMapper {
         DATA_TRANSFORMER_MAP.toString());
     return messageBytes -> {
       try {
-        return DATA_TRANSFORMER_MAP.get(dataTransformer).toTraceSpan(messageBytes);
+        return DATA_TRANSFORMER_MAP.get(dataTransformer).toTraceSpans(messageBytes);
       } catch (Exception e) {
         LOG.error("Error converting byte array to Trace.ListOfSpans", e);
-        return null;
+        return Collections.emptyList();
       }
     };
   }

--- a/kaldb/src/main/java/com/slack/kaldb/server/KaldbConfig.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/KaldbConfig.java
@@ -97,7 +97,9 @@ public class KaldbConfig {
           "spans",
           LogMessageWriterImpl.spanTransformer,
           "json",
-          LogMessageWriterImpl.jsonLogMessageTransformer);
+          LogMessageWriterImpl.jsonLogMessageTransformer,
+          "trace_list_of_spans",
+          LogMessageWriterImpl.traceListOfSpansTransformer);
 
   public static void validateDataTransformerConfig(String dataTransformerConfig) {
     checkArgument(

--- a/kaldb/src/main/java/com/slack/kaldb/server/KaldbConfig.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/KaldbConfig.java
@@ -98,8 +98,8 @@ public class KaldbConfig {
           LogMessageWriterImpl.spanTransformer,
           "json",
           LogMessageWriterImpl.jsonLogMessageTransformer,
-          "trace_list_of_spans",
-          LogMessageWriterImpl.traceListOfSpansTransformer);
+          "trace_span",
+          LogMessageWriterImpl.traceSpanTransformer);
 
   public static void validateDataTransformerConfig(String dataTransformerConfig) {
     checkArgument(

--- a/kaldb/src/main/java/com/slack/kaldb/writer/LogMessageWriterImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/LogMessageWriterImpl.java
@@ -78,10 +78,11 @@ public class LogMessageWriterImpl implements MessageWriter {
         return msg.map(List::of).orElse(Collections.emptyList());
       };
 
-  // A protobuf Trace.ListOfSpans
-  public static final LogMessageTransformer traceListOfSpansTransformer =
+  // A protobuf Trace.Span
+  public static final LogMessageTransformer traceSpanTransformer =
       (ConsumerRecord<String, byte[]> record) -> {
-        final Trace.ListOfSpans listOfSpans = Trace.ListOfSpans.parseFrom(record.value());
+        final Trace.Span span = Trace.Span.parseFrom(record.value());
+        final Trace.ListOfSpans listOfSpans = Trace.ListOfSpans.newBuilder().addSpans(span).build();
         return SpanFormatter.toLogMessage(listOfSpans);
       };
 

--- a/kaldb/src/main/java/com/slack/kaldb/writer/LogMessageWriterImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/LogMessageWriterImpl.java
@@ -78,6 +78,13 @@ public class LogMessageWriterImpl implements MessageWriter {
         return msg.map(List::of).orElse(Collections.emptyList());
       };
 
+  // A protobuf Trace.ListOfSpans
+  public static final LogMessageTransformer traceListOfSpansTransformer =
+      (ConsumerRecord<String, byte[]> record) -> {
+        final Trace.ListOfSpans listOfSpans = Trace.ListOfSpans.parseFrom(record.value());
+        return SpanFormatter.toLogMessage(listOfSpans);
+      };
+
   private final IndexingChunkManager<LogMessage> chunkManager;
   private final LogMessageTransformer dataTransformer;
 
@@ -114,6 +121,12 @@ public class LogMessageWriterImpl implements MessageWriter {
     return true;
   }
 
+  /**
+   * Move all Kafka message serializers to common class
+   *
+   * @see com.slack.kaldb.preprocessor.KaldbSerdes
+   */
+  @Deprecated
   public static Murron.MurronMessage toMurronMessage(byte[] recordStr) {
     Murron.MurronMessage murronMsg = null;
     if (recordStr == null || recordStr.length == 0) return null;

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -11,6 +11,7 @@ enum NodeRole {
   CACHE = 2;
   MANAGER = 3;
   RECOVERY = 4;
+  PREPROCESSOR = 5;
 };
 
 // KalDb is a single binary consisting of multiple components.
@@ -27,9 +28,12 @@ message KaldbConfig {
   CacheConfig cache_config = 8;
   ManagerConfig manager_config = 9;
   RecoveryConfig recovery_config = 10;
+  PreprocessorConfig preprocessor_config = 11;
 }
 
-// Configuration for Kafka producer and consumer.
+// todo - move this to a nested IndexerConfig message, and refactor as KafkaConsumerConfig
+// todo - this is only ever used by the indexer and should have reduced visibility
+// Configuration for Kafka consumer.
 message KafkaConfig {
   string kafka_topic = 1;
   string kafka_topic_partition = 2;
@@ -163,4 +167,25 @@ message ManagerConfig {
 // Config for the recovery node.
 message RecoveryConfig {
   ServerConfig server_config = 1;
+}
+
+// Config for the preprocessor node.
+message PreprocessorConfig {
+  // Configuration for the kafka stream processor
+  message KafkaStreamConfig {
+    string downstream_topic = 1;
+    string bootstrap_servers = 2;
+    string application_id = 3;
+    int32 num_stream_threads = 4;
+  }
+
+  ServerConfig server_config = 1;
+  KafkaStreamConfig kafka_stream_config = 2;
+
+  // The number of preprocessor instances
+  // Used for calculating target throughput per instance
+  int32 preprocessor_instance_count = 3;
+
+  // Name of the data transformation pipeline to use when ingesting the data.
+  string data_transformer = 4;
 }

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -173,19 +173,29 @@ message RecoveryConfig {
 message PreprocessorConfig {
   // Configuration for the kafka stream processor
   message KafkaStreamConfig {
-    string downstream_topic = 1;
-    string bootstrap_servers = 2;
-    string application_id = 3;
-    int32 num_stream_threads = 4;
+    string bootstrap_servers = 1;
+    // An identifier for the stream processing application. Must be unique within the Kafka cluster
+    string application_id = 2;
+    // The number of threads to execute stream processing
+    int32 num_stream_threads = 3;
+    // This will allow parallel processing up to the amount of upstream partitions. You cannot have
+    // more threads than you have upstreams due to how the work is partitioned. E
+    string processing_guarantee = 4;
   }
 
   ServerConfig server_config = 1;
   KafkaStreamConfig kafka_stream_config = 2;
 
-  // The number of preprocessor instances
-  // Used for calculating target throughput per instance
-  int32 preprocessor_instance_count = 3;
+  // Upstream topics to consume from
+  repeated string upstream_topics = 3;
+
+  // Downstream topic to write to
+  string downstream_topic = 4;
 
   // Name of the data transformation pipeline to use when ingesting the data.
-  string data_transformer = 4;
+  string data_transformer = 5;
+
+  // The number of preprocessor instances
+  // Used for calculating target throughput per instance
+  int32 preprocessor_instance_count = 6;
 }

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/SnapshotDeletionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/SnapshotDeletionServiceTest.java
@@ -663,7 +663,7 @@ public class SnapshotDeletionServiceTest {
     int deletesRetry = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
     assertThat(deletesRetry).isEqualTo(1);
 
-    assertThat(snapshotMetadataStore.getCached().size()).isEqualTo(0);
+    await().until(() -> snapshotMetadataStore.getCached().size() == 0);
     // delete was called once before - should still be only once
     verify(s3BlobFs, times(1)).delete(any(), anyBoolean());
     assertThat(s3BlobFs.listFiles(directoryPath, true)).isEmpty();

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/KaldbSerdesTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/KaldbSerdesTest.java
@@ -1,0 +1,114 @@
+package com.slack.kaldb.preprocessor;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.google.protobuf.ByteString;
+import com.slack.service.murron.Murron;
+import com.slack.service.murron.trace.Trace;
+import java.time.Instant;
+import org.apache.kafka.common.serialization.Serde;
+import org.junit.Test;
+
+public class KaldbSerdesTest {
+
+  @Test
+  public void shouldSerializeAndDeserializeMurronMessage() {
+    Serde<Murron.MurronMessage> serdes = KaldbSerdes.MurronMurronMessage();
+
+    String topic = "topic";
+    String message = "hello message";
+    String host = "host";
+    String type = "type";
+    long timestamp = Instant.now().toEpochMilli();
+
+    Murron.MurronMessage messageToSerialize =
+        Murron.MurronMessage.newBuilder()
+            .setMessage(ByteString.copyFromUtf8(message))
+            .setHost(host)
+            .setType(type)
+            .setTimestamp(timestamp)
+            .build();
+
+    byte[] serializedBytes = serdes.serializer().serialize(topic, messageToSerialize);
+    Murron.MurronMessage deserializedMessage =
+        serdes.deserializer().deserialize(topic, serializedBytes);
+
+    assertThat(deserializedMessage.getMessage()).isEqualTo(ByteString.copyFromUtf8(message));
+    assertThat(deserializedMessage.getHost()).isEqualTo(host);
+    assertThat(deserializedMessage.getType()).isEqualTo(type);
+    assertThat(timestamp).isEqualTo(timestamp);
+  }
+
+  @Test
+  public void shouldSerializeAndDeserializeMurronMessageNullsCorrectly() {
+    Serde<Murron.MurronMessage> serdes = KaldbSerdes.MurronMurronMessage();
+
+    byte[] serializedBytes = serdes.serializer().serialize("topic", null);
+    assertThat(serializedBytes).isNull();
+
+    Murron.MurronMessage deserializedMessage = serdes.deserializer().deserialize("topic", null);
+    assertThat(deserializedMessage).isNull();
+  }
+
+  @Test
+  public void shouldSerializeAndDeserializeTraceListOfSpans() {
+    Serde<Trace.ListOfSpans> serdes = KaldbSerdes.TraceListOfSpans();
+
+    String topic = "topic";
+    String id = "id";
+    String traceId = "traceId";
+    String name = "name";
+    long timestamp = Instant.now().toEpochMilli() * 1000;
+    long duration = 10;
+    Trace.Span span =
+        Trace.Span.newBuilder()
+            .setId(ByteString.copyFromUtf8(id))
+            .setTraceId(ByteString.copyFromUtf8(traceId))
+            .setName(name)
+            .setStartTimestampMicros(timestamp)
+            .setDurationMicros(duration)
+            .build();
+    Trace.ListOfSpans listOfSpans = Trace.ListOfSpans.newBuilder().addSpans(span).build();
+
+    byte[] serializedBytes = serdes.serializer().serialize(topic, listOfSpans);
+    Trace.ListOfSpans deserializedMessage =
+        serdes.deserializer().deserialize(topic, serializedBytes);
+
+    assertThat(deserializedMessage.getSpansList().size()).isEqualTo(1);
+    assertThat(deserializedMessage.getTagsList().size()).isEqualTo(0);
+
+    assertThat(deserializedMessage.getSpansList().get(0).getId())
+        .isEqualTo(ByteString.copyFromUtf8(id));
+    assertThat(deserializedMessage.getSpansList().get(0).getTraceId())
+        .isEqualTo(ByteString.copyFromUtf8(traceId));
+    assertThat(deserializedMessage.getSpansList().get(0).getName()).isEqualTo(name);
+    assertThat(deserializedMessage.getSpansList().get(0).getStartTimestampMicros())
+        .isEqualTo(timestamp);
+    assertThat(deserializedMessage.getSpansList().get(0).getDurationMicros()).isEqualTo(duration);
+    assertThat(deserializedMessage.getSpansList().get(0).getTagsList().size()).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldSerializeAndDeserializeTraceListOfSpansNullsCorrectly() {
+    Serde<Trace.ListOfSpans> serdes = KaldbSerdes.TraceListOfSpans();
+
+    byte[] serializedBytes = serdes.serializer().serialize("topic", null);
+    assertThat(serializedBytes).isNull();
+
+    Trace.ListOfSpans deserializedMessage = serdes.deserializer().deserialize("topic", null);
+    assertThat(deserializedMessage).isNull();
+  }
+
+  @Test
+  public void shouldGracefullyHandleWrongMessageTypes() {
+    byte[] malformedData = "malformed data".getBytes();
+
+    Trace.ListOfSpans deserializedTraceListOfSpans =
+        KaldbSerdes.TraceListOfSpans().deserializer().deserialize("topic", malformedData);
+    assertThat(deserializedTraceListOfSpans).isEqualTo(null);
+
+    Murron.MurronMessage deserializedMurronMessage =
+        KaldbSerdes.MurronMurronMessage().deserializer().deserialize("topic", malformedData);
+    assertThat(deserializedMurronMessage).isEqualTo(null);
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiterTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiterTest.java
@@ -2,12 +2,14 @@ package com.slack.kaldb.preprocessor;
 
 import static com.slack.kaldb.preprocessor.PreprocessorRateLimiter.BYTES_DROPPED;
 import static com.slack.kaldb.preprocessor.PreprocessorRateLimiter.MESSAGES_DROPPED;
+import static com.slack.kaldb.preprocessor.PreprocessorValueMapper.SERVICE_NAME_KEY;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-import com.slack.kaldb.testlib.MetricsUtil;
+import com.slack.service.murron.trace.Trace;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.Map;
 import org.apache.kafka.streams.kstream.Predicate;
 import org.junit.Test;
 
@@ -21,24 +23,80 @@ public class PreprocessorRateLimiterTest {
         new PreprocessorRateLimiter(meterRegistry, preprocessorCount);
 
     String name = "rateLimiter";
-    long targetThroughput = 1000;
-    Predicate<String, byte[]> predicate = rateLimiter.createRateLimiter(name, targetThroughput);
+    Trace.Span span =
+        Trace.Span.newBuilder()
+            .addTags(Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(name).build())
+            .build();
+
+    // set the target so that we pass the first add, then fail the second
+    long targetThroughput = ((long) span.toByteArray().length * preprocessorCount) + 1;
+    Predicate<String, Trace.Span> predicate =
+        rateLimiter.createRateLimiter(Map.of(name, targetThroughput));
 
     // try to get just below the scaled limit, then try to go over
-    assertThat(predicate.test("key", new byte[Math.round((float) targetThroughput / 2 - 1)]))
-        .isTrue();
-    assertThat(predicate.test("key", new byte[10])).isFalse();
+    assertThat(predicate.test("key", span)).isTrue();
+    assertThat(predicate.test("key", span)).isFalse();
 
     // rate limit is targetThroughput per second, so 1 second should refill our limit
     Thread.sleep(1000);
 
     // try to get just below the scaled limit, then try to go over
-    assertThat(predicate.test("key", new byte[Math.round((float) targetThroughput / 2 - 1)]))
-        .isTrue();
-    assertThat(predicate.test("key", new byte[10])).isFalse();
+    assertThat(predicate.test("key", span)).isTrue();
+    assertThat(predicate.test("key", span)).isFalse();
 
-    assertThat(MetricsUtil.getCount(MESSAGES_DROPPED, meterRegistry)).isEqualTo(2);
-    assertThat(MetricsUtil.getCount(BYTES_DROPPED, meterRegistry)).isEqualTo(20);
+    assertThat(
+            meterRegistry
+                .get(MESSAGES_DROPPED)
+                .tag("reason", String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
+                .counter()
+                .count())
+        .isEqualTo(2);
+    assertThat(
+            meterRegistry
+                .get(BYTES_DROPPED)
+                .tag("reason", String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
+                .counter()
+                .count())
+        .isEqualTo(span.toByteArray().length * 2);
+  }
+
+  @Test
+  public void shouldDropMessagesWithNoConfiguration() {
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    PreprocessorRateLimiter rateLimiter = new PreprocessorRateLimiter(meterRegistry, 1);
+
+    Trace.Span span =
+        Trace.Span.newBuilder()
+            .addTags(
+                Trace.KeyValue.newBuilder()
+                    .setKey(SERVICE_NAME_KEY)
+                    .setVStr("unprovisioned_service")
+                    .build())
+            .build();
+    Predicate<String, Trace.Span> predicate =
+        rateLimiter.createRateLimiter(Map.of("provisioned_service", Long.MAX_VALUE));
+
+    // this should be immediately dropped
+    assertThat(predicate.test("key", span)).isFalse();
+
+    assertThat(
+            meterRegistry
+                .get(MESSAGES_DROPPED)
+                .tag(
+                    "reason",
+                    String.valueOf(PreprocessorRateLimiter.MessageDropReason.NOT_PROVISIONED))
+                .counter()
+                .count())
+        .isEqualTo(1);
+    assertThat(
+            meterRegistry
+                .get(BYTES_DROPPED)
+                .tag(
+                    "reason",
+                    String.valueOf(PreprocessorRateLimiter.MessageDropReason.NOT_PROVISIONED))
+                .counter()
+                .count())
+        .isEqualTo(span.toByteArray().length);
   }
 
   @Test
@@ -50,10 +108,11 @@ public class PreprocessorRateLimiterTest {
 
     String name = "rateLimiter";
     long targetThroughput = 1000;
-    Predicate<String, byte[]> predicate = rateLimiter.createRateLimiter(name, targetThroughput);
+    Predicate<String, Trace.Span> predicate =
+        rateLimiter.createRateLimiter(Map.of(name, targetThroughput));
 
-    assertThat(predicate.test("key", new byte[0])).isTrue();
-    assertThat(predicate.test("key", null)).isTrue();
+    assertThat(predicate.test("key", Trace.Span.newBuilder().build())).isFalse();
+    assertThat(predicate.test("key", null)).isFalse();
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiterTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiterTest.java
@@ -1,0 +1,65 @@
+package com.slack.kaldb.preprocessor;
+
+import static com.slack.kaldb.preprocessor.PreprocessorRateLimiter.BYTES_DROPPED;
+import static com.slack.kaldb.preprocessor.PreprocessorRateLimiter.MESSAGES_DROPPED;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.slack.kaldb.testlib.MetricsUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.kafka.streams.kstream.Predicate;
+import org.junit.Test;
+
+public class PreprocessorRateLimiterTest {
+
+  @Test
+  public void shouldApplyScaledRateLimit() throws InterruptedException {
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    int preprocessorCount = 2;
+    PreprocessorRateLimiter rateLimiter =
+        new PreprocessorRateLimiter(meterRegistry, preprocessorCount);
+
+    String name = "rateLimiter";
+    long targetThroughput = 1000;
+    Predicate<String, byte[]> predicate = rateLimiter.createRateLimiter(name, targetThroughput);
+
+    // try to get just below the scaled limit, then try to go over
+    assertThat(predicate.test("key", new byte[Math.round((float) targetThroughput / 2 - 1)]))
+        .isTrue();
+    assertThat(predicate.test("key", new byte[10])).isFalse();
+
+    // rate limit is targetThroughput per second, so 1 second should refill our limit
+    Thread.sleep(1000);
+
+    // try to get just below the scaled limit, then try to go over
+    assertThat(predicate.test("key", new byte[Math.round((float) targetThroughput / 2 - 1)]))
+        .isTrue();
+    assertThat(predicate.test("key", new byte[10])).isFalse();
+
+    assertThat(MetricsUtil.getCount(MESSAGES_DROPPED, meterRegistry)).isEqualTo(2);
+    assertThat(MetricsUtil.getCount(BYTES_DROPPED, meterRegistry)).isEqualTo(20);
+  }
+
+  @Test
+  public void shouldHandleEmptyMessages() {
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    int preprocessorCount = 1;
+    PreprocessorRateLimiter rateLimiter =
+        new PreprocessorRateLimiter(meterRegistry, preprocessorCount);
+
+    String name = "rateLimiter";
+    long targetThroughput = 1000;
+    Predicate<String, byte[]> predicate = rateLimiter.createRateLimiter(name, targetThroughput);
+
+    assertThat(predicate.test("key", new byte[0])).isTrue();
+    assertThat(predicate.test("key", null)).isTrue();
+  }
+
+  @Test
+  public void shouldThrowOnInvalidConfigurations() {
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> new PreprocessorRateLimiter(meterRegistry, 0));
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
@@ -1,0 +1,233 @@
+package com.slack.kaldb.preprocessor;
+
+import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.slack.kaldb.metadata.service.ServiceMetadata;
+import com.slack.kaldb.metadata.service.ServiceMetadataStore;
+import com.slack.kaldb.metadata.service.ServicePartitionMetadata;
+import com.slack.kaldb.metadata.zookeeper.MetadataStore;
+import com.slack.kaldb.metadata.zookeeper.ZookeeperMetadataStoreImpl;
+import com.slack.kaldb.proto.config.KaldbConfigs;
+import com.slack.kaldb.testlib.MetricsUtil;
+import com.slack.kaldb.testlib.TestKafkaServer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Properties;
+import org.apache.curator.test.TestingServer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PreprocessorServiceIntegrationTest {
+
+  private TestKafkaServer kafkaServer;
+  private TestingServer zkServer;
+
+  @Before
+  public void setUp() throws Exception {
+    zkServer = new TestingServer();
+    kafkaServer = new TestKafkaServer();
+  }
+
+  @After
+  public void teardown() throws Exception {
+    kafkaServer.close();
+    zkServer.close();
+  }
+
+  @Test
+  public void shouldLoadConfigOnStartAndReloadOnMetadataChange() throws Exception {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    KaldbConfigs.ZookeeperConfig zkConfig =
+        KaldbConfigs.ZookeeperConfig.newBuilder()
+            .setZkConnectString(zkServer.getConnectString())
+            .setZkPathPrefix("test")
+            .setZkSessionTimeoutMs(30000)
+            .setZkConnectionTimeoutMs(30000)
+            .setSleepBetweenRetriesMs(30000)
+            .build();
+    MetadataStore metadataStore = ZookeeperMetadataStoreImpl.fromConfig(meterRegistry, zkConfig);
+    ServiceMetadataStore serviceMetadataStore = new ServiceMetadataStore(metadataStore, true);
+
+    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+            .setApplicationId("applicationId")
+            .setBootstrapServers(kafkaServer.getBroker().getBrokerList().get())
+            .setNumStreamThreads(1)
+            .build();
+    KaldbConfigs.ServerConfig serverConfig =
+        KaldbConfigs.ServerConfig.newBuilder()
+            .setServerPort(8080)
+            .setServerAddress("localhost")
+            .build();
+    KaldbConfigs.PreprocessorConfig preprocessorConfig =
+        KaldbConfigs.PreprocessorConfig.newBuilder()
+            .setKafkaStreamConfig(kafkaStreamConfig)
+            .setServerConfig(serverConfig)
+            .setPreprocessorInstanceCount(1)
+            .setDataTransformer("api_log")
+            .build();
+
+    PreprocessorService preprocessorService =
+        new PreprocessorService(serviceMetadataStore, preprocessorConfig, meterRegistry);
+
+    preprocessorService.startAsync();
+    preprocessorService.awaitRunning(DEFAULT_START_STOP_DURATION);
+
+    assertThat(MetricsUtil.getCount(PreprocessorService.CONFIG_RELOAD_COUNTER, meterRegistry))
+        .isEqualTo(1);
+    serviceMetadataStore.createSync(new ServiceMetadata("name", "owner", 0, List.of()));
+
+    // wait for the cache to be updated
+    await().until(() -> serviceMetadataStore.listSync().size() == 1);
+    assertThat(MetricsUtil.getCount(PreprocessorService.CONFIG_RELOAD_COUNTER, meterRegistry))
+        .isEqualTo(2);
+
+    preprocessorService.stopAsync();
+    preprocessorService.awaitTerminated();
+
+    // close out the metadata stores
+    serviceMetadataStore.close();
+    metadataStore.close();
+  }
+
+  @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public void shouldProcessMessageStartToFinish() throws Exception {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    KaldbConfigs.ZookeeperConfig zkConfig =
+        KaldbConfigs.ZookeeperConfig.newBuilder()
+            .setZkConnectString(zkServer.getConnectString())
+            .setZkPathPrefix("test")
+            .setZkSessionTimeoutMs(30000)
+            .setZkConnectionTimeoutMs(30000)
+            .setSleepBetweenRetriesMs(30000)
+            .build();
+    MetadataStore metadataStore = ZookeeperMetadataStoreImpl.fromConfig(meterRegistry, zkConfig);
+    ServiceMetadataStore serviceMetadataStore = new ServiceMetadataStore(metadataStore, true);
+
+    // initialize the downstream topic
+    String downstreamTopic = "test-topic-out";
+    kafkaServer.createTopicWithPartitions(downstreamTopic, 3);
+
+    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+            .setApplicationId("applicationId")
+            .setBootstrapServers(kafkaServer.getBroker().getBrokerList().get())
+            .setNumStreamThreads(1)
+            .setDownstreamTopic(downstreamTopic)
+            .build();
+    KaldbConfigs.ServerConfig serverConfig =
+        KaldbConfigs.ServerConfig.newBuilder()
+            .setServerPort(8080)
+            .setServerAddress("localhost")
+            .build();
+    KaldbConfigs.PreprocessorConfig preprocessorConfig =
+        KaldbConfigs.PreprocessorConfig.newBuilder()
+            .setKafkaStreamConfig(kafkaStreamConfig)
+            .setServerConfig(serverConfig)
+            .setPreprocessorInstanceCount(1)
+            .setDataTransformer("api_log")
+            .build();
+
+    PreprocessorService preprocessorService =
+        new PreprocessorService(serviceMetadataStore, preprocessorConfig, meterRegistry);
+
+    preprocessorService.startAsync();
+    preprocessorService.awaitRunning(DEFAULT_START_STOP_DURATION);
+
+    assertThat(MetricsUtil.getCount(PreprocessorService.CONFIG_RELOAD_COUNTER, meterRegistry))
+        .isEqualTo(1);
+
+    // create a new service config with dummy data
+    ServiceMetadata serviceMetadata =
+        new ServiceMetadata(
+            "test-topic",
+            "owner",
+            100,
+            List.of(new ServicePartitionMetadata(1, Long.MAX_VALUE, List.of("3"))));
+    serviceMetadataStore.createSync(serviceMetadata);
+
+    // wait for the cache to be updated
+    await().until(() -> serviceMetadataStore.listSync().size() == 1);
+    assertThat(MetricsUtil.getCount(PreprocessorService.CONFIG_RELOAD_COUNTER, meterRegistry))
+        .isEqualTo(2);
+
+    // update the service config with our desired configuration
+    ServiceMetadata updatedServiceMetadata =
+        new ServiceMetadata(
+            serviceMetadata.getName(),
+            serviceMetadata.getOwner(),
+            Long.MAX_VALUE,
+            List.of(
+                new ServicePartitionMetadata(1, 10000, List.of("3")),
+                new ServicePartitionMetadata(10001, Long.MAX_VALUE, List.of("2"))));
+    serviceMetadataStore.updateSync(updatedServiceMetadata);
+
+    // wait for the cache to be updated
+    await()
+        .until(
+            () ->
+                MetricsUtil.getCount(PreprocessorService.CONFIG_RELOAD_COUNTER, meterRegistry)
+                    == 3);
+    assertThat(serviceMetadataStore.listSync().size()).isEqualTo(1);
+    assertThat(serviceMetadataStore.listSync().get(0).getThroughputBytes())
+        .isEqualTo(Long.MAX_VALUE);
+
+    // produce messages to upstream
+    final Instant startTime = Instant.now();
+    TestKafkaServer.produceMessagesToKafka(kafkaServer.getBroker(), startTime);
+
+    // verify the message exist on the downstream
+    Properties properties = kafkaServer.getBroker().consumerConfig();
+    properties.put(
+        ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+        "org.apache.kafka.common.serialization.StringDeserializer");
+    properties.put(
+        ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+        "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    properties.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 30000);
+    KafkaConsumer kafkaConsumer = new KafkaConsumer(properties);
+    kafkaConsumer.subscribe(List.of(downstreamTopic));
+
+    // wait until we see an offset of 100 on our target partition before we poll
+    //noinspection OptionalGetWithoutIsPresent
+    await()
+        .until(
+            () ->
+                ((Long)
+                        kafkaConsumer
+                            .endOffsets(List.of(new TopicPartition(downstreamTopic, 2)))
+                            .values()
+                            .stream()
+                            .findFirst()
+                            .get())
+                    == 100);
+
+    // double check that only 100 records were fetched and all are on partition 2
+    ConsumerRecords<String, byte[]> records =
+        kafkaConsumer.poll(Duration.of(10, ChronoUnit.SECONDS));
+    assertThat(records.count()).isEqualTo(100);
+    records.forEach(record -> assertThat(record.partition()).isEqualTo(2));
+
+    // close the kafka consumer used in the test
+    kafkaConsumer.close();
+
+    // close the preprocessor
+    preprocessorService.stopAsync();
+    preprocessorService.awaitTerminated();
+
+    // close out the metadata stores
+    serviceMetadataStore.close();
+    metadataStore.close();
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
@@ -87,13 +87,13 @@ public class PreprocessorServiceIntegrationTest {
     preprocessorService.startAsync();
     preprocessorService.awaitRunning(DEFAULT_START_STOP_DURATION);
 
-    assertThat(MetricsUtil.getCount(PreprocessorService.CONFIG_RELOAD_COUNTER, meterRegistry))
+    assertThat(MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry))
         .isEqualTo(1);
     serviceMetadataStore.createSync(new ServiceMetadata("name", "owner", 0, List.of()));
 
     // wait for the cache to be updated
     await().until(() -> serviceMetadataStore.listSync().size() == 1);
-    assertThat(MetricsUtil.getCount(PreprocessorService.CONFIG_RELOAD_COUNTER, meterRegistry))
+    assertThat(MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry))
         .isEqualTo(2);
 
     preprocessorService.stopAsync();
@@ -153,7 +153,7 @@ public class PreprocessorServiceIntegrationTest {
     preprocessorService.startAsync();
     preprocessorService.awaitRunning(DEFAULT_START_STOP_DURATION);
 
-    assertThat(MetricsUtil.getCount(PreprocessorService.CONFIG_RELOAD_COUNTER, meterRegistry))
+    assertThat(MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry))
         .isEqualTo(1);
 
     // create a new service config with dummy data
@@ -168,8 +168,11 @@ public class PreprocessorServiceIntegrationTest {
 
     // wait for the cache to be updated
     await().until(() -> serviceMetadataStore.listSync().size() == 1);
-    assertThat(MetricsUtil.getCount(PreprocessorService.CONFIG_RELOAD_COUNTER, meterRegistry))
-        .isEqualTo(2);
+    await()
+        .until(
+            () ->
+                MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry)
+                    == 2);
 
     // update the service config with our desired configuration
     ServiceMetadata updatedServiceMetadata =
@@ -186,7 +189,7 @@ public class PreprocessorServiceIntegrationTest {
     await()
         .until(
             () ->
-                MetricsUtil.getCount(PreprocessorService.CONFIG_RELOAD_COUNTER, meterRegistry)
+                MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry)
                     == 3);
     assertThat(serviceMetadataStore.listSync().size()).isEqualTo(1);
     assertThat(serviceMetadataStore.listSync().get(0).getThroughputBytes())

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
@@ -1,0 +1,329 @@
+package com.slack.kaldb.preprocessor;
+
+import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.slack.kaldb.metadata.service.ServiceMetadata;
+import com.slack.kaldb.metadata.service.ServiceMetadataStore;
+import com.slack.kaldb.metadata.service.ServicePartitionMetadata;
+import com.slack.kaldb.proto.config.KaldbConfigs;
+import com.slack.kaldb.testlib.MetricsUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeoutException;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.processor.StreamPartitioner;
+import org.junit.Test;
+
+public class PreprocessorServiceUnitTest {
+
+  @Test
+  public void shouldBuildValidPropsFromStreamConfig() {
+    String applicationId = "applicationId";
+    String bootstrapServers = "bootstrap";
+    int numStreamThreads = 1;
+
+    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+            .setApplicationId(applicationId)
+            .setBootstrapServers(bootstrapServers)
+            .setNumStreamThreads(numStreamThreads)
+            .build();
+
+    Properties properties = PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+    assertThat(properties.size()).isEqualTo(4);
+
+    assertThat(properties.get(StreamsConfig.APPLICATION_ID_CONFIG)).isEqualTo(applicationId);
+    assertThat(properties.get(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG)).isEqualTo(bootstrapServers);
+    assertThat(properties.get(StreamsConfig.NUM_STREAM_THREADS_CONFIG)).isEqualTo(numStreamThreads);
+
+    // static property
+    assertThat(properties.get(StreamsConfig.PROCESSING_GUARANTEE_CONFIG))
+        .isEqualTo(StreamsConfig.AT_LEAST_ONCE);
+  }
+
+  @Test
+  public void shouldPreventInvalidStreamPropsConfig() {
+    String applicationId = "applicationId";
+    String bootstrapServers = "bootstrap";
+    int numStreamThreads = 1;
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () -> {
+              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+                      .setBootstrapServers(bootstrapServers)
+                      .setNumStreamThreads(numStreamThreads)
+                      .build();
+              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+            });
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () -> {
+              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+                      .setApplicationId(applicationId)
+                      .setNumStreamThreads(numStreamThreads)
+                      .build();
+              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+            });
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () -> {
+              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+                      .setApplicationId(applicationId)
+                      .setBootstrapServers(bootstrapServers)
+                      .build();
+              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+            });
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () -> {
+              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+                      .setApplicationId(applicationId)
+                      .setBootstrapServers(bootstrapServers)
+                      .setNumStreamThreads(0)
+                      .build();
+              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+            });
+  }
+
+  @Test
+  public void shouldReturnRandomPartitionFromStreamPartitioner() {
+    List<Integer> partitionList = List.of(33, 44, 55);
+    StreamPartitioner<Object, Object> streamPartitioner =
+        PreprocessorService.streamPartitioner(partitionList);
+
+    // all arguments are currently unused for determining the partition to assign, as this
+    // comes the internal partition list that is set on stream partitioner initialization
+    assertTrue(partitionList.contains(streamPartitioner.partition("topic", null, null, 0)));
+    assertTrue(partitionList.contains(streamPartitioner.partition("topic", null, null, 1)));
+    assertTrue(
+        partitionList.contains(
+            streamPartitioner.partition("topic", new Object(), new Object(), 0)));
+    assertTrue(partitionList.contains(streamPartitioner.partition("", null, null, 0)));
+  }
+
+  @Test
+  public void shouldPreventInvalidStreamPartitionConfigurations() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> PreprocessorService.streamPartitioner(List.of()));
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> PreprocessorService.streamPartitioner(List.of(-1)));
+  }
+
+  @Test
+  public void shouldFilterInvalidConfigurationsFromServiceMetadata() {
+    ServiceMetadata validServiceMetadata =
+        new ServiceMetadata(
+            "valid",
+            "owner1",
+            1000,
+            List.of(new ServicePartitionMetadata(1, Long.MAX_VALUE, List.of("1"))));
+
+    List<ServiceMetadata> serviceMetadataList =
+        List.of(
+            new ServiceMetadata("invalidServicePartitionList", "owner1", 1000, List.of()),
+            new ServiceMetadata(
+                "invalidThroughputBytes",
+                "owner1",
+                0,
+                List.of(new ServicePartitionMetadata(1, Long.MAX_VALUE, List.of("1")))),
+            new ServiceMetadata(
+                "invalidActivePartitions",
+                "owner1",
+                1000,
+                List.of(new ServicePartitionMetadata(1, Long.MAX_VALUE, List.of()))),
+            new ServiceMetadata(
+                "invalidNoActivePartitions",
+                "owner1",
+                1000,
+                List.of(
+                    new ServicePartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1")))),
+            validServiceMetadata);
+
+    List<ServiceMetadata> serviceMetadata1 =
+        PreprocessorService.filterValidServiceMetadata(serviceMetadataList);
+
+    assertThat(serviceMetadata1.size()).isEqualTo(1);
+    assertTrue(serviceMetadata1.contains(validServiceMetadata));
+
+    Collections.shuffle(serviceMetadata1);
+
+    List<ServiceMetadata> serviceMetadata2 =
+        PreprocessorService.filterValidServiceMetadata(serviceMetadataList);
+
+    assertThat(serviceMetadata2.size()).isEqualTo(1);
+    assertTrue(serviceMetadata2.contains(validServiceMetadata));
+
+    List<ServiceMetadata> serviceMetadata3 =
+        PreprocessorService.filterValidServiceMetadata(List.of());
+    assertThat(serviceMetadata3.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldGetActivePartitionsFromServiceMetadata() {
+    ServiceMetadata serviceMetadataEmptyPartitions =
+        new ServiceMetadata("empty", "owner1", 1000, List.of());
+    ServiceMetadata serviceMetadataNoActivePartitions =
+        new ServiceMetadata(
+            "empty",
+            "owner1",
+            1000,
+            List.of(
+                new ServicePartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1", "2"))));
+
+    ServiceMetadata serviceMetadataNoPartitions =
+        new ServiceMetadata(
+            "empty",
+            "owner1",
+            1000,
+            List.of(new ServicePartitionMetadata(1, Long.MAX_VALUE, List.of())));
+
+    ServiceMetadata serviceMetadataMultiplePartitions =
+        new ServiceMetadata(
+            "empty",
+            "owner1",
+            1000,
+            List.of(
+                new ServicePartitionMetadata(1, 10000, List.of("3", "4")),
+                new ServicePartitionMetadata(10001, Long.MAX_VALUE, List.of("5", "6"))));
+
+    assertThat(PreprocessorService.getActivePartitionList(serviceMetadataEmptyPartitions))
+        .isEqualTo(List.of());
+    assertThat(PreprocessorService.getActivePartitionList(serviceMetadataNoActivePartitions))
+        .isEqualTo(List.of());
+    assertThat(PreprocessorService.getActivePartitionList(serviceMetadataNoPartitions))
+        .isEqualTo(List.of());
+    assertThat(PreprocessorService.getActivePartitionList(serviceMetadataMultiplePartitions))
+        .isEqualTo(List.of(5, 6));
+  }
+
+  @Test
+  public void shouldBuildStreamTopology() {
+    List<ServiceMetadata> serviceMetadata =
+        List.of(
+            new ServiceMetadata(
+                "service1",
+                "owner1",
+                1000,
+                List.of(new ServicePartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2")))),
+            new ServiceMetadata(
+                "service2",
+                "owner1",
+                1000,
+                List.of(new ServicePartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2")))));
+
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    int preprocessorCount = 1;
+    PreprocessorRateLimiter rateLimiter =
+        new PreprocessorRateLimiter(meterRegistry, preprocessorCount);
+
+    String downstreamTopic = "downstream";
+    String dataTransformer = "api_log";
+    Topology topology =
+        PreprocessorService.buildTopology(
+            serviceMetadata, rateLimiter, downstreamTopic, dataTransformer);
+
+    // we have limited visibility into the topology, so we just verify we have the correct number of
+    // stream processors as we expect
+    assertThat(topology.describe().subtopologies().size()).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldThrowOnInvalidTopologyConfigs() {
+    ServiceMetadata serviceMetadata =
+        new ServiceMetadata(
+            "service1",
+            "owner1",
+            1000,
+            List.of(new ServicePartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2"))));
+
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    int preprocessorCount = 1;
+    PreprocessorRateLimiter rateLimiter =
+        new PreprocessorRateLimiter(meterRegistry, preprocessorCount);
+    String downstreamTopic = "downstream";
+    String dataTransformer = "api_log";
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                PreprocessorService.buildTopology(
+                    List.of(), rateLimiter, downstreamTopic, dataTransformer));
+    assertThatNullPointerException()
+        .isThrownBy(
+            () ->
+                PreprocessorService.buildTopology(
+                    List.of(serviceMetadata), null, downstreamTopic, dataTransformer));
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                PreprocessorService.buildTopology(
+                    List.of(serviceMetadata), rateLimiter, "", dataTransformer));
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                PreprocessorService.buildTopology(
+                    List.of(serviceMetadata), rateLimiter, downstreamTopic, ""));
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                PreprocessorService.buildTopology(
+                    List.of(serviceMetadata), rateLimiter, downstreamTopic, "invalid"));
+  }
+
+  @Test
+  public void shouldHandleEmptyServiceMetadata() throws TimeoutException {
+    ServiceMetadataStore serviceMetadataStore = mock(ServiceMetadataStore.class);
+    when(serviceMetadataStore.listSync()).thenReturn(List.of());
+
+    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+            .setApplicationId("applicationId")
+            .setBootstrapServers("bootstrap")
+            .setNumStreamThreads(1)
+            .build();
+    KaldbConfigs.ServerConfig serverConfig =
+        KaldbConfigs.ServerConfig.newBuilder()
+            .setServerPort(8080)
+            .setServerAddress("localhost")
+            .build();
+    KaldbConfigs.PreprocessorConfig preprocessorConfig =
+        KaldbConfigs.PreprocessorConfig.newBuilder()
+            .setKafkaStreamConfig(kafkaStreamConfig)
+            .setServerConfig(serverConfig)
+            .setPreprocessorInstanceCount(1)
+            .setDataTransformer("api_log")
+            .build();
+
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    PreprocessorService preprocessorService =
+        new PreprocessorService(serviceMetadataStore, preprocessorConfig, meterRegistry);
+
+    preprocessorService.startAsync();
+    preprocessorService.awaitRunning(DEFAULT_START_STOP_DURATION);
+
+    assertThat(MetricsUtil.getCount(PreprocessorService.CONFIG_RELOAD_COUNTER, meterRegistry))
+        .isEqualTo(1);
+
+    preprocessorService.stopAsync();
+    preprocessorService.awaitTerminated();
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
@@ -350,7 +350,7 @@ public class PreprocessorServiceUnitTest {
     preprocessorService.startAsync();
     preprocessorService.awaitRunning(DEFAULT_START_STOP_DURATION);
 
-    assertThat(MetricsUtil.getCount(PreprocessorService.CONFIG_RELOAD_COUNTER, meterRegistry))
+    assertThat(MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry))
         .isEqualTo(1);
 
     preprocessorService.stopAsync();

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorValueMapperTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorValueMapperTest.java
@@ -1,0 +1,160 @@
+package com.slack.kaldb.preprocessor;
+
+import static com.slack.kaldb.testlib.SpanUtil.makeSpan;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import com.google.protobuf.ByteString;
+import com.slack.service.murron.Murron;
+import com.slack.service.murron.trace.Trace;
+import java.nio.charset.StandardCharsets;
+import org.apache.kafka.streams.kstream.ValueMapper;
+import org.junit.Test;
+
+public class PreprocessorValueMapperTest {
+
+  @Test
+  public void shouldValueMapApiLog() {
+    // Make a test message
+    String message =
+        "{\"http_method\":\"POST\",\"method\":\"verifyToken\",\"type\":\"api_log\",\"level\":\"info\"}";
+    String indexName = "api_log";
+    String host = "www-host";
+    long timestamp = 1612550512340953000L;
+    Murron.MurronMessage testMurronMsg =
+        Murron.MurronMessage.newBuilder()
+            .setMessage(ByteString.copyFrom(message.getBytes(StandardCharsets.UTF_8)))
+            .setType(indexName)
+            .setHost(host)
+            .setTimestamp(timestamp)
+            .build();
+
+    ValueMapper<byte[], Trace.ListOfSpans> valueMapper =
+        PreprocessorValueMapper.byteArrayToTraceListOfSpans("api_log");
+    byte[] inputBytes =
+        KaldbSerdes.MurronMurronMessage().serializer().serialize(indexName, testMurronMsg);
+
+    Trace.ListOfSpans listOfSpans = valueMapper.apply(inputBytes);
+
+    assertThat(listOfSpans.getTagsList().size()).isEqualTo(0);
+    assertThat(listOfSpans.getSpansList().size()).isEqualTo(1);
+
+    assertThat(listOfSpans.getSpansList().get(0).getStartTimestampMicros())
+        .isEqualTo(timestamp / 1000);
+    assertThat(listOfSpans.getSpansList().get(0).getDurationMicros()).isEqualTo(1);
+
+    assertThat(listOfSpans.getSpansList().get(0).getTagsList().size()).isEqualTo(6);
+    assertTrue(
+        listOfSpans
+            .getSpansList()
+            .get(0)
+            .getTagsList()
+            .contains(Trace.KeyValue.newBuilder().setKey("http_method").setVStr("POST").build()));
+    assertTrue(
+        listOfSpans
+            .getSpansList()
+            .get(0)
+            .getTagsList()
+            .contains(Trace.KeyValue.newBuilder().setKey("method").setVStr("verifyToken").build()));
+    assertTrue(
+        listOfSpans
+            .getSpansList()
+            .get(0)
+            .getTagsList()
+            .contains(Trace.KeyValue.newBuilder().setKey("type").setVStr(indexName).build()));
+    assertTrue(
+        listOfSpans
+            .getSpansList()
+            .get(0)
+            .getTagsList()
+            .contains(Trace.KeyValue.newBuilder().setKey("level").setVStr("info").build()));
+    assertTrue(
+        listOfSpans
+            .getSpansList()
+            .get(0)
+            .getTagsList()
+            .contains(Trace.KeyValue.newBuilder().setKey("hostname").setVStr(host).build()));
+    assertTrue(
+        listOfSpans
+            .getSpansList()
+            .get(0)
+            .getTagsList()
+            .contains(
+                Trace.KeyValue.newBuilder().setKey("service_name").setVStr(indexName).build()));
+  }
+
+  @Test
+  public void shouldValueMapSpans() {
+    final String traceId = "t1";
+    final String id = "i1";
+    final String parentId = "p2";
+    final long timestampMicros = 1612550512340953L;
+    final long durationMicros = 500000L;
+    final String serviceName = "test_service";
+    final String name = "testSpanName";
+    final String msgType = "test_message_type";
+    final Trace.Span span =
+        makeSpan(
+            traceId, id, parentId, timestampMicros, durationMicros, name, serviceName, msgType);
+
+    final String type = "testIndex";
+    final String host = "testHost";
+    final Murron.MurronMessage murronMessage =
+        Murron.MurronMessage.newBuilder()
+            .setMessage(Trace.ListOfSpans.newBuilder().addSpans(span).build().toByteString())
+            .setType(type)
+            .setHost(host)
+            .setTimestamp(timestampMicros * 1000 + 1)
+            .build();
+
+    ValueMapper<byte[], Trace.ListOfSpans> valueMapper =
+        PreprocessorValueMapper.byteArrayToTraceListOfSpans("spans");
+    byte[] inputBytes =
+        KaldbSerdes.MurronMurronMessage().serializer().serialize(serviceName, murronMessage);
+
+    Trace.ListOfSpans listOfSpans = valueMapper.apply(inputBytes);
+
+    assertThat(listOfSpans.getTagsList().size()).isEqualTo(0);
+    assertThat(listOfSpans.getSpansList().size()).isEqualTo(1);
+
+    assertThat(listOfSpans.getSpansList().get(0).getStartTimestampMicros())
+        .isEqualTo(timestampMicros);
+    assertThat(listOfSpans.getSpansList().get(0).getDurationMicros()).isEqualTo(durationMicros);
+
+    assertThat(listOfSpans.getSpansList().get(0).getTagsList().size()).isEqualTo(8);
+    assertTrue(
+        listOfSpans
+            .getSpansList()
+            .get(0)
+            .getTagsList()
+            .contains(
+                Trace.KeyValue.newBuilder()
+                    .setKey("service_name")
+                    .setVStr("test_service")
+                    .build()));
+    assertTrue(
+        listOfSpans
+            .getSpansList()
+            .get(0)
+            .getTagsList()
+            .contains(Trace.KeyValue.newBuilder().setKey("http_method").setVStr("POST").build()));
+    assertTrue(
+        listOfSpans
+            .getSpansList()
+            .get(0)
+            .getTagsList()
+            .contains(
+                Trace.KeyValue.newBuilder().setKey("method").setVStr("callbacks.flannel").build()));
+  }
+
+  @Test
+  public void shouldPreventInvalidTransform() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () -> {
+              ValueMapper<byte[], Trace.ListOfSpans> valueMapper =
+                  PreprocessorValueMapper.byteArrayToTraceListOfSpans("invalid");
+            });
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
@@ -250,6 +250,8 @@ public class KaldbConfigTest {
 
     final KaldbConfigs.PreprocessorConfig preprocessorConfig = config.getPreprocessorConfig();
     assertThat(preprocessorConfig.getPreprocessorInstanceCount()).isEqualTo(1);
+    assertThat(preprocessorConfig.getUpstreamTopicsList()).isEqualTo(List.of("test-topic"));
+    assertThat(preprocessorConfig.getDownstreamTopic()).isEqualTo("test-topic-out");
     assertThat(preprocessorConfig.getDataTransformer()).isEqualTo("api_log");
 
     final KaldbConfigs.ServerConfig preprocessorServerConfig = preprocessorConfig.getServerConfig();
@@ -258,10 +260,10 @@ public class KaldbConfigTest {
 
     final KaldbConfigs.PreprocessorConfig.KafkaStreamConfig preprocessorKafkaStreamConfig =
         preprocessorConfig.getKafkaStreamConfig();
-    assertThat(preprocessorKafkaStreamConfig.getDownstreamTopic()).isEqualTo("test-topic-out");
     assertThat(preprocessorKafkaStreamConfig.getBootstrapServers()).isEqualTo("localhost:9092");
     assertThat(preprocessorKafkaStreamConfig.getApplicationId()).isEqualTo("kaldb_preprocessor");
     assertThat(preprocessorKafkaStreamConfig.getNumStreamThreads()).isEqualTo(2);
+    assertThat(preprocessorKafkaStreamConfig.getProcessingGuarantee()).isEqualTo("at_least_once");
   }
 
   @Test
@@ -376,6 +378,8 @@ public class KaldbConfigTest {
 
     final KaldbConfigs.PreprocessorConfig preprocessorConfig = config.getPreprocessorConfig();
     assertThat(preprocessorConfig.getPreprocessorInstanceCount()).isEqualTo(1);
+    assertThat(preprocessorConfig.getUpstreamTopicsList()).isEqualTo(List.of("test-topic"));
+    assertThat(preprocessorConfig.getDownstreamTopic()).isEqualTo("test-topic-out");
     assertThat(preprocessorConfig.getDataTransformer()).isEqualTo("api_log");
 
     final KaldbConfigs.ServerConfig preprocessorServerConfig = preprocessorConfig.getServerConfig();
@@ -384,10 +388,10 @@ public class KaldbConfigTest {
 
     final KaldbConfigs.PreprocessorConfig.KafkaStreamConfig preprocessorKafkaStreamConfig =
         preprocessorConfig.getKafkaStreamConfig();
-    assertThat(preprocessorKafkaStreamConfig.getDownstreamTopic()).isEqualTo("test-topic-out");
     assertThat(preprocessorKafkaStreamConfig.getBootstrapServers()).isEqualTo("localhost:9092");
     assertThat(preprocessorKafkaStreamConfig.getApplicationId()).isEqualTo("kaldb_preprocessor");
     assertThat(preprocessorKafkaStreamConfig.getNumStreamThreads()).isEqualTo(2);
+    assertThat(preprocessorKafkaStreamConfig.getProcessingGuarantee()).isEqualTo("at_least_once");
   }
 
   @Test(expected = RuntimeException.class)
@@ -508,6 +512,8 @@ public class KaldbConfigTest {
 
     final KaldbConfigs.PreprocessorConfig preprocessorConfig = config.getPreprocessorConfig();
     assertThat(preprocessorConfig.getPreprocessorInstanceCount()).isZero();
+    assertThat(preprocessorConfig.getUpstreamTopicsList()).isEmpty();
+    assertThat(preprocessorConfig.getDownstreamTopic()).isEmpty();
     assertThat(preprocessorConfig.getDataTransformer()).isEmpty();
 
     final KaldbConfigs.ServerConfig preprocessorServerConfig = preprocessorConfig.getServerConfig();
@@ -516,10 +522,10 @@ public class KaldbConfigTest {
 
     final KaldbConfigs.PreprocessorConfig.KafkaStreamConfig preprocessorKafkaStreamConfig =
         preprocessorConfig.getKafkaStreamConfig();
-    assertThat(preprocessorKafkaStreamConfig.getDownstreamTopic()).isEmpty();
     assertThat(preprocessorKafkaStreamConfig.getBootstrapServers()).isEmpty();
     assertThat(preprocessorKafkaStreamConfig.getApplicationId()).isEmpty();
     assertThat(preprocessorKafkaStreamConfig.getNumStreamThreads()).isZero();
+    assertThat(preprocessorKafkaStreamConfig.getProcessingGuarantee()).isEmpty();
   }
 
   @Test
@@ -615,6 +621,8 @@ public class KaldbConfigTest {
 
     final KaldbConfigs.PreprocessorConfig preprocessorConfig = config.getPreprocessorConfig();
     assertThat(preprocessorConfig.getPreprocessorInstanceCount()).isZero();
+    assertThat(preprocessorConfig.getUpstreamTopicsList()).isEmpty();
+    assertThat(preprocessorConfig.getDownstreamTopic()).isEmpty();
     assertThat(preprocessorConfig.getDataTransformer()).isEmpty();
 
     final KaldbConfigs.ServerConfig preprocessorServerConfig = preprocessorConfig.getServerConfig();
@@ -623,10 +631,10 @@ public class KaldbConfigTest {
 
     final KaldbConfigs.PreprocessorConfig.KafkaStreamConfig preprocessorKafkaStreamConfig =
         preprocessorConfig.getKafkaStreamConfig();
-    assertThat(preprocessorKafkaStreamConfig.getDownstreamTopic()).isEmpty();
     assertThat(preprocessorKafkaStreamConfig.getBootstrapServers()).isEmpty();
     assertThat(preprocessorKafkaStreamConfig.getApplicationId()).isEmpty();
     assertThat(preprocessorKafkaStreamConfig.getNumStreamThreads()).isZero();
+    assertThat(preprocessorKafkaStreamConfig.getProcessingGuarantee()).isEmpty();
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
@@ -247,6 +247,21 @@ public class KaldbConfigTest {
     final KaldbConfigs.ServerConfig recoveryServerConfig = recoveryConfig.getServerConfig();
     assertThat(recoveryServerConfig.getServerPort()).isEqualTo(8084);
     assertThat(recoveryServerConfig.getServerAddress()).isEqualTo("localhost");
+
+    final KaldbConfigs.PreprocessorConfig preprocessorConfig = config.getPreprocessorConfig();
+    assertThat(preprocessorConfig.getPreprocessorInstanceCount()).isEqualTo(1);
+    assertThat(preprocessorConfig.getDataTransformer()).isEqualTo("api_log");
+
+    final KaldbConfigs.ServerConfig preprocessorServerConfig = preprocessorConfig.getServerConfig();
+    assertThat(preprocessorServerConfig.getServerPort()).isEqualTo(8085);
+    assertThat(preprocessorServerConfig.getServerAddress()).isEqualTo("localhost");
+
+    final KaldbConfigs.PreprocessorConfig.KafkaStreamConfig preprocessorKafkaStreamConfig =
+        preprocessorConfig.getKafkaStreamConfig();
+    assertThat(preprocessorKafkaStreamConfig.getDownstreamTopic()).isEqualTo("test-topic-out");
+    assertThat(preprocessorKafkaStreamConfig.getBootstrapServers()).isEqualTo("localhost:9092");
+    assertThat(preprocessorKafkaStreamConfig.getApplicationId()).isEqualTo("kaldb_preprocessor");
+    assertThat(preprocessorKafkaStreamConfig.getNumStreamThreads()).isEqualTo(2);
   }
 
   @Test
@@ -358,6 +373,21 @@ public class KaldbConfigTest {
     final KaldbConfigs.ServerConfig recoveryServerConfig = recoveryConfig.getServerConfig();
     assertThat(recoveryServerConfig.getServerPort()).isEqualTo(8084);
     assertThat(recoveryServerConfig.getServerAddress()).isEqualTo("localhost");
+
+    final KaldbConfigs.PreprocessorConfig preprocessorConfig = config.getPreprocessorConfig();
+    assertThat(preprocessorConfig.getPreprocessorInstanceCount()).isEqualTo(1);
+    assertThat(preprocessorConfig.getDataTransformer()).isEqualTo("api_log");
+
+    final KaldbConfigs.ServerConfig preprocessorServerConfig = preprocessorConfig.getServerConfig();
+    assertThat(preprocessorServerConfig.getServerPort()).isEqualTo(8085);
+    assertThat(preprocessorServerConfig.getServerAddress()).isEqualTo("localhost");
+
+    final KaldbConfigs.PreprocessorConfig.KafkaStreamConfig preprocessorKafkaStreamConfig =
+        preprocessorConfig.getKafkaStreamConfig();
+    assertThat(preprocessorKafkaStreamConfig.getDownstreamTopic()).isEqualTo("test-topic-out");
+    assertThat(preprocessorKafkaStreamConfig.getBootstrapServers()).isEqualTo("localhost:9092");
+    assertThat(preprocessorKafkaStreamConfig.getApplicationId()).isEqualTo("kaldb_preprocessor");
+    assertThat(preprocessorKafkaStreamConfig.getNumStreamThreads()).isEqualTo(2);
   }
 
   @Test(expected = RuntimeException.class)
@@ -475,6 +505,21 @@ public class KaldbConfigTest {
     final KaldbConfigs.ServerConfig recoveryServerConfig = recoveryConfig.getServerConfig();
     assertThat(recoveryServerConfig.getServerPort()).isZero();
     assertThat(recoveryServerConfig.getServerAddress()).isEmpty();
+
+    final KaldbConfigs.PreprocessorConfig preprocessorConfig = config.getPreprocessorConfig();
+    assertThat(preprocessorConfig.getPreprocessorInstanceCount()).isZero();
+    assertThat(preprocessorConfig.getDataTransformer()).isEmpty();
+
+    final KaldbConfigs.ServerConfig preprocessorServerConfig = preprocessorConfig.getServerConfig();
+    assertThat(preprocessorServerConfig.getServerPort()).isZero();
+    assertThat(preprocessorServerConfig.getServerAddress()).isEmpty();
+
+    final KaldbConfigs.PreprocessorConfig.KafkaStreamConfig preprocessorKafkaStreamConfig =
+        preprocessorConfig.getKafkaStreamConfig();
+    assertThat(preprocessorKafkaStreamConfig.getDownstreamTopic()).isEmpty();
+    assertThat(preprocessorKafkaStreamConfig.getBootstrapServers()).isEmpty();
+    assertThat(preprocessorKafkaStreamConfig.getApplicationId()).isEmpty();
+    assertThat(preprocessorKafkaStreamConfig.getNumStreamThreads()).isZero();
   }
 
   @Test
@@ -567,6 +612,21 @@ public class KaldbConfigTest {
     final KaldbConfigs.ServerConfig managerServerConfig = managerConfig.getServerConfig();
     assertThat(managerServerConfig.getServerPort()).isZero();
     assertThat(managerServerConfig.getServerAddress()).isEmpty();
+
+    final KaldbConfigs.PreprocessorConfig preprocessorConfig = config.getPreprocessorConfig();
+    assertThat(preprocessorConfig.getPreprocessorInstanceCount()).isZero();
+    assertThat(preprocessorConfig.getDataTransformer()).isEmpty();
+
+    final KaldbConfigs.ServerConfig preprocessorServerConfig = preprocessorConfig.getServerConfig();
+    assertThat(preprocessorServerConfig.getServerPort()).isZero();
+    assertThat(preprocessorServerConfig.getServerAddress()).isEmpty();
+
+    final KaldbConfigs.PreprocessorConfig.KafkaStreamConfig preprocessorKafkaStreamConfig =
+        preprocessorConfig.getKafkaStreamConfig();
+    assertThat(preprocessorKafkaStreamConfig.getDownstreamTopic()).isEmpty();
+    assertThat(preprocessorKafkaStreamConfig.getBootstrapServers()).isEmpty();
+    assertThat(preprocessorKafkaStreamConfig.getApplicationId()).isEmpty();
+    assertThat(preprocessorKafkaStreamConfig.getNumStreamThreads()).isZero();
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
@@ -281,6 +281,8 @@ public class KaldbTest {
         .isEqualTo(true);
     assertThat(runHealthCheckOnPort(kaldbConfig.getManagerConfig().getServerConfig()))
         .isEqualTo(true);
+    assertThat(runHealthCheckOnPort(kaldbConfig.getPreprocessorConfig().getServerConfig()))
+        .isEqualTo(true);
 
     // shutdown
     kaldb.shutdown();

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/TestKafkaServer.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/TestKafkaServer.java
@@ -13,6 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
@@ -22,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -117,6 +119,14 @@ public class TestKafkaServer {
     return adminClient.listConsumerGroups().all().get().size();
   }
 
+  public void createTopicWithPartitions(String topic, int numPartitions)
+      throws ExecutionException, InterruptedException {
+    adminClient
+        .createTopics(Collections.singleton(new NewTopic(topic, numPartitions, (short) 1)))
+        .all()
+        .get();
+  }
+
   public CompletableFuture<Void> getBrokerStart() {
     return brokerStart;
   }
@@ -126,6 +136,7 @@ public class TestKafkaServer {
   }
 
   public void close() throws ExecutionException, InterruptedException {
+    adminClient.close();
     if (broker != null) {
       broker.stop();
     }

--- a/kaldb/src/test/java/com/slack/kaldb/writer/LogMessageWriterImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/LogMessageWriterImplTest.java
@@ -564,7 +564,7 @@ public class LogMessageWriterImplTest {
   }
 
   @Test
-  public void testIngestTraceListOfSpans() throws IOException {
+  public void testIngestTraceSpan() throws IOException {
     final String traceId = "t1";
     final String id = "i1";
     final String parentId = "p2";
@@ -576,15 +576,13 @@ public class LogMessageWriterImplTest {
     final Trace.Span span =
         makeSpan(
             traceId, id, parentId, timestampMicros, durationMicros, name, serviceName, msgType);
-    final Trace.ListOfSpans listOfSpans = Trace.ListOfSpans.newBuilder().addSpans(span).build();
-    ConsumerRecord<String, byte[]> listOfSpansRecord =
-        consumerRecordWithValue(listOfSpans.toByteArray());
+    ConsumerRecord<String, byte[]> spanRecord = consumerRecordWithValue(span.toByteArray());
 
     LogMessageWriterImpl messageWriter =
         new LogMessageWriterImpl(
-            chunkManagerUtil.chunkManager, LogMessageWriterImpl.traceListOfSpansTransformer);
+            chunkManagerUtil.chunkManager, LogMessageWriterImpl.traceSpanTransformer);
 
-    assertThat(messageWriter.insertRecord(listOfSpansRecord)).isTrue();
+    assertThat(messageWriter.insertRecord(spanRecord)).isTrue();
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, metricsRegistry)).isEqualTo(1);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, metricsRegistry)).isEqualTo(0);
     chunkManagerUtil.chunkManager.getActiveChunk().commit();
@@ -606,15 +604,11 @@ public class LogMessageWriterImplTest {
   }
 
   @Test
-  public void testNullTraceListOfSpans() throws IOException {
-    final Trace.ListOfSpans listOfSpans = Trace.ListOfSpans.newBuilder().build();
-    ConsumerRecord<String, byte[]> listOfSpansRecord =
-        consumerRecordWithValue(listOfSpans.toByteArray());
-
+  public void testNullTraceSpan() throws IOException {
     LogMessageWriterImpl messageWriter =
         new LogMessageWriterImpl(
-            chunkManagerUtil.chunkManager, LogMessageWriterImpl.traceListOfSpansTransformer);
+            chunkManagerUtil.chunkManager, LogMessageWriterImpl.traceSpanTransformer);
 
-    assertThat(messageWriter.insertRecord(listOfSpansRecord)).isFalse();
+    assertThat(messageWriter.insertRecord(null)).isFalse();
   }
 }

--- a/kaldb/src/test/resources/test_config.json
+++ b/kaldb/src/test/resources/test_config.json
@@ -97,15 +97,17 @@
   },
   "preprocessorConfig": {
     "kafkaStreamConfig": {
-      "downstreamTopic": "test-topic-out",
       "bootstrapServers": "localhost:9092",
       "applicationId": "kaldb_preprocessor",
-      "numStreamThreads": 2
+      "numStreamThreads": 2,
+      "processingGuarantee": "at_least_once"
     },
     "serverConfig": {
       "serverPort": 8085,
       "serverAddress": "localhost"
     },
+    "upstreamTopics": ["test-topic"],
+    "downstreamTopic": "test-topic-out",
     "preprocessorInstanceCount": 1,
     "dataTransformer": "api_log"
   }

--- a/kaldb/src/test/resources/test_config.json
+++ b/kaldb/src/test/resources/test_config.json
@@ -94,5 +94,19 @@
       "serverPort": 8084,
       "serverAddress": "localhost"
     }
+  },
+  "preprocessorConfig": {
+    "kafkaStreamConfig": {
+      "downstreamTopic": "test-topic-out",
+      "bootstrapServers": "localhost:9092",
+      "applicationId": "kaldb_preprocessor",
+      "numStreamThreads": 2
+    },
+    "serverConfig": {
+      "serverPort": 8085,
+      "serverAddress": "localhost"
+    },
+    "preprocessorInstanceCount": 1,
+    "dataTransformer": "api_log"
   }
 }

--- a/kaldb/src/test/resources/test_config.yaml
+++ b/kaldb/src/test/resources/test_config.yaml
@@ -79,12 +79,14 @@ recoveryConfig:
 
 preprocessorConfig:
   kafkaStreamConfig:
-    downstreamTopic: test-topic-out
     bootstrapServers: localhost:9092
     applicationId: kaldb_preprocessor
     numStreamThreads: 2
+    processingGuarantee: at_least_once
   serverConfig:
     serverPort: 8085
     serverAddress: localhost
+  upstreamTopics: [test-topic]
+  downstreamTopic: test-topic-out
   preprocessorInstanceCount: 1
   dataTransformer: "api_log"

--- a/kaldb/src/test/resources/test_config.yaml
+++ b/kaldb/src/test/resources/test_config.yaml
@@ -76,3 +76,15 @@ recoveryConfig:
   serverConfig:
     serverPort: 8084
     serverAddress: localhost
+
+preprocessorConfig:
+  kafkaStreamConfig:
+    downstreamTopic: test-topic-out
+    bootstrapServers: localhost:9092
+    applicationId: kaldb_preprocessor
+    numStreamThreads: 2
+  serverConfig:
+    serverPort: 8085
+    serverAddress: localhost
+  preprocessorInstanceCount: 1
+  dataTransformer: "api_log"


### PR DESCRIPTION
Adds the preprocessor component to KalDb. This uses Kafka Streams to read messages from one or more upstream topics, apply rate-limiting, message transforms, topic partitioning, and outputs to a singular downstream topic. Service rate limiting and partition information are read in via the service metadata, and will automatically reload the configuration when the metadata changes.