### PR TITLE
Granular recovery tasks

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadata.java
@@ -23,7 +23,8 @@ public class RecoveryTaskMetadata extends KaldbMetadata {
     checkArgument(
         partitionId != null && !partitionId.isEmpty(), "partitionId can't be null or empty");
     checkArgument(startOffset >= 0, "startOffset must greater than 0");
-    checkArgument(endOffset > startOffset, "endOffset must be greater than the startOffset");
+    checkArgument(
+        endOffset >= startOffset, "endOffset must be greater than or equal to the startOffset");
     checkArgument(createdTimeEpochMs > 0, "createdTimeEpochMs must be greater than 0");
 
     this.partitionId = partitionId;

--- a/kaldb/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
@@ -98,12 +98,15 @@ public class KaldbIndexer extends AbstractExecutionThreadService {
     String partitionId = kafkaConfig.getKafkaTopicPartition();
     long maxOffsetDelay = indexerConfig.getMaxOffsetDelayMessages();
 
+    // TODO: Move this to it's own config var.
+    final long maxMessagesPerRecoveryTask = indexerConfig.getMaxMessagesPerChunk();
     RecoveryTaskCreator recoveryTaskCreator =
         new RecoveryTaskCreator(
             snapshotMetadataStore,
             recoveryTaskMetadataStore,
             partitionId,
             maxOffsetDelay,
+            maxMessagesPerRecoveryTask,
             meterRegistry);
 
     long currentHeadOffsetForPartition = kafkaConsumer.getEndOffSetForPartition();

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataTest.java
@@ -57,12 +57,18 @@ public class RecoveryTaskMetadataTest {
   }
 
   @Test
+  public void testSingleMessageRecoveryTask() {
+    RecoveryTaskMetadata recoveryTask =
+        new RecoveryTaskMetadata("name", "partitionId", 10, 10, Instant.now().toEpochMilli());
+    assertThat(recoveryTask.startOffset).isEqualTo(recoveryTask.endOffset);
+
+    RecoveryTaskMetadata recoveryTask2 =
+        new RecoveryTaskMetadata("name", "partitionId", 0, 0, Instant.now().toEpochMilli());
+    assertThat(recoveryTask2.startOffset).isEqualTo(recoveryTask2.endOffset);
+  }
+
+  @Test
   public void invalidArgumentsShouldThrow() {
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () ->
-                new RecoveryTaskMetadata(
-                    "name", "partitionId", 0, 0, Instant.now().toEpochMilli()));
     assertThatIllegalArgumentException()
         .isThrownBy(() -> new RecoveryTaskMetadata("name", "", 0, 1, Instant.now().toEpochMilli()));
     assertThatIllegalArgumentException()

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -1458,23 +1458,23 @@ public class RecoveryTaskCreatorTest {
     assertThat(recoveryTaskStore.listSync()).isEmpty();
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
-    // assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(recoveryTaskStore.listSync()).isEmpty();
 
-    //    final String name = "testSnapshotId";
-    //    final String path = "/testPath_" + name;
-    //    final long startTime = 1;
-    //    final long endTime = 100;
-    //    final long maxOffset = 100;
-    //
-    //    final SnapshotMetadata partition1 =
-    //        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId);
-    //    snapshotMetadataStore.createSync(partition1);
-    //    assertThat(snapshotMetadataStore.listSync()).contains(partition1);
-    //    assertThat(
-    //            getHighestDurableOffsetForPartition(
-    //                snapshotMetadataStore.listSync(), Collections.emptyList(), partitionId))
-    //        .isEqualTo(100);
-    //    assertThat(recoveryTaskCreator.determineStartingOffset(1150)).isEqualTo(1150);
+    final String name = "testSnapshotId";
+    final String path = "/testPath_" + name;
+    final long startTime = 1;
+    final long endTime = 100;
+    final long maxOffset = 100;
+
+    final SnapshotMetadata partition1 =
+        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId);
+    snapshotMetadataStore.createSync(partition1);
+    assertThat(snapshotMetadataStore.listSync()).contains(partition1);
+    assertThat(
+            getHighestDurableOffsetForPartition(
+                snapshotMetadataStore.listSync(), Collections.emptyList(), partitionId))
+        .isEqualTo(100);
+    assertThat(recoveryTaskCreator.determineStartingOffset(1150)).isEqualTo(1150);
     //    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSync();
     //    assertThat(recoveryTasks1.size()).isEqualTo(3);
     //    assertThat(recoveryTasks1.stream().mapToLong(r -> r.startOffset).sorted().toArray())

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -1488,7 +1488,7 @@ public class RecoveryTaskCreatorTest {
         .isEqualTo(3);
     assertThatIllegalStateException()
         .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(50));
-    //    assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(0);
-    //    assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(3);
+    assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(0);
+    assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(3);
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -1475,20 +1475,21 @@ public class RecoveryTaskCreatorTest {
                 snapshotMetadataStore.listSync(), Collections.emptyList(), partitionId))
         .isEqualTo(100);
     assertThat(recoveryTaskCreator.determineStartingOffset(1150)).isEqualTo(1150);
-    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSync();
-    assertThat(recoveryTasks1.size()).isEqualTo(3);
-    assertThat(recoveryTasks1.stream().mapToLong(r -> r.startOffset).sorted().toArray())
-        .containsExactly(101, 601, 1101);
-    assertThat(recoveryTasks1.stream().mapToLong(r -> r.endOffset).sorted().toArray())
-        .containsExactly(600, 1100, 1149);
-    assertThat(
-            recoveryTasks1.stream().mapToLong(r -> r.endOffset - r.startOffset).sorted().toArray())
-        .containsExactly(48, 499, 499);
-    assertThat(recoveryTasks1.stream().filter(r -> r.partitionId.equals(partitionId)).count())
-        .isEqualTo(3);
-    assertThatIllegalStateException()
-        .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(50));
-    assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(0);
-    assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(3);
+    //    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSync();
+    //    assertThat(recoveryTasks1.size()).isEqualTo(3);
+    //    assertThat(recoveryTasks1.stream().mapToLong(r -> r.startOffset).sorted().toArray())
+    //        .containsExactly(101, 601, 1101);
+    //    assertThat(recoveryTasks1.stream().mapToLong(r -> r.endOffset).sorted().toArray())
+    //        .containsExactly(600, 1100, 1149);
+    //    assertThat(
+    //            recoveryTasks1.stream().mapToLong(r -> r.endOffset -
+    // r.startOffset).sorted().toArray())
+    //        .containsExactly(48, 499, 499);
+    //    assertThat(recoveryTasks1.stream().filter(r -> r.partitionId.equals(partitionId)).count())
+    //        .isEqualTo(3);
+    //    assertThatIllegalStateException()
+    //        .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(50));
+    //    assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(0);
+    //    assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(3);
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -1475,21 +1475,21 @@ public class RecoveryTaskCreatorTest {
                 snapshotMetadataStore.listSync(), Collections.emptyList(), partitionId))
         .isEqualTo(100);
     assertThat(recoveryTaskCreator.determineStartingOffset(1150)).isEqualTo(1150);
