### PR TITLE
Better metrics for lucene commit/refresh

### DIFF
--- a/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
@@ -4,12 +4,13 @@ import static com.slack.kaldb.chunk.ReadWriteChunk.INDEX_FILES_UPLOAD;
 import static com.slack.kaldb.chunk.ReadWriteChunk.INDEX_FILES_UPLOAD_FAILED;
 import static com.slack.kaldb.chunk.ReadWriteChunk.LIVE_SNAPSHOT_PREFIX;
 import static com.slack.kaldb.chunk.ReadWriteChunk.SNAPSHOT_TIMER;
-import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.COMMITS_COUNTER;
+import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.COMMITS_TIMER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_FAILED_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_RECEIVED_COUNTER;
-import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.REFRESHES_COUNTER;
+import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.REFRESHES_TIMER;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_ZK_TIMEOUT_SECS;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
+import static com.slack.kaldb.testlib.MetricsUtil.getTimerCount;
 import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.MAX_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -160,8 +161,8 @@ public class IndexingChunkImplTest {
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, registry)).isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, registry)).isEqualTo(0);
-      assertThat(getCount(REFRESHES_COUNTER, registry)).isEqualTo(1);
-      assertThat(getCount(COMMITS_COUNTER, registry)).isEqualTo(1);
+      assertThat(getTimerCount(REFRESHES_TIMER, registry)).isEqualTo(1);
+      assertThat(getTimerCount(COMMITS_TIMER, registry)).isEqualTo(1);
     }
 
     @Test
@@ -175,8 +176,8 @@ public class IndexingChunkImplTest {
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, registry)).isEqualTo(1);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, registry)).isEqualTo(1);
-      assertThat(getCount(REFRESHES_COUNTER, registry)).isEqualTo(1);
-      assertThat(getCount(COMMITS_COUNTER, registry)).isEqualTo(1);
+      assertThat(getTimerCount(REFRESHES_TIMER, registry)).isEqualTo(1);
+      assertThat(getTimerCount(COMMITS_TIMER, registry)).isEqualTo(1);
     }
 
     @Test
@@ -195,8 +196,8 @@ public class IndexingChunkImplTest {
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, registry)).isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, registry)).isEqualTo(0);
-      assertThat(getCount(REFRESHES_COUNTER, registry)).isEqualTo(1);
-      assertThat(getCount(COMMITS_COUNTER, registry)).isEqualTo(1);
+      assertThat(getTimerCount(REFRESHES_TIMER, registry)).isEqualTo(1);
+      assertThat(getTimerCount(COMMITS_TIMER, registry)).isEqualTo(1);
 
       final long expectedEndTimeEpochMs = messageStartTimeMs + (99 * 1000);
       // Ensure chunk info is correct.
@@ -236,8 +237,8 @@ public class IndexingChunkImplTest {
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, registry)).isEqualTo(200);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, registry)).isEqualTo(0);
-      assertThat(getCount(REFRESHES_COUNTER, registry)).isEqualTo(2);
-      assertThat(getCount(COMMITS_COUNTER, registry)).isEqualTo(2);
+      assertThat(getTimerCount(REFRESHES_TIMER, registry)).isEqualTo(2);
+      assertThat(getTimerCount(COMMITS_TIMER, registry)).isEqualTo(2);
 
       assertThat(chunk.info().getDataStartTimeEpochMs()).isEqualTo(messageStartTimeMs);
       assertThat(chunk.info().getDataEndTimeEpochMs())
@@ -309,8 +310,8 @@ public class IndexingChunkImplTest {
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, registry)).isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, registry)).isEqualTo(0);
-      assertThat(getCount(REFRESHES_COUNTER, registry)).isEqualTo(1);
-      assertThat(getCount(COMMITS_COUNTER, registry)).isEqualTo(1);
+      assertThat(getTimerCount(REFRESHES_TIMER, registry)).isEqualTo(1);
+      assertThat(getTimerCount(COMMITS_TIMER, registry)).isEqualTo(1);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -459,8 +460,8 @@ public class IndexingChunkImplTest {
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, registry)).isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, registry)).isEqualTo(0);
-      assertThat(getCount(REFRESHES_COUNTER, registry)).isEqualTo(1);
-      assertThat(getCount(COMMITS_COUNTER, registry)).isEqualTo(1);
+      assertThat(getTimerCount(REFRESHES_TIMER, registry)).isEqualTo(1);
+      assertThat(getTimerCount(COMMITS_TIMER, registry)).isEqualTo(1);
       assertThat(getCount(INDEX_FILES_UPLOAD, registry)).isEqualTo(0);
       assertThat(getCount(INDEX_FILES_UPLOAD_FAILED, registry)).isEqualTo(0);
 
