### PR TITLE
Reduce Armeria limits/timeouts

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
@@ -35,7 +35,7 @@ import zipkin2.reporter.urlconnection.URLConnectionSender;
 public class ArmeriaService extends AbstractIdleService {
   private static final Logger LOG = LoggerFactory.getLogger(ArmeriaService.class);
 
-  private static final int WORKER_EVENT_LOOP_THREADS = 16;
+  private static final int MAX_CONNECTIONS = 100;
 
   private final String serviceName;
   private final Server server;
@@ -54,14 +54,15 @@ public class ArmeriaService extends AbstractIdleService {
       this.serviceName = serviceName;
       this.serverBuilder = Server.builder().http(port);
 
-      initializeTimeouts();
+      initializeLimits();
       initializeCompression();
       initializeLogging();
       initializeManagementEndpoints(prometheusMeterRegistry);
     }
 
-    private void initializeTimeouts() {
+    private void initializeLimits() {
       serverBuilder.requestTimeout(ARMERIA_TIMEOUT_DURATION);
+      serverBuilder.maxNumConnections(MAX_CONNECTIONS);
     }
 
     private void initializeCompression() {

--- a/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
@@ -110,6 +110,9 @@ public class ArmeriaService extends AbstractIdleService {
           GrpcService.builder()
               .addService(grpcService)
               .enableUnframedRequests(true)
+              // if not using the client timeout header - separate, lower timeouts
+              // should be configured for indexer / cache nodes than that of the query server
+              .useClientTimeoutHeader(true)
               .useBlockingTaskExecutor(true);
       serverBuilder.decorator(
           MetricCollectingService.newDecorator(GrpcMeterIdPrefixFunction.of("grpc.service")));

--- a/kaldb/src/main/java/com/slack/kaldb/server/KaldbConfig.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/KaldbConfig.java
@@ -37,7 +37,7 @@ public class KaldbConfig {
   // include metadata that should always be present. The Armeria timeout is used at the top request,
   // distributed query is used as a deadline for all nodes to return, and the local query timeout
   // is used for controlling lucene future timeouts.
-  public static final Duration ARMERIA_TIMEOUT_DURATION = Duration.of(15, ChronoUnit.SECONDS);
+  public static final Duration ARMERIA_TIMEOUT_DURATION = Duration.of(10, ChronoUnit.SECONDS);
   public static Duration DISTRIBUTED_QUERY_TIMEOUT_DURATION =
       ARMERIA_TIMEOUT_DURATION.minus(Duration.of(2, ChronoUnit.SECONDS));
   public static Duration LOCAL_QUERY_TIMEOUT_DURATION =


### PR DESCRIPTION
Adds a max connection limit to Armeria, reduces the global timeout value from 15s to 10s, and switches grpc to use the client supplied timeout value instead of relying on the `ServerBuilder.requestTimeout` value.