### PR TITLE
Split kaldb admin ports to separate serverbuilder

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -11,7 +11,8 @@ indexerConfig:
   dataDirectory: ${INDEXER_DATA_DIR:-/tmp}
   maxOffsetDelayMessages: ${INDEXER_MAX_OFFSET_DELAY_MESSAGES:-10000000}
   serverConfig:
-    serverPort: ${KALDB_INDEX_SERVER_PORT:-8080}
+    appServerPort: ${KALDB_INDEX_APP_SERVER_PORT:-8080}
+    adminServerPort: ${KALDB_INDEX_ADMIN_SERVER_PORT:-8180}
     serverAddress: ${KALDB_INDEX_SERVER_ADDRESS:-localhost}
 
 kafkaConfig:
@@ -35,7 +36,8 @@ tracingConfig:
 
 queryConfig:
   serverConfig:
-    serverPort: ${KALDB_QUERY_SERVER_PORT:-8081}
+    appServerPort: ${KALDB_QUERY_APP_SERVER_PORT:-8081}
+    adminServerPort: ${KALDB_QUERY_ADMIN_SERVER_PORT:-8181}
     serverAddress: ${KALDB_QUERY_SERVER_ADDRESS:-localhost}
 
 metadataStoreConfig:
@@ -50,15 +52,17 @@ cacheConfig:
   slotsPerInstance: ${KALDB_CACHE_SLOTS_PER_INSTANCE:-10}
   dataDirectory: ${KALDB_CACHE_DATA_DIR:-/tmp}
   serverConfig:
-    serverPort: ${KALDB_CACHE_SERVER_PORT:-8082}
+    appServerPort: ${KALDB_CACHE_APP_SERVER_PORT:-8082}
+    adminServerPort: ${KALDB_CACHE_ADMIN_SERVER_PORT:-8182}
     serverAddress: ${KALDB_CACHE_SERVER_ADDRESS:-localhost}
 
 managerConfig:
   eventAggregationSecs: ${KALDB_MANAGER_AGGREGATION_SECS:-10}
   scheduleInitialDelayMins: ${KALDB_MANAGER_INITIAL_DELAY_MINS:-1}
   serverConfig:
-    serverPort: ${KALDB_MANAGER_SERVER_PORT:-8083}
-    serverAddress: ${KALDB_MANAGER_SERVER_ADDRESS:-localhost}
+    appServerPort: ${KALDB_MANAGER_APP_SERVER_PORT:-8083}
+    adminServerPort: ${KALDB_MANAGER_CLIENT_SERVER_PORT:-8183}
+    serverAddress: ${KALDB_MANAGER_ADMIN_SERVER_ADDRESS:-localhost}
   replicaCreationServiceConfig:
     replicasPerSnapshot: ${KALDB_MANAGER_REPLICAS_PER_SNAPSHOT:-1}
     schedulePeriodMins: ${KALDB_MANAGER_REPLICAS_PERIOD_MINS:-15}
@@ -77,7 +81,8 @@ managerConfig:
 
 recoveryConfig:
   serverConfig:
-    serverPort: ${KALDB_RECOVERY_SERVER_PORT:-8085}
+    appServerPort: ${KALDB_RECOVERY_APP_SERVER_PORT:-8085}
+    adminServerPort: ${KALDB_RECOVERY_ADMIN_SERVER_PORT:-8185}
     serverAddress: ${KALDB_RECOVERY_SERVER_ADDRESS:-localhost}
 
 preprocessorConfig:
@@ -87,7 +92,8 @@ preprocessorConfig:
     numStreamThreads: ${KAFKA_STREAM_THREADS:-2}
     processingGuarantee: ${KAFKA_STREAM_PROCESSING_GUARANTEE:-at_least_once}
   serverConfig:
-    serverPort: ${KALDB_PREPROCESSOR_SERVER_PORT:-8086}
+    appServerPort: ${KALDB_PREPROCESSOR_APP_SERVER_PORT:-8086}
+    adminServerPort: ${KALDB_PREPROCESSOR_ADMIN_SERVER_PORT:-8186}
     serverAddress: ${KALDB_PREPROCESSOR_SERVER_ADDRESS:-localhost}
   upstreamTopics: [${KAKFA_UPSTREAM_TOPICS:-test-topic}]
   downstreamTopic: ${KAKFA_DOWNSTREAM_TOPIC:-test-topic-out}

