### PR TITLE
Revert "Disable ZK metadatastore fatal error handler"

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/metadata/zookeeper/ZookeeperMetadataStoreImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/zookeeper/ZookeeperMetadataStoreImpl.java
@@ -143,8 +143,7 @@ public class ZookeeperMetadataStoreImpl implements MetadataStore {
                   && curatorEvent.getWatchedEvent().getState()
                       == Watcher.Event.KeeperState.Expired) {
                 LOG.warn("The ZK session has expired {}.", curatorEvent);
-                // todo - temporarily disabled to test ZK instability issues
-                // fatalErrorHandler.handleFatal(new Throwable("ZK session expired."));
+                fatalErrorHandler.handleFatal(new Throwable("ZK session expired."));
               }
             });
 

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/zookeeper/ZookeeperMetadataStoreImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/zookeeper/ZookeeperMetadataStoreImplTest.java
@@ -24,7 +24,6 @@ import org.apache.curator.test.TestingServer;
 import org.apache.zookeeper.ZooKeeper;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class ZookeeperMetadataStoreImplTest {
@@ -498,7 +497,6 @@ public class ZookeeperMetadataStoreImplTest {
   }
 
   @Test
-  @Ignore
   public void testFatalErrorHandlerInvocation() throws Exception {
     String root = "/root/1/2/3";
     assertThat(metadataStore.create(root, "", true).get()).isNull();


### PR DESCRIPTION
Reverts slackhq/kaldb#257. This doesn't appear to have been a contributing factor so reverting to see if any ZK issues re-occur. 