### PR TITLE
Remove deprecated log transformers like api-log transformer..

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorValueMapper.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorValueMapper.java
@@ -1,7 +1,5 @@
 package com.slack.kaldb.preprocessor;
 
-import static com.slack.kaldb.writer.LogMessageWriterImpl.toMurronMessage;
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.slack.kaldb.writer.MurronLogFormatter;
@@ -11,6 +9,7 @@ import com.slack.service.murron.trace.Trace;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.streams.kstream.ValueMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,6 +20,9 @@ import org.slf4j.LoggerFactory;
 public class PreprocessorValueMapper {
   private static final Logger LOG = LoggerFactory.getLogger(PreprocessorValueMapper.class);
 
+  private static Deserializer<Murron.MurronMessage> murronMessageDeserializer =
+      KaldbSerdes.MurronMurronMessage().deserializer();
+
   @FunctionalInterface
   private interface MessageTransformer {
     List<Trace.Span> toTraceSpans(byte[] record) throws Exception;
@@ -29,21 +31,29 @@ public class PreprocessorValueMapper {
   // An apiLog message is a json blob wrapped in a murron message.
   public static final MessageTransformer apiLogTransformer =
       record -> {
-        final Murron.MurronMessage murronMsg = toMurronMessage(record);
+        final Murron.MurronMessage murronMsg = murronMessageDeserializer.deserialize("", record);
         return List.of(MurronLogFormatter.fromApiLog(murronMsg));
+      };
+
+  // An envoy log message is a json blob wrapped in a murron message.
+  public static final MessageTransformer envoyLogTransformer =
+      record -> {
+        final Murron.MurronMessage murronMsg = murronMessageDeserializer.deserialize("", record);
+        return List.of(MurronLogFormatter.fromEnvoyLog(murronMsg));
       };
 
   // A single trace record consists of a list of spans wrapped in a murron message.
   public static final MessageTransformer spanTransformer =
       record -> {
-        Murron.MurronMessage murronMsg = toMurronMessage(record);
+        Murron.MurronMessage murronMsg = murronMessageDeserializer.deserialize("", record);
         return SpanFormatter.fromMurronMessage(murronMsg).getSpansList();
       };
 
   // todo - add a json blob transformer, ie LogMessageWriterImpl.jsonLogMessageTransformer
 
-  private static final Map<String, MessageTransformer> DATA_TRANSFORMER_MAP =
-      ImmutableMap.of("api_log", apiLogTransformer, "spans", spanTransformer);
+  private static final Map<String, MessageTransformer> PRE_PROCESSOR_DATA_TRANSFORMER_MAP =
+      ImmutableMap.of(
+          "api_log", apiLogTransformer, "spans", spanTransformer, "envoy_log", envoyLogTransformer);
 
   /** Span key for KeyValue pair to use as the service name */
   public static String SERVICE_NAME_KEY = "service_name";
@@ -66,12 +76,12 @@ public class PreprocessorValueMapper {
   public static ValueMapper<byte[], Iterable<Trace.Span>> byteArrayToTraceSpans(
       String dataTransformer) {
     Preconditions.checkArgument(
-        DATA_TRANSFORMER_MAP.containsKey(dataTransformer),
+        PRE_PROCESSOR_DATA_TRANSFORMER_MAP.containsKey(dataTransformer),
         "Invalid data transformer provided, must be one of {}",
-        DATA_TRANSFORMER_MAP.toString());
+        PRE_PROCESSOR_DATA_TRANSFORMER_MAP.toString());
     return messageBytes -> {
       try {
-        return DATA_TRANSFORMER_MAP.get(dataTransformer).toTraceSpans(messageBytes);
+        return PRE_PROCESSOR_DATA_TRANSFORMER_MAP.get(dataTransformer).toTraceSpans(messageBytes);
       } catch (Exception e) {
         LOG.error("Error converting byte array to Trace.ListOfSpans", e);
         return Collections.emptyList();

--- a/kaldb/src/main/java/com/slack/kaldb/server/KaldbConfig.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/KaldbConfig.java
@@ -90,25 +90,15 @@ public class KaldbConfig {
   }
 
   @VisibleForTesting
-  public static final Map<String, LogMessageTransformer> DATA_TRANSFORMER_MAP =
-      ImmutableMap.of(
-          "api_log",
-          LogMessageWriterImpl.apiLogTransformer,
-          "envoy_log",
-          LogMessageWriterImpl.envoyLogTransformer,
-          "spans",
-          LogMessageWriterImpl.spanTransformer,
-          "json",
-          LogMessageWriterImpl.jsonLogMessageTransformer,
-          "trace_span",
-          LogMessageWriterImpl.traceSpanTransformer);
+  public static final Map<String, LogMessageTransformer> INDEXER_DATA_TRANSFORMER_MAP =
+      ImmutableMap.of("trace_span", LogMessageWriterImpl.traceSpanTransformer);
 
   public static void validateDataTransformerConfig(String dataTransformerConfig) {
     checkArgument(
         dataTransformerConfig != null && !dataTransformerConfig.isEmpty(),
         "IndexerConfig can't have an empty dataTransformer config.");
     checkArgument(
-        DATA_TRANSFORMER_MAP.containsKey(dataTransformerConfig),
+        INDEXER_DATA_TRANSFORMER_MAP.containsKey(dataTransformerConfig),
         "Invalid data transformer config: " + dataTransformerConfig);
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
@@ -1,8 +1,8 @@
 package com.slack.kaldb.server;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.slack.kaldb.server.KaldbConfig.DATA_TRANSFORMER_MAP;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
+import static com.slack.kaldb.server.KaldbConfig.INDEXER_DATA_TRANSFORMER_MAP;
 
 import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import com.slack.kaldb.chunkManager.ChunkRollOverException;
@@ -68,7 +68,7 @@ public class KaldbIndexer extends AbstractExecutionThreadService {
     this.chunkManager = chunkManager;
     // set up indexing pipelne
     LogMessageTransformer messageTransformer =
-        DATA_TRANSFORMER_MAP.get(indexerConfig.getDataTransformer());
+        INDEXER_DATA_TRANSFORMER_MAP.get(indexerConfig.getDataTransformer());
     LogMessageWriterImpl logMessageWriterImpl =
         new LogMessageWriterImpl(chunkManager, messageTransformer);
     this.kafkaConsumer =

--- a/kaldb/src/main/java/com/slack/kaldb/writer/LogMessageWriterImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/LogMessageWriterImpl.java
@@ -1,8 +1,8 @@
 package com.slack.kaldb.writer;
 
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.slack.kaldb.chunkManager.IndexingChunkManager;
 import com.slack.kaldb.logstore.LogMessage;
+import com.slack.kaldb.preprocessor.KaldbSerdes;
 import com.slack.service.murron.Murron;
 import com.slack.service.murron.trace.Trace;
 import java.io.IOException;
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.serialization.Deserializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,31 +55,30 @@ import org.slf4j.LoggerFactory;
 public class LogMessageWriterImpl implements MessageWriter {
   private static final Logger LOG = LoggerFactory.getLogger(LogMessageWriterImpl.class);
 
+  private static Deserializer<Murron.MurronMessage> murronMessageDeserializer =
+      KaldbSerdes.MurronMurronMessage().deserializer();
+
   // An apiLog message is a json blob wrapped in a murron message.
+  @Deprecated
   public static final LogMessageTransformer apiLogTransformer =
       (ConsumerRecord<String, byte[]> record) -> {
-        final Murron.MurronMessage murronMsg = toMurronMessage(record.value());
+        final Murron.MurronMessage murronMsg =
+            murronMessageDeserializer.deserialize("", record.value());
         Trace.Span apiSpan = MurronLogFormatter.fromApiLog(murronMsg);
         return SpanFormatter.toLogMessage(Trace.ListOfSpans.newBuilder().addSpans(apiSpan).build());
       };
 
-  // An envoy log message is a json blob wrapped in a murron message.
-  public static final LogMessageTransformer envoyLogTransformer =
-      (ConsumerRecord<String, byte[]> record) -> {
-        final Murron.MurronMessage murronMsg = toMurronMessage(record.value());
-        Trace.Span apiSpan = MurronLogFormatter.fromEnvoyLog(murronMsg);
-        return SpanFormatter.toLogMessage(Trace.ListOfSpans.newBuilder().addSpans(apiSpan).build());
-      };
-
   // A single trace record consists of a list of spans wrapped in a murron message.
+  @Deprecated
   public static final LogMessageTransformer spanTransformer =
       (ConsumerRecord<String, byte[]> record) -> {
-        Murron.MurronMessage murronMsg = toMurronMessage(record.value());
+        Murron.MurronMessage murronMsg = murronMessageDeserializer.deserialize("", record.value());
         Trace.ListOfSpans spanList = SpanFormatter.fromMurronMessage(murronMsg);
         return SpanFormatter.toLogMessage(spanList);
       };
 
   // A json blob with a few fields.
+  @Deprecated
   public static final LogMessageTransformer jsonLogMessageTransformer =
       (ConsumerRecord<String, byte[]> record) -> {
         Optional<LogMessage> msg =
@@ -128,23 +128,5 @@ public class LogMessageWriterImpl implements MessageWriter {
           logMessage, avgMsgSize, String.valueOf(record.partition()), record.offset());
     }
     return true;
-  }
-
-  /**
-   * Move all Kafka message serializers to common class
-   *
-   * @see com.slack.kaldb.preprocessor.KaldbSerdes
-   */
-  @Deprecated
-  public static Murron.MurronMessage toMurronMessage(byte[] recordStr) {
-    Murron.MurronMessage murronMsg = null;
-    if (recordStr == null || recordStr.length == 0) return null;
-
-    try {
-      murronMsg = Murron.MurronMessage.parseFrom(recordStr);
-    } catch (InvalidProtocolBufferException e) {
-      LOG.info("Error parsing byte string into MurronMessage: {}", new String(recordStr), e);
-    }
-    return murronMsg;
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
@@ -62,7 +62,7 @@ public class KaldbConfigTest {
             .createObjectNode()
             .put("maxMessagesPerChunk", 1)
             .put("maxBytesPerChunk", 100)
-            .put("dataTransformer", "api_log");
+            .put("dataTransformer", "trace_span");
     ObjectNode kafkaConfig =
         mapper.createObjectNode().put("kafkaTopicPartition", 1).put("kafkaSessionTimeout", 30000);
     ObjectNode node = mapper.createObjectNode();
@@ -88,7 +88,7 @@ public class KaldbConfigTest {
             .createObjectNode()
             .put("maxMessagesPerChunk", 1)
             .put("maxBytesPerChunk", 100)
-            .put("dataTransformer", "api_log");
+            .put("dataTransformer", "trace_span");
     ObjectNode node = mapper.createObjectNode();
     node.set("nodeRoles", mapper.createArrayNode().add("INDEX"));
     node.set("indexerConfig", indexerConfig);
@@ -110,7 +110,7 @@ public class KaldbConfigTest {
             .createObjectNode()
             .put("maxMessagesPerChunk", 1)
             .put("maxBytesPerChunk", 100)
-            .put("dataTransformer", "api_log")
+            .put("dataTransformer", "trace_span")
             .put("ignoredField", "ignore");
     ObjectNode kafkaConfig =
         mapper
@@ -182,7 +182,7 @@ public class KaldbConfigTest {
     assertThat(indexerConfig.getLuceneConfig().getCommitDurationSecs()).isEqualTo(10);
     assertThat(indexerConfig.getLuceneConfig().getRefreshDurationSecs()).isEqualTo(11);
     assertThat(indexerConfig.getStaleDurationSecs()).isEqualTo(7200);
-    assertThat(indexerConfig.getDataTransformer()).isEqualTo("api_log");
+    assertThat(indexerConfig.getDataTransformer()).isEqualTo("trace_span");
     assertThat(indexerConfig.getDataDirectory()).isEqualTo("/tmp");
     assertThat(indexerConfig.getServerConfig().getServerPort()).isEqualTo(8080);
     assertThat(indexerConfig.getServerConfig().getServerAddress()).isEqualTo("localhost");
@@ -311,7 +311,7 @@ public class KaldbConfigTest {
     assertThat(indexerConfig.getLuceneConfig().getCommitDurationSecs()).isEqualTo(10);
     assertThat(indexerConfig.getLuceneConfig().getRefreshDurationSecs()).isEqualTo(11);
     assertThat(indexerConfig.getStaleDurationSecs()).isEqualTo(7200);
-    assertThat(indexerConfig.getDataTransformer()).isEqualTo("api_log");
+    assertThat(indexerConfig.getDataTransformer()).isEqualTo("trace_span");
     assertThat(indexerConfig.getDataDirectory()).isEqualTo("/tmp");
     assertThat(indexerConfig.getMaxOffsetDelayMessages()).isEqualTo(10001);
     assertThat(indexerConfig.getServerConfig().getServerPort()).isEqualTo(8080);
@@ -421,7 +421,7 @@ public class KaldbConfigTest {
   public void testEmptyJsonStringInit() throws InvalidProtocolBufferException {
     KaldbConfigs.KaldbConfig config =
         KaldbConfig.fromJsonConfig(
-            "{nodeRoles: [INDEX], " + "indexerConfig:{dataTransformer:api_log}}");
+            "{nodeRoles: [INDEX], " + "indexerConfig:{dataTransformer:trace_span}}");
 
     assertThat(config.getNodeRolesList().size()).isEqualTo(1);
 
@@ -447,7 +447,7 @@ public class KaldbConfigTest {
     assertThat(indexerConfig.getLuceneConfig().getRefreshDurationSecs()).isZero();
     assertThat(indexerConfig.getStaleDurationSecs()).isZero();
     assertThat(indexerConfig.getDataDirectory()).isEmpty();
-    assertThat(indexerConfig.getDataTransformer()).isEqualTo("api_log");
+    assertThat(indexerConfig.getDataTransformer()).isEqualTo("trace_span");
     assertThat(indexerConfig.getMaxOffsetDelayMessages()).isZero();
     assertThat(indexerConfig.getServerConfig().getServerPort()).isZero();
     assertThat(indexerConfig.getServerConfig().getServerAddress()).isEmpty();
@@ -535,7 +535,7 @@ public class KaldbConfigTest {
   public void testEmptyYamlStringInit()
       throws InvalidProtocolBufferException, JsonProcessingException {
     String yamlCfgString =
-        "nodeRoles: [INDEX]\n" + "indexerConfig:\n" + "  dataTransformer: api_log";
+        "nodeRoles: [INDEX]\n" + "indexerConfig:\n" + "  dataTransformer: trace_span";
     KaldbConfigs.KaldbConfig config = KaldbConfig.fromYamlConfig(yamlCfgString);
 
     assertThat(config.getNodeRolesList().size()).isEqualTo(1);
@@ -562,7 +562,7 @@ public class KaldbConfigTest {
     assertThat(indexerConfig.getLuceneConfig().getRefreshDurationSecs()).isZero();
     assertThat(indexerConfig.getStaleDurationSecs()).isZero();
     assertThat(indexerConfig.getDataDirectory()).isEmpty();
-    assertThat(indexerConfig.getDataTransformer()).isEqualTo("api_log");
+    assertThat(indexerConfig.getDataTransformer()).isEqualTo("trace_span");
     assertThat(indexerConfig.getMaxOffsetDelayMessages()).isZero();
     assertThat(indexerConfig.getServerConfig().getServerPort()).isZero();
     assertThat(indexerConfig.getServerConfig().getServerAddress()).isEmpty();
@@ -650,7 +650,7 @@ public class KaldbConfigTest {
         .isThrownBy(() -> KaldbConfig.fromYamlConfig("nodeRoles: [index]"));
 
     String yamlCfgString =
-        "nodeRoles: [INDEX]\n" + "indexerConfig:\n" + "  dataTransformer: api_log";
+        "nodeRoles: [INDEX]\n" + "indexerConfig:\n" + "  dataTransformer: trace_span";
     List<KaldbConfigs.NodeRole> roles =
         KaldbConfig.fromYamlConfig(yamlCfgString).getNodeRolesList();
     assertThat(roles.size()).isEqualTo(1);

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -151,7 +151,7 @@ public class KaldbIndexerTest {
         new KaldbIndexer(
             chunkManagerUtil.chunkManager,
             zkMetadataStore,
-            makeIndexerConfig(1000, "api_log"),
+            makeIndexerConfig(1000, "trace_span"),
             getKafkaConfig(),
             metricsRegistry);
     kaldbIndexer.startAsync();
@@ -188,7 +188,7 @@ public class KaldbIndexerTest {
         new KaldbIndexer(
             chunkManagerUtil.chunkManager,
             zkMetadataStore,
-            makeIndexerConfig(1000, "api_log"),
+            makeIndexerConfig(1000, "trace_span"),
             getKafkaConfig(),
             metricsRegistry);
     kaldbIndexer.startAsync();
@@ -234,7 +234,7 @@ public class KaldbIndexerTest {
         new KaldbIndexer(
             chunkManagerUtil.chunkManager,
             zkMetadataStore,
-            makeIndexerConfig(1000, "api_log"),
+            makeIndexerConfig(1000, "trace_span"),
             getKafkaConfig(),
             metricsRegistry);
     kaldbIndexer.startAsync();
@@ -270,7 +270,7 @@ public class KaldbIndexerTest {
         new KaldbIndexer(
             chunkManagerUtil.chunkManager,
             zkMetadataStore,
-            makeIndexerConfig(1000, "api_log"),
+            makeIndexerConfig(1000, "trace_span"),
             getKafkaConfig(),
             metricsRegistry);
     kaldbIndexer.startAsync();
@@ -320,7 +320,7 @@ public class KaldbIndexerTest {
         new KaldbIndexer(
             chunkManagerUtil.chunkManager,
             zkMetadataStore,
-            makeIndexerConfig(1000, "api_log"),
+            makeIndexerConfig(1000, "trace_span"),
             getKafkaConfig(),
             metricsRegistry);
     kaldbIndexer.startAsync();
@@ -372,7 +372,7 @@ public class KaldbIndexerTest {
         new KaldbIndexer(
             chunkManagerUtil.chunkManager,
             zkMetadataStore,
-            makeIndexerConfig(50, "api_log"),
+            makeIndexerConfig(50, "trace_span"),
             getKafkaConfig(),
             metricsRegistry);
     kaldbIndexer.startAsync();
@@ -431,7 +431,7 @@ public class KaldbIndexerTest {
         new KaldbIndexer(
             chunkManagerUtil.chunkManager,
             zkMetadataStore,
-            makeIndexerConfig(50, "api_log"),
+            makeIndexerConfig(50, "trace_span"),
             getKafkaConfig(),
             metricsRegistry);
     kaldbIndexer.startAsync();
@@ -494,7 +494,7 @@ public class KaldbIndexerTest {
         new KaldbIndexer(
             chunkManagerUtil.chunkManager,
             zkMetadataStore,
-            makeIndexerConfig(1000, "api_log"),
+            makeIndexerConfig(1000, "trace_span"),
             getKafkaConfig(),
             metricsRegistry);
     kaldbIndexer.startAsync();
@@ -542,7 +542,7 @@ public class KaldbIndexerTest {
         new KaldbIndexer(
             chunkManagerUtil.chunkManager,
             zkMetadataStore,
-            makeIndexerConfig(1000, "api_log"),
+            makeIndexerConfig(1000, "trace_span"),
             getKafkaConfig(),
             metricsRegistry);
     kaldbIndexer.startAsync();

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -8,6 +8,7 @@ import static com.slack.kaldb.testlib.ChunkManagerUtil.*;
 import static com.slack.kaldb.testlib.KaldbConfigUtil.*;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
 import static com.slack.kaldb.testlib.TestKafkaServer.produceMessagesToKafka;
+import static com.slack.kaldb.testlib.TestKafkaServer.produceSpansToKafka;
 import static org.assertj.core.api.Assertions.*;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
@@ -118,6 +119,7 @@ public class KaldbIndexerTest {
   }
 
   private KaldbConfigs.KafkaConfig getKafkaConfig() {
+    //noinspection OptionalGetWithoutIsPresent
     return makeKafkaConfig(
         TEST_KAFKA_TOPIC,
         TEST_KAFKA_PARTITION,
@@ -380,7 +382,7 @@ public class KaldbIndexerTest {
     await().until(() -> kafkaServer.getConnectedConsumerGroups() == 1);
 
     // Produce more messages since the recovery task is created for head.
-    produceMessagesToKafka(kafkaServer.getBroker(), startTime);
+    produceSpansToKafka(kafkaServer.getBroker(), startTime);
 
     consumeMessagesAndSearchMessagesTest(100, 1);
 

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/MessageUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/MessageUtil.java
@@ -4,8 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.logstore.LogWireMessage;
 import com.slack.kaldb.util.JsonUtil;
-import java.io.IOException;
-import java.net.ServerSocket;
+import com.slack.service.murron.trace.Trace;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -152,9 +151,23 @@ public class MessageUtil {
     return result;
   }
 
-  // TODO: Move this to TestKafkaServer class.
-  public int getPort() throws IOException {
-    ServerSocket socket = new ServerSocket(0);
-    return socket.getLocalPort();
+  public static List<Trace.Span> makeSpanMessagesWithTimeDifference(
+      int low, int high, long timeDeltaMills, Instant start) {
+    List<Trace.Span> result = new ArrayList<>();
+    for (int i = 0; i <= (high - low); i++) {
+      result.add(
+          MessageUtil.makeSpanMessage(
+              low + i, start.plusNanos(1000 * 1000 * timeDeltaMills * i).toEpochMilli()));
+    }
+    return result;
+  }
+
+  private static Trace.Span makeSpanMessage(int i, long timestampMillis) {
+    final String serviceName = "test_service";
+    final String name = "testSpanName";
+    final String msgType = "test_message_type";
+    final String id = DEFAULT_MESSAGE_PREFIX + i;
+    return SpanUtil.makeSpan(
+        id, id, "", timestampMillis * 1000, 1000 * 500, name, serviceName, msgType);
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumerTest.java
@@ -1,7 +1,7 @@
 package com.slack.kaldb.writer.kafka;
 
-import static com.slack.kaldb.server.KaldbConfig.DATA_TRANSFORMER_MAP;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
+import static com.slack.kaldb.server.KaldbConfig.INDEXER_DATA_TRANSFORMER_MAP;
 import static com.slack.kaldb.testlib.ChunkManagerUtil.makeChunkManagerUtil;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -60,7 +60,7 @@ public class KaldbKafkaConsumerTest {
 
       LogMessageWriterImpl logMessageWriter =
           new LogMessageWriterImpl(
-              chunkManagerUtil.chunkManager, DATA_TRANSFORMER_MAP.get("spans"));
+              chunkManagerUtil.chunkManager, INDEXER_DATA_TRANSFORMER_MAP.get("spans"));
       testConsumer =
           new KaldbKafkaConsumer(
               TestKafkaServer.TEST_KAFKA_TOPIC,
@@ -147,7 +147,7 @@ public class KaldbKafkaConsumerTest {
 
       logMessageWriter =
           new LogMessageWriterImpl(
-              chunkManagerUtil.chunkManager, DATA_TRANSFORMER_MAP.get("spans"));
+              chunkManagerUtil.chunkManager, INDEXER_DATA_TRANSFORMER_MAP.get("spans"));
     }
 
     @After

--- a/kaldb/src/test/resources/test_config.json
+++ b/kaldb/src/test/resources/test_config.json
@@ -29,7 +29,7 @@
       "refreshDurationSecs": 11
     },
     "staleDurationSecs": 7200,
-    "dataTransformer": "api_log",
+    "dataTransformer": "trace_span",
     "dataDirectory": "/tmp",
     "maxOffsetDelayMessages" : 10002,
     "serverConfig": {

--- a/kaldb/src/test/resources/test_config.yaml
+++ b/kaldb/src/test/resources/test_config.yaml
@@ -7,7 +7,7 @@ indexerConfig:
     commitDurationSecs: 10
     refreshDurationSecs: 11
   staleDurationSecs: 7200
-  dataTransformer: "api_log"
+  dataTransformer: "trace_span"
   dataDirectory: "/tmp"
   maxOffsetDelayMessages: 10001
   serverConfig:


### PR DESCRIPTION
Add envoy log parser to pre-processor value mapper so we can parse envoy logs.