### PR TITLE
Revert "Add extra distributed query troubleshooting instrumentation"

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/server/KaldbQueryServiceBase.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/KaldbQueryServiceBase.java
@@ -1,7 +1,5 @@
 package com.slack.kaldb.server;
 
-import brave.ScopedSpan;
-import brave.Tracing;
 import com.slack.kaldb.proto.service.KaldbSearch;
 import com.slack.kaldb.proto.service.KaldbServiceGrpc;
 import io.grpc.Status;
@@ -17,18 +15,16 @@ public abstract class KaldbQueryServiceBase extends KaldbServiceGrpc.KaldbServic
   public void search(
       KaldbSearch.SearchRequest request,
       StreamObserver<KaldbSearch.SearchResult> responseObserver) {
+
     LOG.info(
         String.format("Search request received: '%s'", request.toString().replace("\n", ", ")));
 
-    ScopedSpan span = Tracing.currentTracer().startScopedSpan("KaldbQueryServiceBase.search");
     try {
       responseObserver.onNext(doSearch(request));
       responseObserver.onCompleted();
     } catch (Exception e) {
       LOG.error("Error completing search request", e);
       responseObserver.onError(Status.UNKNOWN.withDescription(e.getMessage()).asException());
-    } finally {
-      span.finish();
     }
   }
 


### PR DESCRIPTION
Reverts slackhq/kaldb#301. This is no longer needed so can be restored to what it was previously.