### PR TITLE
Disable ZK metadatastore fatal error handler

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/metadata/zookeeper/ZookeeperMetadataStoreImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/zookeeper/ZookeeperMetadataStoreImpl.java
@@ -143,7 +143,8 @@ public class ZookeeperMetadataStoreImpl implements MetadataStore {
                   && curatorEvent.getWatchedEvent().getState()
                       == Watcher.Event.KeeperState.Expired) {
                 LOG.warn("The ZK session has expired {}.", curatorEvent);
-                fatalErrorHandler.handleFatal(new Throwable("ZK session expired."));
+                // todo - temporarily disabled to test ZK instability issues
+                // fatalErrorHandler.handleFatal(new Throwable("ZK session expired."));
               }
             });
 

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/zookeeper/ZookeeperMetadataStoreImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/zookeeper/ZookeeperMetadataStoreImplTest.java
@@ -24,6 +24,7 @@ import org.apache.curator.test.TestingServer;
 import org.apache.zookeeper.ZooKeeper;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class ZookeeperMetadataStoreImplTest {
@@ -497,6 +498,7 @@ public class ZookeeperMetadataStoreImplTest {
   }
 
   @Test
+  @Ignore
   public void testFatalErrorHandlerInvocation() throws Exception {
     String root = "/root/1/2/3";
     assertThat(metadataStore.create(root, "", true).get()).isNull();


### PR DESCRIPTION
Temporarily disables the fatal error handler for the zk metadata store. The observed behavior seems to indicate this is being triggered while curator attempts to renegotiate a connection. This results in the container being terminated even if curator is able to reconnect successfully. 