### PR TITLE
Change preprocessor to start from latest offset on bootstrap

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorService.java
@@ -310,6 +310,7 @@ public class PreprocessorService extends AbstractService {
     props.put(StreamsConfig.APPLICATION_ID_CONFIG, kafkaStreamConfig.getApplicationId());
     props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaStreamConfig.getBootstrapServers());
     props.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, kafkaStreamConfig.getNumStreamThreads());
+    props.put("auto.offset.reset", "latest");
 
     // This will allow parallel processing up to the amount of upstream partitions. You cannot have
     // more threads than you have upstreams due to how the work is partitioned


### PR DESCRIPTION
When we start a new service, indexing from latest offset would be a better start experience.

From my understanding this setting defines the behavior of the consumer when there is no committed position (which would be the case when the group is first initialized) or when an offset is out of range.

So once the bootstrap of a new service has taken place this setting isn't going to govern anything.