### PR TITLE
Export kafka consumer metrics.

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbLocalQueryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbLocalQueryService.java
@@ -27,6 +27,7 @@ public class KaldbLocalQueryService<T> extends KaldbQueryServiceBase {
     KaldbSearch.SearchResult result = SearchResultUtils.toSearchResultProto(searchResult);
     span.tag("totalNodes", String.valueOf(result.getTotalNodes()));
     span.tag("failedNodes", String.valueOf(result.getFailedNodes()));
+    span.tag("hitCount", String.valueOf(result.getHitsCount()));
     span.finish();
     LOG.info("Finished search request: {}", request);
     return result;

--- a/kaldb/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
@@ -9,6 +9,7 @@ import com.slack.kaldb.server.KaldbConfig;
 import com.slack.kaldb.writer.LogMessageWriterImpl;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.kafka.KafkaClientMetrics;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Collections;
@@ -144,6 +145,7 @@ public class KaldbKafkaConsumer {
             kafkaAutoCommitInterval,
             kafkaSessionTimeout);
     kafkaConsumer = new KafkaConsumer<>(consumerProps);
+    new KafkaClientMetrics(kafkaConsumer).bindTo(meterRegistry);
   }
 
   /** Start consuming the partition from an offset. */


### PR DESCRIPTION
Export kafka consumer metrics.

Add hit count to span so it can help in analysis.