### PR TITLE
Add parallel result building

### DIFF
--- a/benchmarks/src/main/java/com/slack/kaldb/QueryBenchmark.java
+++ b/benchmarks/src/main/java/com/slack/kaldb/QueryBenchmark.java
@@ -114,7 +114,12 @@ public class QueryBenchmark {
   }
 
   @Benchmark
-  public void measureLogSearcherSearch() {
+  public void measureLogSearcherSearcherOne() {
+    logIndexSearcher.search("*", "", 0, Long.MAX_VALUE, 1, 60);
+  }
+
+  @Benchmark
+  public void measureLogSearcherSearcherFiveHundred() {
     logIndexSearcher.search("*", "", 0, Long.MAX_VALUE, 500, 60);
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/LogIndexSearcherImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/LogIndexSearcherImpl.java
@@ -123,6 +123,7 @@ public class LogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
           ScoreDoc[] hits = topFieldCollector.topDocs().scoreDocs;
           results =
               Stream.of(hits)
+                  .parallel()
                   .map(hit -> buildLogMessage(searcher, hit))
                   .collect(Collectors.toList());
         } else {


### PR DESCRIPTION
This work is CPU bound and easily done in parallel, so is an easy win. Reduces the performance penalty we're seeing with large result sets.

### Local benchmark comparison

#### Before:
```
Benchmark                                              Mode  Cnt   Score   Error  Units
QueryBenchmark.measureLogSearcherSearcherFivehundred  thrpt    5  10.775 ± 1.553  ops/s
QueryBenchmark.measureLogSearcherSearcherOne          thrpt    5  13.067 ± 1.441  ops/s
```
#### After:
```
Benchmark                                              Mode  Cnt   Score   Error  Units
QueryBenchmark.measureLogSearcherSearcherFiveHundred  thrpt    5  14.904 ± 2.143  ops/s
QueryBenchmark.measureLogSearcherSearcherOne          thrpt    5  15.057 ± 2.927  ops/s
```