### PR TITLE
Fix management binding, put under new path

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
@@ -95,7 +95,7 @@ public class ArmeriaService extends AbstractIdleService {
       serverBuilder
           .service("/health", HealthCheckService.builder().build())
           .service("/metrics", (ctx, req) -> HttpResponse.of(prometheusMeterRegistry.scrape()))
-          .service("/management", ManagementService.of())
+          .serviceUnder("/internal/management", ManagementService.of())
           .serviceUnder("/docs", new DocService());
     }
 


### PR DESCRIPTION
Fixes issue where the management endpoints weren't correctly accessible with the previous binding. Also moves it to the same path as the example.