### PR TITLE
Reduce time spent in creating strings that we throw away

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ChunkInfo.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ChunkInfo.java
@@ -176,10 +176,12 @@ public class ChunkInfo {
       long dataStartTimeEpochMs, long dataEndTimeEpochMs, long startTimeMs, long endTimeMs) {
     ensureTrue(endTimeMs >= 0, "end timestamp should be greater than zero: " + endTimeMs);
     ensureTrue(startTimeMs >= 0, "start timestamp should be greater than zero: " + startTimeMs);
-    ensureTrue(
-        endTimeMs - startTimeMs >= 0,
-        String.format(
-            "end timestamp %d can't be less than the start timestamp %d.", endTimeMs, startTimeMs));
+    if (endTimeMs - startTimeMs < 0) {
+      throw new IllegalArgumentException(
+          String.format(
+              "end timestamp %d can't be less than the start timestamp %d.",
+              endTimeMs, startTimeMs));
+    }
     return (dataStartTimeEpochMs <= startTimeMs && dataEndTimeEpochMs >= startTimeMs)
         || (dataStartTimeEpochMs <= endTimeMs && dataEndTimeEpochMs >= endTimeMs)
         || (dataStartTimeEpochMs >= startTimeMs && dataEndTimeEpochMs <= endTimeMs);


### PR DESCRIPTION
We call ChunkInfo#containsDataInTimeRange method to check which snapshot falls within the query time range

Currently it our system we have over 5000 snapshots, and this nethod gets invoked for every snapshot

This small tweak doesn't cause String.format to get called every single time but only when the end timestamp is invalid

Before 50% of time was spent in string formatting
![before](https://user-images.githubusercontent.com/158041/170336064-2208345f-87ec-45d5-9248-e6cae2ff5c7c.png)

After - none since the benchmark query I am using is a valid timestamp
![after](https://user-images.githubusercontent.com/158041/170336389-86cdf593-65dd-4c6e-a298-2939996d1bbe.png)