@@ -514,8 +515,8 @@ public class IndexingChunkImplTest {
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, registry)).isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, registry)).isEqualTo(0);
-      assertThat(getCount(REFRESHES_COUNTER, registry)).isEqualTo(1);
-      assertThat(getCount(COMMITS_COUNTER, registry)).isEqualTo(1);
+      assertThat(getTimerCount(REFRESHES_TIMER, registry)).isEqualTo(1);
+      assertThat(getTimerCount(COMMITS_TIMER, registry)).isEqualTo(1);
       assertThat(getCount(INDEX_FILES_UPLOAD, registry)).isEqualTo(0);
       assertThat(getCount(INDEX_FILES_UPLOAD_FAILED, registry)).isEqualTo(0);
 

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -3,11 +3,12 @@ package com.slack.kaldb.chunk;
 import static com.slack.kaldb.chunk.ReadOnlyChunkImpl.CHUNK_ASSIGNMENT_TIMER;
 import static com.slack.kaldb.chunk.ReadOnlyChunkImpl.CHUNK_EVICTION_TIMER;
 import static com.slack.kaldb.logstore.BlobFsUtils.copyToS3;
-import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.COMMITS_COUNTER;
+import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.COMMITS_TIMER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_FAILED_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_RECEIVED_COUNTER;
-import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.REFRESHES_COUNTER;
+import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.REFRESHES_TIMER;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
+import static com.slack.kaldb.testlib.MetricsUtil.getTimerCount;
 import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.addMessages;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -484,8 +485,8 @@ public class ReadOnlyChunkImplTest {
     addMessages(logStore, 1, 10, true);
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, meterRegistry)).isEqualTo(10);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
-    assertThat(getCount(REFRESHES_COUNTER, meterRegistry)).isEqualTo(1);
-    assertThat(getCount(COMMITS_COUNTER, meterRegistry)).isEqualTo(1);
+    assertThat(getTimerCount(REFRESHES_TIMER, meterRegistry)).isEqualTo(1);
+    assertThat(getTimerCount(COMMITS_TIMER, meterRegistry)).isEqualTo(1);
 
     Path dirPath = logStore.getDirectory().toAbsolutePath();
     IndexCommit indexCommit = logStore.getIndexCommit();

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
@@ -4,11 +4,12 @@ import static com.slack.kaldb.logstore.BlobFsUtils.DELIMITER;
 import static com.slack.kaldb.logstore.BlobFsUtils.copyFromS3;
 import static com.slack.kaldb.logstore.BlobFsUtils.copyToLocalPath;
 import static com.slack.kaldb.logstore.BlobFsUtils.copyToS3;
-import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.COMMITS_COUNTER;
+import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.COMMITS_TIMER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_FAILED_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_RECEIVED_COUNTER;
-import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.REFRESHES_COUNTER;
+import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.REFRESHES_TIMER;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
+import static com.slack.kaldb.testlib.MetricsUtil.getTimerCount;
 import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.MAX_TIME;
 import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.addMessages;
 import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.findAllMessages;
@@ -72,8 +73,8 @@ public class LuceneIndexStoreImplTest {
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, forgivingLogStore.metricsRegistry)).isEqualTo(0);
-      assertThat(getCount(REFRESHES_COUNTER, forgivingLogStore.metricsRegistry)).isEqualTo(1);
-      assertThat(getCount(COMMITS_COUNTER, forgivingLogStore.metricsRegistry)).isEqualTo(1);
+      assertThat(getTimerCount(REFRESHES_TIMER, forgivingLogStore.metricsRegistry)).isEqualTo(1);
+      assertThat(getTimerCount(COMMITS_TIMER, forgivingLogStore.metricsRegistry)).isEqualTo(1);
     }
 
     @Test
@@ -124,8 +125,8 @@ public class LuceneIndexStoreImplTest {
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, forgivingLogStore.metricsRegistry)).isEqualTo(0);
-      assertThat(getCount(REFRESHES_COUNTER, forgivingLogStore.metricsRegistry)).isEqualTo(1);
-      assertThat(getCount(COMMITS_COUNTER, forgivingLogStore.metricsRegistry)).isEqualTo(1);
+      assertThat(getTimerCount(REFRESHES_TIMER, forgivingLogStore.metricsRegistry)).isEqualTo(1);
+      assertThat(getTimerCount(COMMITS_TIMER, forgivingLogStore.metricsRegistry)).isEqualTo(1);
     }
 
     @Test
