### PR TITLE
Simplify IndexingChunkManager class.

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/IndexingChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/IndexingChunkManager.java
@@ -405,14 +405,4 @@ public class IndexingChunkManager<T> extends ChunkManager<T> {
         SearchContext.fromConfig(indexerConfig.getServerConfig()),
         indexerConfig);
   }
-
-  @VisibleForTesting
-  public SnapshotMetadataStore getSnapshotMetadataStore() {
-    return snapshotMetadataStore;
-  }
-
-  @VisibleForTesting
-  public SearchMetadataStore getSearchMetadataStore() {
-    return searchMetadataStore;
-  }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/ChunkCleanerServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/ChunkCleanerServiceTest.java
@@ -15,7 +15,9 @@ import com.slack.kaldb.chunk.ChunkInfo;
 import com.slack.kaldb.chunk.ReadWriteChunk;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.metadata.search.SearchMetadata;
+import com.slack.kaldb.metadata.search.SearchMetadataStore;
 import com.slack.kaldb.metadata.snapshot.SnapshotMetadata;
+import com.slack.kaldb.metadata.snapshot.SnapshotMetadataStore;
 import com.slack.kaldb.testlib.ChunkManagerUtil;
 import com.slack.kaldb.testlib.KaldbConfigUtil;
 import com.slack.kaldb.testlib.MessageUtil;