--- a/kaldb/src/main/java/com/slack/kaldb/chunk/SearchContext.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/SearchContext.java
@@ -14,7 +14,7 @@ public class SearchContext {
   public static final String GRPC_PROTOCOL = "gproto+http://";
 
   public static SearchContext fromConfig(KaldbConfigs.ServerConfig serverConfig) {
-    return new SearchContext(serverConfig.getServerAddress(), serverConfig.getServerPort());
+    return new SearchContext(serverConfig.getServerAddress(), serverConfig.getAppServerPort());
   }
 
   public final String hostname;

--- a/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
@@ -11,6 +11,7 @@ import com.linecorp.armeria.common.brave.RequestContextCurrentTraceContext;
 import com.linecorp.armeria.common.grpc.GrpcMeterIdPrefixFunction;
 import com.linecorp.armeria.common.logging.LogLevel;
 import com.linecorp.armeria.common.util.EventLoopGroups;
+import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.brave.BraveService;
@@ -20,6 +21,7 @@ import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
 import com.linecorp.armeria.server.healthcheck.HealthCheckService;
 import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.server.management.ManagementService;
 import com.linecorp.armeria.server.metric.MetricCollectingService;
 import io.grpc.BindableService;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
@@ -27,6 +29,7 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zipkin2.reporter.Sender;
@@ -39,21 +42,29 @@ public class ArmeriaService extends AbstractIdleService {
   private static final int WORKER_EVENT_LOOP_THREADS = 16;
 
   private final String serviceName;
-  private final Server server;
+  private final Server appServer;
+  private final Server adminServer;
 
-  private ArmeriaService(Server server, String serviceName) {
-    this.server = server;
+  private ArmeriaService(Server appServer, Server adminServer, String serviceName) {
+    this.appServer = appServer;
+    this.adminServer = adminServer;
     this.serviceName = serviceName;
   }
 
   public static class Builder {
     private final String serviceName;
-    private final ServerBuilder serverBuilder;
+    private final ServerBuilder appServerBuilder;
+    private final ServerBuilder adminServerBuilder;
     private SpanHandler spanHandler = new SpanHandler() {};
 
-    public Builder(int port, String serviceName, PrometheusMeterRegistry prometheusMeterRegistry) {
+    public Builder(
+        int appPort,
+        int adminPort,
+        String serviceName,
+        PrometheusMeterRegistry prometheusMeterRegistry) {
       this.serviceName = serviceName;
-      this.serverBuilder = Server.builder().http(port);
+      this.appServerBuilder = Server.builder().http(appPort);
+      this.adminServerBuilder = Server.builder().http(adminPort);
 
       initializeEventLoop();
       initializeTimeouts();
@@ -65,35 +76,41 @@ public class ArmeriaService extends AbstractIdleService {
     private void initializeEventLoop() {
       EventLoopGroup eventLoopGroup = EventLoopGroups.newEventLoopGroup(WORKER_EVENT_LOOP_THREADS);
       EventLoopGroups.warmUp(eventLoopGroup);
-      serverBuilder.workerGroup(eventLoopGroup, true);
+      appServerBuilder.workerGroup(eventLoopGroup, true);
     }
 
     private void initializeTimeouts() {
-      serverBuilder.requestTimeout(ARMERIA_TIMEOUT_DURATION);
+      appServerBuilder.requestTimeout(ARMERIA_TIMEOUT_DURATION);
+      adminServerBuilder.requestTimeout(ARMERIA_TIMEOUT_DURATION);
     }
 
     private void initializeCompression() {
-      serverBuilder.decorator(EncodingService.builder().newDecorator());
+      appServerBuilder.decorator(EncodingService.builder().newDecorator());
     }
 
     private void initializeLogging() {
-      serverBuilder.decorator(
+      Function<? super HttpService, LoggingService> loggingDecorator =
           LoggingService.builder()
-              // Not logging any successful response, say prom scraping /metrics every 30 seconds at
-              // INFO
+              // Not logging any successful response
               .successfulResponseLogLevel(LogLevel.DEBUG)
               .failureResponseLogLevel(LogLevel.ERROR)
               // Remove the content to prevent blowing up the logs
               .responseContentSanitizer((ctx, content) -> "truncated")
               // Remove all headers to be sure we aren't leaking any auth/cookie info
               .requestHeadersSanitizer((ctx, headers) -> DefaultHttpHeaders.EMPTY_HEADERS)
-              .newDecorator());
+              .newDecorator();
+
+      appServerBuilder.decorator(loggingDecorator);
+      adminServerBuilder.decorator(loggingDecorator);
     }
 
     private void initializeManagementEndpoints(PrometheusMeterRegistry prometheusMeterRegistry) {
-      serverBuilder
+      appServerBuilder.service("/ping", (ctx, req) -> HttpResponse.of("pong"));
+      adminServerBuilder
+          .service("/ping", (ctx, req) -> HttpResponse.of("pong"))
           .service("/health", HealthCheckService.builder().build())
           .service("/metrics", (ctx, req) -> HttpResponse.of(prometheusMeterRegistry.scrape()))
+          .service("/management", ManagementService.of())
           .serviceUnder("/docs", new DocService());
     }
 
@@ -107,7 +124,7 @@ public class ArmeriaService extends AbstractIdleService {
     }
 
     public Builder withAnnotatedService(Object service) {
-      serverBuilder.annotatedService(service);
+      appServerBuilder.annotatedService(service);
       return this;
     }
 
@@ -117,15 +134,15 @@ public class ArmeriaService extends AbstractIdleService {
               .addService(grpcService)
               .enableUnframedRequests(true)
               .useBlockingTaskExecutor(true);
-      serverBuilder.decorator(
+      appServerBuilder.decorator(
           MetricCollectingService.newDecorator(GrpcMeterIdPrefixFunction.of("grpc.service")));
-      serverBuilder.service(searchBuilder.build());
+      appServerBuilder.service(searchBuilder.build());
       return this;
     }
 
     public ArmeriaService build() {
       // always add tracing, even if it's not being reported to an endpoint
-      serverBuilder.decorator(
+      appServerBuilder.decorator(
           BraveService.newDecorator(
               Tracing.newBuilder()
                   .localServiceName(serviceName)
@@ -136,29 +153,34 @@ public class ArmeriaService extends AbstractIdleService {
                   .addSpanHandler(spanHandler)
                   .build()));
 
-      return new ArmeriaService(serverBuilder.build(), serviceName);
+      return new ArmeriaService(appServerBuilder.build(), adminServerBuilder.build(), serviceName);
     }
   }
 
   @Override
   protected void startUp() throws Exception {
-    LOG.info("Starting {} on ports {}", serviceName, server.config().ports());
-    CompletableFuture<Void> serverFuture = server.start();
-    serverFuture.get(15, TimeUnit.SECONDS);
+    LOG.info("Starting appServer for {} on ports {}", serviceName, appServer.config().ports());
+    CompletableFuture<Void> appFuture = appServer.start();
+
+    LOG.info("Starting adminServer for {} on ports {}", serviceName, adminServer.config().ports());
+    CompletableFuture<Void> adminFuture = adminServer.start();
+
+    appFuture.get(15, TimeUnit.SECONDS);
+    adminFuture.get(15, TimeUnit.SECONDS);
   }
 
   @Override
   protected void shutDown() throws Exception {
-    LOG.info("Shutting down");
-
     // On server close there is an option for a graceful shutdown, which is disabled by default.
-    // When it is
-    // disabled it immediately starts rejecting requests and begins the shutdown process, which
-    // includes
-    // running any remaining AsyncClosableSupport closeAsync actions. We want to allow this to take
-    // up to the
-    // maximum permissible shutdown time to successfully close.
-    server.close();
+    // When it is disabled it immediately starts rejecting requests and begins the shutdown
+    // process, which includes running any remaining AsyncClosableSupport closeAsync actions. We
+    // want to allow this to take up to the maximum permissible shutdown time to successfully close.
+
+    LOG.info("Shutting down appServer for {}", serviceName);
+    appServer.close();
+
+    LOG.info("Shutting down adminServer for {}", serviceName);
+    adminServer.close();
   }
 
   @Override

--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -146,9 +146,14 @@ public class Kaldb {
       services.add(indexer);
 
       KaldbLocalQueryService<LogMessage> searcher = new KaldbLocalQueryService<>(chunkManager);
-      final int serverPort = kaldbConfig.getIndexerConfig().getServerConfig().getServerPort();
+      final KaldbConfigs.ServerConfig serverConfig =
+          kaldbConfig.getIndexerConfig().getServerConfig();
       ArmeriaService armeriaService =
-          new ArmeriaService.Builder(serverPort, "kalDbIndex", prometheusMeterRegistry)
+          new ArmeriaService.Builder(
+                  serverConfig.getAppServerPort(),
+                  serverConfig.getAdminServerPort(),
+                  "kalDbIndex",
+                  prometheusMeterRegistry)
               .withTracingEndpoint(kaldbConfig.getTracingConfig().getZipkinEndpoint())
               .withGrpcService(searcher)
               .build();
@@ -163,9 +168,13 @@ public class Kaldb {
 
       KaldbDistributedQueryService kaldbDistributedQueryService =
           new KaldbDistributedQueryService(searchMetadataStore, prometheusMeterRegistry);
-      final int serverPort = kaldbConfig.getQueryConfig().getServerConfig().getServerPort();
+      final KaldbConfigs.ServerConfig serverConfig = kaldbConfig.getQueryConfig().getServerConfig();
       ArmeriaService armeriaService =
-          new ArmeriaService.Builder(serverPort, "kalDbQuery", prometheusMeterRegistry)
+          new ArmeriaService.Builder(
+                  serverConfig.getAppServerPort(),
+                  serverConfig.getAdminServerPort(),
+                  "kalDbQuery",
+                  prometheusMeterRegistry)
               .withTracingEndpoint(kaldbConfig.getTracingConfig().getZipkinEndpoint())
               .withAnnotatedService(new ElasticsearchApiService(kaldbDistributedQueryService))
               .withGrpcService(kaldbDistributedQueryService)
@@ -184,9 +193,13 @@ public class Kaldb {
       services.add(chunkManager);
 
       KaldbLocalQueryService<LogMessage> searcher = new KaldbLocalQueryService<>(chunkManager);
-      final int serverPort = kaldbConfig.getCacheConfig().getServerConfig().getServerPort();
+      final KaldbConfigs.ServerConfig serverConfig = kaldbConfig.getCacheConfig().getServerConfig();
       ArmeriaService armeriaService =
-          new ArmeriaService.Builder(serverPort, "kalDbCache", prometheusMeterRegistry)
+          new ArmeriaService.Builder(
+                  serverConfig.getAppServerPort(),
+                  serverConfig.getAdminServerPort(),
+                  "kalDbCache",
+                  prometheusMeterRegistry)
               .withTracingEndpoint(kaldbConfig.getTracingConfig().getZipkinEndpoint())
               .withGrpcService(searcher)
               .build();
@@ -195,7 +208,8 @@ public class Kaldb {
 
     if (roles.contains(KaldbConfigs.NodeRole.MANAGER)) {
       final KaldbConfigs.ManagerConfig managerConfig = kaldbConfig.getManagerConfig();
-      final int serverPort = managerConfig.getServerConfig().getServerPort();
+      final KaldbConfigs.ServerConfig serverConfig =
+          kaldbConfig.getManagerConfig().getServerConfig();
 
       ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(metadataStore, true);
       SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(metadataStore, true);
@@ -208,7 +222,11 @@ public class Kaldb {
       ServiceMetadataStore serviceMetadataStore = new ServiceMetadataStore(metadataStore, true);
 
       ArmeriaService armeriaService =
-          new ArmeriaService.Builder(serverPort, "kalDbManager", prometheusMeterRegistry)
+          new ArmeriaService.Builder(
+                  serverConfig.getAppServerPort(),
+                  serverConfig.getAdminServerPort(),
+                  "kalDbManager",
+                  prometheusMeterRegistry)
               .withTracingEndpoint(kaldbConfig.getTracingConfig().getZipkinEndpoint())
               .withGrpcService(new ManagerApiGrpc(serviceMetadataStore))
               .build();
@@ -264,10 +282,15 @@ public class Kaldb {
 
     if (roles.contains(KaldbConfigs.NodeRole.RECOVERY)) {
       final KaldbConfigs.RecoveryConfig recoveryConfig = kaldbConfig.getRecoveryConfig();
-      final int serverPort = recoveryConfig.getServerConfig().getServerPort();
+      final KaldbConfigs.ServerConfig serverConfig =
+          kaldbConfig.getRecoveryConfig().getServerConfig();
 
       ArmeriaService armeriaService =
-          new ArmeriaService.Builder(serverPort, "kalDbRecovery", prometheusMeterRegistry)
+          new ArmeriaService.Builder(
+                  serverConfig.getAppServerPort(),
+                  serverConfig.getAdminServerPort(),
+                  "kalDbRecovery",
+                  prometheusMeterRegistry)
               .withTracingEndpoint(kaldbConfig.getTracingConfig().getZipkinEndpoint())
               .build();
       services.add(armeriaService);
@@ -280,10 +303,15 @@ public class Kaldb {
     if (roles.contains(KaldbConfigs.NodeRole.PREPROCESSOR)) {
       final KaldbConfigs.PreprocessorConfig preprocessorConfig =
           kaldbConfig.getPreprocessorConfig();
-      final int serverPort = preprocessorConfig.getServerConfig().getServerPort();
+      final KaldbConfigs.ServerConfig serverConfig =
+          kaldbConfig.getPreprocessorConfig().getServerConfig();
 
       ArmeriaService armeriaService =
-          new ArmeriaService.Builder(serverPort, "kalDbPreprocessor", prometheusMeterRegistry)
+          new ArmeriaService.Builder(
+                  serverConfig.getAppServerPort(),
+                  serverConfig.getAdminServerPort(),
+                  "kalDbPreprocessor",
+                  prometheusMeterRegistry)
               .withTracingEndpoint(kaldbConfig.getTracingConfig().getZipkinEndpoint())
               .build();
       services.add(armeriaService);

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -105,8 +105,9 @@ message LuceneConfig {
 
 // ServerConfig contains the address and port info of a Kaldb service.
 message ServerConfig {
-  int32 server_port = 1;
-  string server_address = 2;
+  int32 app_server_port = 1;
+  int32 admin_server_port = 2;
+  string server_address = 3;
 }
 
 // Configuration for cache node.

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/CachingChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/CachingChunkManagerTest.java
@@ -63,7 +63,8 @@ public class CachingChunkManagerTest {
             .setServerConfig(
                 KaldbConfigs.ServerConfig.newBuilder()
                     .setServerAddress("localhost")
-                    .setServerPort(8080)
+                    .setAppServerPort(8080)
+                    .setAdminServerPort(8180)
                     .build())
             .build();
 

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -510,7 +510,8 @@ public class ReadOnlyChunkImplTest {
             .setServerConfig(
                 KaldbConfigs.ServerConfig.newBuilder()
                     .setServerAddress("localhost")
-                    .setServerPort(8080)
+                    .setAppServerPort(8080)
+                    .setAdminServerPort(8180)
                     .build())
             .build();
 

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
@@ -70,7 +70,8 @@ public class PreprocessorServiceIntegrationTest {
             .build();
     KaldbConfigs.ServerConfig serverConfig =
         KaldbConfigs.ServerConfig.newBuilder()
-            .setServerPort(8080)
+            .setAppServerPort(8080)
+            .setAdminServerPort(8180)
             .setServerAddress("localhost")
             .build();
     KaldbConfigs.PreprocessorConfig preprocessorConfig =
@@ -132,7 +133,8 @@ public class PreprocessorServiceIntegrationTest {
             .build();
     KaldbConfigs.ServerConfig serverConfig =
         KaldbConfigs.ServerConfig.newBuilder()
-            .setServerPort(8080)
+            .setAppServerPort(8080)
+            .setAdminServerPort(8180)
             .setServerAddress("localhost")
             .build();
 

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
@@ -334,7 +334,8 @@ public class PreprocessorServiceUnitTest {
             .build();
     KaldbConfigs.ServerConfig serverConfig =
         KaldbConfigs.ServerConfig.newBuilder()
-            .setServerPort(8080)
+            .setAppServerPort(8080)
+            .setAdminServerPort(8180)
             .setServerAddress("localhost")
             .build();
     KaldbConfigs.PreprocessorConfig preprocessorConfig =

--- a/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
@@ -52,7 +52,8 @@ public class RecoveryServiceTest {
 
     KaldbConfigs.ServerConfig serverConfig =
         KaldbConfigs.ServerConfig.newBuilder()
-            .setServerPort(1234)
+            .setAppServerPort(1234)
+            .setAdminServerPort(1235)
             .setServerAddress("localhost")
             .build();
 

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
@@ -184,12 +184,14 @@ public class KaldbConfigTest {
     assertThat(indexerConfig.getStaleDurationSecs()).isEqualTo(7200);
     assertThat(indexerConfig.getDataTransformer()).isEqualTo("api_log");
     assertThat(indexerConfig.getDataDirectory()).isEqualTo("/tmp");
-    assertThat(indexerConfig.getServerConfig().getServerPort()).isEqualTo(8080);
+    assertThat(indexerConfig.getServerConfig().getAppServerPort()).isEqualTo(8080);
+    assertThat(indexerConfig.getServerConfig().getAdminServerPort()).isEqualTo(8180);
     assertThat(indexerConfig.getServerConfig().getServerAddress()).isEqualTo("localhost");
     assertThat(indexerConfig.getMaxOffsetDelayMessages()).isEqualTo(10002);
 
     final KaldbConfigs.QueryServiceConfig queryServiceConfig = config.getQueryConfig();
-    assertThat(queryServiceConfig.getServerConfig().getServerPort()).isEqualTo(8081);
+    assertThat(queryServiceConfig.getServerConfig().getAppServerPort()).isEqualTo(8081);
+    assertThat(queryServiceConfig.getServerConfig().getAdminServerPort()).isEqualTo(8181);
     assertThat(queryServiceConfig.getServerConfig().getServerAddress()).isEqualTo("1.2.3.4");
 
     final KaldbConfigs.MetadataStoreConfig metadataStoreConfig = config.getMetadataStoreConfig();
@@ -204,7 +206,8 @@ public class KaldbConfigTest {
     final KaldbConfigs.ServerConfig cacheServerConfig = cacheConfig.getServerConfig();
     assertThat(cacheConfig.getSlotsPerInstance()).isEqualTo(10);
     assertThat(cacheConfig.getDataDirectory()).isEqualTo("/tmp");
-    assertThat(cacheServerConfig.getServerPort()).isEqualTo(8082);
+    assertThat(cacheServerConfig.getAppServerPort()).isEqualTo(8082);
+    assertThat(cacheServerConfig.getAdminServerPort()).isEqualTo(8182);
     assertThat(cacheServerConfig.getServerAddress()).isEqualTo("localhost");
 
     final KaldbConfigs.ManagerConfig managerConfig = config.getManagerConfig();
@@ -240,12 +243,14 @@ public class KaldbConfigTest {
     assertThat(snapshotDeletionServiceConfig.getSnapshotLifespanMins()).isEqualTo(10080);
 
     final KaldbConfigs.ServerConfig managerServerConfig = managerConfig.getServerConfig();
-    assertThat(managerServerConfig.getServerPort()).isEqualTo(8083);
+    assertThat(managerServerConfig.getAppServerPort()).isEqualTo(8083);
+    assertThat(managerServerConfig.getAdminServerPort()).isEqualTo(8183);
     assertThat(managerServerConfig.getServerAddress()).isEqualTo("localhost");
 
     final KaldbConfigs.RecoveryConfig recoveryConfig = config.getRecoveryConfig();
     final KaldbConfigs.ServerConfig recoveryServerConfig = recoveryConfig.getServerConfig();
-    assertThat(recoveryServerConfig.getServerPort()).isEqualTo(8084);
+    assertThat(recoveryServerConfig.getAppServerPort()).isEqualTo(8084);
+    assertThat(recoveryServerConfig.getAdminServerPort()).isEqualTo(8184);
     assertThat(recoveryServerConfig.getServerAddress()).isEqualTo("localhost");
 
     final KaldbConfigs.PreprocessorConfig preprocessorConfig = config.getPreprocessorConfig();
@@ -255,7 +260,8 @@ public class KaldbConfigTest {
     assertThat(preprocessorConfig.getDataTransformer()).isEqualTo("api_log");
 
     final KaldbConfigs.ServerConfig preprocessorServerConfig = preprocessorConfig.getServerConfig();
-    assertThat(preprocessorServerConfig.getServerPort()).isEqualTo(8085);
+    assertThat(preprocessorServerConfig.getAppServerPort()).isEqualTo(8085);
+    assertThat(preprocessorServerConfig.getAdminServerPort()).isEqualTo(8185);
     assertThat(preprocessorServerConfig.getServerAddress()).isEqualTo("localhost");
 
     final KaldbConfigs.PreprocessorConfig.KafkaStreamConfig preprocessorKafkaStreamConfig =
@@ -313,11 +319,13 @@ public class KaldbConfigTest {
     assertThat(indexerConfig.getDataTransformer()).isEqualTo("api_log");
     assertThat(indexerConfig.getDataDirectory()).isEqualTo("/tmp");
     assertThat(indexerConfig.getMaxOffsetDelayMessages()).isEqualTo(10001);
-    assertThat(indexerConfig.getServerConfig().getServerPort()).isEqualTo(8080);
+    assertThat(indexerConfig.getServerConfig().getAppServerPort()).isEqualTo(8080);
+    assertThat(indexerConfig.getServerConfig().getAdminServerPort()).isEqualTo(8180);
     assertThat(indexerConfig.getServerConfig().getServerAddress()).isEqualTo("localhost");
 
     final KaldbConfigs.QueryServiceConfig readConfig = config.getQueryConfig();
-    assertThat(readConfig.getServerConfig().getServerPort()).isEqualTo(8081);
+    assertThat(readConfig.getServerConfig().getAppServerPort()).isEqualTo(8081);
+    assertThat(readConfig.getServerConfig().getAdminServerPort()).isEqualTo(8181);
     assertThat(readConfig.getServerConfig().getServerAddress()).isEqualTo("1.2.3.4");
 
     final KaldbConfigs.MetadataStoreConfig metadataStoreConfig = config.getMetadataStoreConfig();
@@ -331,7 +339,8 @@ public class KaldbConfigTest {
     final KaldbConfigs.CacheConfig cacheConfig = config.getCacheConfig();
     final KaldbConfigs.ServerConfig cacheServerConfig = cacheConfig.getServerConfig();
     assertThat(cacheConfig.getSlotsPerInstance()).isEqualTo(10);
-    assertThat(cacheServerConfig.getServerPort()).isEqualTo(8082);
+    assertThat(cacheServerConfig.getAppServerPort()).isEqualTo(8082);
+    assertThat(cacheServerConfig.getAdminServerPort()).isEqualTo(8182);
     assertThat(cacheConfig.getDataDirectory()).isEqualTo("/tmp");
     assertThat(cacheServerConfig.getServerAddress()).isEqualTo("localhost");
 
@@ -368,12 +377,14 @@ public class KaldbConfigTest {
     assertThat(snapshotDeletionServiceConfig.getSnapshotLifespanMins()).isEqualTo(10080);
 
     final KaldbConfigs.ServerConfig managerServerConfig = managerConfig.getServerConfig();
-    assertThat(managerServerConfig.getServerPort()).isEqualTo(8083);
+    assertThat(managerServerConfig.getAppServerPort()).isEqualTo(8083);
+    assertThat(managerServerConfig.getAdminServerPort()).isEqualTo(8183);
     assertThat(managerServerConfig.getServerAddress()).isEqualTo("localhost");
 
     final KaldbConfigs.RecoveryConfig recoveryConfig = config.getRecoveryConfig();
     final KaldbConfigs.ServerConfig recoveryServerConfig = recoveryConfig.getServerConfig();
-    assertThat(recoveryServerConfig.getServerPort()).isEqualTo(8084);
+    assertThat(recoveryServerConfig.getAppServerPort()).isEqualTo(8084);
+    assertThat(recoveryServerConfig.getAdminServerPort()).isEqualTo(8184);
     assertThat(recoveryServerConfig.getServerAddress()).isEqualTo("localhost");
 
     final KaldbConfigs.PreprocessorConfig preprocessorConfig = config.getPreprocessorConfig();
@@ -383,7 +394,8 @@ public class KaldbConfigTest {
     assertThat(preprocessorConfig.getDataTransformer()).isEqualTo("api_log");
 
     final KaldbConfigs.ServerConfig preprocessorServerConfig = preprocessorConfig.getServerConfig();
-    assertThat(preprocessorServerConfig.getServerPort()).isEqualTo(8085);
+    assertThat(preprocessorServerConfig.getAppServerPort()).isEqualTo(8085);
+    assertThat(preprocessorServerConfig.getAdminServerPort()).isEqualTo(8185);
     assertThat(preprocessorServerConfig.getServerAddress()).isEqualTo("localhost");
 
     final KaldbConfigs.PreprocessorConfig.KafkaStreamConfig preprocessorKafkaStreamConfig =
@@ -447,11 +459,13 @@ public class KaldbConfigTest {
     assertThat(indexerConfig.getDataDirectory()).isEmpty();
     assertThat(indexerConfig.getDataTransformer()).isEqualTo("api_log");
     assertThat(indexerConfig.getMaxOffsetDelayMessages()).isZero();
-    assertThat(indexerConfig.getServerConfig().getServerPort()).isZero();
+    assertThat(indexerConfig.getServerConfig().getAppServerPort()).isZero();
+    assertThat(indexerConfig.getServerConfig().getAdminServerPort()).isZero();
     assertThat(indexerConfig.getServerConfig().getServerAddress()).isEmpty();
 
     final KaldbConfigs.QueryServiceConfig queryServiceConfig = config.getQueryConfig();
-    assertThat(queryServiceConfig.getServerConfig().getServerPort()).isZero();
+    assertThat(queryServiceConfig.getServerConfig().getAppServerPort()).isZero();
+    assertThat(queryServiceConfig.getServerConfig().getAdminServerPort()).isZero();
     assertThat(queryServiceConfig.getServerConfig().getServerAddress()).isEmpty();
 
     final KaldbConfigs.MetadataStoreConfig metadataStoreConfig = config.getMetadataStoreConfig();
@@ -466,7 +480,8 @@ public class KaldbConfigTest {
     final KaldbConfigs.ServerConfig cacheServerConfig = cacheConfig.getServerConfig();
     assertThat(cacheConfig.getSlotsPerInstance()).isZero();
     assertThat(cacheConfig.getDataDirectory()).isEmpty();
-    assertThat(cacheServerConfig.getServerPort()).isZero();
+    assertThat(cacheServerConfig.getAppServerPort()).isZero();
+    assertThat(cacheServerConfig.getAdminServerPort()).isZero();
     assertThat(cacheServerConfig.getServerAddress()).isEmpty();
 
     final KaldbConfigs.ManagerConfig managerConfig = config.getManagerConfig();
@@ -502,12 +517,14 @@ public class KaldbConfigTest {
     assertThat(snapshotDeletionServiceConfig.getSnapshotLifespanMins()).isZero();
 
     final KaldbConfigs.ServerConfig managerServerConfig = managerConfig.getServerConfig();
-    assertThat(managerServerConfig.getServerPort()).isZero();
+    assertThat(managerServerConfig.getAppServerPort()).isZero();
+    assertThat(managerServerConfig.getAdminServerPort()).isZero();
     assertThat(managerServerConfig.getServerAddress()).isEmpty();
 
     final KaldbConfigs.RecoveryConfig recoveryConfig = config.getRecoveryConfig();
     final KaldbConfigs.ServerConfig recoveryServerConfig = recoveryConfig.getServerConfig();
-    assertThat(recoveryServerConfig.getServerPort()).isZero();
+    assertThat(recoveryServerConfig.getAppServerPort()).isZero();
+    assertThat(recoveryServerConfig.getAdminServerPort()).isZero();
     assertThat(recoveryServerConfig.getServerAddress()).isEmpty();
 
     final KaldbConfigs.PreprocessorConfig preprocessorConfig = config.getPreprocessorConfig();
@@ -517,7 +534,8 @@ public class KaldbConfigTest {
     assertThat(preprocessorConfig.getDataTransformer()).isEmpty();
 
     final KaldbConfigs.ServerConfig preprocessorServerConfig = preprocessorConfig.getServerConfig();
-    assertThat(preprocessorServerConfig.getServerPort()).isZero();
+    assertThat(preprocessorServerConfig.getAppServerPort()).isZero();
+    assertThat(preprocessorServerConfig.getAdminServerPort()).isZero();
     assertThat(preprocessorServerConfig.getServerAddress()).isEmpty();
 
     final KaldbConfigs.PreprocessorConfig.KafkaStreamConfig preprocessorKafkaStreamConfig =
@@ -561,11 +579,13 @@ public class KaldbConfigTest {
     assertThat(indexerConfig.getDataDirectory()).isEmpty();
     assertThat(indexerConfig.getDataTransformer()).isEqualTo("api_log");
     assertThat(indexerConfig.getMaxOffsetDelayMessages()).isZero();
-    assertThat(indexerConfig.getServerConfig().getServerPort()).isZero();
+    assertThat(indexerConfig.getServerConfig().getAppServerPort()).isZero();
+    assertThat(indexerConfig.getServerConfig().getAdminServerPort()).isZero();
     assertThat(indexerConfig.getServerConfig().getServerAddress()).isEmpty();
 
     final KaldbConfigs.QueryServiceConfig queryServiceConfig = config.getQueryConfig();
-    assertThat(queryServiceConfig.getServerConfig().getServerPort()).isZero();
+    assertThat(queryServiceConfig.getServerConfig().getAppServerPort()).isZero();
+    assertThat(queryServiceConfig.getServerConfig().getAdminServerPort()).isZero();
     assertThat(queryServiceConfig.getServerConfig().getServerAddress()).isEmpty();
 
     final KaldbConfigs.MetadataStoreConfig metadataStoreConfig = config.getMetadataStoreConfig();
@@ -580,7 +600,8 @@ public class KaldbConfigTest {
     final KaldbConfigs.ServerConfig cacheServerConfig = cacheConfig.getServerConfig();
     assertThat(cacheConfig.getSlotsPerInstance()).isZero();
     assertThat(cacheConfig.getDataDirectory()).isEmpty();
-    assertThat(cacheServerConfig.getServerPort()).isZero();
+    assertThat(cacheServerConfig.getAppServerPort()).isZero();
+    assertThat(cacheServerConfig.getAdminServerPort()).isZero();
     assertThat(cacheServerConfig.getServerAddress()).isEmpty();
 
     final KaldbConfigs.ManagerConfig managerConfig = config.getManagerConfig();
@@ -616,7 +637,8 @@ public class KaldbConfigTest {
     assertThat(snapshotDeletionServiceConfig.getSnapshotLifespanMins()).isZero();
 
     final KaldbConfigs.ServerConfig managerServerConfig = managerConfig.getServerConfig();
-    assertThat(managerServerConfig.getServerPort()).isZero();
+    assertThat(managerServerConfig.getAppServerPort()).isZero();
+    assertThat(managerServerConfig.getAdminServerPort()).isZero();
     assertThat(managerServerConfig.getServerAddress()).isEmpty();
 
     final KaldbConfigs.PreprocessorConfig preprocessorConfig = config.getPreprocessorConfig();
@@ -626,7 +648,8 @@ public class KaldbConfigTest {
     assertThat(preprocessorConfig.getDataTransformer()).isEmpty();
 
     final KaldbConfigs.ServerConfig preprocessorServerConfig = preprocessorConfig.getServerConfig();
-    assertThat(preprocessorServerConfig.getServerPort()).isZero();
+    assertThat(preprocessorServerConfig.getAppServerPort()).isZero();
+    assertThat(preprocessorServerConfig.getAdminServerPort()).isZero();
     assertThat(preprocessorServerConfig.getServerAddress()).isEmpty();
 
     final KaldbConfigs.PreprocessorConfig.KafkaStreamConfig preprocessorKafkaStreamConfig =

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/KaldbConfigUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/KaldbConfigUtil.java
@@ -5,12 +5,14 @@ import com.slack.kaldb.proto.config.KaldbConfigs;
 public class KaldbConfigUtil {
   public static KaldbConfigs.KaldbConfig makeKaldbConfig(
       String bootstrapServers,
-      int indexerPort,
+      int indexerAppPort,
+      int indexerAdminPort,
       String kafkaTopic,
       int kafkaPartition,
       String kafkaClientGroup,
       String s3Bucket,
-      int queryPort,
+      int queryAppPort,
+      int queryAdminPort,
       String metadataZkConnectionString,
       String metadataZkPathPrefix,
       KaldbConfigs.NodeRole nodeRole,
@@ -39,7 +41,8 @@ public class KaldbConfigUtil {
         KaldbConfigs.IndexerConfig.newBuilder()
             .setServerConfig(
                 KaldbConfigs.ServerConfig.newBuilder()
-                    .setServerPort(indexerPort)
+                    .setAppServerPort(indexerAppPort)
+                    .setAdminServerPort(indexerAdminPort)
                     .setServerAddress("localhost")
                     .build())
             .setMaxBytesPerChunk(10L * 1024 * 1024 * 1024)
@@ -69,7 +72,8 @@ public class KaldbConfigUtil {
         KaldbConfigs.QueryServiceConfig.newBuilder()
             .setServerConfig(
                 KaldbConfigs.ServerConfig.newBuilder()
-                    .setServerPort(queryPort)
+                    .setAppServerPort(queryAppPort)
+                    .setAdminServerPort(queryAdminPort)
                     .setServerAddress("localhost")
                     .build())
             .build();
@@ -113,7 +117,7 @@ public class KaldbConfigUtil {
     return KaldbConfigs.IndexerConfig.newBuilder()
         .setServerConfig(
             KaldbConfigs.ServerConfig.newBuilder()
-                .setServerPort(indexerPort)
+                .setAppServerPort(indexerPort)
                 .setServerAddress("localhost")
                 .build())
         .setMaxBytesPerChunk(10L * 1024 * 1024 * 1024)

--- a/kaldb/src/test/resources/test_config.json
+++ b/kaldb/src/test/resources/test_config.json
@@ -33,13 +33,15 @@
     "dataDirectory": "/tmp",
     "maxOffsetDelayMessages" : 10002,
     "serverConfig": {
-      "serverPort": 8080,
+      "appServerPort": 8080,
+      "adminServerPort": 8180,
       "serverAddress": "localhost"
     }
   },
   "queryConfig": {
     "serverConfig": {
-      "serverPort": 8081,
+      "appServerPort": 8081,
+      "adminServerPort": 8181,
       "serverAddress": "1.2.3.4"
     }
   },
@@ -56,7 +58,8 @@
     "slotsPerInstance": 10,
     "dataDirectory": "/tmp",
     "serverConfig": {
-      "serverPort": 8082,
+      "appServerPort": 8082,
+      "adminServerPort": 8182,
       "serverAddress": "localhost"
     }
   },
@@ -64,7 +67,8 @@
     "eventAggregationSecs": 10,
     "scheduleInitialDelayMins": 1,
     "serverConfig": {
-      "serverPort": 8083,
+      "appServerPort": 8083,
+      "adminServerPort": 8183,
       "serverAddress": "localhost"
     },
     "replicaCreationServiceConfig": {
@@ -91,7 +95,8 @@
   },
   "recoveryConfig": {
     "serverConfig": {
-      "serverPort": 8084,
+      "appServerPort": 8084,
+      "adminServerPort": 8184,
       "serverAddress": "localhost"
     }
   },
@@ -103,7 +108,8 @@
       "processingGuarantee": "at_least_once"
     },
     "serverConfig": {
-      "serverPort": 8085,
+      "appServerPort": 8085,
+      "adminServerPort": 8185,
       "serverAddress": "localhost"
     },
     "upstreamTopics": ["test-topic"],

--- a/kaldb/src/test/resources/test_config.yaml
+++ b/kaldb/src/test/resources/test_config.yaml
@@ -11,12 +11,14 @@ indexerConfig:
   dataDirectory: "/tmp"
   maxOffsetDelayMessages: 10001
   serverConfig:
-    serverPort: 8080
+    appServerPort: 8080
+    adminServerPort: 8180
     serverAddress: "localhost"
 
 queryConfig:
   serverConfig:
-    serverPort: 8081
+    appServerPort: 8081
+    adminServerPort: 8181
     serverAddress: "1.2.3.4"
 
 kafkaConfig:
@@ -47,14 +49,16 @@ cacheConfig:
   slotsPerInstance: 10
   dataDirectory: "/tmp"
   serverConfig:
-    serverPort: 8082
+    appServerPort: 8082
+    adminServerPort: 8182
     serverAddress: localhost
 
 managerConfig:
   eventAggregationSecs: 10
   scheduleInitialDelayMins: 1
   serverConfig:
-    serverPort: 8083
+    appServerPort: 8083
+    adminServerPort: 8183
     serverAddress: localhost
   replicaCreationServiceConfig:
     replicasPerSnapshot: 2
@@ -74,7 +78,8 @@ managerConfig:
 
 recoveryConfig:
   serverConfig:
-    serverPort: 8084
+    appServerPort: 8084
+    adminServerPort: 8184
     serverAddress: localhost
 
 preprocessorConfig:
@@ -84,7 +89,8 @@ preprocessorConfig:
     numStreamThreads: 2
     processingGuarantee: at_least_once
   serverConfig:
-    serverPort: 8085
+    appServerPort: 8085
+    adminServerPort: 8185
     serverAddress: localhost
   upstreamTopics: [test-topic]
   downstreamTopic: test-topic-out


### PR DESCRIPTION
Splits admin ports from general purpose application ports. Also adds the management service to admin.