### PR TITLE
Remove streams in hot code paths.

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
@@ -177,6 +177,7 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
     ScopedSpan pickSearchNodeToQuerySpan =
         Tracing.currentTracer()
             .startScopedSpan("KaldbDistributedQueryService.pickSearchNodeToQuery");
+    // TODO: Re-write this code using a for loop.
     var nodes =
         searchMetadataStore
             .getCached()

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
@@ -158,7 +158,7 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
     // step 1 - find all snapshots that match time window and partition
     ScopedSpan snapshotsToSearchSpan =
         Tracing.currentTracer().startScopedSpan("KaldbDistributedQueryService.snapshotsToSearch");
-    Set<String> snapshotsToSearch = new HashSet<>(256);
+    Set<String> snapshotsToSearch = new HashSet<>();
     for (SnapshotMetadata snapshotMetadata : snapshotMetadataStore.getCached()) {
       if (containsDataInTimeRange(
               snapshotMetadata.startTimeEpochMs,

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/LogIndexSearcherImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/LogIndexSearcherImpl.java
@@ -18,11 +18,10 @@ import com.slack.kaldb.logstore.LogWireMessage;
 import com.slack.kaldb.util.JsonUtil;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.index.DirectoryReader;
@@ -121,10 +120,10 @@ public class LogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
         List<LogMessage> results;
         if (howMany > 0) {
           ScoreDoc[] hits = topFieldCollector.topDocs().scoreDocs;
-          results =
-              Stream.of(hits)
-                  .map(hit -> buildLogMessage(searcher, hit))
-                  .collect(Collectors.toList());
+          results = new ArrayList<>(hits.length);
+          for (ScoreDoc hit : hits) {
+            results.add(buildLogMessage(searcher, hit));
+          }
         } else {
           results = Collections.emptyList();
         }


### PR DESCRIPTION
Remove streams usage in hot code paths so the code is more efficient. For example, in this case, there is less garbage since we are able to fix the size of result set and also no wrapper objects are created to iterate on the stream. 