### PR TITLE
Make all assertion imports consistent.

### DIFF
--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/CachingChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/CachingChunkManagerTest.java
@@ -1,7 +1,7 @@
 package com.slack.kaldb.chunkManager;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 import com.adobe.testing.s3mock.junit4.S3MockRule;

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentServiceTest.java
@@ -1,7 +1,7 @@
 package com.slack.kaldb.clusterManager;
 
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -30,7 +30,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.curator.test.TestingServer;
-import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -138,19 +137,19 @@ public class RecoveryTaskAssignmentServiceTest {
     assertTrue(recoveryTaskMetadataStore.listSync().isEmpty());
     assertTrue(recoveryNodeMetadataStore.listSync().isEmpty());
 
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_CREATED, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_FAILED, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_INSUFFICIENT_CAPACITY, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getTimerCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASK_ASSIGNMENT_TIMER, meterRegistry))
         .isEqualTo(1);
@@ -189,19 +188,19 @@ public class RecoveryTaskAssignmentServiceTest {
     assertThat(recoveryTaskMetadataStore.listSync().size()).isEqualTo(3);
     assertTrue(recoveryNodeMetadataStore.listSync().isEmpty());
 
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_CREATED, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_FAILED, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_INSUFFICIENT_CAPACITY, meterRegistry))
         .isEqualTo(3);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getTimerCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASK_ASSIGNMENT_TIMER, meterRegistry))
         .isEqualTo(1);
@@ -278,19 +277,19 @@ public class RecoveryTaskAssignmentServiceTest {
                 .count())
         .isEqualTo(2);
 
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_CREATED, meterRegistry))
         .isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_FAILED, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_INSUFFICIENT_CAPACITY, meterRegistry))
         .isEqualTo(2);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getTimerCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASK_ASSIGNMENT_TIMER, meterRegistry))
         .isEqualTo(1);
@@ -332,19 +331,19 @@ public class RecoveryTaskAssignmentServiceTest {
     assertTrue(recoveryTaskMetadataStore.listSync().isEmpty());
     assertThat(recoveryNodeMetadataStore.listSync().size()).isEqualTo(3);
 
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_CREATED, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_FAILED, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_INSUFFICIENT_CAPACITY, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getTimerCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASK_ASSIGNMENT_TIMER, meterRegistry))
         .isEqualTo(1);
@@ -403,19 +402,19 @@ public class RecoveryTaskAssignmentServiceTest {
     assertThat(recoveryNodeMetadataStore.listSync().get(0).recoveryNodeState)
         .isEqualTo(Metadata.RecoveryNodeMetadata.RecoveryNodeState.ASSIGNED);
 
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_CREATED, meterRegistry))
         .isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_FAILED, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_INSUFFICIENT_CAPACITY, meterRegistry))
         .isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getTimerCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASK_ASSIGNMENT_TIMER, meterRegistry))
         .isEqualTo(1);
@@ -466,11 +465,11 @@ public class RecoveryTaskAssignmentServiceTest {
 
     int firstAttemptAssignment = recoveryTaskAssignmentService.assignRecoveryTasksToNodes();
     assertThat(firstAttemptAssignment).isEqualTo(2);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_CREATED, meterRegistry))
         .isEqualTo(2);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_FAILED, meterRegistry))
         .isEqualTo(1);
@@ -506,19 +505,19 @@ public class RecoveryTaskAssignmentServiceTest {
                         .count()
                     == 3);
 
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_CREATED, meterRegistry))
         .isEqualTo(3);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_FAILED, meterRegistry))
         .isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_INSUFFICIENT_CAPACITY, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getTimerCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASK_ASSIGNMENT_TIMER, meterRegistry))
         .isEqualTo(2);
@@ -580,19 +579,19 @@ public class RecoveryTaskAssignmentServiceTest {
     int assignments = recoveryTaskAssignmentService.assignRecoveryTasksToNodes();
 
     assertThat(assignments).isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_CREATED, meterRegistry))
         .isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_FAILED, meterRegistry))
         .isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_INSUFFICIENT_CAPACITY, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getTimerCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASK_ASSIGNMENT_TIMER, meterRegistry))
         .isEqualTo(1);