-    //    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSync();
-    //    assertThat(recoveryTasks1.size()).isEqualTo(3);
-    //    assertThat(recoveryTasks1.stream().mapToLong(r -> r.startOffset).sorted().toArray())
-    //        .containsExactly(101, 601, 1101);
-    //    assertThat(recoveryTasks1.stream().mapToLong(r -> r.endOffset).sorted().toArray())
-    //        .containsExactly(600, 1100, 1149);
-    //    assertThat(
-    //            recoveryTasks1.stream().mapToLong(r -> r.endOffset -
-    // r.startOffset).sorted().toArray())
-    //        .containsExactly(48, 499, 499);
-    //    assertThat(recoveryTasks1.stream().filter(r -> r.partitionId.equals(partitionId)).count())
-    //        .isEqualTo(3);
-    //    assertThatIllegalStateException()
-    //        .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(50));
-    //    assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(0);
-    //    assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(3);
+        List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSync();
+        assertThat(recoveryTasks1.size()).isEqualTo(3);
+        assertThat(recoveryTasks1.stream().mapToLong(r -> r.startOffset).sorted().toArray())
+            .containsExactly(101, 601, 1101);
+        assertThat(recoveryTasks1.stream().mapToLong(r -> r.endOffset).sorted().toArray())
+            .containsExactly(600, 1100, 1149);
+        assertThat(
+                recoveryTasks1.stream().mapToLong(r -> r.endOffset -
+     r.startOffset).sorted().toArray())
+            .containsExactly(48, 499, 499);
+        assertThat(recoveryTasks1.stream().filter(r -> r.partitionId.equals(partitionId)).count())
+            .isEqualTo(3);
+        assertThatIllegalStateException()
+            .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(50));
+        assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(0);
+        assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(3);
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -1457,7 +1457,7 @@ public class RecoveryTaskCreatorTest {
     assertThat(snapshotMetadataStore.listSync()).isEmpty();
     assertThat(recoveryTaskStore.listSync()).isEmpty();
     // When there is no data return -1.
-    // assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
+    assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
     // assertThat(recoveryTaskStore.listSync()).isEmpty();
 
     //    final String name = "testSnapshotId";

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -1458,6 +1458,7 @@ public class RecoveryTaskCreatorTest {
     assertThat(recoveryTaskStore.listSync()).isEmpty();
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
+    assertThat(recoveryTaskStore.listSync()).isEmpty();
 
     final String name = "testSnapshotId";
     final String path = "/testPath_" + name;

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -1442,54 +1442,54 @@ public class RecoveryTaskCreatorTest {
     assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(3);
   }
 
-  //  @Test
-  //  public void testMultipleRecoveryTaskCreationWithSnapshotDelay() {
-  //    final long maxMessagesPerRecoveryTask = 500;
-  //    RecoveryTaskCreator recoveryTaskCreator =
-  //        new RecoveryTaskCreator(
-  //            snapshotMetadataStore,
-  //            recoveryTaskStore,
-  //            partitionId,
-  //            100,
-  //            maxMessagesPerRecoveryTask,
-  //            meterRegistry);
-  //
-  //    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-  //    assertThat(recoveryTaskStore.listSync()).isEmpty();
-  //    // When there is no data return -1.
-  //    assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
-  //    assertThat(recoveryTaskStore.listSync()).isEmpty();
-  //
-  //    final String name = "testSnapshotId";
-  //    final String path = "/testPath_" + name;
-  //    final long startTime = 1;
-  //    final long endTime = 100;
-  //    final long maxOffset = 100;
-  //
-  //    final SnapshotMetadata partition1 =
-  //        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId);
-  //    snapshotMetadataStore.createSync(partition1);
-  //    assertThat(snapshotMetadataStore.listSync()).contains(partition1);
-  //    assertThat(
-  //            getHighestDurableOffsetForPartition(
-  //                snapshotMetadataStore.listSync(), Collections.emptyList(), partitionId))
-  //        .isEqualTo(100);
-  //    assertThat(recoveryTaskCreator.determineStartingOffset(1150)).isEqualTo(1150);
-  //    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSync();
-  //    assertThat(recoveryTasks1.size()).isEqualTo(3);
-  //    assertThat(recoveryTasks1.stream().mapToLong(r -> r.startOffset).sorted().toArray())
-  //        .containsExactly(101, 601, 1101);
-  //    assertThat(recoveryTasks1.stream().mapToLong(r -> r.endOffset).sorted().toArray())
-  //        .containsExactly(600, 1100, 1149);
-  //    assertThat(
-  //            recoveryTasks1.stream().mapToLong(r -> r.endOffset -
-  // r.startOffset).sorted().toArray())
-  //        .containsExactly(48, 499, 499);
-  //    assertThat(recoveryTasks1.stream().filter(r -> r.partitionId.equals(partitionId)).count())
-  //        .isEqualTo(3);
-  //    assertThatIllegalStateException()
-  //        .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(50));
-  //    assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(0);
-  //    assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(3);
-  //  }
+  @Test
+  public void testMultipleRecoveryTaskCreationWithSnapshotDelay() {
+    final long maxMessagesPerRecoveryTask = 500;
+    RecoveryTaskCreator recoveryTaskCreator =
+        new RecoveryTaskCreator(
+            snapshotMetadataStore,
+            recoveryTaskStore,
+            partitionId,
+            100,
+            maxMessagesPerRecoveryTask,
+            meterRegistry);
+
+    assertThat(snapshotMetadataStore.listSync()).isEmpty();
+    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    // When there is no data return -1.
+    assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
+    assertThat(recoveryTaskStore.listSync()).isEmpty();
+
+    //    final String name = "testSnapshotId";
+    //    final String path = "/testPath_" + name;
+    //    final long startTime = 1;
+    //    final long endTime = 100;
+    //    final long maxOffset = 100;
+    //
+    //    final SnapshotMetadata partition1 =
+    //        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId);
+    //    snapshotMetadataStore.createSync(partition1);
+    //    assertThat(snapshotMetadataStore.listSync()).contains(partition1);
+    //    assertThat(
+    //            getHighestDurableOffsetForPartition(
+    //                snapshotMetadataStore.listSync(), Collections.emptyList(), partitionId))
+    //        .isEqualTo(100);
+    //    assertThat(recoveryTaskCreator.determineStartingOffset(1150)).isEqualTo(1150);
+    //    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSync();
+    //    assertThat(recoveryTasks1.size()).isEqualTo(3);
+    //    assertThat(recoveryTasks1.stream().mapToLong(r -> r.startOffset).sorted().toArray())
+    //        .containsExactly(101, 601, 1101);
+    //    assertThat(recoveryTasks1.stream().mapToLong(r -> r.endOffset).sorted().toArray())
+    //        .containsExactly(600, 1100, 1149);
+    //    assertThat(
+    //            recoveryTasks1.stream().mapToLong(r -> r.endOffset -
+    // r.startOffset).sorted().toArray())
+    //        .containsExactly(48, 499, 499);
+    //    assertThat(recoveryTasks1.stream().filter(r -> r.partitionId.equals(partitionId)).count())
+    //        .isEqualTo(3);
+    //    assertThatIllegalStateException()
+    //        .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(50));
+    //    assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(0);
+    //    assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(3);
+  }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 
 @SuppressWarnings("UnstableApiUsage")
 public class RecoveryTaskCreatorTest {
+  private static final long TEST_MAX_MESSAGES_PER_RECOVERY_TASK = 10000;
   private SimpleMeterRegistry meterRegistry;
   private TestingServer testingServer;
   private ZookeeperMetadataStoreImpl zkMetadataStore;
@@ -175,7 +176,12 @@ public class RecoveryTaskCreatorTest {
 
     RecoveryTaskCreator recoveryTaskCreator =
         new RecoveryTaskCreator(
-            snapshotMetadataStore, recoveryTaskStore, partitionId, 1, meterRegistry);
+            snapshotMetadataStore,
+            recoveryTaskStore,
+            partitionId,
+            1,
+            TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
+            meterRegistry);
     assertThat(recoveryTaskCreator.deleteStaleLiveSnapshots(actualSnapshots).size())
         .isEqualTo(deletedSnapshotSize);
     assertThat(snapshotMetadataStore.listSync())
@@ -234,7 +240,12 @@ public class RecoveryTaskCreatorTest {
 
     RecoveryTaskCreator recoveryTaskCreator =
         new RecoveryTaskCreator(
-            snapshotMetadataStore, recoveryTaskStore, partitionId, 1, meterRegistry);
+            snapshotMetadataStore,
+            recoveryTaskStore,
+            partitionId,
+            1,
+            TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
+            meterRegistry);
 
     // Throw exceptions on delete.
     doReturn(Futures.immediateFailedFuture(new RuntimeException()))
@@ -285,7 +296,12 @@ public class RecoveryTaskCreatorTest {
 
     RecoveryTaskCreator recoveryTaskCreator =
         new RecoveryTaskCreator(
-            snapshotMetadataStore, recoveryTaskStore, partitionId, 1, meterRegistry);
+            snapshotMetadataStore,
+            recoveryTaskStore,
+            partitionId,
+            1,
+            TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
+            meterRegistry);
 
     // Pass first call, fail second call.
     ExecutorService timeoutServiceExecutor = Executors.newSingleThreadExecutor();
@@ -526,20 +542,47 @@ public class RecoveryTaskCreatorTest {
         .isThrownBy(
             () ->
                 new RecoveryTaskCreator(
-                    snapshotMetadataStore, recoveryTaskStore, partitionId, 0, meterRegistry));
+                    snapshotMetadataStore,
+                    recoveryTaskStore,
+                    partitionId,
+                    0,
+                    TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
+                    meterRegistry));
 
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
                 new RecoveryTaskCreator(
-                    snapshotMetadataStore, recoveryTaskStore, "", 100, meterRegistry));
+                    snapshotMetadataStore,
+                    recoveryTaskStore,
+                    "",
+                    100,
+                    TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
+                    meterRegistry));
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                new RecoveryTaskCreator(
+                    snapshotMetadataStore, recoveryTaskStore, partitionId, 100, 0, meterRegistry));
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                new RecoveryTaskCreator(
+                    snapshotMetadataStore, recoveryTaskStore, partitionId, 100, -1, meterRegistry));
   }
 
   @Test
   public void testDetermineStartOffsetReturnsNegativeWhenNoOffset() {
     RecoveryTaskCreator recoveryTaskCreator =
         new RecoveryTaskCreator(
-            snapshotMetadataStore, recoveryTaskStore, partitionId, 1, meterRegistry);
+            snapshotMetadataStore,
+            recoveryTaskStore,
+            partitionId,
+            1,
+            TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
+            meterRegistry);
 
     assertThat(snapshotMetadataStore.listSync()).isEmpty();
     assertThat(recoveryTaskStore.listSync()).isEmpty();
