### PR TITLE
Add rate limit smoothing option

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -93,3 +93,4 @@ preprocessorConfig:
   downstreamTopic: ${KAKFA_DOWNSTREAM_TOPIC:-test-topic-out}
   preprocessorInstanceCount: ${PREPROCESSOR_INSTANCE_COUNT:-1}
   dataTransformer: ${PREPROCESSOR_TRANSFORMER:-api_log}
+  rateLimitSmoothingMicros: ${PREPROCESSOR_RATE_LIMIT_SMOOTHING_MICROS:-0}

--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorService.java
@@ -79,7 +79,9 @@ public class PreprocessorService extends AbstractService {
     this.dataTransformer = preprocessorConfig.getDataTransformer();
     this.rateLimiter =
         new PreprocessorRateLimiter(
-            meterRegistry, preprocessorConfig.getPreprocessorInstanceCount());
+            meterRegistry,
+            preprocessorConfig.getPreprocessorInstanceCount(),
+            preprocessorConfig.getRateLimitSmoothingMicros());
   }
 
   @Override

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -198,4 +198,7 @@ message PreprocessorConfig {
   // The number of preprocessor instances
   // Used for calculating target throughput per instance
   int32 preprocessor_instance_count = 6;
+
+  // Amount of time in microseconds the rate limiter can wait for acquire
+  int64 rateLimitSmoothingMicros = 7;
 }

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
@@ -243,8 +243,9 @@ public class PreprocessorServiceUnitTest {
 
     MeterRegistry meterRegistry = new SimpleMeterRegistry();
     int preprocessorCount = 1;
+    int rateLimitSmoothingMicros = 0;
     PreprocessorRateLimiter rateLimiter =
-        new PreprocessorRateLimiter(meterRegistry, preprocessorCount);
+        new PreprocessorRateLimiter(meterRegistry, preprocessorCount, rateLimitSmoothingMicros);
 
     List<String> upstreamTopics = List.of("upstream1", "upstream2", "upstream3");
     String downstreamTopic = "downstream";
@@ -269,8 +270,9 @@ public class PreprocessorServiceUnitTest {
 
     MeterRegistry meterRegistry = new SimpleMeterRegistry();
     int preprocessorCount = 1;
+    int rateLimitSmoothingMicros = 0;
     PreprocessorRateLimiter rateLimiter =
-        new PreprocessorRateLimiter(meterRegistry, preprocessorCount);
+        new PreprocessorRateLimiter(meterRegistry, preprocessorCount, rateLimitSmoothingMicros);
     List<String> upstreamTopics = List.of("upstream");
     String downstreamTopic = "downstream";
     String dataTransformer = "api_log";


### PR DESCRIPTION
Introduces an optional param for pre-processor rate limiting that allows for waiting on permit that could be fulfilled in a future window. This is an additional tuning option to help smooth the bursty nature we can see with kafka polling.

A value of 0 (default) disables any smoothing.