### PR TITLE
Force replica slot shuffle

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaAssignmentService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaAssignmentService.java
@@ -21,6 +21,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
@@ -146,6 +147,11 @@ public class ReplicaAssignmentService extends AbstractScheduledService {
                     cacheSlotMetadata.cacheSlotState.equals(
                         Metadata.CacheSlotMetadata.CacheSlotState.FREE))
             .collect(Collectors.toList());
+
+    // Force a shuffle of the available slots, to reduce the chance of a single cache node getting
+    // assigned chunks that matches all recent queries. This should help balance out the load
+    // across all available hosts.
+    Collections.shuffle(availableCacheSlots);
 
     Set<String> assignedReplicaIds =
         cacheSlotMetadataStore


### PR DESCRIPTION
Force shuffling of the available cache slots to prevent the possibility of nodes from getting sequential chunks assigned. 