@@ -587,7 +630,12 @@ public class RecoveryTaskCreatorTest {
   public void testDetermineStartingOffsetOnlyRecoveryNotBehind() {
     RecoveryTaskCreator recoveryTaskCreator =
         new RecoveryTaskCreator(
-            snapshotMetadataStore, recoveryTaskStore, partitionId, 100, meterRegistry);
+            snapshotMetadataStore,
+            recoveryTaskStore,
+            partitionId,
+            100,
+            TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
+            meterRegistry);
 
     assertThat(snapshotMetadataStore.listSync()).isEmpty();
     assertThat(recoveryTaskStore.listSync()).isEmpty();
@@ -635,7 +683,12 @@ public class RecoveryTaskCreatorTest {
   public void testDetermineStartingOffsetOnlyRecoveryBehind() {
     RecoveryTaskCreator recoveryTaskCreator =
         new RecoveryTaskCreator(
-            snapshotMetadataStore, recoveryTaskStore, partitionId, 100, meterRegistry);
+            snapshotMetadataStore,
+            recoveryTaskStore,
+            partitionId,
+            100,
+            TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
+            meterRegistry);
 
     assertThat(snapshotMetadataStore.listSync()).isEmpty();
     assertThat(recoveryTaskStore.listSync()).isEmpty();
@@ -674,7 +727,12 @@ public class RecoveryTaskCreatorTest {
   public void testDetermineStartingOffsetOnlyMultipleRecoveryBehind() {
     RecoveryTaskCreator recoveryTaskCreator =
         new RecoveryTaskCreator(
-            snapshotMetadataStore, recoveryTaskStore, partitionId, 100, meterRegistry);
+            snapshotMetadataStore,
+            recoveryTaskStore,
+            partitionId,
+            100,
+            TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
+            meterRegistry);
 
     assertThat(snapshotMetadataStore.listSync()).isEmpty();
     assertThat(recoveryTaskStore.listSync()).isEmpty();
@@ -722,7 +780,12 @@ public class RecoveryTaskCreatorTest {
   public void testDetermineStartingOffsetMultiplePartitionRecoveriesBehind() {
     RecoveryTaskCreator recoveryTaskCreator =
         new RecoveryTaskCreator(
-            snapshotMetadataStore, recoveryTaskStore, partitionId, 100, meterRegistry);
+            snapshotMetadataStore,
+            recoveryTaskStore,
+            partitionId,
+            100,
+            TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
+            meterRegistry);
 
     assertThat(snapshotMetadataStore.listSync()).isEmpty();
     assertThat(recoveryTaskStore.listSync()).isEmpty();
@@ -784,7 +847,12 @@ public class RecoveryTaskCreatorTest {
   public void testDetermineStartingOffsetOnlySnapshotsNoDelay() {
     RecoveryTaskCreator recoveryTaskCreator =
         new RecoveryTaskCreator(
-            snapshotMetadataStore, recoveryTaskStore, partitionId, 100, meterRegistry);
+            snapshotMetadataStore,
+            recoveryTaskStore,
+            partitionId,
+            100,
+            TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
+            meterRegistry);
 
     assertThat(snapshotMetadataStore.listSync()).isEmpty();
     assertThat(recoveryTaskStore.listSync()).isEmpty();
@@ -887,7 +955,12 @@ public class RecoveryTaskCreatorTest {
   public void testDetermineStartingOffsetOnlySnapshotsWithDelay() {
     RecoveryTaskCreator recoveryTaskCreator =
         new RecoveryTaskCreator(
-            snapshotMetadataStore, recoveryTaskStore, partitionId, 100, meterRegistry);
+            snapshotMetadataStore,
+            recoveryTaskStore,
+            partitionId,
+            100,
+            TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
+            meterRegistry);
 
     assertThat(snapshotMetadataStore.listSync()).isEmpty();
     assertThat(recoveryTaskStore.listSync()).isEmpty();
@@ -1077,7 +1150,12 @@ public class RecoveryTaskCreatorTest {
   public void testRecoveryTaskCreationFailureFailsDetermineStartOffset() {
     RecoveryTaskCreator recoveryTaskCreator =
         new RecoveryTaskCreator(
-            snapshotMetadataStore, recoveryTaskStore, partitionId, 100, meterRegistry);
+            snapshotMetadataStore,
+            recoveryTaskStore,
+            partitionId,
+            100,
+            TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
+            meterRegistry);
 
     assertThat(snapshotMetadataStore.listSync()).isEmpty();
     assertThat(recoveryTaskStore.listSync()).isEmpty();
@@ -1121,7 +1199,12 @@ public class RecoveryTaskCreatorTest {
       throws ExecutionException, InterruptedException {
     RecoveryTaskCreator recoveryTaskCreator =
         new RecoveryTaskCreator(
-            snapshotMetadataStore, recoveryTaskStore, partitionId, 100, meterRegistry);
+            snapshotMetadataStore,
+            recoveryTaskStore,
+            partitionId,
+            100,
+            TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
+            meterRegistry);
 
     assertThat(snapshotMetadataStore.listSync()).isEmpty();
     assertThat(recoveryTaskStore.listSync()).isEmpty();
@@ -1165,7 +1248,12 @@ public class RecoveryTaskCreatorTest {
       throws ExecutionException, InterruptedException {
     RecoveryTaskCreator recoveryTaskCreator =
         new RecoveryTaskCreator(
-            snapshotMetadataStore, recoveryTaskStore, partitionId, 100, meterRegistry);
+            snapshotMetadataStore,
+            recoveryTaskStore,
+            partitionId,
+            100,
+            TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
+            meterRegistry);
 
     assertThat(snapshotMetadataStore.listSync()).isEmpty();
     assertThat(recoveryTaskStore.listSync()).isEmpty();
@@ -1209,7 +1297,12 @@ public class RecoveryTaskCreatorTest {
       throws ExecutionException, InterruptedException {
     RecoveryTaskCreator recoveryTaskCreator =
         new RecoveryTaskCreator(
-            snapshotMetadataStore, recoveryTaskStore, partitionId, 100, meterRegistry);
+            snapshotMetadataStore,
+            recoveryTaskStore,
+            partitionId,
+            100,
+            TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
+            meterRegistry);
 
     assertThat(snapshotMetadataStore.listSync()).isEmpty();
     assertThat(recoveryTaskStore.listSync()).isEmpty();
@@ -1257,5 +1350,144 @@ public class RecoveryTaskCreatorTest {
     assertThat(recoveryTaskStore.list().get()).containsExactly(recoveryTasks1.get(0));
     assertThat(snapshotMetadataStore.list().get())
         .containsExactlyInAnyOrder(partition1, livePartition1);
+  }
+
+  @Test
+  public void testChunkingRecoveryTaskLongRange() {
+    final long maxMessagesPerRecoveryTask = 100;
+    RecoveryTaskCreator recoveryTaskCreator =
+        new RecoveryTaskCreator(
+            snapshotMetadataStore,
+            recoveryTaskStore,
+            partitionId,
+            100,
+            maxMessagesPerRecoveryTask,
+            meterRegistry);
+
+    // Long range - 1 chunk
+    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    recoveryTaskCreator.createRecoveryTasks("1", 10, 100, maxMessagesPerRecoveryTask);
+    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSync();
+    assertThat(recoveryTasks.size()).isEqualTo(1);
+    assertThat(recoveryTasks.get(0).startOffset).isEqualTo(10);
+    assertThat(recoveryTasks.get(0).endOffset).isEqualTo(100);
+    assertThat((recoveryTasks.get(0)).partitionId).isEqualTo(partitionId);
+    assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(1);
+  }
+
+  @Test
+  public void testChunkingRecoveryOneChunk() {
+    final long maxMessagesPerRecoveryTask = 100;
+    final String testPartitionId = "2";
+    RecoveryTaskCreator recoveryTaskCreator =
+        new RecoveryTaskCreator(
+            snapshotMetadataStore,
+            recoveryTaskStore,
+            testPartitionId,
+            100,
+            maxMessagesPerRecoveryTask,
+            meterRegistry);
+
+    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    recoveryTaskCreator.createRecoveryTasks(testPartitionId, 100, 101, maxMessagesPerRecoveryTask);
+    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSync();
+    assertThat(recoveryTasks.size()).isEqualTo(1);
+    assertThat(recoveryTasks.get(0).startOffset).isEqualTo(100);
+    assertThat(recoveryTasks.get(0).endOffset).isEqualTo(101);
+    assertThat((recoveryTasks.get(0)).partitionId).isEqualTo(testPartitionId);
+    assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(1);
+  }
+
+  @Test
+  public void testChunkingRecoveryTasksSameSizeTasks() {
+    final String testPartitionId = "3";
+    RecoveryTaskCreator recoveryTaskCreator =
+        new RecoveryTaskCreator(
+            snapshotMetadataStore, recoveryTaskStore, testPartitionId, 100, 2, meterRegistry);
+
+    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    recoveryTaskCreator.createRecoveryTasks(testPartitionId, 100, 105, 2);
+    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSync();
+    assertThat(recoveryTasks.size()).isEqualTo(3);
+    assertThat(recoveryTasks.stream().mapToLong(r -> r.startOffset).sorted().toArray())
+        .containsExactly(100, 102, 104);
+    assertThat(recoveryTasks.stream().mapToLong(r -> r.endOffset).sorted().toArray())
+        .containsExactly(101, 103, 105);
+    assertThat(recoveryTasks.stream().mapToLong(r -> r.endOffset - r.startOffset).toArray())
+        .containsExactly(1, 1, 1);
+    assertThat(recoveryTasks.stream().filter(r -> r.partitionId.equals(testPartitionId)).count())
+        .isEqualTo(3);
+    assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(3);
+  }
+
+  @Test
+  public void testChunkingRecoveryTasksWithOddSizeTask() {
+    RecoveryTaskCreator recoveryTaskCreator =
+        new RecoveryTaskCreator(
+            snapshotMetadataStore, recoveryTaskStore, partitionId, 100, 2, meterRegistry);
+
+    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    recoveryTaskCreator.createRecoveryTasks(partitionId, 100, 104, 2);
+    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSync();
+    assertThat(recoveryTasks.size()).isEqualTo(3);
+    assertThat(recoveryTasks.stream().mapToLong(r -> r.startOffset).sorted().toArray())
+        .containsExactly(100, 102, 104);
+    assertThat(recoveryTasks.stream().mapToLong(r -> r.endOffset).sorted().toArray())
+        .containsExactly(101, 103, 104);
+    assertThat(
+            recoveryTasks.stream().mapToLong(r -> r.endOffset - r.startOffset).sorted().toArray())
+        .containsExactly(0, 1, 1);
+    assertThat(recoveryTasks.stream().filter(r -> r.partitionId.equals(partitionId)).count())
+        .isEqualTo(3);
+    assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(3);
+  }
+
+  @Test
+  public void testMultipleRecoveryTaskCreationWithSnapshotDelay() {
+    final long maxMessagesPerRecoveryTask = 500;
+    RecoveryTaskCreator recoveryTaskCreator =
+        new RecoveryTaskCreator(
+            snapshotMetadataStore,
+            recoveryTaskStore,
+            partitionId,
+            100,
+            maxMessagesPerRecoveryTask,
+            meterRegistry);
+
+    assertThat(snapshotMetadataStore.listSync()).isEmpty();
+    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    // When there is no data return -1.
+    assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
+
+    final String name = "testSnapshotId";
+    final String path = "/testPath_" + name;
+    final long startTime = 1;
+    final long endTime = 100;
+    final long maxOffset = 100;
+
+    final SnapshotMetadata partition1 =
+        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId);
+    snapshotMetadataStore.createSync(partition1);
+    assertThat(snapshotMetadataStore.listSync()).contains(partition1);
+    assertThat(
+            getHighestDurableOffsetForPartition(
+                snapshotMetadataStore.listSync(), Collections.emptyList(), partitionId))
+        .isEqualTo(100);
+    assertThat(recoveryTaskCreator.determineStartingOffset(1150)).isEqualTo(1150);
+    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSync();
+    assertThat(recoveryTasks1.size()).isEqualTo(3);
+    assertThat(recoveryTasks1.stream().mapToLong(r -> r.startOffset).sorted().toArray())
+        .containsExactly(101, 601, 1101);
+    assertThat(recoveryTasks1.stream().mapToLong(r -> r.endOffset).sorted().toArray())
+        .containsExactly(600, 1100, 1149);
+    assertThat(
+            recoveryTasks1.stream().mapToLong(r -> r.endOffset - r.startOffset).sorted().toArray())
+        .containsExactly(48, 499, 499);
+    assertThat(recoveryTasks1.stream().filter(r -> r.partitionId.equals(partitionId)).count())
+        .isEqualTo(3);
+    assertThatIllegalStateException()
+        .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(50));
+    assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(0);
+    assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(3);
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -1475,21 +1475,20 @@ public class RecoveryTaskCreatorTest {
                 snapshotMetadataStore.listSync(), Collections.emptyList(), partitionId))
         .isEqualTo(100);
     assertThat(recoveryTaskCreator.determineStartingOffset(1150)).isEqualTo(1150);
-        List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSync();
-        assertThat(recoveryTasks1.size()).isEqualTo(3);
-        assertThat(recoveryTasks1.stream().mapToLong(r -> r.startOffset).sorted().toArray())
-            .containsExactly(101, 601, 1101);
-        assertThat(recoveryTasks1.stream().mapToLong(r -> r.endOffset).sorted().toArray())
-            .containsExactly(600, 1100, 1149);
-        assertThat(
-                recoveryTasks1.stream().mapToLong(r -> r.endOffset -
-     r.startOffset).sorted().toArray())
-            .containsExactly(48, 499, 499);
-        assertThat(recoveryTasks1.stream().filter(r -> r.partitionId.equals(partitionId)).count())
-            .isEqualTo(3);
-        assertThatIllegalStateException()
-            .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(50));
-        assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(0);
-        assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(3);
+    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSync();
+    assertThat(recoveryTasks1.size()).isEqualTo(3);
+    assertThat(recoveryTasks1.stream().mapToLong(r -> r.startOffset).sorted().toArray())
+        .containsExactly(101, 601, 1101);
+    assertThat(recoveryTasks1.stream().mapToLong(r -> r.endOffset).sorted().toArray())
+        .containsExactly(600, 1100, 1149);
+    assertThat(
+            recoveryTasks1.stream().mapToLong(r -> r.endOffset - r.startOffset).sorted().toArray())
+        .containsExactly(48, 499, 499);
+    assertThat(recoveryTasks1.stream().filter(r -> r.partitionId.equals(partitionId)).count())
+        .isEqualTo(3);
+    assertThatIllegalStateException()
+        .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(50));
+    assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(0);
+    assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(3);
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -1442,53 +1442,54 @@ public class RecoveryTaskCreatorTest {
     assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(3);
   }
 
-  @Test
-  public void testMultipleRecoveryTaskCreationWithSnapshotDelay() {
-    final long maxMessagesPerRecoveryTask = 500;
-    RecoveryTaskCreator recoveryTaskCreator =
-        new RecoveryTaskCreator(
-            snapshotMetadataStore,
-            recoveryTaskStore,
-            partitionId,
-            100,
-            maxMessagesPerRecoveryTask,
-            meterRegistry);
-
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
-    // When there is no data return -1.
-    assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
-
-    final String name = "testSnapshotId";
-    final String path = "/testPath_" + name;
-    final long startTime = 1;
-    final long endTime = 100;
-    final long maxOffset = 100;
-
-    final SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId);
-    snapshotMetadataStore.createSync(partition1);
-    assertThat(snapshotMetadataStore.listSync()).contains(partition1);
-    assertThat(
-            getHighestDurableOffsetForPartition(
-                snapshotMetadataStore.listSync(), Collections.emptyList(), partitionId))
-        .isEqualTo(100);
-    assertThat(recoveryTaskCreator.determineStartingOffset(1150)).isEqualTo(1150);
-    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSync();
-    assertThat(recoveryTasks1.size()).isEqualTo(3);
-    assertThat(recoveryTasks1.stream().mapToLong(r -> r.startOffset).sorted().toArray())
-        .containsExactly(101, 601, 1101);
-    assertThat(recoveryTasks1.stream().mapToLong(r -> r.endOffset).sorted().toArray())
-        .containsExactly(600, 1100, 1149);
-    assertThat(
-            recoveryTasks1.stream().mapToLong(r -> r.endOffset - r.startOffset).sorted().toArray())
-        .containsExactly(48, 499, 499);
-    assertThat(recoveryTasks1.stream().filter(r -> r.partitionId.equals(partitionId)).count())
-        .isEqualTo(3);
-    assertThatIllegalStateException()
-        .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(50));
-    assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(0);
-    assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(3);
-  }
+  //  @Test
+  //  public void testMultipleRecoveryTaskCreationWithSnapshotDelay() {
+  //    final long maxMessagesPerRecoveryTask = 500;
+  //    RecoveryTaskCreator recoveryTaskCreator =
+  //        new RecoveryTaskCreator(
+  //            snapshotMetadataStore,
+  //            recoveryTaskStore,
+  //            partitionId,
+  //            100,
+  //            maxMessagesPerRecoveryTask,
+  //            meterRegistry);
+  //
+  //    assertThat(snapshotMetadataStore.listSync()).isEmpty();
+  //    assertThat(recoveryTaskStore.listSync()).isEmpty();
+  //    // When there is no data return -1.
+  //    assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
+  //    assertThat(recoveryTaskStore.listSync()).isEmpty();
+  //
+  //    final String name = "testSnapshotId";
+  //    final String path = "/testPath_" + name;
+  //    final long startTime = 1;
+  //    final long endTime = 100;
+  //    final long maxOffset = 100;
+  //
+  //    final SnapshotMetadata partition1 =
+  //        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId);
+  //    snapshotMetadataStore.createSync(partition1);
+  //    assertThat(snapshotMetadataStore.listSync()).contains(partition1);
+  //    assertThat(
+  //            getHighestDurableOffsetForPartition(
+  //                snapshotMetadataStore.listSync(), Collections.emptyList(), partitionId))
+  //        .isEqualTo(100);
+  //    assertThat(recoveryTaskCreator.determineStartingOffset(1150)).isEqualTo(1150);
+  //    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSync();
+  //    assertThat(recoveryTasks1.size()).isEqualTo(3);
+  //    assertThat(recoveryTasks1.stream().mapToLong(r -> r.startOffset).sorted().toArray())
+  //        .containsExactly(101, 601, 1101);
+  //    assertThat(recoveryTasks1.stream().mapToLong(r -> r.endOffset).sorted().toArray())
+  //        .containsExactly(600, 1100, 1149);
+  //    assertThat(
+  //            recoveryTasks1.stream().mapToLong(r -> r.endOffset -
+  // r.startOffset).sorted().toArray())
+  //        .containsExactly(48, 499, 499);
+  //    assertThat(recoveryTasks1.stream().filter(r -> r.partitionId.equals(partitionId)).count())
+  //        .isEqualTo(3);
+  //    assertThatIllegalStateException()
+  //        .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(50));
+  //    assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(0);
+  //    assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(3);
+  //  }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -1486,8 +1486,8 @@ public class RecoveryTaskCreatorTest {
         .containsExactly(48, 499, 499);
     assertThat(recoveryTasks1.stream().filter(r -> r.partitionId.equals(partitionId)).count())
         .isEqualTo(3);
-    //    assertThatIllegalStateException()
-    //        .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(50));
+    assertThatIllegalStateException()
+        .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(50));
     //    assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(0);
     //    assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(3);
   }

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -1479,14 +1479,13 @@ public class RecoveryTaskCreatorTest {
     assertThat(recoveryTasks1.size()).isEqualTo(3);
     assertThat(recoveryTasks1.stream().mapToLong(r -> r.startOffset).sorted().toArray())
         .containsExactly(101, 601, 1101);
-    //    assertThat(recoveryTasks1.stream().mapToLong(r -> r.endOffset).sorted().toArray())
-    //        .containsExactly(600, 1100, 1149);
-    //    assertThat(
-    //            recoveryTasks1.stream().mapToLong(r -> r.endOffset -
-    // r.startOffset).sorted().toArray())
-    //        .containsExactly(48, 499, 499);
-    //    assertThat(recoveryTasks1.stream().filter(r -> r.partitionId.equals(partitionId)).count())
-    //        .isEqualTo(3);
+    assertThat(recoveryTasks1.stream().mapToLong(r -> r.endOffset).sorted().toArray())
+        .containsExactly(600, 1100, 1149);
+    assertThat(
+            recoveryTasks1.stream().mapToLong(r -> r.endOffset - r.startOffset).sorted().toArray())
+        .containsExactly(48, 499, 499);
+    assertThat(recoveryTasks1.stream().filter(r -> r.partitionId.equals(partitionId)).count())
+        .isEqualTo(3);
     //    assertThatIllegalStateException()
     //        .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(50));
     //    assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(0);

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -1475,10 +1475,10 @@ public class RecoveryTaskCreatorTest {
                 snapshotMetadataStore.listSync(), Collections.emptyList(), partitionId))
         .isEqualTo(100);
     assertThat(recoveryTaskCreator.determineStartingOffset(1150)).isEqualTo(1150);
-    //    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSync();
-    //    assertThat(recoveryTasks1.size()).isEqualTo(3);
-    //    assertThat(recoveryTasks1.stream().mapToLong(r -> r.startOffset).sorted().toArray())
-    //        .containsExactly(101, 601, 1101);
+    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSync();
+    assertThat(recoveryTasks1.size()).isEqualTo(3);
+    assertThat(recoveryTasks1.stream().mapToLong(r -> r.startOffset).sorted().toArray())
+        .containsExactly(101, 601, 1101);
     //    assertThat(recoveryTasks1.stream().mapToLong(r -> r.endOffset).sorted().toArray())
     //        .containsExactly(600, 1100, 1149);
     //    assertThat(

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -1457,8 +1457,8 @@ public class RecoveryTaskCreatorTest {
     assertThat(snapshotMetadataStore.listSync()).isEmpty();
     assertThat(recoveryTaskStore.listSync()).isEmpty();
     // When there is no data return -1.
-    assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    // assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
+    // assertThat(recoveryTaskStore.listSync()).isEmpty();
 
     //    final String name = "testSnapshotId";
     //    final String path = "/testPath_" + name;

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -1486,9 +1486,5 @@ public class RecoveryTaskCreatorTest {
         .containsExactly(48, 499, 499);
     assertThat(recoveryTasks1.stream().filter(r -> r.partitionId.equals(partitionId)).count())
         .isEqualTo(3);
-    assertThatIllegalStateException()
-        .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(50));
-    assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(0);
-    assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(3);
   }
 }


### PR DESCRIPTION
Currently, we can create only one chunk per recovery task. However, during recovery task creation the recovery task range can be arbitrarily long which can cause very large chunks and all the recovery chunks will be of different non-uniform sizes.
To work around this, break down large recovery task into smaller uniformly sized tasks.

Currently, `RecoveryTaskMetadata` doesn't allow tasks of size 1. So, updated the code to allow for chunks of size 1. 

Added new unit tests for the new code.

NOTE: We use the `getMaxMessagesPerChunk` setting from indexer config for now. I can add a new config setting if needed.