### PR TITLE
Close metadatastores in CachingChunkManager.

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/CachingChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/CachingChunkManager.java
@@ -29,10 +29,10 @@ public class CachingChunkManager<T> extends ChunkManager<T> {
   private final String s3Bucket;
   private final String dataDirectoryPrefix;
   private final int slotCountPerInstance;
-  private final ReplicaMetadataStore replicaMetadataStore;
-  private final SnapshotMetadataStore snapshotMetadataStore;
-  private final SearchMetadataStore searchMetadataStore;
-  private final CacheSlotMetadataStore cacheSlotMetadataStore;
+  private ReplicaMetadataStore replicaMetadataStore;
+  private SnapshotMetadataStore snapshotMetadataStore;
+  private SearchMetadataStore searchMetadataStore;
+  private CacheSlotMetadataStore cacheSlotMetadataStore;
 
   public CachingChunkManager(
       MeterRegistry registry,
@@ -41,8 +41,7 @@ public class CachingChunkManager<T> extends ChunkManager<T> {
       SearchContext searchContext,
       String s3Bucket,
       String dataDirectoryPrefix,
-      int slotCountPerInstance)
-      throws Exception {
+      int slotCountPerInstance) {
     this.meterRegistry = registry;
     this.metadataStore = metadataStore;
     this.blobFs = blobFs;
@@ -50,16 +49,16 @@ public class CachingChunkManager<T> extends ChunkManager<T> {
     this.s3Bucket = s3Bucket;
     this.dataDirectoryPrefix = dataDirectoryPrefix;
     this.slotCountPerInstance = slotCountPerInstance;
-
-    replicaMetadataStore = new ReplicaMetadataStore(metadataStore, false);
-    snapshotMetadataStore = new SnapshotMetadataStore(metadataStore, false);
-    searchMetadataStore = new SearchMetadataStore(metadataStore, false);
-    cacheSlotMetadataStore = new CacheSlotMetadataStore(metadataStore, false);
   }
 
   @Override
   protected void startUp() throws Exception {
     LOG.info("Starting caching chunk manager");
+
+    replicaMetadataStore = new ReplicaMetadataStore(metadataStore, false);
+    snapshotMetadataStore = new SnapshotMetadataStore(metadataStore, false);
+    searchMetadataStore = new SearchMetadataStore(metadataStore, false);
+    cacheSlotMetadataStore = new CacheSlotMetadataStore(metadataStore, false);
 
     for (int i = 0; i < slotCountPerInstance; i++) {
       chunkList.add(
@@ -90,10 +89,11 @@ public class CachingChunkManager<T> extends ChunkManager<T> {
           }
         });
 
-    replicaMetadataStore.close();
-    snapshotMetadataStore.close();
-    searchMetadataStore.close();
     cacheSlotMetadataStore.close();
+    searchMetadataStore.close();
+    snapshotMetadataStore.close();
+    replicaMetadataStore.close();
+
     LOG.info("Closed caching chunk manager.");
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/CachingChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/CachingChunkManager.java
@@ -29,6 +29,10 @@ public class CachingChunkManager<T> extends ChunkManager<T> {
   private final String s3Bucket;
   private final String dataDirectoryPrefix;
   private final int slotCountPerInstance;
+  private ReplicaMetadataStore replicaMetadataStore;
+  private SnapshotMetadataStore snapshotMetadataStore;
+  private SearchMetadataStore searchMetadataStore;
+  private CacheSlotMetadataStore cacheSlotMetadataStore;
 
   public CachingChunkManager(
       MeterRegistry registry,
@@ -51,11 +55,10 @@ public class CachingChunkManager<T> extends ChunkManager<T> {
   protected void startUp() throws Exception {
     LOG.info("Starting caching chunk manager");
 
-    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(metadataStore, false);
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(metadataStore, false);
-    SearchMetadataStore searchMetadataStore = new SearchMetadataStore(metadataStore, false);
-    CacheSlotMetadataStore cacheSlotMetadataStore =
-        new CacheSlotMetadataStore(metadataStore, false);
+    replicaMetadataStore = new ReplicaMetadataStore(metadataStore, false);
+    snapshotMetadataStore = new SnapshotMetadataStore(metadataStore, false);
+    searchMetadataStore = new SearchMetadataStore(metadataStore, false);
+    cacheSlotMetadataStore = new CacheSlotMetadataStore(metadataStore, false);
 
     for (int i = 0; i < slotCountPerInstance; i++) {
       chunkList.add(
@@ -86,6 +89,10 @@ public class CachingChunkManager<T> extends ChunkManager<T> {
           }
         });
 
+    replicaMetadataStore.close();
+    snapshotMetadataStore.close();
+    searchMetadataStore.close();
+    cacheSlotMetadataStore.close();
     LOG.info("Closed caching chunk manager.");
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/CachingChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/CachingChunkManager.java
@@ -29,10 +29,10 @@ public class CachingChunkManager<T> extends ChunkManager<T> {
   private final String s3Bucket;
   private final String dataDirectoryPrefix;
   private final int slotCountPerInstance;
-  private ReplicaMetadataStore replicaMetadataStore;
-  private SnapshotMetadataStore snapshotMetadataStore;
-  private SearchMetadataStore searchMetadataStore;
-  private CacheSlotMetadataStore cacheSlotMetadataStore;
+  private final ReplicaMetadataStore replicaMetadataStore;
+  private final SnapshotMetadataStore snapshotMetadataStore;
+  private final SearchMetadataStore searchMetadataStore;
+  private final CacheSlotMetadataStore cacheSlotMetadataStore;
 
   public CachingChunkManager(
       MeterRegistry registry,
@@ -41,7 +41,8 @@ public class CachingChunkManager<T> extends ChunkManager<T> {
       SearchContext searchContext,
       String s3Bucket,
       String dataDirectoryPrefix,
-      int slotCountPerInstance) {
+      int slotCountPerInstance)
+      throws Exception {
     this.meterRegistry = registry;
     this.metadataStore = metadataStore;
     this.blobFs = blobFs;
@@ -49,16 +50,16 @@ public class CachingChunkManager<T> extends ChunkManager<T> {
     this.s3Bucket = s3Bucket;
     this.dataDirectoryPrefix = dataDirectoryPrefix;
     this.slotCountPerInstance = slotCountPerInstance;
-  }
-
-  @Override
-  protected void startUp() throws Exception {
-    LOG.info("Starting caching chunk manager");
 
     replicaMetadataStore = new ReplicaMetadataStore(metadataStore, false);
     snapshotMetadataStore = new SnapshotMetadataStore(metadataStore, false);
     searchMetadataStore = new SearchMetadataStore(metadataStore, false);
     cacheSlotMetadataStore = new CacheSlotMetadataStore(metadataStore, false);
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    LOG.info("Starting caching chunk manager");
 
     for (int i = 0; i < slotCountPerInstance; i++) {
       chunkList.add(

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/CachingChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/CachingChunkManagerTest.java
@@ -132,4 +132,8 @@ public class CachingChunkManagerTest {
 
     metadataStore.close();
   }
+
+  // TODO: Add a unit test to ensure caching chunk manager can search messages.
+  // TODO: Add a unit test to ensure that all chunks in caching chunk manager are read only.
+  // TODO: Add a unit test to ensure that caching chunk manager can handle exceptions gracefully.
 }


### PR DESCRIPTION
Close metadata stores in `CachingChunkManager` so we are consistent with the rest of the code base. 