@@ -27,7 +29,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import org.assertj.core.data.Offset;
@@ -41,6 +42,8 @@ public class ChunkCleanerServiceTest {
   private static final String TEST_KAFKA_PARTITION_ID = "10";
   private SimpleMeterRegistry metricsRegistry;
   private ChunkManagerUtil<LogMessage> chunkManagerUtil;
+  private SearchMetadataStore searchMetadataStore;
+  private SnapshotMetadataStore snapshotMetadataStore;
 
   @Before
   public void setUp() throws Exception {
@@ -54,6 +57,8 @@ public class ChunkCleanerServiceTest {
             KaldbConfigUtil.makeIndexerConfig());
     chunkManagerUtil.chunkManager.startAsync();
     chunkManagerUtil.chunkManager.awaitRunning(DEFAULT_START_STOP_DURATION);
+    searchMetadataStore = new SearchMetadataStore(chunkManagerUtil.getMetadataStore(), false);
+    snapshotMetadataStore = new SnapshotMetadataStore(chunkManagerUtil.getMetadataStore(), false);
   }
 
   @After
@@ -65,8 +70,7 @@ public class ChunkCleanerServiceTest {
   }
 
   @Test
-  public void testDeleteStaleDataOn1Chunk()
-      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+  public void testDeleteStaleDataOn1Chunk() throws IOException {
     IndexingChunkManager<LogMessage> chunkManager = chunkManagerUtil.chunkManager;
     final Instant creationTime = Instant.now();
     ChunkCleanerService<LogMessage> chunkCleanerService =
@@ -91,7 +95,7 @@ public class ChunkCleanerServiceTest {
     assertThat(chunk.isReadOnly()).isFalse();
     assertThat(chunk.info().getChunkSnapshotTimeEpochMs()).isZero();
 
-    testBasicSnapshotMetadata(chunkManager, creationTime);
+    testBasicSnapshotMetadata(creationTime);
 
     // try to delete active chunk
     assertThat(chunkCleanerService.deleteStaleData(Instant.now().plusSeconds(100))).isEqualTo(0);
@@ -105,7 +109,7 @@ public class ChunkCleanerServiceTest {
     assertThat(getCount(RollOverChunkTask.ROLLOVERS_INITIATED, metricsRegistry)).isEqualTo(1);
     assertThat(getCount(RollOverChunkTask.ROLLOVERS_FAILED, metricsRegistry)).isEqualTo(0);
 
-    List<SnapshotMetadata> afterSnapshots = fetchSnapshots(chunkManager);
+    List<SnapshotMetadata> afterSnapshots = snapshotMetadataStore.listSync();
     assertThat(afterSnapshots.size()).isEqualTo(2);
     assertThat(afterSnapshots).contains(ChunkInfo.toSnapshotMetadata(chunk.info(), ""));
     SnapshotMetadata liveSnapshot = fetchLiveSnapshot(afterSnapshots).get(0);
@@ -126,7 +130,7 @@ public class ChunkCleanerServiceTest {
     assertThat(nonLiveSnapshot.startTimeEpochMs).isEqualTo(startTime.toEpochMilli());
     assertThat(nonLiveSnapshot.endTimeEpochMs).isEqualTo(startTime.plusSeconds(8).toEpochMilli());
 
-    List<SearchMetadata> afterSearchNodes = fetchSearchNodes(chunkManager);
+    List<SearchMetadata> afterSearchNodes = searchMetadataStore.listSync();
     assertThat(afterSearchNodes.size()).isEqualTo(1);
     assertThat(afterSearchNodes.get(0).url).contains(TEST_HOST);
     assertThat(afterSearchNodes.get(0).url).contains(String.valueOf(TEST_PORT));
@@ -155,7 +159,7 @@ public class ChunkCleanerServiceTest {
     assertThat(chunkManager.getChunkList().size()).isZero();
 
     // Check metadata after chunk is deleted.
-    List<SnapshotMetadata> chunkDeletedSnapshots = fetchSnapshots(chunkManager);
+    List<SnapshotMetadata> chunkDeletedSnapshots = snapshotMetadataStore.listSync();
     assertThat(chunkDeletedSnapshots.size()).isEqualTo(1);
     SnapshotMetadata nonLiveSnapshotAfterChunkDelete =
         fetchNonLiveSnapshot(chunkDeletedSnapshots).get(0);
@@ -172,13 +176,11 @@ public class ChunkCleanerServiceTest {
         .isEqualTo(startTime.toEpochMilli());
     assertThat(nonLiveSnapshotAfterChunkDelete.endTimeEpochMs)
         .isEqualTo(startTime.plusSeconds(8).toEpochMilli());
-    assertThat(fetchSearchNodes(chunkManager)).isEmpty();
+    assertThat(searchMetadataStore.listSync()).isEmpty();
   }
 
-  private static void testBasicSnapshotMetadata(
-      IndexingChunkManager<LogMessage> chunkManager, Instant creationTime)
-      throws InterruptedException, ExecutionException, TimeoutException {
-    final List<SnapshotMetadata> snapshotNodes = fetchSnapshots(chunkManager);
+  private void testBasicSnapshotMetadata(Instant creationTime) {
+    final List<SnapshotMetadata> snapshotNodes = snapshotMetadataStore.listSync();
     assertThat(snapshotNodes.size()).isEqualTo(1);
     assertThat(snapshotNodes.get(0).snapshotPath).startsWith(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
     assertThat(snapshotNodes.get(0).maxOffset).isEqualTo(0);
@@ -187,7 +189,7 @@ public class ChunkCleanerServiceTest {
     assertThat(snapshotNodes.get(0).startTimeEpochMs)
         .isCloseTo(creationTime.toEpochMilli(), Offset.offset(1000L));
     assertThat(snapshotNodes.get(0).endTimeEpochMs).isEqualTo(MAX_FUTURE_TIME);
-    final List<SearchMetadata> searchNodes = fetchSearchNodes(chunkManager);
+    final List<SearchMetadata> searchNodes = searchMetadataStore.listSync();
     assertThat(searchNodes.size()).isEqualTo(1);
     assertThat(searchNodes.get(0).url).contains(TEST_HOST);
     assertThat(searchNodes.get(0).url).contains(String.valueOf(TEST_PORT));
@@ -195,8 +197,7 @@ public class ChunkCleanerServiceTest {
   }
 
   @Test
-  public void testDeleteStateDataOn2Chunks()
-      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+  public void testDeleteStateDataOn2Chunks() throws IOException {
     Instant creationTime = Instant.now();
     IndexingChunkManager<LogMessage> chunkManager = chunkManagerUtil.chunkManager;
     ChunkCleanerService<LogMessage> chunkCleanerService =
@@ -215,7 +216,7 @@ public class ChunkCleanerServiceTest {
     assertThat(chunkManager.getChunkList().size()).isEqualTo(1);
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, metricsRegistry)).isEqualTo(9);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, metricsRegistry)).isEqualTo(0);
-    testBasicSnapshotMetadata(chunkManager, creationTime);
+    testBasicSnapshotMetadata(creationTime);
 
     final ReadWriteChunk<LogMessage> chunk1 = chunkManager.getActiveChunk();
     assertThat(chunk1.isReadOnly()).isFalse();
@@ -234,7 +235,7 @@ public class ChunkCleanerServiceTest {
     assertThat(getCount(RollOverChunkTask.ROLLOVERS_FAILED, metricsRegistry)).isEqualTo(0);
     assertThat(getCount(RollOverChunkTask.ROLLOVERS_COMPLETED, metricsRegistry)).isEqualTo(1);
 
-    checkMetadata(chunkManager, 3, 2, 1, 2, 1);
+    checkMetadata(3, 2, 1, 2, 1);
 
     final ReadWriteChunk<LogMessage> chunk2 = chunkManager.getActiveChunk();
     assertThat(chunk1.isReadOnly()).isTrue();
@@ -252,9 +253,10 @@ public class ChunkCleanerServiceTest {
     assertThat(getCount(RollOverChunkTask.ROLLOVERS_FAILED, metricsRegistry)).isEqualTo(0);
     assertThat(getCount(RollOverChunkTask.ROLLOVERS_COMPLETED, metricsRegistry)).isEqualTo(2);
 
-    checkMetadata(chunkManager, 4, 2, 2, 2, 0);
+    checkMetadata(4, 2, 2, 2, 0);
     assertThat(
-            fetchSnapshots(chunkManager)
+            snapshotMetadataStore
+                .listSync()
                 .stream()
                 .map(s -> s.maxOffset)
                 .sorted()
@@ -288,9 +290,10 @@ public class ChunkCleanerServiceTest {
     assertThat(chunkManager.getChunkList().contains(chunk1)).isTrue();
     assertThat(chunkManager.getChunkList().contains(chunk2)).isFalse();
 
-    checkMetadata(chunkManager, 3, 1, 2, 1, 0);
+    checkMetadata(3, 1, 2, 1, 0);
     assertThat(
-            fetchSnapshots(chunkManager)
+            snapshotMetadataStore
+                .listSync()
                 .stream()
                 .map(s -> s.maxOffset)
                 .sorted()
@@ -304,9 +307,10 @@ public class ChunkCleanerServiceTest {
         .isEqualTo(1);
     assertThat(chunkManager.getChunkList().size()).isZero();
 
-    checkMetadata(chunkManager, 2, 0, 2, 0, 0);
+    checkMetadata(2, 0, 2, 0, 0);
     assertThat(
-            fetchSnapshots(chunkManager)
+            snapshotMetadataStore
+                .listSync()
                 .stream()
                 .map(s -> s.maxOffset)
                 .sorted()
@@ -315,19 +319,17 @@ public class ChunkCleanerServiceTest {
   }
 
   private void checkMetadata(
-      IndexingChunkManager<LogMessage> chunkManager,
       int expectedSnapshotSize,
       int expectedLiveSnapshotSize,
       int expectedNonLiveSnapshotSize,
       int expectedSearchNodeSize,
-      int expectedInfinitySnapshotSize)
-      throws InterruptedException, ExecutionException, TimeoutException {
-    List<SnapshotMetadata> snapshots = fetchSnapshots(chunkManager);
+      int expectedInfinitySnapshotSize) {
+    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSync();
     assertThat(snapshots.size()).isEqualTo(expectedSnapshotSize);
     List<SnapshotMetadata> liveSnapshots = fetchLiveSnapshot(snapshots);
     assertThat(liveSnapshots.size()).isEqualTo(expectedLiveSnapshotSize);
     assertThat(fetchNonLiveSnapshot(snapshots).size()).isEqualTo(expectedNonLiveSnapshotSize);
-    List<SearchMetadata> searchNodes = fetchSearchNodes(chunkManager);
+    List<SearchMetadata> searchNodes = searchMetadataStore.listSync();
     assertThat(searchNodes.size()).isEqualTo(expectedSearchNodeSize);
     assertThat(liveSnapshots.stream().map(s -> s.snapshotId).collect(Collectors.toList()))
         .containsExactlyInAnyOrderElementsOf(
@@ -337,8 +339,7 @@ public class ChunkCleanerServiceTest {
   }
 
   @Test
-  public void testDeleteStaleDataOnMultipleChunks()
-      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+  public void testDeleteStaleDataOnMultipleChunks() throws IOException {
     IndexingChunkManager<LogMessage> chunkManager = chunkManagerUtil.chunkManager;
     final long startTimeSecs = 1580515200; // Sat, 01 Feb 2020 00:00:00 UTC
     ChunkCleanerService<LogMessage> chunkCleanerService =
@@ -383,7 +384,7 @@ public class ChunkCleanerServiceTest {
       assertThat(c.info().getChunkSnapshotTimeEpochMs()).isNotZero();
     }
 
-    checkMetadata(chunkManager, 8, 4, 4, 4, 0);
+    checkMetadata(8, 4, 4, 4, 0);
 
     final Instant snapshotTime = Instant.now();
     // Modify snapshot time on chunks
@@ -401,7 +402,7 @@ public class ChunkCleanerServiceTest {
                 snapshotTime.minusSeconds(3600 * 3).plusSeconds(100)))
         .isEqualTo(1);
 
-    checkMetadata(chunkManager, 7, 3, 4, 3, 0);
+    checkMetadata(7, 3, 4, 3, 0);
 
     assertThat(chunkManager.getChunkList().size()).isEqualTo(3);
     assertThat(
@@ -409,11 +410,11 @@ public class ChunkCleanerServiceTest {
         .isEqualTo(2);
     assertThat(chunkManager.getChunkList().size()).isEqualTo(1);
 
-    checkMetadata(chunkManager, 5, 1, 4, 1, 0);
+    checkMetadata(5, 1, 4, 1, 0);
 
     assertThat(chunkCleanerService.deleteStaleData(snapshotTime.plusSeconds(100))).isEqualTo(1);
     assertThat(chunkManager.getChunkList().size()).isZero();
 
-    checkMetadata(chunkManager, 4, 0, 4, 0, 0);
+    checkMetadata(4, 0, 4, 0, 0);
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
@@ -11,8 +11,6 @@ import static com.slack.kaldb.testlib.ChunkManagerUtil.TEST_HOST;
 import static com.slack.kaldb.testlib.ChunkManagerUtil.TEST_PORT;
 import static com.slack.kaldb.testlib.ChunkManagerUtil.fetchLiveSnapshot;
 import static com.slack.kaldb.testlib.ChunkManagerUtil.fetchNonLiveSnapshot;
-import static com.slack.kaldb.testlib.ChunkManagerUtil.fetchSearchNodes;
-import static com.slack.kaldb.testlib.ChunkManagerUtil.fetchSnapshots;
 import static com.slack.kaldb.testlib.MetricsUtil.*;
 import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.MAX_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -90,6 +88,8 @@ public class IndexingChunkManagerTest {
   private S3BlobFs s3BlobFs;
   private TestingServer localZkServer;
   private MetadataStore metadataStore;
+  private SnapshotMetadataStore snapshotMetadataStore;
+  private SearchMetadataStore searchMetadataStore;
 
   @Before
   public void setUp() throws Exception {
@@ -114,6 +114,8 @@ public class IndexingChunkManagerTest {
             .build();
 
     metadataStore = ZookeeperMetadataStoreImpl.fromConfig(metricsRegistry, zkConfig);
+    snapshotMetadataStore = new SnapshotMetadataStore(metadataStore, false);
+    searchMetadataStore = new SearchMetadataStore(metadataStore, false);
   }
 
   @After
@@ -223,8 +225,8 @@ public class IndexingChunkManagerTest {
     assertThat(getValue(LIVE_BYTES_INDEXED, metricsRegistry)).isEqualTo(actualChunkSize);
 
     // Check metadata registration.
-    assertThat(chunkManager.getSnapshotMetadataStore().list().get().size()).isEqualTo(1);
-    assertThat(chunkManager.getSearchMetadataStore().list().get().size()).isEqualTo(1);
+    assertThat(snapshotMetadataStore.listSync().size()).isEqualTo(1);
+    assertThat(searchMetadataStore.listSync().size()).isEqualTo(1);
 
     SearchQuery searchQuery =
         new SearchQuery(MessageUtil.TEST_INDEX_NAME, "Message1", 0, MAX_TIME, 10, 1000);
@@ -241,7 +243,7 @@ public class IndexingChunkManagerTest {
     assertThat(chunkInfo.getDataStartTimeEpochMs()).isEqualTo(messages.get(0).timeSinceEpochMilli);
     assertThat(chunkInfo.getDataEndTimeEpochMs()).isEqualTo(messages.get(99).timeSinceEpochMilli);
 
-    List<SnapshotMetadata> snapshots = fetchSnapshots(chunkManager);
+    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSync();
     assertThat(snapshots.size()).isEqualTo(1);
     List<SnapshotMetadata> liveSnapshots = fetchLiveSnapshot(snapshots);
     assertThat(liveSnapshots.size()).isEqualTo(1);
@@ -254,7 +256,7 @@ public class IndexingChunkManagerTest {
         .isCloseTo(creationTime.toEpochMilli(), Offset.offset(1000L));
     assertThat(snapshots.get(0).endTimeEpochMs).isEqualTo(MAX_FUTURE_TIME);
 
-    List<SearchMetadata> searchNodes = fetchSearchNodes(chunkManager);
+    List<SearchMetadata> searchNodes = searchMetadataStore.listSync();
     assertThat(searchNodes.size()).isEqualTo(1);
     assertThat(searchNodes.get(0).url).contains(TEST_HOST);
     assertThat(searchNodes.get(0).url).contains(String.valueOf(TEST_PORT));
@@ -416,12 +418,12 @@ public class IndexingChunkManagerTest {
       int expectedSearchNodeSize,
       int expectedInfinitySnapshotsCount)
       throws InterruptedException, ExecutionException, TimeoutException {
-    List<SnapshotMetadata> snapshots = fetchSnapshots(chunkManager);
+    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSync();
     assertThat(snapshots.size()).isEqualTo(expectedSnapshotSize);
     List<SnapshotMetadata> liveSnapshots = fetchLiveSnapshot(snapshots);
     assertThat(liveSnapshots.size()).isEqualTo(expectedLiveSnapshotSize);
     assertThat(fetchNonLiveSnapshot(snapshots).size()).isEqualTo(expectedNonLiveSnapshotSize);
-    List<SearchMetadata> searchNodes = fetchSearchNodes(chunkManager);
+    List<SearchMetadata> searchNodes = searchMetadataStore.listSync();
     assertThat(searchNodes.size()).isEqualTo(expectedSearchNodeSize);
     assertThat(liveSnapshots.stream().map(s -> s.snapshotId).collect(Collectors.toList()))
         .containsExactlyInAnyOrderElementsOf(
@@ -856,10 +858,10 @@ public class IndexingChunkManagerTest {
         IndexingChunkManager.makeDefaultRollOverExecutor(),
         10000);
 
-    assertThat(fetchSnapshots(chunkManager)).isEmpty();
-    assertThat(fetchLiveSnapshot(fetchSnapshots(chunkManager))).isEmpty();
-    assertThat(fetchNonLiveSnapshot(fetchSnapshots(chunkManager))).isEmpty();
-    assertThat(fetchSearchNodes(chunkManager)).isEmpty();
+    assertThat(snapshotMetadataStore.listSync()).isEmpty();
+    assertThat(fetchLiveSnapshot(snapshotMetadataStore.listSync())).isEmpty();
+    assertThat(fetchNonLiveSnapshot(snapshotMetadataStore.listSync())).isEmpty();
+    assertThat(searchMetadataStore.listSync()).isEmpty();
 
     // Adding a messages very quickly when running a rollover in background would result in an
     // exception.
@@ -874,12 +876,12 @@ public class IndexingChunkManagerTest {
       assertThat(e).isInstanceOf(ChunkRollOverException.class);
     }
 
-    List<SnapshotMetadata> snapshots = fetchSnapshots(chunkManager);
+    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSync();
     assertThat(snapshots.size()).isEqualTo(2);
     List<SnapshotMetadata> liveSnapshots = fetchLiveSnapshot(snapshots);
     assertThat(liveSnapshots.size()).isGreaterThanOrEqualTo(2);
     assertThat(fetchNonLiveSnapshot(snapshots).size()).isEqualTo(0);
-    List<SearchMetadata> searchNodes = fetchSearchNodes(chunkManager);
+    List<SearchMetadata> searchNodes = searchMetadataStore.listSync();
     assertThat(searchNodes.size()).isEqualTo(2);
     assertThat(liveSnapshots.stream().map(s -> s.snapshotId).collect(Collectors.toList()))
         .containsExactlyInAnyOrderElementsOf(

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/ChunkManagerUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/ChunkManagerUtil.java
@@ -1,7 +1,6 @@
 package com.slack.kaldb.testlib;
 
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
-import static com.slack.kaldb.server.KaldbConfig.DEFAULT_ZK_TIMEOUT_SECS;
 
 import com.adobe.testing.s3mock.junit4.S3MockRule;
 import com.google.common.io.Files;
@@ -12,7 +11,6 @@ import com.slack.kaldb.chunkManager.ChunkRollOverStrategy;
 import com.slack.kaldb.chunkManager.ChunkRollOverStrategyImpl;
 import com.slack.kaldb.chunkManager.IndexingChunkManager;
 import com.slack.kaldb.logstore.LogMessage;
-import com.slack.kaldb.metadata.search.SearchMetadata;
 import com.slack.kaldb.metadata.snapshot.SnapshotMetadata;
 import com.slack.kaldb.metadata.zookeeper.MetadataStore;
 import com.slack.kaldb.metadata.zookeeper.ZookeeperMetadataStoreImpl;
@@ -21,8 +19,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -143,19 +139,7 @@ public class ChunkManagerUtil<T> {
     return afterSnapshots.stream().filter(condition).collect(Collectors.toList());
   }
 
-  public static List<SearchMetadata> fetchSearchNodes(IndexingChunkManager<LogMessage> chunkManager)
-      throws InterruptedException, ExecutionException, TimeoutException {
-    return chunkManager
-        .getSearchMetadataStore()
-        .list()
-        .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
-  }
-
-  public static List<SnapshotMetadata> fetchSnapshots(IndexingChunkManager<LogMessage> chunkManager)
-      throws InterruptedException, ExecutionException, TimeoutException {
-    return chunkManager
-        .getSnapshotMetadataStore()
-        .list()
-        .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+  public MetadataStore getMetadataStore() {
+    return metadataStore;
   }
 }


### PR DESCRIPTION
Minor refactor to `IndexingChunkManager` to remove a couple getters. In the past, creating metadata stores was more complex. Since it's more easy not, removing the getters simplifies the class and makes future refactors easier.

Fix code warnings in indexing chunk manager tests.