### PR TITLE
Remove event loop initialization

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
@@ -10,7 +10,6 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.brave.RequestContextCurrentTraceContext;
 import com.linecorp.armeria.common.grpc.GrpcMeterIdPrefixFunction;
 import com.linecorp.armeria.common.logging.LogLevel;
-import com.linecorp.armeria.common.util.EventLoopGroups;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.brave.BraveService;
@@ -24,7 +23,6 @@ import com.linecorp.armeria.server.management.ManagementService;
 import com.linecorp.armeria.server.metric.MetricCollectingService;
 import io.grpc.BindableService;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
-import io.netty.channel.EventLoopGroup;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -56,17 +54,10 @@ public class ArmeriaService extends AbstractIdleService {
       this.serviceName = serviceName;
       this.serverBuilder = Server.builder().http(port);
 
-      initializeEventLoop();
       initializeTimeouts();
       initializeCompression();
       initializeLogging();
       initializeManagementEndpoints(prometheusMeterRegistry);
-    }
-
-    private void initializeEventLoop() {
-      EventLoopGroup eventLoopGroup = EventLoopGroups.newEventLoopGroup(WORKER_EVENT_LOOP_THREADS);
-      EventLoopGroups.warmUp(eventLoopGroup);
-      serverBuilder.workerGroup(eventLoopGroup, true);
     }
 
     private void initializeTimeouts() {


### PR DESCRIPTION
As identified while troubleshooting an unrelated issue, it was noted that we don't correctly scale the event loop for CPU count. This removes this logic as we shouldn't need this anymore.