### PR TITLE
Add missing RunWith annotation to run all tests in KaldbKafkaConsumerTest.

### DIFF
--- a/kaldb/src/test/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumerTest.java
@@ -27,7 +27,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
 
+@RunWith(Enclosed.class)
 public class KaldbKafkaConsumerTest {
   private static final String TEST_KAFKA_CLIENT_GROUP = "test_kaldb_consumer";
 


### PR DESCRIPTION
Currently, we don't run all the tests in this class since we are missing the Enclosed annotation. So, adding it.

In future, we should have a linter rule to catch these cases automatically. 