### PR TITLE
Add SnapshotMetadata filtering functionality

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
@@ -165,7 +165,7 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
             .startScopedSpan("KaldbDistributedQueryService.findPartitionsToQuery");
 
     List<ServicePartitionMetadata> partitions =
-        findPartitionsToQuery(
+        ServicePartitionMetadata.findPartitionsToQuery(
             serviceMetadataStore, queryStartTimeEpochMs, queryEndTimeEpochMs, dataset);
     findPartitionsToQuerySpan.finish();
 
@@ -262,33 +262,6 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
           url);
       return null;
     }
-  }
-
-  /*
-   get partitions that match on two criteria
-   1. index name
-   2. partitions that have an overlap with the query window
-  */
-  @VisibleForTesting
-  protected static List<ServicePartitionMetadata> findPartitionsToQuery(
-      ServiceMetadataStore serviceMetadataStore,
-      long startTimeEpochMs,
-      long endTimeEpochMs,
-      String dataset) {
-    return serviceMetadataStore
-        .getCached()
-        .stream()
-        .filter(serviceMetadata -> serviceMetadata.name.equals(dataset))
-        .flatMap(
-            serviceMetadata -> serviceMetadata.partitionConfigs.stream()) // will always return one
-        .filter(
-            partitionMetadata ->
-                containsDataInTimeRange(
-                    partitionMetadata.startTimeEpochMs,
-                    partitionMetadata.endTimeEpochMs,
-                    startTimeEpochMs,
-                    endTimeEpochMs))
-        .collect(Collectors.toList());
   }
 
   private List<SearchResult<LogMessage>> distributedSearch(KaldbSearch.SearchRequest request) {

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/service/ServicePartitionMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/service/ServicePartitionMetadataTest.java
@@ -1,17 +1,60 @@
 package com.slack.kaldb.metadata.service;
 
+import static com.slack.kaldb.metadata.service.ServicePartitionMetadata.findPartitionsToQuery;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.awaitility.Awaitility.await;
 
+import brave.Tracing;
+import com.slack.kaldb.metadata.zookeeper.MetadataStore;
+import com.slack.kaldb.metadata.zookeeper.ZookeeperMetadataStoreImpl;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 public class ServicePartitionMetadataTest {
+
+  private SimpleMeterRegistry metricsRegistry;
+  private MetadataStore zkMetadataStore;
+  private ServiceMetadataStore serviceMetadataStore;
+  private TestingServer testZKServer;
+
+  @Before
+  public void setUp() throws Exception {
+    Tracing.newBuilder().build();
+
+    metricsRegistry = new SimpleMeterRegistry();
+    testZKServer = new TestingServer();
+
+    // Metadata store
+    com.slack.kaldb.proto.config.KaldbConfigs.ZookeeperConfig zkConfig =
+        com.slack.kaldb.proto.config.KaldbConfigs.ZookeeperConfig.newBuilder()
+            .setZkConnectString(testZKServer.getConnectString())
+            .setZkPathPrefix("servicePartitionMetadataTest")
+            .setZkSessionTimeoutMs(1000)
+            .setZkConnectionTimeoutMs(1000)
+            .setSleepBetweenRetriesMs(1000)
+            .build();
+
+    zkMetadataStore = ZookeeperMetadataStoreImpl.fromConfig(metricsRegistry, zkConfig);
+    serviceMetadataStore = new ServiceMetadataStore(zkMetadataStore, true);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    serviceMetadataStore.close();
+    zkMetadataStore.close();
+    testZKServer.close();
+    metricsRegistry.close();
+  }
 
   @Test
   public void testServicePartitionMetadata() {
@@ -78,5 +121,121 @@ public class ServicePartitionMetadataTest {
     assertThatIllegalArgumentException()
         .isThrownBy(
             () -> new ServicePartitionMetadata(start.toEpochMilli(), end.toEpochMilli(), null));
+  }
+
+  @Test
+  public void testOneServiceOnePartition() {
+    final String name = "testService";
+    final String owner = "serviceOwner";
+    final long throughputBytes = 1000;
+    final ServicePartitionMetadata partition = new ServicePartitionMetadata(100, 200, List.of("1"));
+
+    ServiceMetadata serviceMetadata =
+        new ServiceMetadata(name, owner, throughputBytes, List.of(partition));
+
+    serviceMetadataStore.createSync(serviceMetadata);
+    await().until(() -> serviceMetadataStore.getCached().size() == 1);
+
+    // Start and end time within query window
+    List<ServicePartitionMetadata> partitionMetadata =
+        findPartitionsToQuery(serviceMetadataStore, 101, 199, name);
+    assertThat(partitionMetadata.size()).isEqualTo(1);
+    assertThat(partitionMetadata.get(0).partitions.size()).isEqualTo(1);
+
+    // End time partially overlapping query window
+    partitionMetadata = findPartitionsToQuery(serviceMetadataStore, 1, 150, name);
+    assertThat(partitionMetadata.size()).isEqualTo(1);
+    assertThat(partitionMetadata.get(0).partitions.size()).isEqualTo(1);
+
+    // End time overlapping entire query window
+    partitionMetadata = findPartitionsToQuery(serviceMetadataStore, 1, 250, name);
+    assertThat(partitionMetadata.size()).isEqualTo(1);
+    assertThat(partitionMetadata.get(0).partitions.size()).isEqualTo(1);
+
+    // Start time at edge of query window
+    partitionMetadata = findPartitionsToQuery(serviceMetadataStore, 200, 250, name);
+    assertThat(partitionMetadata.size()).isEqualTo(1);
+    assertThat(partitionMetadata.get(0).partitions.size()).isEqualTo(1);
+
+    // Start and end time outside of query window
+    partitionMetadata = findPartitionsToQuery(serviceMetadataStore, 201, 250, name);
+    assertThat(partitionMetadata.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void testOneServiceMultipleWindows() {
+    final String name = "testService";
+    final String owner = "serviceOwner";
+    final long throughputBytes = 1000;
+    final ServicePartitionMetadata partition1 =
+        new ServicePartitionMetadata(100, 200, List.of("1"));
+
+    final ServicePartitionMetadata partition2 =
+        new ServicePartitionMetadata(201, 300, List.of("2", "3"));
+
+    ServiceMetadata serviceMetadata =
+        new ServiceMetadata(name, owner, throughputBytes, List.of(partition1, partition2));
+
+    serviceMetadataStore.createSync(serviceMetadata);
+    await().until(() -> serviceMetadataStore.getCached().size() == 1);
+
+    // Fetch first partition between time 101 and 199
+    List<ServicePartitionMetadata> partitionMetadata =
+        findPartitionsToQuery(serviceMetadataStore, 101, 199, name);
+    assertThat(partitionMetadata.size()).isEqualTo(1);
+    assertThat(partitionMetadata.get(0).partitions.size()).isEqualTo(1);
+    assertThat(partitionMetadata.get(0).startTimeEpochMs).isEqualTo(100);
+    assertThat(partitionMetadata.get(0).endTimeEpochMs).isEqualTo(200);
+
+    // Fetch second partition between time 201 and 300
+    partitionMetadata = findPartitionsToQuery(serviceMetadataStore, 201, 300, name);
+    assertThat(partitionMetadata.size()).isEqualTo(1);
+    assertThat(partitionMetadata.get(0).partitions.size()).isEqualTo(2);
+    assertThat(partitionMetadata.get(0).startTimeEpochMs).isEqualTo(201);
+    assertThat(partitionMetadata.get(0).endTimeEpochMs).isEqualTo(300);
+
+    // Fetch both partitions
+    partitionMetadata = findPartitionsToQuery(serviceMetadataStore, 100, 202, name);
+    assertThat(partitionMetadata.size()).isEqualTo(2);
+
+    assertThat(partitionMetadata.get(0).partitions.size()).isEqualTo(1);
+    assertThat(partitionMetadata.get(0).startTimeEpochMs).isEqualTo(100);
+    assertThat(partitionMetadata.get(0).endTimeEpochMs).isEqualTo(200);
+
+    assertThat(partitionMetadata.get(1).partitions.size()).isEqualTo(2);
+    assertThat(partitionMetadata.get(1).startTimeEpochMs).isEqualTo(201);
+    assertThat(partitionMetadata.get(1).endTimeEpochMs).isEqualTo(300);
+  }
+
+  @Test
+  public void testMultipleServicesOneTimeRange() {
+    final String name = "testService";
+    final String owner = "serviceOwner";
+    final long throughputBytes = 1000;
+    final ServicePartitionMetadata partition = new ServicePartitionMetadata(100, 200, List.of("1"));
+
+    ServiceMetadata serviceMetadata =
+        new ServiceMetadata(name, owner, throughputBytes, List.of(partition));
+
+    serviceMetadataStore.createSync(serviceMetadata);
+    await().until(() -> serviceMetadataStore.getCached().size() == 1);
+
+    final String name1 = "testService1";
+    final String owner1 = "serviceOwner1";
+    final long throughputBytes1 = 1;
+    final ServicePartitionMetadata partition1 =
+        new ServicePartitionMetadata(100, 200, List.of("2"));
+
+    ServiceMetadata serviceMetadata1 =
+        new ServiceMetadata(name1, owner1, throughputBytes1, List.of(partition1));
+
+    serviceMetadataStore.createSync(serviceMetadata1);
+    await().until(() -> serviceMetadataStore.getCached().size() == 2);
+
+    List<ServicePartitionMetadata> partitionMetadata =
+        findPartitionsToQuery(serviceMetadataStore, 101, 199, name);
+    assertThat(partitionMetadata.size()).isEqualTo(1);
+    assertThat(partitionMetadata.get(0).partitions.size()).isEqualTo(1);
+    assertThat(partitionMetadata.get(0).partitions.get(0)).isEqualTo("1");
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
@@ -3,6 +3,7 @@ package com.slack.kaldb.server;
 import static com.slack.kaldb.server.ManagerApiGrpc.MAX_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
@@ -10,6 +11,8 @@ import static org.mockito.Mockito.spy;
 import brave.Tracing;
 import com.slack.kaldb.metadata.service.ServiceMetadata;
 import com.slack.kaldb.metadata.service.ServiceMetadataStore;
+import com.slack.kaldb.metadata.service.ServicePartitionMetadata;
+import com.slack.kaldb.metadata.snapshot.SnapshotMetadata;
 import com.slack.kaldb.metadata.zookeeper.InternalMetadataStoreException;
 import com.slack.kaldb.metadata.zookeeper.MetadataStore;
 import com.slack.kaldb.metadata.zookeeper.ZookeeperMetadataStoreImpl;
@@ -26,6 +29,7 @@ import io.grpc.testing.GrpcCleanupRule;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.curator.test.TestingServer;
@@ -462,5 +466,77 @@ public class ManagerApiGrpcTest {
     assertThat(throwableUpdate.getStatus().getDescription()).contains(serviceName);
 
     assertThat(serviceMetadataStore.listSync().size()).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldFetchSnapshotsWithinTimeframeAndPartition() {
+    long startTime = Instant.now().toEpochMilli();
+    long start = startTime + 5;
+    long end = startTime + 10;
+
+    SnapshotMetadata overlapsStartTimeIncluded =
+        new SnapshotMetadata("a", "a", startTime, startTime + 6, 0, "a");
+    SnapshotMetadata overlapsStartTimeExcluded =
+        new SnapshotMetadata("b", "b", startTime, startTime + 6, 0, "b");
+
+    SnapshotMetadata fullyOverlapsStartEndTimeIncluded =
+        new SnapshotMetadata("c", "c", startTime + 4, startTime + 11, 0, "a");
+    SnapshotMetadata fullyOverlapsStartEndTimeExcluded =
+        new SnapshotMetadata("d", "d", startTime + 4, startTime + 11, 0, "b");
+
+    SnapshotMetadata partiallyOverlapsStartEndTimeIncluded =
+        new SnapshotMetadata("e", "e", startTime + 4, startTime + 5, 0, "a");
+    SnapshotMetadata partiallyOverlapsStartEndTimeExcluded =
+        new SnapshotMetadata("f", "f", startTime + 4, startTime + 5, 0, "b");
+
+    SnapshotMetadata overlapsEndTimeIncluded =
+        new SnapshotMetadata("g", "g", startTime + 10, startTime + 15, 0, "a");
+    SnapshotMetadata overlapsEndTimeExcluded =
+        new SnapshotMetadata("h", "h", startTime + 10, startTime + 15, 0, "b");
+
+    SnapshotMetadata notWithinStartEndTimeExcluded1 =
+        new SnapshotMetadata("i", "i", startTime, startTime + 4, 0, "a");
+    SnapshotMetadata notWithinStartEndTimeExcluded2 =
+        new SnapshotMetadata("j", "j", startTime + 11, startTime + 15, 0, "a");
+
+    ServiceMetadata serviceWithDataInPartitionA =
+        new ServiceMetadata(
+            "foo",
+            "a",
+            1,
+            Arrays.asList(
+                new ServicePartitionMetadata(startTime + 5, startTime + 6, List.of("a"))));
+
+    serviceMetadataStore.createSync(serviceWithDataInPartitionA);
+
+    await().until(() -> serviceMetadataStore.getCached().size() == 1);
+
+    List<SnapshotMetadata> snapshotsWithData =
+        ManagerApiGrpc.fetchSnapshots(
+            Arrays.asList(
+                overlapsEndTimeIncluded,
+                overlapsEndTimeExcluded,
+                partiallyOverlapsStartEndTimeIncluded,
+                partiallyOverlapsStartEndTimeExcluded,
+                fullyOverlapsStartEndTimeIncluded,
+                fullyOverlapsStartEndTimeExcluded,
+                overlapsStartTimeIncluded,
+                overlapsStartTimeExcluded,
+                notWithinStartEndTimeExcluded1,
+                notWithinStartEndTimeExcluded2),
+            serviceMetadataStore,
+            start,
+            end,
+            "foo");
+
+    assertThat(snapshotsWithData.size()).isEqualTo(4);
+    assertThat(
+            snapshotsWithData.containsAll(
+                Arrays.asList(
+                    overlapsStartTimeIncluded,
+                    fullyOverlapsStartEndTimeIncluded,
+                    partiallyOverlapsStartEndTimeIncluded,
+                    overlapsEndTimeIncluded)))
+        .isTrue();
   }
 }


### PR DESCRIPTION
- Add functionality and tests for filtering `SnapshotMetadata`s by time and service name
- Move static method`findPartitionsToQuery` from `KaldbDistributedService` to `ServicePartitionMetadata`