@@ -138,8 +139,8 @@ public class LuceneIndexStoreImplTest {
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, forgivingLogStore.metricsRegistry)).isEqualTo(0);
-      assertThat(getCount(REFRESHES_COUNTER, forgivingLogStore.metricsRegistry)).isEqualTo(1);
-      assertThat(getCount(COMMITS_COUNTER, forgivingLogStore.metricsRegistry)).isEqualTo(1);
+      assertThat(getTimerCount(REFRESHES_TIMER, forgivingLogStore.metricsRegistry)).isEqualTo(1);
+      assertThat(getTimerCount(COMMITS_TIMER, forgivingLogStore.metricsRegistry)).isEqualTo(1);
       assertThat(results.get(0).id).isEqualTo(msgs.get(msgs.size() - 1).id);
     }
 
@@ -156,8 +157,8 @@ public class LuceneIndexStoreImplTest {
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, forgivingLogStore.metricsRegistry)).isEqualTo(0);
-      assertThat(getCount(REFRESHES_COUNTER, forgivingLogStore.metricsRegistry)).isEqualTo(1);
-      assertThat(getCount(COMMITS_COUNTER, forgivingLogStore.metricsRegistry)).isEqualTo(1);
+      assertThat(getTimerCount(REFRESHES_TIMER, forgivingLogStore.metricsRegistry)).isEqualTo(1);
+      assertThat(getTimerCount(COMMITS_TIMER, forgivingLogStore.metricsRegistry)).isEqualTo(1);
     }
 
     @Test
@@ -173,8 +174,8 @@ public class LuceneIndexStoreImplTest {
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, forgivingLogStore.metricsRegistry)).isEqualTo(0);
-      assertThat(getCount(REFRESHES_COUNTER, forgivingLogStore.metricsRegistry)).isEqualTo(1);
-      assertThat(getCount(COMMITS_COUNTER, forgivingLogStore.metricsRegistry)).isEqualTo(1);
+      assertThat(getTimerCount(REFRESHES_TIMER, forgivingLogStore.metricsRegistry)).isEqualTo(1);
+      assertThat(getTimerCount(COMMITS_TIMER, forgivingLogStore.metricsRegistry)).isEqualTo(1);
     }
   }
 
@@ -198,8 +199,8 @@ public class LuceneIndexStoreImplTest {
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry))
           .isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
