### PR TITLE
Move envoy_log parser from indexer to indexer.

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorValueMapper.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorValueMapper.java
@@ -1,7 +1,5 @@
 package com.slack.kaldb.preprocessor;
 
-import static com.slack.kaldb.writer.LogMessageWriterImpl.toMurronMessage;
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.slack.kaldb.writer.MurronLogFormatter;
@@ -11,6 +9,7 @@ import com.slack.service.murron.trace.Trace;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.streams.kstream.ValueMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,6 +20,9 @@ import org.slf4j.LoggerFactory;
 public class PreprocessorValueMapper {
   private static final Logger LOG = LoggerFactory.getLogger(PreprocessorValueMapper.class);
 
+  private static Deserializer<Murron.MurronMessage> murronMessageDeserializer =
+      KaldbSerdes.MurronMurronMessage().deserializer();
+
   @FunctionalInterface
   private interface MessageTransformer {
     List<Trace.Span> toTraceSpans(byte[] record) throws Exception;
@@ -29,21 +31,29 @@ public class PreprocessorValueMapper {
   // An apiLog message is a json blob wrapped in a murron message.
   public static final MessageTransformer apiLogTransformer =
       record -> {
-        final Murron.MurronMessage murronMsg = toMurronMessage(record);
+        final Murron.MurronMessage murronMsg = murronMessageDeserializer.deserialize("", record);
         return List.of(MurronLogFormatter.fromApiLog(murronMsg));
+      };
+
+  // An envoy log message is a json blob wrapped in a murron message.
+  public static final MessageTransformer envoyLogTransformer =
+      record -> {
+        final Murron.MurronMessage murronMsg = murronMessageDeserializer.deserialize("", record);
+        return List.of(MurronLogFormatter.fromEnvoyLog(murronMsg));
       };
 
   // A single trace record consists of a list of spans wrapped in a murron message.
   public static final MessageTransformer spanTransformer =
       record -> {
-        Murron.MurronMessage murronMsg = toMurronMessage(record);
+        Murron.MurronMessage murronMsg = murronMessageDeserializer.deserialize("", record);
         return SpanFormatter.fromMurronMessage(murronMsg).getSpansList();
       };
 
   // todo - add a json blob transformer, ie LogMessageWriterImpl.jsonLogMessageTransformer
 
-  private static final Map<String, MessageTransformer> DATA_TRANSFORMER_MAP =
-      ImmutableMap.of("api_log", apiLogTransformer, "spans", spanTransformer);
+  private static final Map<String, MessageTransformer> PRE_PROCESSOR_DATA_TRANSFORMER_MAP =
+      ImmutableMap.of(
+          "api_log", apiLogTransformer, "spans", spanTransformer, "envoy_log", envoyLogTransformer);
 
   /** Span key for KeyValue pair to use as the service name */
   public static String SERVICE_NAME_KEY = "service_name";
@@ -66,12 +76,12 @@ public class PreprocessorValueMapper {
   public static ValueMapper<byte[], Iterable<Trace.Span>> byteArrayToTraceSpans(
       String dataTransformer) {
     Preconditions.checkArgument(
-        DATA_TRANSFORMER_MAP.containsKey(dataTransformer),
+        PRE_PROCESSOR_DATA_TRANSFORMER_MAP.containsKey(dataTransformer),
         "Invalid data transformer provided, must be one of {}",
-        DATA_TRANSFORMER_MAP.toString());
+        PRE_PROCESSOR_DATA_TRANSFORMER_MAP.toString());
     return messageBytes -> {
       try {
-        return DATA_TRANSFORMER_MAP.get(dataTransformer).toTraceSpans(messageBytes);
+        return PRE_PROCESSOR_DATA_TRANSFORMER_MAP.get(dataTransformer).toTraceSpans(messageBytes);
       } catch (Exception e) {
         LOG.error("Error converting byte array to Trace.ListOfSpans", e);
         return Collections.emptyList();

--- a/kaldb/src/main/java/com/slack/kaldb/server/KaldbConfig.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/KaldbConfig.java
@@ -90,25 +90,15 @@ public class KaldbConfig {
   }
 
   @VisibleForTesting
-  public static final Map<String, LogMessageTransformer> DATA_TRANSFORMER_MAP =
-      ImmutableMap.of(
-          "api_log",
-          LogMessageWriterImpl.apiLogTransformer,
-          "envoy_log",
-          LogMessageWriterImpl.envoyLogTransformer,
-          "spans",
-          LogMessageWriterImpl.spanTransformer,
-          "json",
-          LogMessageWriterImpl.jsonLogMessageTransformer,
-          "trace_span",
-          LogMessageWriterImpl.traceSpanTransformer);
+  public static final Map<String, LogMessageTransformer> INDEXER_DATA_TRANSFORMER_MAP =
+      ImmutableMap.of("trace_span", LogMessageWriterImpl.traceSpanTransformer);
 
   public static void validateDataTransformerConfig(String dataTransformerConfig) {
     checkArgument(
         dataTransformerConfig != null && !dataTransformerConfig.isEmpty(),
         "IndexerConfig can't have an empty dataTransformer config.");
     checkArgument(
-        DATA_TRANSFORMER_MAP.containsKey(dataTransformerConfig),
+        INDEXER_DATA_TRANSFORMER_MAP.containsKey(dataTransformerConfig),
         "Invalid data transformer config: " + dataTransformerConfig);
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/server/KaldbConfig.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/KaldbConfig.java
@@ -91,7 +91,11 @@ public class KaldbConfig {
 
   @VisibleForTesting
   public static final Map<String, LogMessageTransformer> INDEXER_DATA_TRANSFORMER_MAP =
-      ImmutableMap.of("trace_span", LogMessageWriterImpl.traceSpanTransformer);
+      ImmutableMap.of(
+          "api_log",
+          LogMessageWriterImpl.apiLogTransformer,
+          "trace_span",
+          LogMessageWriterImpl.traceSpanTransformer);
 
   public static void validateDataTransformerConfig(String dataTransformerConfig) {
     checkArgument(

--- a/kaldb/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
@@ -1,8 +1,8 @@
 package com.slack.kaldb.server;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.slack.kaldb.server.KaldbConfig.DATA_TRANSFORMER_MAP;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
+import static com.slack.kaldb.server.KaldbConfig.INDEXER_DATA_TRANSFORMER_MAP;
 
 import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import com.slack.kaldb.chunkManager.ChunkRollOverException;
@@ -68,7 +68,7 @@ public class KaldbIndexer extends AbstractExecutionThreadService {
     this.chunkManager = chunkManager;
     // set up indexing pipelne
     LogMessageTransformer messageTransformer =
-        DATA_TRANSFORMER_MAP.get(indexerConfig.getDataTransformer());
+        INDEXER_DATA_TRANSFORMER_MAP.get(indexerConfig.getDataTransformer());
     LogMessageWriterImpl logMessageWriterImpl =
         new LogMessageWriterImpl(chunkManager, messageTransformer);
     this.kafkaConsumer =

--- a/kaldb/src/main/java/com/slack/kaldb/writer/LogMessageWriterImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/LogMessageWriterImpl.java
@@ -1,8 +1,8 @@
 package com.slack.kaldb.writer;
 
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.slack.kaldb.chunkManager.IndexingChunkManager;
 import com.slack.kaldb.logstore.LogMessage;
+import com.slack.kaldb.preprocessor.KaldbSerdes;
 import com.slack.service.murron.Murron;
 import com.slack.service.murron.trace.Trace;
 import java.io.IOException;
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.serialization.Deserializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,31 +55,30 @@ import org.slf4j.LoggerFactory;
 public class LogMessageWriterImpl implements MessageWriter {
   private static final Logger LOG = LoggerFactory.getLogger(LogMessageWriterImpl.class);
 
+  private static Deserializer<Murron.MurronMessage> murronMessageDeserializer =
+      KaldbSerdes.MurronMurronMessage().deserializer();
+
   // An apiLog message is a json blob wrapped in a murron message.
+  @Deprecated
   public static final LogMessageTransformer apiLogTransformer =
       (ConsumerRecord<String, byte[]> record) -> {
-        final Murron.MurronMessage murronMsg = toMurronMessage(record.value());
+        final Murron.MurronMessage murronMsg =
+            murronMessageDeserializer.deserialize("", record.value());
         Trace.Span apiSpan = MurronLogFormatter.fromApiLog(murronMsg);
         return SpanFormatter.toLogMessage(Trace.ListOfSpans.newBuilder().addSpans(apiSpan).build());
       };
 
-  // An envoy log message is a json blob wrapped in a murron message.
-  public static final LogMessageTransformer envoyLogTransformer =
-      (ConsumerRecord<String, byte[]> record) -> {
-        final Murron.MurronMessage murronMsg = toMurronMessage(record.value());
-        Trace.Span apiSpan = MurronLogFormatter.fromEnvoyLog(murronMsg);
-        return SpanFormatter.toLogMessage(Trace.ListOfSpans.newBuilder().addSpans(apiSpan).build());
-      };
-
   // A single trace record consists of a list of spans wrapped in a murron message.
+  @Deprecated
   public static final LogMessageTransformer spanTransformer =
       (ConsumerRecord<String, byte[]> record) -> {
-        Murron.MurronMessage murronMsg = toMurronMessage(record.value());
+        Murron.MurronMessage murronMsg = murronMessageDeserializer.deserialize("", record.value());
         Trace.ListOfSpans spanList = SpanFormatter.fromMurronMessage(murronMsg);
         return SpanFormatter.toLogMessage(spanList);
       };
 
   // A json blob with a few fields.
+  @Deprecated
   public static final LogMessageTransformer jsonLogMessageTransformer =
       (ConsumerRecord<String, byte[]> record) -> {
         Optional<LogMessage> msg =
@@ -128,23 +128,5 @@ public class LogMessageWriterImpl implements MessageWriter {
           logMessage, avgMsgSize, String.valueOf(record.partition()), record.offset());
     }
     return true;
-  }
-
-  /**
-   * Move all Kafka message serializers to common class
-   *
-   * @see com.slack.kaldb.preprocessor.KaldbSerdes
-   */
-  @Deprecated
-  public static Murron.MurronMessage toMurronMessage(byte[] recordStr) {
-    Murron.MurronMessage murronMsg = null;
-    if (recordStr == null || recordStr.length == 0) return null;
-
-    try {
-      murronMsg = Murron.MurronMessage.parseFrom(recordStr);
-    } catch (InvalidProtocolBufferException e) {
-      LOG.info("Error parsing byte string into MurronMessage: {}", new String(recordStr), e);
-    }
-    return murronMsg;
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumerTest.java
@@ -1,7 +1,7 @@
 package com.slack.kaldb.writer.kafka;
 
-import static com.slack.kaldb.server.KaldbConfig.DATA_TRANSFORMER_MAP;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
+import static com.slack.kaldb.server.KaldbConfig.INDEXER_DATA_TRANSFORMER_MAP;
 import static com.slack.kaldb.testlib.ChunkManagerUtil.makeChunkManagerUtil;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -60,7 +60,7 @@ public class KaldbKafkaConsumerTest {
 
       LogMessageWriterImpl logMessageWriter =
           new LogMessageWriterImpl(
-              chunkManagerUtil.chunkManager, DATA_TRANSFORMER_MAP.get("spans"));
+              chunkManagerUtil.chunkManager, INDEXER_DATA_TRANSFORMER_MAP.get("spans"));
       testConsumer =
           new KaldbKafkaConsumer(
               TestKafkaServer.TEST_KAFKA_TOPIC,
@@ -147,7 +147,7 @@ public class KaldbKafkaConsumerTest {
 
       logMessageWriter =
           new LogMessageWriterImpl(
-              chunkManagerUtil.chunkManager, DATA_TRANSFORMER_MAP.get("spans"));
+              chunkManagerUtil.chunkManager, INDEXER_DATA_TRANSFORMER_MAP.get("spans"));
     }
 
     @After


### PR DESCRIPTION
The envoy log parser is incorrectly added to indexer path where it should have been added to the pre-processor path. So, adding it correctly.

Remove deprecartd method `toMurronMessage`. 

Deprecate older log transformers in indexer.