### PR TITLE
Improve ES api instrumentation

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -32,6 +32,8 @@ s3Config:
 
 tracingConfig:
   zipkinEndpoint: ${ZIPKIN_TRACING_ENDPOINT:-http://localhost:9411/api/v2/spans}
+  commonTags:
+    clusterName: ${KALDB_CLUSTER_NAME:-kaldb_local}
 
 queryConfig:
   serverConfig:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -34,6 +34,7 @@ tracingConfig:
   zipkinEndpoint: ${ZIPKIN_TRACING_ENDPOINT:-http://localhost:9411/api/v2/spans}
   commonTags:
     clusterName: ${KALDB_CLUSTER_NAME:-kaldb_local}
+    env: ${KALDB_CLUSTER_ENV:-local}
 
 queryConfig:
   serverConfig:

--- a/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
@@ -24,6 +24,8 @@ import com.slack.kaldb.proto.service.KaldbSearch;
 import com.slack.kaldb.server.KaldbQueryServiceBase;
 import com.slack.kaldb.util.JsonUtil;
 import java.io.IOException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -105,6 +107,8 @@ public class ElasticsearchApiService {
           .aggregations(aggregations)
           .debugMetadata(
               Map.of("traceId", Tracing.current().currentTraceContext().get().traceIdString()))
+          .took(Duration.of(searchResult.getTookMicros(), ChronoUnit.MICROS).toMillis())
+          .shardsMetadata(searchResult.getTotalNodes(), searchResult.getFailedNodes())
           .status(200)
           .build();
     } finally {

--- a/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
@@ -21,16 +21,14 @@ import com.slack.kaldb.elasticsearchApi.searchResponse.HitsMetadata;
 import com.slack.kaldb.elasticsearchApi.searchResponse.SearchResponseHit;
 import com.slack.kaldb.elasticsearchApi.searchResponse.SearchResponseMetadata;
 import com.slack.kaldb.proto.service.KaldbSearch;
-import com.slack.kaldb.proto.service.KaldbServiceGrpc;
+import com.slack.kaldb.server.KaldbQueryServiceBase;
 import com.slack.kaldb.util.JsonUtil;
-import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Elasticsearch compatible API service, for use in Grafana
@@ -42,9 +40,9 @@ import java.util.concurrent.CompletableFuture;
 @SuppressWarnings(
     "OptionalUsedAsFieldOrParameterType") // Per https://armeria.dev/docs/server-annotated-service/
 public class ElasticsearchApiService {
-  private final KaldbServiceGrpc.KaldbServiceImplBase searcher;
+  private final KaldbQueryServiceBase searcher;
 
-  public ElasticsearchApiService(KaldbServiceGrpc.KaldbServiceImplBase searcher) {
+  public ElasticsearchApiService(KaldbQueryServiceBase searcher) {
     this.searcher = searcher;
   }
 
@@ -61,6 +59,7 @@ public class ElasticsearchApiService {
   public HttpResponse multiSearch(String postBody) throws IOException {
     List<EsSearchRequest> requests = EsSearchRequest.parse(postBody);
     List<EsSearchResponse> responses = new ArrayList<>();
+
     Tracing.current()
         .tracer()
         .currentSpanCustomizer()
@@ -79,39 +78,13 @@ public class ElasticsearchApiService {
   private EsSearchResponse doSearch(EsSearchRequest request) throws IOException {
     ScopedSpan span = Tracing.currentTracer().startScopedSpan("ElasticsearchApiService.doSearch");
     KaldbSearch.SearchRequest searchRequest = request.toKaldbSearchRequest();
+    KaldbSearch.SearchResult searchResult = searcher.doSearch(searchRequest);
+
     span.tag("requestIndexName", searchRequest.getIndexName());
     span.tag("requestQueryString", searchRequest.getQueryString());
     span.tag("requestQueryStartTimeEpochMs", String.valueOf(searchRequest.getStartTimeEpochMs()));
     span.tag("requestQueryEndTimeEpochMs", String.valueOf(searchRequest.getEndTimeEpochMs()));
     span.tag("requestHowMany", String.valueOf(searchRequest.getHowMany()));
-
-    // TODO remove join when we move to query service
-    List<SearchResponseHit> responseHits = new ArrayList<>();
-
-    CompletableFuture<KaldbSearch.SearchResult> searchResultFuture = new CompletableFuture<>();
-    StreamObserver<KaldbSearch.SearchResult> responseObserver =
-        new StreamObserver<>() {
-          private KaldbSearch.SearchResult searchResult;
-
-          @Override
-          public void onNext(KaldbSearch.SearchResult searchResult) {
-            this.searchResult = searchResult;
-          }
-
-          @Override
-          public void onError(Throwable throwable) {
-            searchResultFuture.completeExceptionally(throwable);
-          }
-
-          @Override
-          public void onCompleted() {
-            searchResultFuture.complete(searchResult);
-          }
-        };
-
-    searcher.search(searchRequest, responseObserver);
-    KaldbSearch.SearchResult searchResult = searchResultFuture.join();
-
     span.tag("resultTotalCount", String.valueOf(searchResult.getTotalCount()));
     span.tag("resultHitsCount", String.valueOf(searchResult.getHitsCount()));
     span.tag("resultBucketCount", String.valueOf(searchResult.getBucketsCount()));
@@ -122,18 +95,45 @@ public class ElasticsearchApiService {
     span.tag(
         "resultSnapshotsWithReplicas", String.valueOf(searchResult.getSnapshotsWithReplicas()));
 
+    HitsMetadata hits = getHits(searchResult);
+    Map<String, AggregationResponse> aggregations =
+        getAggregations(request.getAggregations(), searchResult);
+
+    try {
+      return new EsSearchResponse.Builder()
+          .hits(hits)
+          .aggregations(aggregations)
+          .status(200)
+          .build();
+    } finally {
+      span.finish();
+    }
+  }
+
+  private HitsMetadata getHits(KaldbSearch.SearchResult searchResult) throws IOException {
     List<ByteString> hitsByteList = searchResult.getHitsList().asByteStringList();
+    List<SearchResponseHit> responseHits = new ArrayList<>(hitsByteList.size());
     for (ByteString bytes : hitsByteList) {
       responseHits.add(SearchResponseHit.fromByteString(bytes));
     }
 
-    // we currently are only supporting a single aggregation of type `date_histogram`
-    // this will need to be refactored if we decide to support more types
+    return new HitsMetadata.Builder()
+        .hitsTotal(ImmutableMap.of("value", responseHits.size(), "relation", "eq"))
+        .hits(responseHits)
+        .build();
+  }
+
+  private Map<String, AggregationResponse> getAggregations(
+      List<SearchRequestAggregation> aggregations, KaldbSearch.SearchResult searchResult) {
+    // todo - we currently are only supporting a single aggregation of type `date_histogram` and
+    //  assume it is the always the first aggregation requested
+    //  this will need to be refactored when we support more aggregation types
+    Optional<SearchRequestAggregation> aggregationRequest = aggregations.stream().findFirst();
+
     Map<String, AggregationResponse> aggregationResponseMap = new HashMap<>();
-    Optional<SearchRequestAggregation> aggregationRequest =
-        request.getAggregations().stream().findFirst();
     if (aggregationRequest.isPresent()) {
-      List<AggregationBucketResponse> buckets = new ArrayList<>();
+      List<AggregationBucketResponse> buckets =
+          new ArrayList<>(searchResult.getBucketsList().size());
       searchResult
           .getBucketsList()
           .forEach(
@@ -149,21 +149,7 @@ public class ElasticsearchApiService {
           aggregationRequest.get().getAggregationKey(), new AggregationResponse(buckets));
     }
 
-    HitsMetadata hitsMetadata =
-        new HitsMetadata.Builder()
-            .hitsTotal(ImmutableMap.of("value", responseHits.size(), "relation", "eq"))
-            .hits(responseHits)
-            .build();
-
-    try {
-      return new EsSearchResponse.Builder()
-          .hits(hitsMetadata)
-          .aggregations(aggregationResponseMap)
-          .status(200)
-          .build();
-    } finally {
-      span.finish();
-    }
+    return aggregationResponseMap;
   }
 
   /**

--- a/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
@@ -103,6 +103,8 @@ public class ElasticsearchApiService {
       return new EsSearchResponse.Builder()
           .hits(hits)
           .aggregations(aggregations)
+          .debugMetadata(
+              Map.of("traceId", Tracing.current().currentTraceContext().get().traceIdString()))
           .status(200)
           .build();
     } finally {

--- a/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
@@ -31,6 +31,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Elasticsearch compatible API service, for use in Grafana
@@ -42,6 +44,7 @@ import java.util.Optional;
 @SuppressWarnings(
     "OptionalUsedAsFieldOrParameterType") // Per https://armeria.dev/docs/server-annotated-service/
 public class ElasticsearchApiService {
+  private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchApiService.class);
   private final KaldbQueryServiceBase searcher;
 
   public ElasticsearchApiService(KaldbQueryServiceBase searcher) {
@@ -59,14 +62,10 @@ public class ElasticsearchApiService {
   @Blocking
   @Path("/_msearch")
   public HttpResponse multiSearch(String postBody) throws IOException {
+    LOG.debug("Search request: {}", postBody);
+
     List<EsSearchRequest> requests = EsSearchRequest.parse(postBody);
     List<EsSearchResponse> responses = new ArrayList<>();
-
-    Tracing.current()
-        .tracer()
-        .currentSpanCustomizer()
-        .tag("postBody", postBody)
-        .tag("multiSearchRequests", String.valueOf(requests.size()));
 
     for (EsSearchRequest request : requests) {
       responses.add(doSearch(request));

--- a/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/searchResponse/EsSearchResponse.java
+++ b/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/searchResponse/EsSearchResponse.java
@@ -88,8 +88,11 @@ public class EsSearchResponse {
       return this;
     }
 
-    public Builder shardsMetadata(Map<String, Integer> shardsMetadata) {
-      this.shardsMetadata = shardsMetadata;
+    public Builder shardsMetadata(int total, int failed) {
+      this.shardsMetadata =
+          Map.of(
+              "total", total,
+              "failed", failed);
       return this;
     }
 

--- a/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/searchResponse/EsSearchResponse.java
+++ b/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/searchResponse/EsSearchResponse.java
@@ -16,6 +16,9 @@ public class EsSearchResponse {
   @JsonProperty("_shards")
   private final Map<String, Integer> shardsMetadata;
 
+  @JsonProperty("_debug")
+  private final Map<String, String> debugMetadata;
+
   @JsonProperty("hits")
   private final HitsMetadata hitsMetadata;
 
@@ -29,12 +32,14 @@ public class EsSearchResponse {
       long took,
       boolean timedOut,
       Map<String, Integer> shardsMetadata,
+      Map<String, String> debugMetadata,
       HitsMetadata hitsMetadata,
       Map<String, AggregationResponse> aggregations,
       int status) {
     this.took = took;
     this.timedOut = timedOut;
     this.shardsMetadata = shardsMetadata;
+    this.debugMetadata = debugMetadata;
     this.hitsMetadata = hitsMetadata;
     this.aggregations = aggregations;
     this.status = status;
@@ -68,6 +73,7 @@ public class EsSearchResponse {
     private long took;
     private boolean timedOut;
     private Map<String, Integer> shardsMetadata = new HashMap<>();
+    private Map<String, String> debugMetadata = new HashMap<>();
     private HitsMetadata hitsMetadata;
     private Map<String, AggregationResponse> aggregations = new HashMap<>();
     private int status;
@@ -84,6 +90,11 @@ public class EsSearchResponse {
 
     public Builder shardsMetadata(Map<String, Integer> shardsMetadata) {
       this.shardsMetadata = shardsMetadata;
+      return this;
+    }
+
+    public Builder debugMetadata(Map<String, String> debugMetadata) {
+      this.debugMetadata = debugMetadata;
       return this;
     }
 
@@ -113,6 +124,7 @@ public class EsSearchResponse {
           this.took,
           this.timedOut,
           this.shardsMetadata,
+          this.debugMetadata,
           this.hitsMetadata,
           this.aggregations,
           this.status);

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
@@ -7,6 +7,7 @@ import brave.ScopedSpan;
 import brave.Tracing;
 import brave.grpc.GrpcTracing;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.AtomicDouble;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -64,6 +65,21 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
 
   private static final long GRPC_TIMEOUT_BUFFER_MS = 100;
 
+  public static final String DISTRIBUTED_QUERY_TOTAL_NODES = "distributed_query_total_nodes";
+  public static final String DISTRIBUTED_QUERY_FAILED_NODES = "distributed_query_failed_nodes";
+  public static final String DISTRIBUTED_QUERY_NODES_SUCCESS_RATE =
+      "distributed_query_nodes_success_rate";
+  public static final String DISTRIBUTED_QUERY_TOTAL_SNAPSHOTS =
+      "distributed_query_total_snapshots";
+  public static final String DISTRIBUTED_QUERY_SNAPSHOTS_WITH_REPLICAS =
+      "distributed_query_snapshots_with_replicas";
+
+  private final AtomicInteger distributedQueryTotalNodes;
+  private final AtomicInteger distributedQueryFailedNodes;
+  private final AtomicDouble distributedQueryNodeSuccessRate;
+  private final AtomicInteger distributedQueryTotalSnapshots;
+  private final AtomicInteger distributedQuerySnapshotsWithReplicas;
+
   // For now we will use SearchMetadataStore to populate servers
   // But this is wasteful since we add snapshots more often than we add/remove nodes ( hopefully )
   // So this should be replaced cache/index metadata store when that info is present in ZK
@@ -79,6 +95,17 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
     this.serviceMetadataStore = serviceMetadataStore;
     searchMetadataTotalChangeCounter = meterRegistry.counter(SEARCH_METADATA_TOTAL_CHANGE_COUNTER);
     this.searchMetadataStore.addListener(this::updateStubs);
+
+    this.distributedQueryTotalNodes =
+        meterRegistry.gauge(DISTRIBUTED_QUERY_TOTAL_NODES, new AtomicInteger(0));
+    this.distributedQueryFailedNodes =
+        meterRegistry.gauge(DISTRIBUTED_QUERY_FAILED_NODES, new AtomicInteger(0));
+    this.distributedQueryNodeSuccessRate =
+        meterRegistry.gauge(DISTRIBUTED_QUERY_NODES_SUCCESS_RATE, new AtomicDouble(0));
+    this.distributedQueryTotalSnapshots =
+        meterRegistry.gauge(DISTRIBUTED_QUERY_TOTAL_SNAPSHOTS, new AtomicInteger(0));
+    this.distributedQuerySnapshotsWithReplicas =
+        meterRegistry.gauge(DISTRIBUTED_QUERY_SNAPSHOTS_WITH_REPLICAS, new AtomicInteger(0));
 
     // first time call this function manually so that we initialize stubs
     updateStubs();
@@ -356,6 +383,16 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
           ((SearchResultAggregator<LogMessage>)
                   new SearchResultAggregatorImpl<>(SearchResultUtils.fromSearchRequest(request)))
               .aggregate(searchResults);
+
+      distributedQueryTotalNodes.set(aggregatedResult.totalNodes);
+      distributedQueryFailedNodes.set(aggregatedResult.failedNodes);
+      if (aggregatedResult.totalNodes > 0) {
+        distributedQueryNodeSuccessRate.set(
+            (aggregatedResult.totalNodes - aggregatedResult.failedNodes)
+                / (double) aggregatedResult.totalNodes);
+      }
+      distributedQueryTotalSnapshots.set(aggregatedResult.totalSnapshots);
+      distributedQuerySnapshotsWithReplicas.set(aggregatedResult.snapshotsWithReplicas);
 
       LOG.debug("aggregatedResult={}", aggregatedResult);
       return SearchResultUtils.toSearchResultProto(aggregatedResult);

--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -177,7 +177,7 @@ public class Kaldb {
       final int serverPort = kaldbConfig.getIndexerConfig().getServerConfig().getServerPort();
       ArmeriaService armeriaService =
           new ArmeriaService.Builder(serverPort, "kalDbIndex", meterRegistry)
-              .withTracingEndpoint(kaldbConfig.getTracingConfig().getZipkinEndpoint())
+              .withTracing(kaldbConfig.getTracingConfig())
               .withGrpcService(searcher)
               .build();
       services.add(armeriaService);
@@ -197,7 +197,7 @@ public class Kaldb {
       final int serverPort = kaldbConfig.getQueryConfig().getServerConfig().getServerPort();
       ArmeriaService armeriaService =
           new ArmeriaService.Builder(serverPort, "kalDbQuery", meterRegistry)
-              .withTracingEndpoint(kaldbConfig.getTracingConfig().getZipkinEndpoint())
+              .withTracing(kaldbConfig.getTracingConfig())
               .withAnnotatedService(new ElasticsearchApiService(kaldbDistributedQueryService))
               .withGrpcService(kaldbDistributedQueryService)
               .build();
@@ -218,7 +218,7 @@ public class Kaldb {
       final int serverPort = kaldbConfig.getCacheConfig().getServerConfig().getServerPort();
       ArmeriaService armeriaService =
           new ArmeriaService.Builder(serverPort, "kalDbCache", meterRegistry)
-              .withTracingEndpoint(kaldbConfig.getTracingConfig().getZipkinEndpoint())
+              .withTracing(kaldbConfig.getTracingConfig())
               .withGrpcService(searcher)
               .build();
       services.add(armeriaService);
@@ -240,7 +240,7 @@ public class Kaldb {
 
       ArmeriaService armeriaService =
           new ArmeriaService.Builder(serverPort, "kalDbManager", meterRegistry)
-              .withTracingEndpoint(kaldbConfig.getTracingConfig().getZipkinEndpoint())
+              .withTracing(kaldbConfig.getTracingConfig())
               .withGrpcService(new ManagerApiGrpc(serviceMetadataStore))
               .build();
       services.add(armeriaService);
@@ -292,7 +292,7 @@ public class Kaldb {
 
       ArmeriaService armeriaService =
           new ArmeriaService.Builder(serverPort, "kalDbRecovery", meterRegistry)
-              .withTracingEndpoint(kaldbConfig.getTracingConfig().getZipkinEndpoint())
+              .withTracing(kaldbConfig.getTracingConfig())
               .build();
       services.add(armeriaService);
 
@@ -308,7 +308,7 @@ public class Kaldb {
 
       ArmeriaService armeriaService =
           new ArmeriaService.Builder(serverPort, "kalDbPreprocessor", meterRegistry)
-              .withTracingEndpoint(kaldbConfig.getTracingConfig().getZipkinEndpoint())
+              .withTracing(kaldbConfig.getTracingConfig())
               .build();
       services.add(armeriaService);
 

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -77,6 +77,7 @@ message S3Config {
 
 message TracingConfig {
   string zipkin_endpoint = 1;
+  map<string, string> common_tags = 2;
 }
 
 // Configuration for the query service.

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -176,6 +177,10 @@ public class KaldbConfigTest {
     assertThat(s3Config.getS3EndPoint()).isEqualTo("https://s3.us-east-1.amazonaws.com/");
     assertThat(s3Config.getS3Bucket()).isEqualTo("test-s3-bucket");
 
+    final KaldbConfigs.TracingConfig tracingConfig = config.getTracingConfig();
+    assertThat(tracingConfig.getZipkinEndpoint()).isEqualTo("http://localhost:9411/api/v2/spans");
+    assertThat(tracingConfig.getCommonTagsMap()).isEqualTo(Map.of("clusterName", "kaldb_local"));
+
     final KaldbConfigs.IndexerConfig indexerConfig = config.getIndexerConfig();
     assertThat(indexerConfig.getMaxMessagesPerChunk()).isEqualTo(1000);
     assertThat(indexerConfig.getMaxBytesPerChunk()).isEqualTo(100000);
@@ -309,6 +314,10 @@ public class KaldbConfigTest {
     assertThat(s3Config.getS3Region()).isEqualTo("us-east-1");
     assertThat(s3Config.getS3EndPoint()).isEqualTo("localhost:9090");
     assertThat(s3Config.getS3Bucket()).isEqualTo("test-s3-bucket");
+
+    final KaldbConfigs.TracingConfig tracingConfig = config.getTracingConfig();
+    assertThat(tracingConfig.getZipkinEndpoint()).isEqualTo("http://localhost:9411/api/v2/spans");
+    assertThat(tracingConfig.getCommonTagsMap()).isEqualTo(Map.of("clusterName", "kaldb_local"));
 
     final KaldbConfigs.IndexerConfig indexerConfig = config.getIndexerConfig();
     assertThat(indexerConfig.getMaxMessagesPerChunk()).isEqualTo(100);
@@ -450,6 +459,10 @@ public class KaldbConfigTest {
     assertThat(s3Config.getS3Region()).isEmpty();
     assertThat(s3Config.getS3EndPoint()).isEmpty();
 
+    final KaldbConfigs.TracingConfig tracingConfig = config.getTracingConfig();
+    assertThat(tracingConfig.getZipkinEndpoint()).isEmpty();
+    assertThat(tracingConfig.getCommonTagsMap()).isEmpty();
+
     final KaldbConfigs.IndexerConfig indexerConfig = config.getIndexerConfig();
     assertThat(indexerConfig.getMaxMessagesPerChunk()).isZero();
     assertThat(indexerConfig.getMaxBytesPerChunk()).isZero();
@@ -569,6 +582,10 @@ public class KaldbConfigTest {
     assertThat(s3Config.getS3SecretKey()).isEmpty();
     assertThat(s3Config.getS3Region()).isEmpty();
     assertThat(s3Config.getS3EndPoint()).isEmpty();
+
+    final KaldbConfigs.TracingConfig tracingConfig = config.getTracingConfig();
+    assertThat(tracingConfig.getZipkinEndpoint()).isEmpty();
+    assertThat(tracingConfig.getCommonTagsMap()).isEmpty();
 
     final KaldbConfigs.IndexerConfig indexerConfig = config.getIndexerConfig();
     assertThat(indexerConfig.getMaxMessagesPerChunk()).isZero();

--- a/kaldb/src/test/resources/test_config.json
+++ b/kaldb/src/test/resources/test_config.json
@@ -21,6 +21,12 @@
     "s3EndPoint": "https://s3.us-east-1.amazonaws.com/",
     "s3Bucket": "test-s3-bucket"
   },
+  "tracingConfig": {
+    "zipkinEndpoint": "http://localhost:9411/api/v2/spans",
+    "commonTags": {
+      "clusterName": "kaldb_local"
+    }
+  },
   "indexerConfig": {
     "maxMessagesPerChunk": 1000,
     "maxBytesPerChunk": 100000,

--- a/kaldb/src/test/resources/test_config.yaml
+++ b/kaldb/src/test/resources/test_config.yaml
@@ -35,6 +35,11 @@ s3Config:
   s3EndPoint: "localhost:9090"
   s3Bucket: "test-s3-bucket"
 
+tracingConfig:
+  zipkinEndpoint: "http://localhost:9411/api/v2/spans"
+  commonTags:
+    clusterName: "kaldb_local"
+
 metadataStoreConfig:
   zookeeperConfig:
     zkConnectString: "1.2.3.4:9092"


### PR DESCRIPTION
Collection of small refactors that should help improve the visibility when troubleshooting ES responses including:

* Support for common tracing tags
* Tracing ID in the response payload
* Return took/shard information into the response payload
* Adding additional meters for distributed query performance