-      assertThat(getCount(REFRESHES_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
-      assertThat(getCount(COMMITS_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
+      assertThat(getTimerCount(REFRESHES_TIMER, strictLogStore.metricsRegistry)).isEqualTo(1);
+      assertThat(getTimerCount(COMMITS_TIMER, strictLogStore.metricsRegistry)).isEqualTo(1);
     }
 
     @Test
@@ -215,8 +216,8 @@ public class LuceneIndexStoreImplTest {
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry))
           .isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
-      assertThat(getCount(REFRESHES_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
-      assertThat(getCount(COMMITS_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
+      assertThat(getTimerCount(REFRESHES_TIMER, strictLogStore.metricsRegistry)).isEqualTo(1);
+      assertThat(getTimerCount(COMMITS_TIMER, strictLogStore.metricsRegistry)).isEqualTo(1);
     }
 
     @Test
@@ -229,8 +230,8 @@ public class LuceneIndexStoreImplTest {
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
       // Counters not set since no commit.
-      assertThat(getCount(REFRESHES_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
-      assertThat(getCount(COMMITS_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
+      assertThat(getTimerCount(REFRESHES_TIMER, strictLogStore.metricsRegistry)).isEqualTo(0);
+      assertThat(getTimerCount(COMMITS_TIMER, strictLogStore.metricsRegistry)).isEqualTo(0);
     }
 
     @Test
@@ -304,8 +305,8 @@ public class LuceneIndexStoreImplTest {
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
-      assertThat(getCount(REFRESHES_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
-      assertThat(getCount(COMMITS_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
+      assertThat(getTimerCount(REFRESHES_TIMER, strictLogStore.metricsRegistry)).isEqualTo(1);
+      assertThat(getTimerCount(COMMITS_TIMER, strictLogStore.metricsRegistry)).isEqualTo(1);
     }
   }
 
@@ -327,8 +328,8 @@ public class LuceneIndexStoreImplTest {
       assertThat(results.size()).isEqualTo(1);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, testLogStore.metricsRegistry)).isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, testLogStore.metricsRegistry)).isEqualTo(0);
-      assertThat(getCount(REFRESHES_COUNTER, testLogStore.metricsRegistry)).isEqualTo(1);
-      assertThat(getCount(COMMITS_COUNTER, testLogStore.metricsRegistry)).isEqualTo(1);
+      assertThat(getTimerCount(REFRESHES_TIMER, testLogStore.metricsRegistry)).isEqualTo(1);
+      assertThat(getTimerCount(COMMITS_TIMER, testLogStore.metricsRegistry)).isEqualTo(1);
     }
   }
 
@@ -363,8 +364,8 @@ public class LuceneIndexStoreImplTest {
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry))
           .isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
-      assertThat(getCount(REFRESHES_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
-      assertThat(getCount(COMMITS_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
+      assertThat(getTimerCount(REFRESHES_TIMER, strictLogStore.metricsRegistry)).isEqualTo(1);
+      assertThat(getTimerCount(COMMITS_TIMER, strictLogStore.metricsRegistry)).isEqualTo(1);
 
       Path dirPath = logStore.getDirectory().toAbsolutePath();
       IndexCommit indexCommit = logStore.getIndexCommit();
@@ -428,8 +429,8 @@ public class LuceneIndexStoreImplTest {
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry))
           .isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
-      assertThat(getCount(REFRESHES_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
-      assertThat(getCount(COMMITS_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
+      assertThat(getTimerCount(REFRESHES_TIMER, strictLogStore.metricsRegistry)).isEqualTo(1);
+      assertThat(getTimerCount(COMMITS_TIMER, strictLogStore.metricsRegistry)).isEqualTo(1);
 
       Path dirPath = logStore.getDirectory().toAbsolutePath();
       IndexCommit indexCommit = logStore.getIndexCommit();
@@ -503,8 +504,8 @@ public class LuceneIndexStoreImplTest {
       addMessages(testLogStore.logStore, 1, 100, false);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, testLogStore.metricsRegistry)).isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, testLogStore.metricsRegistry)).isEqualTo(0);
-      assertThat(getCount(REFRESHES_COUNTER, testLogStore.metricsRegistry)).isEqualTo(0);
-      assertThat(getCount(COMMITS_COUNTER, testLogStore.metricsRegistry)).isEqualTo(0);
+      assertThat(getTimerCount(REFRESHES_TIMER, testLogStore.metricsRegistry)).isEqualTo(0);
+      assertThat(getTimerCount(COMMITS_TIMER, testLogStore.metricsRegistry)).isEqualTo(0);
 
       Thread.sleep(2 * commitDuration.toMillis());
       Collection<LogMessage> results =
@@ -513,10 +514,10 @@ public class LuceneIndexStoreImplTest {
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, testLogStore.metricsRegistry)).isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, testLogStore.metricsRegistry)).isEqualTo(0);
-      assertThat(getCount(REFRESHES_COUNTER, testLogStore.metricsRegistry))
+      assertThat(getTimerCount(REFRESHES_TIMER, testLogStore.metricsRegistry))
           .isGreaterThanOrEqualTo(1)
           .isLessThanOrEqualTo(3);
-      assertThat(getCount(COMMITS_COUNTER, testLogStore.metricsRegistry))
+      assertThat(getTimerCount(COMMITS_TIMER, testLogStore.metricsRegistry))
           .isGreaterThanOrEqualTo(1)
           .isLessThanOrEqualTo(3);
     }

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
@@ -1,12 +1,13 @@
 package com.slack.kaldb.logstore.search;
 
-import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.COMMITS_COUNTER;
+import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.COMMITS_TIMER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_FAILED_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_RECEIVED_COUNTER;
-import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.REFRESHES_COUNTER;
+import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.REFRESHES_TIMER;
 import static com.slack.kaldb.testlib.MessageUtil.TEST_INDEX_NAME;
 import static com.slack.kaldb.testlib.MessageUtil.makeMessageWithIndexAndTimestamp;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
+import static com.slack.kaldb.testlib.MetricsUtil.getTimerCount;
 import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.MAX_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -70,7 +71,7 @@ public class LogIndexSearcherImplTest {
 
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(2);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
-    assertThat(getCount(REFRESHES_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
+    assertThat(getTimerCount(REFRESHES_TIMER, strictLogStore.metricsRegistry)).isEqualTo(1);
 
     // Start inclusive.
     assertThat(
@@ -144,7 +145,7 @@ public class LogIndexSearcherImplTest {
 
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(2);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
-    assertThat(getCount(REFRESHES_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
+    assertThat(getTimerCount(REFRESHES_TIMER, strictLogStore.metricsRegistry)).isEqualTo(1);
 
     assertThat(
             strictLogStore
@@ -265,8 +266,8 @@ public class LogIndexSearcherImplTest {
     assertThat(baby.hits.get(0).id).isEqualTo("2");
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(2);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
-    assertThat(getCount(REFRESHES_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
-    assertThat(getCount(COMMITS_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
+    assertThat(getTimerCount(REFRESHES_TIMER, strictLogStore.metricsRegistry)).isEqualTo(1);
+    assertThat(getTimerCount(COMMITS_TIMER, strictLogStore.metricsRegistry)).isEqualTo(1);
 
     // Add car but don't commit. So, no results for car.
     strictLogStore.logStore.addMessage(
@@ -274,8 +275,8 @@ public class LogIndexSearcherImplTest {
 
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(3);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
-    assertThat(getCount(REFRESHES_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
-    assertThat(getCount(COMMITS_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
+    assertThat(getTimerCount(REFRESHES_TIMER, strictLogStore.metricsRegistry)).isEqualTo(1);
+    assertThat(getTimerCount(COMMITS_TIMER, strictLogStore.metricsRegistry)).isEqualTo(1);
 
     SearchResult<LogMessage> car =
         strictLogStore.logSearcher.search(
@@ -287,8 +288,8 @@ public class LogIndexSearcherImplTest {
 
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(3);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
-    assertThat(getCount(REFRESHES_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
-    assertThat(getCount(COMMITS_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(2);
+    assertThat(getTimerCount(REFRESHES_TIMER, strictLogStore.metricsRegistry)).isEqualTo(1);
+    assertThat(getTimerCount(COMMITS_TIMER, strictLogStore.metricsRegistry)).isEqualTo(2);
 
     SearchResult<LogMessage> carAfterCommit =
         strictLogStore.logSearcher.search(
@@ -300,8 +301,8 @@ public class LogIndexSearcherImplTest {
 
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(3);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
-    assertThat(getCount(REFRESHES_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(2);
-    assertThat(getCount(COMMITS_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(2);
+    assertThat(getTimerCount(REFRESHES_TIMER, strictLogStore.metricsRegistry)).isEqualTo(2);
+    assertThat(getTimerCount(COMMITS_TIMER, strictLogStore.metricsRegistry)).isEqualTo(2);
 
     SearchResult<LogMessage> carAfterRefresh =
         strictLogStore.logSearcher.search(
@@ -316,8 +317,8 @@ public class LogIndexSearcherImplTest {
 
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(4);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
-    assertThat(getCount(REFRESHES_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(3);
-    assertThat(getCount(COMMITS_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(2);
+    assertThat(getTimerCount(REFRESHES_TIMER, strictLogStore.metricsRegistry)).isEqualTo(3);
+    assertThat(getTimerCount(COMMITS_TIMER, strictLogStore.metricsRegistry)).isEqualTo(2);
 
     // Item shows up in search without commit.
     SearchResult<LogMessage> babies =
@@ -337,8 +338,8 @@ public class LogIndexSearcherImplTest {
     strictLogStore.logStore.commit();
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(4);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
-    assertThat(getCount(REFRESHES_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(3);
-    assertThat(getCount(COMMITS_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(3);
+    assertThat(getTimerCount(REFRESHES_TIMER, strictLogStore.metricsRegistry)).isEqualTo(3);
+    assertThat(getTimerCount(COMMITS_TIMER, strictLogStore.metricsRegistry)).isEqualTo(3);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/StatsCollectorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/StatsCollectorTest.java
@@ -1,12 +1,13 @@
 package com.slack.kaldb.logstore.search;
 
-import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.COMMITS_COUNTER;
+import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.COMMITS_TIMER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_FAILED_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_RECEIVED_COUNTER;
-import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.REFRESHES_COUNTER;
+import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.REFRESHES_TIMER;
 import static com.slack.kaldb.testlib.MessageUtil.TEST_INDEX_NAME;
 import static com.slack.kaldb.testlib.MessageUtil.makeMessageWithIndexAndTimestamp;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
+import static com.slack.kaldb.testlib.MetricsUtil.getTimerCount;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.slack.kaldb.histogram.HistogramBucket;
@@ -66,7 +67,7 @@ public class StatsCollectorTest {
 
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(5);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
-    assertThat(getCount(REFRESHES_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
-    assertThat(getCount(COMMITS_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
+    assertThat(getTimerCount(REFRESHES_TIMER, strictLogStore.metricsRegistry)).isEqualTo(1);
+    assertThat(getTimerCount(COMMITS_TIMER, strictLogStore.metricsRegistry)).isEqualTo(1);
   }
 }


### PR DESCRIPTION
Converts the commit and refresh instrumentation to use timers instead of counters, so we have better visibility into how long these calls are taking.