### PR TITLE
Remove overrides for ramBuffer, compound file

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreConfig.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreConfig.java
@@ -26,9 +26,6 @@ public class LuceneIndexStoreConfig {
   // The name of the lucene log file.
   public final String logFileName;
 
-  // Config to set the IndexWriterConfig.setRAMBufferSizeMB.
-  public final int ramBufferSizeMB;
-
   // A flag that turns on internal logging.
   public final boolean enableTracing;
 
@@ -47,18 +44,8 @@ public class LuceneIndexStoreConfig {
   }
 
   public LuceneIndexStoreConfig(
-      Duration commitDuration,
-      Duration refreshDuration,
-      String indexRoot,
-      int ramBufferSizeMB,
-      boolean enableTracing) {
-    this(
-        commitDuration,
-        refreshDuration,
-        indexRoot,
-        DEFAULT_LOG_FILE_NAME,
-        ramBufferSizeMB,
-        enableTracing);
+      Duration commitDuration, Duration refreshDuration, String indexRoot, boolean enableTracing) {
+    this(commitDuration, refreshDuration, indexRoot, DEFAULT_LOG_FILE_NAME, enableTracing);
   }
 
   public LuceneIndexStoreConfig(
@@ -66,7 +53,6 @@ public class LuceneIndexStoreConfig {
       Duration refreshDuration,
       String indexRoot,
       String logFileName,
-      int ramBufferSizeMB,
       boolean enableTracing) {
     ensureTrue(
         !(commitDuration.isZero() || commitDuration.isNegative()),
@@ -78,7 +64,6 @@ public class LuceneIndexStoreConfig {
     this.refreshDuration = refreshDuration;
     this.indexRoot = indexRoot;
     this.logFileName = logFileName;
-    this.ramBufferSizeMB = ramBufferSizeMB;
     this.enableTracing = enableTracing;
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreImpl.java
@@ -77,7 +77,7 @@ public class LuceneIndexStoreImpl implements LogStore<LogMessage> {
     // TODO: Chunk should create log store?
     LuceneIndexStoreConfig indexStoreCfg =
         new LuceneIndexStoreConfig(
-            commitInterval, refreshInterval, dataDirectory.getAbsolutePath(), 8, false);
+            commitInterval, refreshInterval, dataDirectory.getAbsolutePath(), false);
 
     // TODO: set ignore property exceptions via CLI flag.
     return new LuceneIndexStoreImpl(
@@ -139,8 +139,6 @@ public class LuceneIndexStoreImpl implements LogStore<LogMessage> {
     final IndexWriterConfig indexWriterCfg =
         new IndexWriterConfig(analyzer)
             .setOpenMode(IndexWriterConfig.OpenMode.CREATE)
-            .setRAMBufferSizeMB(config.ramBufferSizeMB)
-            .setUseCompoundFile(false)
             .setMergeScheduler(new KalDBMergeScheduler(metricsRegistry))
             .setIndexDeletionPolicy(snapshotDeletionPolicy);
 

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
@@ -531,7 +531,7 @@ public class IndexingChunkImplTest {
       assertThat(chunk.snapshotToS3(bucket, "", s3BlobFs)).isTrue();
       assertThat(chunk.info().getSnapshotPath()).isNotEmpty();
 
-      assertThat(getCount(INDEX_FILES_UPLOAD, registry)).isEqualTo(15);
+      assertThat(getCount(INDEX_FILES_UPLOAD, registry)).isEqualTo(4);
       assertThat(getCount(INDEX_FILES_UPLOAD_FAILED, registry)).isEqualTo(0);
       assertThat(registry.get(SNAPSHOT_TIMER).timer().totalTime(TimeUnit.SECONDS)).isGreaterThan(0);
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreConfigTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreConfigTest.java
@@ -6,25 +6,23 @@ import org.junit.Test;
 public class LuceneIndexStoreConfigTest {
   @Test(expected = IllegalArgumentException.class)
   public void testZeroCommitDuration() {
-    new LuceneIndexStoreConfig(
-        Duration.ZERO, Duration.ofSeconds(10), "indexRoot", "logfile", 20, true);
+    new LuceneIndexStoreConfig(Duration.ZERO, Duration.ofSeconds(10), "indexRoot", "logfile", true);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testZeroRefreshDuration() {
-    new LuceneIndexStoreConfig(
-        Duration.ofSeconds(10), Duration.ZERO, "indexRoot", "logfile", 20, true);
+    new LuceneIndexStoreConfig(Duration.ofSeconds(10), Duration.ZERO, "indexRoot", "logfile", true);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testNegativeCommitDuration() {
     new LuceneIndexStoreConfig(
-        Duration.ofSeconds(-10), Duration.ofSeconds(10), "indexRoot", "logfile", 20, true);
+        Duration.ofSeconds(-10), Duration.ofSeconds(10), "indexRoot", "logfile", true);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testNegativeRefreshDuration() {
     new LuceneIndexStoreConfig(
-        Duration.ofSeconds(10), Duration.ofSeconds(-100), "indexRoot", "logfile", 20, true);
+        Duration.ofSeconds(10), Duration.ofSeconds(-100), "indexRoot", "logfile", true);
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/TemporaryLogStoreAndSearcherRule.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/TemporaryLogStoreAndSearcherRule.java
@@ -73,7 +73,7 @@ public class TemporaryLogStoreAndSearcherRule implements TestRule {
   public static LuceneIndexStoreConfig getIndexStoreConfig(
       Duration commitInterval, Duration refreshInterval, File tempFolder) throws IOException {
     return new LuceneIndexStoreConfig(
-        commitInterval, refreshInterval, tempFolder.getCanonicalPath(), 8, false);
+        commitInterval, refreshInterval, tempFolder.getCanonicalPath(), false);
   }
 
   @Override


### PR DESCRIPTION
Reverts to the default Lucene behavior. The `ramBuffer` config we may want to expose again, but we'll need to rework it to support setting all of the various config options by passing an `engineConfig` instead of each param separately. This matches the approach that OpenSearch does, as there are several engine configs we will want to configure ([1](https://github.com/opensearch-project/OpenSearch/blob/a0030dfb47b4312eb4087f17cc3cee0139c74b6a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java#L2470), [2](https://github.com/opensearch-project/OpenSearch/blob/a0030dfb47b4312eb4087f17cc3cee0139c74b6a/server/src/main/java/org/opensearch/index/engine/EngineConfig.java)).