@@ -667,19 +666,19 @@ public class RecoveryTaskAssignmentServiceTest {
     int assignments = recoveryTaskAssignmentService.assignRecoveryTasksToNodes();
 
     assertThat(assignments).isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_CREATED, meterRegistry))
         .isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_FAILED, meterRegistry))
         .isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASKS_INSUFFICIENT_CAPACITY, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getTimerCount(
                 RecoveryTaskAssignmentService.RECOVERY_TASK_ASSIGNMENT_TIMER, meterRegistry))
         .isEqualTo(1);

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentServiceTest.java
@@ -3,7 +3,6 @@ package com.slack.kaldb.clusterManager;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.spy;
@@ -134,8 +133,8 @@ public class RecoveryTaskAssignmentServiceTest {
     int assignments = recoveryTaskAssignmentService.assignRecoveryTasksToNodes();
 
     assertThat(assignments).isEqualTo(0);
-    assertTrue(recoveryTaskMetadataStore.listSync().isEmpty());
-    assertTrue(recoveryNodeMetadataStore.listSync().isEmpty());
+    assertThat(recoveryTaskMetadataStore.listSync().isEmpty()).isTrue();
+    assertThat(recoveryNodeMetadataStore.listSync().isEmpty()).isTrue();
 
     assertThat(
             MetricsUtil.getCount(
@@ -186,7 +185,7 @@ public class RecoveryTaskAssignmentServiceTest {
 
     assertThat(assignments).isEqualTo(0);
     assertThat(recoveryTaskMetadataStore.listSync().size()).isEqualTo(3);
-    assertTrue(recoveryNodeMetadataStore.listSync().isEmpty());
+    assertThat(recoveryNodeMetadataStore.listSync().isEmpty()).isTrue();
 
     assertThat(
             MetricsUtil.getCount(
@@ -265,7 +264,7 @@ public class RecoveryTaskAssignmentServiceTest {
     assertThat(assignments).isEqualTo(1);
     assertThat(recoveryTaskMetadataStore.listSync().size()).isEqualTo(3);
     assertThat(recoveryNodeMetadataStore.listSync().size()).isEqualTo(3);
-    assertTrue(recoveryNodeMetadataStore.listSync().containsAll(ineligibleRecoveryNodes));
+    assertThat(recoveryNodeMetadataStore.listSync().containsAll(ineligibleRecoveryNodes)).isTrue();
     assertThat(
             recoveryNodeMetadataStore
                 .listSync()
@@ -328,7 +327,7 @@ public class RecoveryTaskAssignmentServiceTest {
     int assignments = recoveryTaskAssignmentService.assignRecoveryTasksToNodes();
 
     assertThat(assignments).isEqualTo(0);
-    assertTrue(recoveryTaskMetadataStore.listSync().isEmpty());
+    assertThat(recoveryTaskMetadataStore.listSync().isEmpty()).isTrue();
     assertThat(recoveryNodeMetadataStore.listSync().size()).isEqualTo(3);
 
     assertThat(

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
@@ -3,7 +3,6 @@ package com.slack.kaldb.clusterManager;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.spy;
@@ -186,7 +185,7 @@ public class ReplicaAssignmentServiceTest {
     assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(0);
     assertThat(replicaMetadataStore.listSync().size()).isEqualTo(3);
 
-    assertTrue(replicaMetadataList.containsAll(replicaMetadataStore.listSync()));
+    assertThat(replicaMetadataList.containsAll(replicaMetadataStore.listSync())).isTrue();
     assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
     assertThat(
@@ -239,7 +238,7 @@ public class ReplicaAssignmentServiceTest {
     assertThat(replicaMetadataStore.listSync().size()).isEqualTo(0);
     assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(3);
 
-    assertTrue(cacheSlotMetadataList.containsAll(cacheSlotMetadataStore.listSync()));
+    assertThat(cacheSlotMetadataList.containsAll(cacheSlotMetadataStore.listSync())).isTrue();
     assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
     assertThat(
@@ -315,8 +314,8 @@ public class ReplicaAssignmentServiceTest {
     assertThat(replicaMetadataStore.listSync().size()).isEqualTo(3);
     assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(5);
 
-    assertTrue(cacheSlotMetadataList.containsAll(cacheSlotMetadataStore.listSync()));
-    assertTrue(replicaMetadataList.containsAll(replicaMetadataStore.listSync()));
+    assertThat(cacheSlotMetadataList.containsAll(cacheSlotMetadataStore.listSync())).isTrue();
+    assertThat(replicaMetadataList.containsAll(replicaMetadataStore.listSync())).isTrue();
     assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
     assertThat(
@@ -404,7 +403,7 @@ public class ReplicaAssignmentServiceTest {
 
     assertThat(replicaMetadataStore.listSync().size()).isEqualTo(4);
     assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(4);
-    assertTrue(cacheSlotMetadataStore.getCached().containsAll(unmutatedSlots));
+    assertThat(cacheSlotMetadataStore.getCached().containsAll(unmutatedSlots)).isTrue();
 
     List<CacheSlotMetadata> mutatedCacheSlots =
         cacheSlotMetadataStore
@@ -416,7 +415,7 @@ public class ReplicaAssignmentServiceTest {
     assertThat(mutatedCacheSlots.get(0).name).isEqualTo(cacheSlotFree.name);
     assertThat(mutatedCacheSlots.get(0).replicaId).isEqualTo(replicaMetadataList.get(3).name);
 
-    assertTrue(replicaMetadataList.containsAll(replicaMetadataStore.listSync()));
+    assertThat(replicaMetadataList.containsAll(replicaMetadataStore.listSync())).isTrue();
 
     assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
@@ -482,8 +481,8 @@ public class ReplicaAssignmentServiceTest {
     assertThat(replicaMetadataStore.listSync().size()).isEqualTo(5);
     assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(3);
 
-    assertTrue(cacheSlotMetadataList.containsAll(cacheSlotMetadataStore.listSync()));
-    assertTrue(replicaMetadataList.containsAll(replicaMetadataStore.listSync()));
+    assertThat(cacheSlotMetadataList.containsAll(cacheSlotMetadataStore.listSync())).isTrue();
+    assertThat(replicaMetadataList.containsAll(replicaMetadataStore.listSync())).isTrue();
     assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
     assertThat(
@@ -586,16 +585,17 @@ public class ReplicaAssignmentServiceTest {
                             Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED))
                 .count())
         .isEqualTo(3);
-    assertTrue(
-        replicaMetadataExpiredList.containsAll(
-            replicaMetadataStore
-                .listSync()
-                .stream()
-                .filter(
-                    replicaMetadata ->
-                        replicaMetadata.createdTimeEpochMs
-                            < Instant.now().minus(1440, ChronoUnit.MINUTES).toEpochMilli())
-                .collect(Collectors.toList())));
+    assertThat(
+            replicaMetadataExpiredList.containsAll(
+                replicaMetadataStore
+                    .listSync()
+                    .stream()
+                    .filter(
+                        replicaMetadata ->
+                            replicaMetadata.createdTimeEpochMs
+                                < Instant.now().minus(1440, ChronoUnit.MINUTES).toEpochMilli())
+                    .collect(Collectors.toList())))
+        .isTrue();
 
     assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
@@ -1068,7 +1068,7 @@ public class ReplicaAssignmentServiceTest {
                                     Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED))
                         .count()
                     == 2);
-    assertTrue(replicaMetadataList.containsAll(replicaMetadataStore.listSync()));
+    assertThat(replicaMetadataList.containsAll(replicaMetadataStore.listSync())).isTrue();
 
     assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
@@ -1,7 +1,7 @@
 package com.slack.kaldb.clusterManager;
 
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -31,7 +31,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import org.apache.curator.test.TestingServer;
-import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -135,17 +134,16 @@ public class ReplicaAssignmentServiceTest {
 
     assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(0);
     assertThat(replicaMetadataStore.listSync().size()).isEqualTo(0);
-    Assertions.assertThat(
-            MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
+    assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getValue(
                 ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
         .isEqualTo(1);
   }
@@ -189,17 +187,16 @@ public class ReplicaAssignmentServiceTest {
     assertThat(replicaMetadataStore.listSync().size()).isEqualTo(3);
 
     assertTrue(replicaMetadataList.containsAll(replicaMetadataStore.listSync()));
-    Assertions.assertThat(
-            MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
+    assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getValue(
                 ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
         .isEqualTo(-3);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
         .isEqualTo(1);
   }
@@ -243,17 +240,16 @@ public class ReplicaAssignmentServiceTest {
     assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(3);
 
     assertTrue(cacheSlotMetadataList.containsAll(cacheSlotMetadataStore.listSync()));
-    Assertions.assertThat(
-            MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
+    assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getValue(
                 ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
         .isEqualTo(3);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
         .isEqualTo(1);
   }
@@ -321,17 +317,16 @@ public class ReplicaAssignmentServiceTest {
 
     assertTrue(cacheSlotMetadataList.containsAll(cacheSlotMetadataStore.listSync()));
     assertTrue(replicaMetadataList.containsAll(replicaMetadataStore.listSync()));
-    Assertions.assertThat(
-            MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
+    assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getValue(
                 ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
         .isEqualTo(2);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
         .isEqualTo(1);
   }
@@ -423,17 +418,16 @@ public class ReplicaAssignmentServiceTest {
 
     assertTrue(replicaMetadataList.containsAll(replicaMetadataStore.listSync()));
 
-    Assertions.assertThat(
-            MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
+    assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getValue(
                 ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
         .isEqualTo(1);
   }
@@ -490,17 +484,16 @@ public class ReplicaAssignmentServiceTest {
 
     assertTrue(cacheSlotMetadataList.containsAll(cacheSlotMetadataStore.listSync()));
     assertTrue(replicaMetadataList.containsAll(replicaMetadataStore.listSync()));
-    Assertions.assertThat(
-            MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
+    assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getValue(
                 ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
         .isEqualTo(-2);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
         .isEqualTo(1);
   }
@@ -604,17 +597,16 @@ public class ReplicaAssignmentServiceTest {
                             < Instant.now().minus(1440, ChronoUnit.MINUTES).toEpochMilli())
                 .collect(Collectors.toList())));
 
-    Assertions.assertThat(
-            MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
+    assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(3);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getValue(
                 ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
         .isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
         .isEqualTo(1);
   }
@@ -690,13 +682,12 @@ public class ReplicaAssignmentServiceTest {
                 .count())
         .isEqualTo(1);
 
-    Assertions.assertThat(
-            MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
+    assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
         .isEqualTo(1);
 
@@ -728,17 +719,16 @@ public class ReplicaAssignmentServiceTest {
                 .count())
         .isEqualTo(1);
 
-    Assertions.assertThat(
-            MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
+    assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(2);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getValue(
                 ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
         .isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
         .isEqualTo(2);
   }
@@ -824,17 +814,16 @@ public class ReplicaAssignmentServiceTest {
                 .count())
         .isEqualTo(1);
 
-    Assertions.assertThat(
-            MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
+    assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getValue(
                 ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
         .isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
         .isEqualTo(1);
 
@@ -912,17 +901,16 @@ public class ReplicaAssignmentServiceTest {
                 .count())
         .isEqualTo(1);
 
-    Assertions.assertThat(
-            MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
+    assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getValue(
                 ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
         .isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
         .isEqualTo(1);
   }
@@ -1006,17 +994,16 @@ public class ReplicaAssignmentServiceTest {
                         .count()
                     == 1);
 
-    Assertions.assertThat(
-            MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
+    assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(2);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getValue(
                 ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
         .isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
         .isEqualTo(1);
 
@@ -1083,17 +1070,16 @@ public class ReplicaAssignmentServiceTest {
                     == 2);
     assertTrue(replicaMetadataList.containsAll(replicaMetadataStore.listSync()));
 
-    Assertions.assertThat(
-            MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
+    assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_SUCCEEDED, meterRegistry))
         .isEqualTo(2);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getValue(
                 ReplicaAssignmentService.REPLICA_ASSIGN_AVAILABLE_CAPACITY, meterRegistry))
         .isEqualTo(-1);
-    Assertions.assertThat(
+    assertThat(
             MetricsUtil.getTimerCount(ReplicaAssignmentService.REPLICA_ASSIGN_TIMER, meterRegistry))
         .isEqualTo(1);
 

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaCreationServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaCreationServiceTest.java
@@ -3,7 +3,6 @@ package com.slack.kaldb.clusterManager;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.spy;
@@ -248,7 +247,7 @@ public class ReplicaCreationServiceTest {
                         .getCached()
                         .containsAll(Arrays.asList(snapshotLive, snapshotNotLive))
                     && snapshotMetadataStore.getCached().size() == 2);
-    assertTrue(replicaMetadataStore.getCached().isEmpty());
+    assertThat(replicaMetadataStore.getCached().isEmpty()).isTrue();
 
     int assignReplicas = replicaCreationService.createReplicasForUnassignedSnapshots();
 
@@ -369,12 +368,13 @@ public class ReplicaCreationServiceTest {
             .stream()
             .map(snapshotMetadata -> snapshotMetadata.snapshotId)
             .collect(Collectors.toList());
-    assertTrue(
-        replicaMetadataStore
-            .listSync()
-            .stream()
-            .allMatch(
-                (replicaMetadata) -> eligibleSnapshotIds.contains(replicaMetadata.snapshotId)));
+    assertThat(
+            replicaMetadataStore
+                .listSync()
+                .stream()
+                .allMatch(
+                    (replicaMetadata) -> eligibleSnapshotIds.contains(replicaMetadata.snapshotId)))
+        .isTrue();
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiServiceTest.java
@@ -1,7 +1,7 @@
 package com.slack.kaldb.elasticsearchApi;
 
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import brave.Tracing;
 import com.adobe.testing.s3mock.junit4.S3MockRule;

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/LogDocumentBuilderImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/LogDocumentBuilderImplTest.java
@@ -1,6 +1,6 @@
 package com.slack.kaldb.logstore;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.slack.kaldb.testlib.MessageUtil;
 import java.io.IOException;
@@ -25,7 +25,7 @@ public class LogDocumentBuilderImplTest {
   @Test
   public void testWithValidMessage() throws IOException {
     Document testDocument = testBuilderAllowExceptions.fromMessage(MessageUtil.makeMessage(0));
-    assertEquals(12, testDocument.getFields().size());
+    assertThat(testDocument.getFields().size()).isEqualTo(12);
   }
 
   // TODO: Test IOException and JSONSerialization exception.

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataTest.java
@@ -1,7 +1,7 @@
 package com.slack.kaldb.metadata.cache;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import com.slack.kaldb.proto.metadata.Metadata;
 import java.time.Instant;

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataTest.java
@@ -1,7 +1,7 @@
 package com.slack.kaldb.metadata.recovery;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import com.slack.kaldb.proto.metadata.Metadata;
 import java.time.Instant;

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataTest.java
@@ -1,7 +1,7 @@
 package com.slack.kaldb.metadata.recovery;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import java.time.Instant;
 import org.junit.Test;

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataTest.java
@@ -1,7 +1,7 @@
 package com.slack.kaldb.metadata.replica;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import java.time.Instant;
 import org.junit.Test;

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/zookeeper/ZookeeperCachedMetadataStoreImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/zookeeper/ZookeeperCachedMetadataStoreImplTest.java
@@ -7,7 +7,6 @@ import static com.slack.kaldb.util.SnapshotUtil.makeSnapshot;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.awaitility.Awaitility.await;
-import static org.junit.Assert.assertEquals;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.slack.kaldb.metadata.core.MetadataSerializer;
@@ -173,7 +172,7 @@ public class ZookeeperCachedMetadataStoreImplTest {
     assertThat(countDownLatch.await(3000, TimeUnit.MILLISECONDS)).isTrue();
 
     // verify that we still did not see any executions
-    assertEquals(0, listenerExecutions.get());
+    assertThat(listenerExecutions.get()).isZero();
   }
 
   @SuppressWarnings("OptionalGetWithoutIsPresent")

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/KaldbSerdesTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/KaldbSerdesTest.java
@@ -1,6 +1,6 @@
 package com.slack.kaldb.preprocessor;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.ByteString;
 import com.slack.service.murron.Murron;

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiterTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiterTest.java
@@ -3,8 +3,8 @@ package com.slack.kaldb.preprocessor;
 import static com.slack.kaldb.preprocessor.PreprocessorRateLimiter.BYTES_DROPPED;
 import static com.slack.kaldb.preprocessor.PreprocessorRateLimiter.MESSAGES_DROPPED;
 import static com.slack.kaldb.preprocessor.PreprocessorValueMapper.SERVICE_NAME_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import com.slack.service.murron.trace.Trace;
 import io.micrometer.core.instrument.MeterRegistry;

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
@@ -1,7 +1,7 @@
 package com.slack.kaldb.preprocessor;
 
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import com.slack.kaldb.metadata.service.ServiceMetadata;

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
@@ -2,10 +2,7 @@ package com.slack.kaldb.preprocessor;
 
 import static com.slack.kaldb.preprocessor.PreprocessorValueMapper.SERVICE_NAME_KEY;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.assertThatNullPointerException;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -123,10 +120,12 @@ public class PreprocessorServiceUnitTest {
 
     // all arguments except value are currently unused for determining the partition to assign, as
     // this comes the internal partition list that is set on stream partitioner initialization
-    assertTrue(partitionList.contains(streamPartitioner.partition("topic", null, span, 0)));
-    assertTrue(partitionList.contains(streamPartitioner.partition("topic", null, span, 1)));
-    assertTrue(partitionList.contains(streamPartitioner.partition("topic", "", span, 0)));
-    assertTrue(partitionList.contains(streamPartitioner.partition("", null, span, 0)));
+    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 0)))
+        .isTrue();
+    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 1)))
+        .isTrue();
+    assertThat(partitionList.contains(streamPartitioner.partition("topic", "", span, 0))).isTrue();
+    assertThat(partitionList.contains(streamPartitioner.partition("", null, span, 0))).isTrue();
   }
 
   @Test
@@ -173,7 +172,7 @@ public class PreprocessorServiceUnitTest {
         PreprocessorService.filterValidServiceMetadata(serviceMetadataList);
 
     assertThat(serviceMetadata1.size()).isEqualTo(1);
-    assertTrue(serviceMetadata1.contains(validServiceMetadata));
+    assertThat(serviceMetadata1.contains(validServiceMetadata)).isTrue();
 
     Collections.shuffle(serviceMetadata1);
 
@@ -181,7 +180,7 @@ public class PreprocessorServiceUnitTest {
         PreprocessorService.filterValidServiceMetadata(serviceMetadataList);
 
     assertThat(serviceMetadata2.size()).isEqualTo(1);
-    assertTrue(serviceMetadata2.contains(validServiceMetadata));
+    assertThat(serviceMetadata2.contains(validServiceMetadata)).isTrue();
 
     List<ServiceMetadata> serviceMetadata3 =
         PreprocessorService.filterValidServiceMetadata(List.of());

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorValueMapperTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorValueMapperTest.java
@@ -1,10 +1,8 @@
 package com.slack.kaldb.preprocessor;
 
 import static com.slack.kaldb.testlib.SpanUtil.makeSpan;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 import com.google.protobuf.ByteString;
 import com.slack.service.murron.Murron;
@@ -45,26 +43,34 @@ public class PreprocessorValueMapperTest {
     assertThat(span.getDurationMicros()).isEqualTo(1);
 
     assertThat(span.getTagsList().size()).isEqualTo(6);
-    assertTrue(
-        span.getTagsList()
-            .contains(Trace.KeyValue.newBuilder().setKey("http_method").setVStr("POST").build()));
-    assertTrue(
-        span.getTagsList()
-            .contains(Trace.KeyValue.newBuilder().setKey("method").setVStr("verifyToken").build()));
-    assertTrue(
-        span.getTagsList()
-            .contains(Trace.KeyValue.newBuilder().setKey("type").setVStr(indexName).build()));
-    assertTrue(
-        span.getTagsList()
-            .contains(Trace.KeyValue.newBuilder().setKey("level").setVStr("info").build()));
-    assertTrue(
-        span.getTagsList()
-            .contains(Trace.KeyValue.newBuilder().setKey("hostname").setVStr(host).build()));
-    assertTrue(
-        span.getTagsList()
-            .contains(
-                Trace.KeyValue.newBuilder().setKey("service_name").setVStr(indexName).build()));
-    assertFalse(spanIterator.hasNext());
+    assertThat(
+            span.getTagsList()
+                .contains(
+                    Trace.KeyValue.newBuilder().setKey("http_method").setVStr("POST").build()))
+        .isTrue();
+    assertThat(
+            span.getTagsList()
+                .contains(
+                    Trace.KeyValue.newBuilder().setKey("method").setVStr("verifyToken").build()))
+        .isTrue();
+    assertThat(
+            span.getTagsList()
+                .contains(Trace.KeyValue.newBuilder().setKey("type").setVStr(indexName).build()))
+        .isTrue();
+    assertThat(
+            span.getTagsList()
+                .contains(Trace.KeyValue.newBuilder().setKey("level").setVStr("info").build()))
+        .isTrue();
+    assertThat(
+            span.getTagsList()
+                .contains(Trace.KeyValue.newBuilder().setKey("hostname").setVStr(host).build()))
+        .isTrue();
+    assertThat(
+            span.getTagsList()
+                .contains(
+                    Trace.KeyValue.newBuilder().setKey("service_name").setVStr(indexName).build()))
+        .isTrue();
+    assertThat(spanIterator.hasNext()).isFalse();
   }
 
   @Test
@@ -104,24 +110,31 @@ public class PreprocessorValueMapperTest {
     assertThat(mappedSpan.getDurationMicros()).isEqualTo(durationMicros);
 
     assertThat(mappedSpan.getTagsList().size()).isEqualTo(8);
-    assertTrue(
-        mappedSpan
-            .getTagsList()
-            .contains(
-                Trace.KeyValue.newBuilder()
-                    .setKey("service_name")
-                    .setVStr("test_service")
-                    .build()));
-    assertTrue(
-        mappedSpan
-            .getTagsList()
-            .contains(Trace.KeyValue.newBuilder().setKey("http_method").setVStr("POST").build()));
-    assertTrue(
-        mappedSpan
-            .getTagsList()
-            .contains(
-                Trace.KeyValue.newBuilder().setKey("method").setVStr("callbacks.flannel").build()));
-    assertFalse(spanIterator.hasNext());
+    assertThat(
+            mappedSpan
+                .getTagsList()
+                .contains(
+                    Trace.KeyValue.newBuilder()
+                        .setKey("service_name")
+                        .setVStr("test_service")
+                        .build()))
+        .isTrue();
+    assertThat(
+            mappedSpan
+                .getTagsList()
+                .contains(
+                    Trace.KeyValue.newBuilder().setKey("http_method").setVStr("POST").build()))
+        .isTrue();
+    assertThat(
+            mappedSpan
+                .getTagsList()
+                .contains(
+                    Trace.KeyValue.newBuilder()
+                        .setKey("method")
+                        .setVStr("callbacks.flannel")
+                        .build()))
+        .isTrue();
+    assertThat(spanIterator.hasNext()).isFalse();
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
@@ -1,7 +1,7 @@
 package com.slack.kaldb.recovery;
 
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import brave.Tracing;

--- a/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
@@ -1,8 +1,8 @@
 package com.slack.kaldb.server;
 
 import static com.slack.kaldb.server.ManagerApiGrpc.MAX_TIME;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;

--- a/kaldb/src/test/java/com/slack/kaldb/server/SearchResultTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/SearchResultTest.java
@@ -1,6 +1,6 @@
 package com.slack.kaldb.server;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import brave.Tracing;
 import com.slack.kaldb.histogram.HistogramBucket;

--- a/kaldb/src/test/java/com/slack/kaldb/writer/ApiLogFormatterTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/ApiLogFormatterTest.java
@@ -1,7 +1,7 @@
 package com.slack.kaldb.writer;
 
 import static com.slack.kaldb.writer.ApiLogFormatter.API_LOG_DURATION_FIELD;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;

--- a/kaldb/src/test/java/com/slack/kaldb/writer/SpanFormatterTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/SpanFormatterTest.java
@@ -1,7 +1,7 @@
 package com.slack.kaldb.writer;
 
 import static com.slack.kaldb.testlib.SpanUtil.BINARY_TAG_VALUE;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.ByteString;
 import com.slack.kaldb.logstore.LogMessage;
@@ -204,14 +204,4 @@ public class SpanFormatterTest {
     assertThat(new String(Base64.getDecoder().decode(binaryTagValue), StandardCharsets.UTF_8))
         .isEqualTo(BINARY_TAG_VALUE);
   }
-
-  // TODO: Remove this code once span parsing is more stable.
-  // @Test
-  // public void testFailingSpanFormat() throws InvalidProtocolBufferException {
-  //  String jsonSpan = "";
-  //  Trace.Span.Builder spanBuilder = Trace.Span.newBuilder();
-  //   JsonFormat.parser().ignoringUnknownFields().merge(jsonSpan, spanBuilder);
-  //   Trace.Span span = spanBuilder.build();
-  //  SpanFormatter.toLogMessage(span);
-  //  }
 }


### PR DESCRIPTION
Import assertions from `Assertions` instead of `AssertionsForClassTypes` so we use the same library everywhere. Also, don't use junit assertions.