### PR TITLE
Reduce logging level for rate limiter

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiter.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiter.java
@@ -72,9 +72,9 @@ public class PreprocessorRateLimiter {
       int bytes = value.toByteArray().length;
       if (serviceName == null || serviceName.isEmpty()) {
         // service name wasn't provided
-        LOG.warn("Message was dropped due to missing service name - '{}'", value);
+        LOG.debug("Message was dropped due to missing service name - '{}'", value);
         // todo - we may consider adding a logging BurstFilter so that a bad actor cannot
-        // inadvertently swamp the system
+        //  inadvertently swamp the system if we want to increase this logging level
         //  https://logging.apache.org/log4j/2.x/manual/filters.html#BurstFilter
         meterRegistry
             .counter(MESSAGES_DROPPED, getMeterTags("", MessageDropReason.MISSING_SERVICE_NAME))


### PR DESCRIPTION
This log doesn't generate a significant value, but is generating an excessive amount of logging - so we should reduce the default log level. 