### PR TITLE
Swap size calculation in preprocessor rate limiter

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiter.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiter.java
@@ -69,7 +69,7 @@ public class PreprocessorRateLimiter {
       }
 
       String serviceName = PreprocessorValueMapper.getServiceName(value);
-      int bytes = value.toByteArray().length;
+      int bytes = value.getSerializedSize();
       if (serviceName == null || serviceName.isEmpty()) {
         // service name wasn't provided
         LOG.debug("Message was dropped due to missing service name - '{}'", value);


### PR DESCRIPTION
Swaps the `value.toByteArray` in favor of serialized size, so that we can avoid the additional processing in creating the byte array when we don't need it. `toByteArray` internally calls `getSerializedSize` to the value will be identical.

In analyzing the flamegraph data, depending on source data format this should reduce our overall CPU time by between 6 and 12 percent. 