### PR TITLE
Update jackson library version.

### DIFF
--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -20,7 +20,7 @@
         <micrometer.version>1.8.5</micrometer.version>
         <kafka.version>2.5.1</kafka.version>
         <jackson.version>2.13.3</jackson.version>
-        <jackson.databind.version>${jackson.version}</jackson.databind.version>
+        <jackson.databind.version>2.10.5.1</jackson.databind.version>
         <lucene.version>8.4.1</lucene.version>
         <curator.version>5.2.1</curator.version>
         <log4j.version>2.17.2</log4j.version>

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -19,8 +19,8 @@
         <armeria.version>1.16.0</armeria.version>
         <micrometer.version>1.8.5</micrometer.version>
         <kafka.version>2.5.1</kafka.version>
-        <jackson.version>2.10.5</jackson.version>
-        <jackson.databind.version>${jackson.version}.1</jackson.databind.version>
+        <jackson.version>2.13.3</jackson.version>
+        <jackson.databind.version>${jackson.version}</jackson.databind.version>
         <lucene.version>8.4.1</lucene.version>
         <curator.version>5.2.1</curator.version>
         <log4j.version>2.17.2</log4j.version>


### PR DESCRIPTION
Update jackson library version to fix [CVE-2020-36518](https://nvd.nist.gov/vuln/detail/CVE-2020-36518).

Keeping the databind version at `2.10.5.1` since armeria scala depends on it.