### PR TITLE
Rename `index_name` field to `data_set` in SearchRequest.

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
@@ -338,7 +338,7 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
   public SearchResult<T> query(SearchQuery query) {
     if (logSearcher != null) {
       return logSearcher.search(
-          query.indexName,
+          query.dataSet,
           query.queryStr,
           query.startTimeEpochMs,
           query.endTimeEpochMs,

--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
@@ -338,7 +338,7 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
   public SearchResult<T> query(SearchQuery query) {
     if (logSearcher != null) {
       return logSearcher.search(
-          query.dataSet,
+          query.dataset,
           query.queryStr,
           query.startTimeEpochMs,
           query.endTimeEpochMs,

--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadWriteChunk.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadWriteChunk.java
@@ -251,7 +251,7 @@ public abstract class ReadWriteChunk<T> implements Chunk<T> {
   @Override
   public SearchResult<T> query(SearchQuery query) {
     return logSearcher.search(
-        query.dataSet,
+        query.dataset,
         query.queryStr,
         query.startTimeEpochMs,
         query.endTimeEpochMs,

--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadWriteChunk.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadWriteChunk.java
@@ -251,7 +251,7 @@ public abstract class ReadWriteChunk<T> implements Chunk<T> {
   @Override
   public SearchResult<T> query(SearchQuery query) {
     return logSearcher.search(
-        query.indexName,
+        query.dataSet,
         query.queryStr,
         query.startTimeEpochMs,
         query.endTimeEpochMs,

--- a/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
@@ -81,7 +81,7 @@ public class ElasticsearchApiService {
     KaldbSearch.SearchRequest searchRequest = request.toKaldbSearchRequest();
     KaldbSearch.SearchResult searchResult = searcher.doSearch(searchRequest);
 
-    span.tag("requestDataSet", searchRequest.getDataSet());
+    span.tag("requestDataSet", searchRequest.getDataset());
     span.tag("requestQueryString", searchRequest.getQueryString());
     span.tag("requestQueryStartTimeEpochMs", String.valueOf(searchRequest.getStartTimeEpochMs()));
     span.tag("requestQueryEndTimeEpochMs", String.valueOf(searchRequest.getEndTimeEpochMs()));

--- a/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
@@ -81,7 +81,7 @@ public class ElasticsearchApiService {
     KaldbSearch.SearchRequest searchRequest = request.toKaldbSearchRequest();
     KaldbSearch.SearchResult searchResult = searcher.doSearch(searchRequest);
 
-    span.tag("requestDataSet", searchRequest.getDataset());
+    span.tag("requestDataset", searchRequest.getDataset());
     span.tag("requestQueryString", searchRequest.getQueryString());
     span.tag("requestQueryStartTimeEpochMs", String.valueOf(searchRequest.getStartTimeEpochMs()));
     span.tag("requestQueryEndTimeEpochMs", String.valueOf(searchRequest.getEndTimeEpochMs()));

--- a/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
@@ -81,7 +81,7 @@ public class ElasticsearchApiService {
     KaldbSearch.SearchRequest searchRequest = request.toKaldbSearchRequest();
     KaldbSearch.SearchResult searchResult = searcher.doSearch(searchRequest);
 
-    span.tag("requestIndexName", searchRequest.getIndexName());
+    span.tag("requestDataSet", searchRequest.getDataSet());
     span.tag("requestQueryString", searchRequest.getQueryString());
     span.tag("requestQueryStartTimeEpochMs", String.valueOf(searchRequest.getStartTimeEpochMs()));
     span.tag("requestQueryEndTimeEpochMs", String.valueOf(searchRequest.getEndTimeEpochMs()));

--- a/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/searchRequest/EsSearchRequest.java
+++ b/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/searchRequest/EsSearchRequest.java
@@ -64,7 +64,7 @@ public class EsSearchRequest {
     int bucketCount = 60;
 
     return KaldbSearch.SearchRequest.newBuilder()
-        .setIndexName(getIndex())
+        .setDataSet(getIndex())
         .setQueryString(getQuery())
         .setStartTimeEpochMs(getRange().getGteEpochMillis())
         .setEndTimeEpochMs(getRange().getLteEpochMillis())

--- a/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/searchRequest/EsSearchRequest.java
+++ b/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/searchRequest/EsSearchRequest.java
@@ -64,7 +64,7 @@ public class EsSearchRequest {
     int bucketCount = 60;
 
     return KaldbSearch.SearchRequest.newBuilder()
-        .setDataSet(getIndex())
+        .setDataset(getIndex())
         .setQueryString(getQuery())
         .setStartTimeEpochMs(getRange().getGteEpochMillis())
         .setEndTimeEpochMs(getRange().getLteEpochMillis())

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LogDocumentBuilderImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LogDocumentBuilderImpl.java
@@ -364,7 +364,7 @@ public class LogDocumentBuilderImpl implements DocumentBuilder<LogMessage> {
     addProperty(
         doc,
         LogMessage.SystemField.SOURCE.fieldName,
-        JsonUtil.<LogWireMessage>writeAsString(message.toWireMessage()));
+        JsonUtil.writeAsString(message.toWireMessage()));
     for (String key : message.source.keySet()) {
       addPropertyHandleExceptions(doc, key, message.source.get(key));
     }

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
@@ -274,11 +274,11 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
       ServiceMetadataStore serviceMetadataStore,
       long startTimeEpochMs,
       long endTimeEpochMs,
-      String dataSet) {
+      String dataset) {
     return serviceMetadataStore
         .getCached()
         .stream()
-        .filter(serviceMetadata -> serviceMetadata.name.equals(dataSet))
+        .filter(serviceMetadata -> serviceMetadata.name.equals(dataset))
         .flatMap(
             serviceMetadata -> serviceMetadata.partitionConfigs.stream()) // will always return one
         .filter(
@@ -300,7 +300,7 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
 
     List<KaldbServiceGrpc.KaldbServiceFutureStub> queryStubs =
         getSnapshotUrlsToSearch(
-            request.getStartTimeEpochMs(), request.getEndTimeEpochMs(), request.getDataSet());
+            request.getStartTimeEpochMs(), request.getEndTimeEpochMs(), request.getDataset());
     span.tag("queryServerCount", String.valueOf(queryStubs.size()));
 
     for (KaldbServiceGrpc.KaldbServiceFutureStub stub : queryStubs) {

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
@@ -159,14 +159,14 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
       ServiceMetadataStore serviceMetadataStore,
       long queryStartTimeEpochMs,
       long queryEndTimeEpochMs,
-      String dataSet) {
+      String dataset) {
     ScopedSpan findPartitionsToQuerySpan =
         Tracing.currentTracer()
             .startScopedSpan("KaldbDistributedQueryService.findPartitionsToQuery");
 
     List<ServicePartitionMetadata> partitions =
         findPartitionsToQuery(
-            serviceMetadataStore, queryStartTimeEpochMs, queryEndTimeEpochMs, dataSet);
+            serviceMetadataStore, queryStartTimeEpochMs, queryEndTimeEpochMs, dataset);
     findPartitionsToQuerySpan.finish();
 
     // step 1 - find all snapshots that match time window and partition
@@ -347,7 +347,7 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
   }
 
   private List<KaldbServiceGrpc.KaldbServiceFutureStub> getSnapshotUrlsToSearch(
-      long startTimeEpochMs, long endTimeEpochMs, String dataSet) {
+      long startTimeEpochMs, long endTimeEpochMs, String dataset) {
     Collection<String> searchNodeUrls =
         getSearchNodesToQuery(
             snapshotMetadataStore,
@@ -355,7 +355,7 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
             serviceMetadataStore,
             startTimeEpochMs,
             endTimeEpochMs,
-            dataSet);
+            dataset);
     ArrayList<KaldbServiceGrpc.KaldbServiceFutureStub> stubs =
         new ArrayList<>(searchNodeUrls.size());
     for (String searchNodeUrl : searchNodeUrls) {

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
@@ -159,14 +159,14 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
       ServiceMetadataStore serviceMetadataStore,
       long queryStartTimeEpochMs,
       long queryEndTimeEpochMs,
-      String indexName) {
+      String dataSet) {
     ScopedSpan findPartitionsToQuerySpan =
         Tracing.currentTracer()
             .startScopedSpan("KaldbDistributedQueryService.findPartitionsToQuery");
 
     List<ServicePartitionMetadata> partitions =
         findPartitionsToQuery(
-            serviceMetadataStore, queryStartTimeEpochMs, queryEndTimeEpochMs, indexName);
+            serviceMetadataStore, queryStartTimeEpochMs, queryEndTimeEpochMs, dataSet);
     findPartitionsToQuerySpan.finish();
 
     // step 1 - find all snapshots that match time window and partition
@@ -274,11 +274,11 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
       ServiceMetadataStore serviceMetadataStore,
       long startTimeEpochMs,
       long endTimeEpochMs,
-      String indexName) {
+      String dataSet) {
     return serviceMetadataStore
         .getCached()
         .stream()
-        .filter(serviceMetadata -> serviceMetadata.name.equals(indexName))
+        .filter(serviceMetadata -> serviceMetadata.name.equals(dataSet))
         .flatMap(
             serviceMetadata -> serviceMetadata.partitionConfigs.stream()) // will always return one
         .filter(
@@ -300,7 +300,7 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
 
     List<KaldbServiceGrpc.KaldbServiceFutureStub> queryStubs =
         getSnapshotUrlsToSearch(
-            request.getStartTimeEpochMs(), request.getEndTimeEpochMs(), request.getIndexName());
+            request.getStartTimeEpochMs(), request.getEndTimeEpochMs(), request.getDataSet());
     span.tag("queryServerCount", String.valueOf(queryStubs.size()));
 
     for (KaldbServiceGrpc.KaldbServiceFutureStub stub : queryStubs) {
@@ -347,7 +347,7 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
   }
 
   private List<KaldbServiceGrpc.KaldbServiceFutureStub> getSnapshotUrlsToSearch(
-      long startTimeEpochMs, long endTimeEpochMs, String indexName) {
+      long startTimeEpochMs, long endTimeEpochMs, String dataSet) {
     Collection<String> searchNodeUrls =
         getSearchNodesToQuery(
             snapshotMetadataStore,
@@ -355,7 +355,7 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase {
             serviceMetadataStore,
             startTimeEpochMs,
             endTimeEpochMs,
-            indexName);
+            dataSet);
     ArrayList<KaldbServiceGrpc.KaldbServiceFutureStub> stubs =
         new ArrayList<>(searchNodeUrls.size());
     for (String searchNodeUrl : searchNodeUrls) {

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/LogIndexSearcher.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/LogIndexSearcher.java
@@ -4,5 +4,5 @@ import java.io.Closeable;
 
 public interface LogIndexSearcher<T> extends Closeable {
   SearchResult<T> search(
-      String indexName, String query, long minTime, long maxTime, int howMany, int bucketCount);
+      String dataset, String query, long minTime, long maxTime, int howMany, int bucketCount);
 }

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/LogIndexSearcherImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/LogIndexSearcherImpl.java
@@ -81,14 +81,14 @@ public class LogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
   }
 
   public SearchResult<LogMessage> search(
-      String indexName,
+      String dataset,
       String queryStr,
       long startTimeMsEpoch,
       long endTimeMsEpoch,
       int howMany,
       int bucketCount) {
 
-    ensureNonEmptyString(indexName, "indexName should be a non-empty string");
+    ensureNonEmptyString(dataset, "dataset should be a non-empty string");
     ensureNonNullString(queryStr, "query should be a non-empty string");
     ensureTrue(startTimeMsEpoch >= 0, "start time should be non-negative value");
     ensureTrue(startTimeMsEpoch < endTimeMsEpoch, "end time should be greater than start time");
@@ -97,7 +97,7 @@ public class LogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
     ensureTrue(howMany > 0 || bucketCount > 0, "Hits or histogram should be requested.");
 
     ScopedSpan span = Tracing.currentTracer().startScopedSpan("LogIndexSearcherImpl.search");
-    span.tag("indexName", indexName);
+    span.tag("dataset", dataset);
     span.tag("queryStr", queryStr);
     span.tag("startTimeMsEpoch", String.valueOf(startTimeMsEpoch));
     span.tag("endTimeMsEpoch", String.valueOf(endTimeMsEpoch));
@@ -106,7 +106,7 @@ public class LogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
 
     Stopwatch elapsedTime = Stopwatch.createStarted();
     try {
-      Query query = buildQuery(indexName, queryStr, startTimeMsEpoch, endTimeMsEpoch);
+      Query query = buildQuery(dataset, queryStr, startTimeMsEpoch, endTimeMsEpoch);
       span.tag("lucene query", query.toString());
 
       // Acquire an index searcher from searcher manager.
@@ -227,14 +227,14 @@ public class LogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
   }
 
   private Query buildQuery(
-      String indexName, String queryStr, long startTimeMsEpoch, long endTimeMsEpoch)
+      String dataset, String queryStr, long startTimeMsEpoch, long endTimeMsEpoch)
       throws ParseException {
     Builder queryBuilder = new Builder();
 
-    // todo - we currently do not enforce searching against an index name, as we do not support
+    // todo - we currently do not enforce searching against an dataset name, as we do not support
     //  multi-tenancy yet - see https://github.com/slackhq/kaldb/issues/223. Once index filtering
     //  is support at snapshot/query layer this should be re-enabled as appropriate.
-    // queryBuilder.add(new TermQuery(new Term(SystemField.INDEX.fieldName, indexName)),
+    // queryBuilder.add(new TermQuery(new Term(SystemField.INDEX.fieldName, dataset)),
     // Occur.MUST);
     queryBuilder.add(
         LongPoint.newRangeQuery(

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchQuery.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchQuery.java
@@ -2,7 +2,8 @@ package com.slack.kaldb.logstore.search;
 
 /** A class that represents a search query internally to LogStore. */
 public class SearchQuery {
-  public final String indexName;
+  // TODO: Remove the dataSet field from this class since it is not a lucene level concept.
+  @Deprecated public final String dataSet;
 
   public final String queryStr;
   public final long startTimeEpochMs;
@@ -11,13 +12,13 @@ public class SearchQuery {
   public final int bucketCount;
 
   public SearchQuery(
-      String indexName,
+      String dataSet,
       String queryStr,
       long startTimeEpochMs,
       long endTimeEpochMs,
       int howMany,
       int bucketCount) {
-    this.indexName = indexName;
+    this.dataSet = dataSet;
     this.queryStr = queryStr;
     this.startTimeEpochMs = startTimeEpochMs;
     this.endTimeEpochMs = endTimeEpochMs;
@@ -28,8 +29,8 @@ public class SearchQuery {
   @Override
   public String toString() {
     return "SearchQuery{"
-        + "indexName='"
-        + indexName
+        + "dataSet='"
+        + dataSet
         + '\''
         + ", queryStr='"
         + queryStr

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchQuery.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchQuery.java
@@ -2,7 +2,7 @@ package com.slack.kaldb.logstore.search;
 
 /** A class that represents a search query internally to LogStore. */
 public class SearchQuery {
-  // TODO: Remove the dataSet field from this class since it is not a lucene level concept.
+  // TODO: Remove the dataset field from this class since it is not a lucene level concept.
   @Deprecated public final String dataset;
 
   public final String queryStr;

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchQuery.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchQuery.java
@@ -3,7 +3,7 @@ package com.slack.kaldb.logstore.search;
 /** A class that represents a search query internally to LogStore. */
 public class SearchQuery {
   // TODO: Remove the dataSet field from this class since it is not a lucene level concept.
-  @Deprecated public final String dataSet;
+  @Deprecated public final String dataset;
 
   public final String queryStr;
   public final long startTimeEpochMs;
@@ -12,13 +12,13 @@ public class SearchQuery {
   public final int bucketCount;
 
   public SearchQuery(
-      String dataSet,
+      String dataset,
       String queryStr,
       long startTimeEpochMs,
       long endTimeEpochMs,
       int howMany,
       int bucketCount) {
-    this.dataSet = dataSet;
+    this.dataset = dataset;
     this.queryStr = queryStr;
     this.startTimeEpochMs = startTimeEpochMs;
     this.endTimeEpochMs = endTimeEpochMs;
@@ -29,8 +29,8 @@ public class SearchQuery {
   @Override
   public String toString() {
     return "SearchQuery{"
-        + "dataSet='"
-        + dataSet
+        + "dataset='"
+        + dataset
         + '\''
         + ", queryStr='"
         + queryStr

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultUtils.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultUtils.java
@@ -17,7 +17,7 @@ public class SearchResultUtils {
 
   public static SearchQuery fromSearchRequest(KaldbSearch.SearchRequest searchRequest) {
     return new SearchQuery(
-        searchRequest.getIndexName(),
+        searchRequest.getDataSet(),
         searchRequest.getQueryString(),
         searchRequest.getStartTimeEpochMs(),
         searchRequest.getEndTimeEpochMs(),

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultUtils.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultUtils.java
@@ -17,7 +17,7 @@ public class SearchResultUtils {
 
   public static SearchQuery fromSearchRequest(KaldbSearch.SearchRequest searchRequest) {
     return new SearchQuery(
-        searchRequest.getDataSet(),
+        searchRequest.getDataset(),
         searchRequest.getQueryString(),
         searchRequest.getStartTimeEpochMs(),
         searchRequest.getEndTimeEpochMs(),

--- a/kaldb/src/main/proto/kaldb_search.proto
+++ b/kaldb/src/main/proto/kaldb_search.proto
@@ -5,8 +5,8 @@ package slack.proto.kaldb;
 option java_package = "com.slack.kaldb.proto.service";
 
 message SearchRequest {
-  string chunk_id = 1;
-  string index_name = 2;
+  string data_set = 1;
+  string chunk_id = 2;
   string query_string = 3;
   int64 start_time_epoch_ms = 4;
   int64 end_time_epoch_ms = 5;

--- a/kaldb/src/main/proto/kaldb_search.proto
+++ b/kaldb/src/main/proto/kaldb_search.proto
@@ -6,7 +6,7 @@ option java_package = "com.slack.kaldb.proto.service";
 
 message SearchRequest {
   // Data sets or chunk_ids to be searched
-  string data_set = 1;
+  string dataset = 1;
   string chunk_id = 2;
 
   // Actual query params

--- a/kaldb/src/main/proto/kaldb_search.proto
+++ b/kaldb/src/main/proto/kaldb_search.proto
@@ -5,8 +5,11 @@ package slack.proto.kaldb;
 option java_package = "com.slack.kaldb.proto.service";
 
 message SearchRequest {
+  // Data sets or chunk_ids to be searched
   string data_set = 1;
   string chunk_id = 2;
+
+  // Actual query params
   string query_string = 3;
   int64 start_time_epoch_ms = 4;
   int64 end_time_epoch_ms = 5;

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
@@ -145,18 +145,17 @@ public class IndexingChunkImplTest {
       chunk.commit();
 
       SearchResult<LogMessage> results =
-          chunk.query(
-              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "*:*", 0, MAX_TIME, 10, 1000));
+          chunk.query(new SearchQuery(MessageUtil.TEST_DATASET_NAME, "*:*", 0, MAX_TIME, 10, 1000));
       assertThat(results.totalCount).isEqualTo(100);
 
       results =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(results.totalCount).isEqualTo(1);
 
       results =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message*", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message*", 0, MAX_TIME, 10, 1000));
       assertThat(results.totalCount).isEqualTo(100);
       assertThat(results.hits.size()).isEqualTo(10);
 
@@ -278,7 +277,7 @@ public class IndexingChunkImplTest {
               chunk
                   .query(
                       new SearchQuery(
-                          MessageUtil.TEST_DATA_SET_NAME,
+                          MessageUtil.TEST_DATASET_NAME,
                           searchString,
                           startTimeMs,
                           endTimeMs,
@@ -306,7 +305,7 @@ public class IndexingChunkImplTest {
 
       SearchResult<LogMessage> results =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(results.hits.size()).isEqualTo(1);
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, registry)).isEqualTo(100);
@@ -359,7 +358,7 @@ public class IndexingChunkImplTest {
 
       SearchResult<LogMessage> resultsBeforeCommit =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(resultsBeforeCommit.hits.size()).isEqualTo(0);
 
       // Snapshot forces commit and refresh
@@ -367,7 +366,7 @@ public class IndexingChunkImplTest {
       assertThat(chunk.isReadOnly()).isTrue();
       SearchResult<LogMessage> resultsAfterPreSnapshot =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(resultsAfterPreSnapshot.hits.size()).isEqualTo(1);
     }
   }
@@ -454,7 +453,7 @@ public class IndexingChunkImplTest {
       chunk.preSnapshot();
 
       SearchQuery searchQuery =
-          new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
+          new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
       assertThat(chunk.isReadOnly()).isTrue();
       SearchResult<LogMessage> resultsAfterPreSnapshot = chunk.query(searchQuery);
       assertThat(resultsAfterPreSnapshot.hits.size()).isEqualTo(1);
@@ -509,7 +508,7 @@ public class IndexingChunkImplTest {
       chunk.preSnapshot();
 
       SearchQuery searchQuery =
-          new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
+          new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
       assertThat(chunk.isReadOnly()).isTrue();
       SearchResult<LogMessage> resultsAfterPreSnapshot = chunk.query(searchQuery);
       assertThat(resultsAfterPreSnapshot.hits.size()).isEqualTo(1);

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
@@ -145,17 +145,18 @@ public class IndexingChunkImplTest {
       chunk.commit();
 
       SearchResult<LogMessage> results =
-          chunk.query(new SearchQuery(MessageUtil.TEST_DATASET_NAME, "*:*", 0, MAX_TIME, 10, 1000));
+          chunk.query(
+              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "*:*", 0, MAX_TIME, 10, 1000));
       assertThat(results.totalCount).isEqualTo(100);
 
       results =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(results.totalCount).isEqualTo(1);
 
       results =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message*", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message*", 0, MAX_TIME, 10, 1000));
       assertThat(results.totalCount).isEqualTo(100);
       assertThat(results.hits.size()).isEqualTo(10);
 
@@ -277,7 +278,7 @@ public class IndexingChunkImplTest {
               chunk
                   .query(
                       new SearchQuery(
-                          MessageUtil.TEST_DATASET_NAME,
+                          MessageUtil.TEST_DATA_SET_NAME,
                           searchString,
                           startTimeMs,
                           endTimeMs,
@@ -305,7 +306,7 @@ public class IndexingChunkImplTest {
 
       SearchResult<LogMessage> results =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(results.hits.size()).isEqualTo(1);
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, registry)).isEqualTo(100);
@@ -358,7 +359,7 @@ public class IndexingChunkImplTest {
 
       SearchResult<LogMessage> resultsBeforeCommit =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(resultsBeforeCommit.hits.size()).isEqualTo(0);
 
       // Snapshot forces commit and refresh
@@ -366,7 +367,7 @@ public class IndexingChunkImplTest {
       assertThat(chunk.isReadOnly()).isTrue();
       SearchResult<LogMessage> resultsAfterPreSnapshot =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(resultsAfterPreSnapshot.hits.size()).isEqualTo(1);
     }
   }
@@ -453,7 +454,7 @@ public class IndexingChunkImplTest {
       chunk.preSnapshot();
 
       SearchQuery searchQuery =
-          new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
+          new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
       assertThat(chunk.isReadOnly()).isTrue();
       SearchResult<LogMessage> resultsAfterPreSnapshot = chunk.query(searchQuery);
       assertThat(resultsAfterPreSnapshot.hits.size()).isEqualTo(1);
@@ -508,7 +509,7 @@ public class IndexingChunkImplTest {
       chunk.preSnapshot();
 
       SearchQuery searchQuery =
-          new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
+          new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
       assertThat(chunk.isReadOnly()).isTrue();
       SearchResult<LogMessage> resultsAfterPreSnapshot = chunk.query(searchQuery);
       assertThat(resultsAfterPreSnapshot.hits.size()).isEqualTo(1);

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
@@ -145,17 +145,17 @@ public class IndexingChunkImplTest {
       chunk.commit();
 
       SearchResult<LogMessage> results =
-          chunk.query(new SearchQuery(MessageUtil.TEST_INDEX_NAME, "*:*", 0, MAX_TIME, 10, 1000));
+          chunk.query(new SearchQuery(MessageUtil.TEST_DATASET_NAME, "*:*", 0, MAX_TIME, 10, 1000));
       assertThat(results.totalCount).isEqualTo(100);
 
       results =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_INDEX_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(results.totalCount).isEqualTo(1);
 
       results =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_INDEX_NAME, "Message*", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message*", 0, MAX_TIME, 10, 1000));
       assertThat(results.totalCount).isEqualTo(100);
       assertThat(results.hits.size()).isEqualTo(10);
 
@@ -277,7 +277,7 @@ public class IndexingChunkImplTest {
               chunk
                   .query(
                       new SearchQuery(
-                          MessageUtil.TEST_INDEX_NAME,
+                          MessageUtil.TEST_DATASET_NAME,
                           searchString,
                           startTimeMs,
                           endTimeMs,
@@ -305,7 +305,7 @@ public class IndexingChunkImplTest {
 
       SearchResult<LogMessage> results =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_INDEX_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(results.hits.size()).isEqualTo(1);
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, registry)).isEqualTo(100);
@@ -358,7 +358,7 @@ public class IndexingChunkImplTest {
 
       SearchResult<LogMessage> resultsBeforeCommit =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_INDEX_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(resultsBeforeCommit.hits.size()).isEqualTo(0);
 
       // Snapshot forces commit and refresh
@@ -366,7 +366,7 @@ public class IndexingChunkImplTest {
       assertThat(chunk.isReadOnly()).isTrue();
       SearchResult<LogMessage> resultsAfterPreSnapshot =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_INDEX_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(resultsAfterPreSnapshot.hits.size()).isEqualTo(1);
     }
   }
@@ -453,7 +453,7 @@ public class IndexingChunkImplTest {
       chunk.preSnapshot();
 
       SearchQuery searchQuery =
-          new SearchQuery(MessageUtil.TEST_INDEX_NAME, "Message1", 0, MAX_TIME, 10, 1000);
+          new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
       assertThat(chunk.isReadOnly()).isTrue();
       SearchResult<LogMessage> resultsAfterPreSnapshot = chunk.query(searchQuery);
       assertThat(resultsAfterPreSnapshot.hits.size()).isEqualTo(1);
@@ -508,7 +508,7 @@ public class IndexingChunkImplTest {
       chunk.preSnapshot();
 
       SearchQuery searchQuery =
-          new SearchQuery(MessageUtil.TEST_INDEX_NAME, "Message1", 0, MAX_TIME, 10, 1000);
+          new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
       assertThat(chunk.isReadOnly()).isTrue();
       SearchResult<LogMessage> resultsAfterPreSnapshot = chunk.query(searchQuery);
       assertThat(resultsAfterPreSnapshot.hits.size()).isEqualTo(1);

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -139,7 +139,7 @@ public class ReadOnlyChunkImplTest {
     SearchResult<LogMessage> logMessageSearchResult =
         readOnlyChunk.query(
             new SearchQuery(
-                MessageUtil.TEST_DATASET_NAME,
+                MessageUtil.TEST_DATA_SET_NAME,
                 "*:*",
                 Instant.now().minus(1, ChronoUnit.MINUTES).toEpochMilli(),
                 Instant.now().toEpochMilli(),
@@ -180,7 +180,7 @@ public class ReadOnlyChunkImplTest {
     SearchResult<LogMessage> logMessageEmptySearchResult =
         readOnlyChunk.query(
             new SearchQuery(
-                MessageUtil.TEST_DATASET_NAME,
+                MessageUtil.TEST_DATA_SET_NAME,
                 "*:*",
                 Instant.now().minus(1, ChronoUnit.MINUTES).toEpochMilli(),
                 Instant.now().toEpochMilli(),
@@ -391,7 +391,7 @@ public class ReadOnlyChunkImplTest {
 
     SearchQuery query =
         new SearchQuery(
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             "*:*",
             Instant.now().minus(1, ChronoUnit.MINUTES).toEpochMilli(),
             Instant.now().toEpochMilli(),

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -139,7 +139,7 @@ public class ReadOnlyChunkImplTest {
     SearchResult<LogMessage> logMessageSearchResult =
         readOnlyChunk.query(
             new SearchQuery(
-                MessageUtil.TEST_DATA_SET_NAME,
+                MessageUtil.TEST_DATASET_NAME,
                 "*:*",
                 Instant.now().minus(1, ChronoUnit.MINUTES).toEpochMilli(),
                 Instant.now().toEpochMilli(),
@@ -180,7 +180,7 @@ public class ReadOnlyChunkImplTest {
     SearchResult<LogMessage> logMessageEmptySearchResult =
         readOnlyChunk.query(
             new SearchQuery(
-                MessageUtil.TEST_DATA_SET_NAME,
+                MessageUtil.TEST_DATASET_NAME,
                 "*:*",
                 Instant.now().minus(1, ChronoUnit.MINUTES).toEpochMilli(),
                 Instant.now().toEpochMilli(),
@@ -391,7 +391,7 @@ public class ReadOnlyChunkImplTest {
 
     SearchQuery query =
         new SearchQuery(
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "*:*",
             Instant.now().minus(1, ChronoUnit.MINUTES).toEpochMilli(),
             Instant.now().toEpochMilli(),

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -139,7 +139,7 @@ public class ReadOnlyChunkImplTest {
     SearchResult<LogMessage> logMessageSearchResult =
         readOnlyChunk.query(
             new SearchQuery(
-                MessageUtil.TEST_INDEX_NAME,
+                MessageUtil.TEST_DATASET_NAME,
                 "*:*",
                 Instant.now().minus(1, ChronoUnit.MINUTES).toEpochMilli(),
                 Instant.now().toEpochMilli(),
@@ -180,7 +180,7 @@ public class ReadOnlyChunkImplTest {
     SearchResult<LogMessage> logMessageEmptySearchResult =
         readOnlyChunk.query(
             new SearchQuery(
-                MessageUtil.TEST_INDEX_NAME,
+                MessageUtil.TEST_DATASET_NAME,
                 "*:*",
                 Instant.now().minus(1, ChronoUnit.MINUTES).toEpochMilli(),
                 Instant.now().toEpochMilli(),
@@ -391,7 +391,7 @@ public class ReadOnlyChunkImplTest {
 
     SearchQuery query =
         new SearchQuery(
-            MessageUtil.TEST_INDEX_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "*:*",
             Instant.now().minus(1, ChronoUnit.MINUTES).toEpochMilli(),
             Instant.now().toEpochMilli(),

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
@@ -126,17 +126,17 @@ public class RecoveryChunkImplTest {
       chunk.commit();
 
       SearchResult<LogMessage> results =
-          chunk.query(new SearchQuery(MessageUtil.TEST_INDEX_NAME, "*:*", 0, MAX_TIME, 10, 1000));
+          chunk.query(new SearchQuery(MessageUtil.TEST_DATASET_NAME, "*:*", 0, MAX_TIME, 10, 1000));
       assertThat(results.totalCount).isEqualTo(100);
 
       results =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_INDEX_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(results.totalCount).isEqualTo(1);
 
       results =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_INDEX_NAME, "Message*", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message*", 0, MAX_TIME, 10, 1000));
       assertThat(results.totalCount).isEqualTo(100);
       assertThat(results.hits.size()).isEqualTo(10);
 
@@ -261,7 +261,7 @@ public class RecoveryChunkImplTest {
               chunk
                   .query(
                       new SearchQuery(
-                          MessageUtil.TEST_INDEX_NAME,
+                          MessageUtil.TEST_DATASET_NAME,
                           searchString,
                           startTimeMs,
                           endTimeMs,
@@ -289,7 +289,7 @@ public class RecoveryChunkImplTest {
 
       SearchResult<LogMessage> results =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_INDEX_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(results.hits.size()).isEqualTo(1);
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, registry)).isEqualTo(100);
@@ -342,7 +342,7 @@ public class RecoveryChunkImplTest {
 
       SearchResult<LogMessage> resultsBeforeCommit =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_INDEX_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(resultsBeforeCommit.hits.size()).isEqualTo(0);
 
       // Snapshot forces commit and refresh
@@ -350,7 +350,7 @@ public class RecoveryChunkImplTest {
       assertThat(chunk.isReadOnly()).isTrue();
       SearchResult<LogMessage> resultsAfterPreSnapshot =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_INDEX_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(resultsAfterPreSnapshot.hits.size()).isEqualTo(1);
     }
   }
@@ -433,7 +433,7 @@ public class RecoveryChunkImplTest {
       chunk.preSnapshot();
 
       SearchQuery searchQuery =
-          new SearchQuery(MessageUtil.TEST_INDEX_NAME, "Message1", 0, MAX_TIME, 10, 1000);
+          new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
       assertThat(chunk.isReadOnly()).isTrue();
       SearchResult<LogMessage> resultsAfterPreSnapshot = chunk.query(searchQuery);
       assertThat(resultsAfterPreSnapshot.hits.size()).isEqualTo(1);
@@ -474,7 +474,7 @@ public class RecoveryChunkImplTest {
       chunk.preSnapshot();
 
       SearchQuery searchQuery =
-          new SearchQuery(MessageUtil.TEST_INDEX_NAME, "Message1", 0, MAX_TIME, 10, 1000);
+          new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
       assertThat(chunk.isReadOnly()).isTrue();
       SearchResult<LogMessage> resultsAfterPreSnapshot = chunk.query(searchQuery);
       assertThat(resultsAfterPreSnapshot.hits.size()).isEqualTo(1);

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
@@ -126,18 +126,17 @@ public class RecoveryChunkImplTest {
       chunk.commit();
 
       SearchResult<LogMessage> results =
-          chunk.query(
-              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "*:*", 0, MAX_TIME, 10, 1000));
+          chunk.query(new SearchQuery(MessageUtil.TEST_DATASET_NAME, "*:*", 0, MAX_TIME, 10, 1000));
       assertThat(results.totalCount).isEqualTo(100);
 
       results =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(results.totalCount).isEqualTo(1);
 
       results =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message*", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message*", 0, MAX_TIME, 10, 1000));
       assertThat(results.totalCount).isEqualTo(100);
       assertThat(results.hits.size()).isEqualTo(10);
 
@@ -262,7 +261,7 @@ public class RecoveryChunkImplTest {
               chunk
                   .query(
                       new SearchQuery(
-                          MessageUtil.TEST_DATA_SET_NAME,
+                          MessageUtil.TEST_DATASET_NAME,
                           searchString,
                           startTimeMs,
                           endTimeMs,
@@ -290,7 +289,7 @@ public class RecoveryChunkImplTest {
 
       SearchResult<LogMessage> results =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(results.hits.size()).isEqualTo(1);
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, registry)).isEqualTo(100);
@@ -343,7 +342,7 @@ public class RecoveryChunkImplTest {
 
       SearchResult<LogMessage> resultsBeforeCommit =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(resultsBeforeCommit.hits.size()).isEqualTo(0);
 
       // Snapshot forces commit and refresh
@@ -351,7 +350,7 @@ public class RecoveryChunkImplTest {
       assertThat(chunk.isReadOnly()).isTrue();
       SearchResult<LogMessage> resultsAfterPreSnapshot =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(resultsAfterPreSnapshot.hits.size()).isEqualTo(1);
     }
   }
@@ -434,7 +433,7 @@ public class RecoveryChunkImplTest {
       chunk.preSnapshot();
 
       SearchQuery searchQuery =
-          new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
+          new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
       assertThat(chunk.isReadOnly()).isTrue();
       SearchResult<LogMessage> resultsAfterPreSnapshot = chunk.query(searchQuery);
       assertThat(resultsAfterPreSnapshot.hits.size()).isEqualTo(1);
@@ -475,7 +474,7 @@ public class RecoveryChunkImplTest {
       chunk.preSnapshot();
 
       SearchQuery searchQuery =
-          new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
+          new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
       assertThat(chunk.isReadOnly()).isTrue();
       SearchResult<LogMessage> resultsAfterPreSnapshot = chunk.query(searchQuery);
       assertThat(resultsAfterPreSnapshot.hits.size()).isEqualTo(1);

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
@@ -126,17 +126,18 @@ public class RecoveryChunkImplTest {
       chunk.commit();
 
       SearchResult<LogMessage> results =
-          chunk.query(new SearchQuery(MessageUtil.TEST_DATASET_NAME, "*:*", 0, MAX_TIME, 10, 1000));
+          chunk.query(
+              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "*:*", 0, MAX_TIME, 10, 1000));
       assertThat(results.totalCount).isEqualTo(100);
 
       results =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(results.totalCount).isEqualTo(1);
 
       results =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message*", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message*", 0, MAX_TIME, 10, 1000));
       assertThat(results.totalCount).isEqualTo(100);
       assertThat(results.hits.size()).isEqualTo(10);
 
@@ -261,7 +262,7 @@ public class RecoveryChunkImplTest {
               chunk
                   .query(
                       new SearchQuery(
-                          MessageUtil.TEST_DATASET_NAME,
+                          MessageUtil.TEST_DATA_SET_NAME,
                           searchString,
                           startTimeMs,
                           endTimeMs,
@@ -289,7 +290,7 @@ public class RecoveryChunkImplTest {
 
       SearchResult<LogMessage> results =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(results.hits.size()).isEqualTo(1);
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, registry)).isEqualTo(100);
@@ -342,7 +343,7 @@ public class RecoveryChunkImplTest {
 
       SearchResult<LogMessage> resultsBeforeCommit =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(resultsBeforeCommit.hits.size()).isEqualTo(0);
 
       // Snapshot forces commit and refresh
@@ -350,7 +351,7 @@ public class RecoveryChunkImplTest {
       assertThat(chunk.isReadOnly()).isTrue();
       SearchResult<LogMessage> resultsAfterPreSnapshot =
           chunk.query(
-              new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
+              new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000));
       assertThat(resultsAfterPreSnapshot.hits.size()).isEqualTo(1);
     }
   }
@@ -433,7 +434,7 @@ public class RecoveryChunkImplTest {
       chunk.preSnapshot();
 
       SearchQuery searchQuery =
-          new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
+          new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
       assertThat(chunk.isReadOnly()).isTrue();
       SearchResult<LogMessage> resultsAfterPreSnapshot = chunk.query(searchQuery);
       assertThat(resultsAfterPreSnapshot.hits.size()).isEqualTo(1);
@@ -474,7 +475,7 @@ public class RecoveryChunkImplTest {
       chunk.preSnapshot();
 
       SearchQuery searchQuery =
-          new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
+          new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
       assertThat(chunk.isReadOnly()).isTrue();
       SearchResult<LogMessage> resultsAfterPreSnapshot = chunk.query(searchQuery);
       assertThat(resultsAfterPreSnapshot.hits.size()).isEqualTo(1);

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
@@ -223,7 +223,7 @@ public class IndexingChunkManagerTest {
     assertThat(searchMetadataStore.listSync().size()).isEqualTo(1);
 
     SearchQuery searchQuery =
-        new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
+        new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
     SearchResult<LogMessage> results = chunkManager.query(searchQuery);
     assertThat(results.hits.size()).isEqualTo(1);
 
@@ -272,7 +272,7 @@ public class IndexingChunkManagerTest {
             chunkManager
                 .query(
                     new SearchQuery(
-                        MessageUtil.TEST_DATA_SET_NAME, "Message101", 0, MAX_TIME, 10, 1000))
+                        MessageUtil.TEST_DATASET_NAME, "Message101", 0, MAX_TIME, 10, 1000))
                 .hits
                 .size())
         .isEqualTo(1);
@@ -294,7 +294,7 @@ public class IndexingChunkManagerTest {
             chunkManager
                 .query(
                     new SearchQuery(
-                        MessageUtil.TEST_DATA_SET_NAME, "Message102", 0, MAX_TIME, 10, 1000))
+                        MessageUtil.TEST_DATASET_NAME, "Message102", 0, MAX_TIME, 10, 1000))
                 .hits
                 .size())
         .isEqualTo(1);
@@ -320,7 +320,7 @@ public class IndexingChunkManagerTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             searchString,
             0,
             com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.MAX_TIME,
@@ -340,7 +340,7 @@ public class IndexingChunkManagerTest {
       long endTimeEpochMs) {
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             searchString,
             startTimeEpochMs,
             endTimeEpochMs,

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
@@ -223,7 +223,7 @@ public class IndexingChunkManagerTest {
     assertThat(searchMetadataStore.listSync().size()).isEqualTo(1);
 
     SearchQuery searchQuery =
-        new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
+        new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
     SearchResult<LogMessage> results = chunkManager.query(searchQuery);
     assertThat(results.hits.size()).isEqualTo(1);
 
@@ -272,7 +272,7 @@ public class IndexingChunkManagerTest {
             chunkManager
                 .query(
                     new SearchQuery(
-                        MessageUtil.TEST_DATASET_NAME, "Message101", 0, MAX_TIME, 10, 1000))
+                        MessageUtil.TEST_DATA_SET_NAME, "Message101", 0, MAX_TIME, 10, 1000))
                 .hits
                 .size())
         .isEqualTo(1);
@@ -294,7 +294,7 @@ public class IndexingChunkManagerTest {
             chunkManager
                 .query(
                     new SearchQuery(
-                        MessageUtil.TEST_DATASET_NAME, "Message102", 0, MAX_TIME, 10, 1000))
+                        MessageUtil.TEST_DATA_SET_NAME, "Message102", 0, MAX_TIME, 10, 1000))
                 .hits
                 .size())
         .isEqualTo(1);
@@ -320,7 +320,7 @@ public class IndexingChunkManagerTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             searchString,
             0,
             com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.MAX_TIME,
@@ -340,7 +340,7 @@ public class IndexingChunkManagerTest {
       long endTimeEpochMs) {
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             searchString,
             startTimeEpochMs,
             endTimeEpochMs,

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
@@ -223,7 +223,7 @@ public class IndexingChunkManagerTest {
     assertThat(searchMetadataStore.listSync().size()).isEqualTo(1);
 
     SearchQuery searchQuery =
-        new SearchQuery(MessageUtil.TEST_INDEX_NAME, "Message1", 0, MAX_TIME, 10, 1000);
+        new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
     SearchResult<LogMessage> results = chunkManager.query(searchQuery);
     assertThat(results.hits.size()).isEqualTo(1);
 
@@ -272,7 +272,7 @@ public class IndexingChunkManagerTest {
             chunkManager
                 .query(
                     new SearchQuery(
-                        MessageUtil.TEST_INDEX_NAME, "Message101", 0, MAX_TIME, 10, 1000))
+                        MessageUtil.TEST_DATASET_NAME, "Message101", 0, MAX_TIME, 10, 1000))
                 .hits
                 .size())
         .isEqualTo(1);
@@ -294,7 +294,7 @@ public class IndexingChunkManagerTest {
             chunkManager
                 .query(
                     new SearchQuery(
-                        MessageUtil.TEST_INDEX_NAME, "Message102", 0, MAX_TIME, 10, 1000))
+                        MessageUtil.TEST_DATASET_NAME, "Message102", 0, MAX_TIME, 10, 1000))
                 .hits
                 .size())
         .isEqualTo(1);
@@ -320,7 +320,7 @@ public class IndexingChunkManagerTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_INDEX_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             searchString,
             0,
             com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.MAX_TIME,
@@ -340,7 +340,12 @@ public class IndexingChunkManagerTest {
       long endTimeEpochMs) {
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_INDEX_NAME, searchString, startTimeEpochMs, endTimeEpochMs, 10, 1000);
+            MessageUtil.TEST_DATASET_NAME,
+            searchString,
+            startTimeEpochMs,
+            endTimeEpochMs,
+            10,
+            1000);
     return chunkManager.query(searchQuery).hits.size();
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
@@ -160,7 +160,7 @@ public class RecoveryChunkManagerTest {
 
     // Search query
     SearchQuery searchQuery =
-        new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
+        new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
     SearchResult<LogMessage> results = chunkManager.getActiveChunk().query(searchQuery);
     assertThat(results.hits.size()).isEqualTo(1);
 
@@ -191,7 +191,7 @@ public class RecoveryChunkManagerTest {
                 .getActiveChunk()
                 .query(
                     new SearchQuery(
-                        MessageUtil.TEST_DATASET_NAME, "Message101", 0, MAX_TIME, 10, 1000))
+                        MessageUtil.TEST_DATA_SET_NAME, "Message101", 0, MAX_TIME, 10, 1000))
                 .hits
                 .size())
         .isEqualTo(1);
@@ -214,7 +214,7 @@ public class RecoveryChunkManagerTest {
                 .getActiveChunk()
                 .query(
                     new SearchQuery(
-                        MessageUtil.TEST_DATASET_NAME, "Message102", 0, MAX_TIME, 10, 1000))
+                        MessageUtil.TEST_DATA_SET_NAME, "Message102", 0, MAX_TIME, 10, 1000))
                 .hits
                 .size())
         .isEqualTo(1);
@@ -260,7 +260,7 @@ public class RecoveryChunkManagerTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             searchString,
             0,
             com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.MAX_TIME,

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
@@ -160,7 +160,7 @@ public class RecoveryChunkManagerTest {
 
     // Search query
     SearchQuery searchQuery =
-        new SearchQuery(MessageUtil.TEST_DATA_SET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
+        new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
     SearchResult<LogMessage> results = chunkManager.getActiveChunk().query(searchQuery);
     assertThat(results.hits.size()).isEqualTo(1);
 
@@ -191,7 +191,7 @@ public class RecoveryChunkManagerTest {
                 .getActiveChunk()
                 .query(
                     new SearchQuery(
-                        MessageUtil.TEST_DATA_SET_NAME, "Message101", 0, MAX_TIME, 10, 1000))
+                        MessageUtil.TEST_DATASET_NAME, "Message101", 0, MAX_TIME, 10, 1000))
                 .hits
                 .size())
         .isEqualTo(1);
@@ -214,7 +214,7 @@ public class RecoveryChunkManagerTest {
                 .getActiveChunk()
                 .query(
                     new SearchQuery(
-                        MessageUtil.TEST_DATA_SET_NAME, "Message102", 0, MAX_TIME, 10, 1000))
+                        MessageUtil.TEST_DATASET_NAME, "Message102", 0, MAX_TIME, 10, 1000))
                 .hits
                 .size())
         .isEqualTo(1);
@@ -260,7 +260,7 @@ public class RecoveryChunkManagerTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             searchString,
             0,
             com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.MAX_TIME,

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
@@ -160,7 +160,7 @@ public class RecoveryChunkManagerTest {
 
     // Search query
     SearchQuery searchQuery =
-        new SearchQuery(MessageUtil.TEST_INDEX_NAME, "Message1", 0, MAX_TIME, 10, 1000);
+        new SearchQuery(MessageUtil.TEST_DATASET_NAME, "Message1", 0, MAX_TIME, 10, 1000);
     SearchResult<LogMessage> results = chunkManager.getActiveChunk().query(searchQuery);
     assertThat(results.hits.size()).isEqualTo(1);
 
@@ -191,7 +191,7 @@ public class RecoveryChunkManagerTest {
                 .getActiveChunk()
                 .query(
                     new SearchQuery(
-                        MessageUtil.TEST_INDEX_NAME, "Message101", 0, MAX_TIME, 10, 1000))
+                        MessageUtil.TEST_DATASET_NAME, "Message101", 0, MAX_TIME, 10, 1000))
                 .hits
                 .size())
         .isEqualTo(1);
@@ -214,7 +214,7 @@ public class RecoveryChunkManagerTest {
                 .getActiveChunk()
                 .query(
                     new SearchQuery(
-                        MessageUtil.TEST_INDEX_NAME, "Message102", 0, MAX_TIME, 10, 1000))
+                        MessageUtil.TEST_DATASET_NAME, "Message102", 0, MAX_TIME, 10, 1000))
                 .hits
                 .size())
         .isEqualTo(1);
@@ -260,7 +260,7 @@ public class RecoveryChunkManagerTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_INDEX_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             searchString,
             0,
             com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.MAX_TIME,

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/FieldConflictsTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/FieldConflictsTest.java
@@ -32,7 +32,7 @@ public class FieldConflictsTest {
 
     LogMessage msg1 =
         new LogMessage(
-            MessageUtil.TEST_INDEX_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "INFO",
             "1",
             Map.of(
@@ -50,7 +50,7 @@ public class FieldConflictsTest {
 
     LogMessage msg2 =
         new LogMessage(
-            MessageUtil.TEST_INDEX_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "INFO",
             "2",
             Map.of(
@@ -76,7 +76,7 @@ public class FieldConflictsTest {
                 assertThat(
                         findAllMessages(
                                 strictLogStore.logSearcher,
-                                MessageUtil.TEST_INDEX_NAME,
+                                MessageUtil.TEST_DATASET_NAME,
                                 queryByHost,
                                 1000,
                                 1)
@@ -87,7 +87,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByInt =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_INDEX_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             conflictingTypeByNumber,
             1000,
             1);
@@ -97,7 +97,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByNumber =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_INDEX_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             conflictingTypeExactMatch,
             1000,
             1);
@@ -110,7 +110,7 @@ public class FieldConflictsTest {
 
     LogMessage msg0 =
         new LogMessage(
-            MessageUtil.TEST_INDEX_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "INFO",
             "0",
             Map.of(
@@ -128,7 +128,7 @@ public class FieldConflictsTest {
 
     LogMessage msg1 =
         new LogMessage(
-            MessageUtil.TEST_INDEX_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "INFO",
             "1",
             Map.of(
@@ -146,7 +146,7 @@ public class FieldConflictsTest {
 
     LogMessage msg2 =
         new LogMessage(
-            MessageUtil.TEST_INDEX_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "INFO",
             "2",
             Map.of(
@@ -172,7 +172,7 @@ public class FieldConflictsTest {
                 assertThat(
                         findAllMessages(
                                 strictLogStore.logSearcher,
-                                MessageUtil.TEST_INDEX_NAME,
+                                MessageUtil.TEST_DATASET_NAME,
                                 queryByHost,
                                 1000,
                                 1)
@@ -183,7 +183,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByString =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_INDEX_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             conflictingTypeByString,
             1000,
             1);
@@ -193,7 +193,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByExactString =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_INDEX_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             conflictingTypeByExactString,
             1000,
             1);
@@ -203,7 +203,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByString1 =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_INDEX_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             conflictingTypeByString1,
             1000,
             1);
@@ -213,7 +213,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByExactString1 =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_INDEX_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             conflictingTypeByExactString1,
             1000,
             1);
@@ -223,7 +223,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByNumber =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_INDEX_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             conflictingTypeByNumber,
             1000,
             1);
@@ -233,7 +233,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByNumberString =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_INDEX_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             conflictingTypeByNumberString,
             1000,
             1);

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/FieldConflictsTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/FieldConflictsTest.java
@@ -32,7 +32,7 @@ public class FieldConflictsTest {
 
     LogMessage msg1 =
         new LogMessage(
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             "INFO",
             "1",
             Map.of(
@@ -50,7 +50,7 @@ public class FieldConflictsTest {
 
     LogMessage msg2 =
         new LogMessage(
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             "INFO",
             "2",
             Map.of(
@@ -76,7 +76,7 @@ public class FieldConflictsTest {
                 assertThat(
                         findAllMessages(
                                 strictLogStore.logSearcher,
-                                MessageUtil.TEST_DATASET_NAME,
+                                MessageUtil.TEST_DATA_SET_NAME,
                                 queryByHost,
                                 1000,
                                 1)
@@ -87,7 +87,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByInt =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             conflictingTypeByNumber,
             1000,
             1);
@@ -97,7 +97,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByNumber =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             conflictingTypeExactMatch,
             1000,
             1);
@@ -110,7 +110,7 @@ public class FieldConflictsTest {
 
     LogMessage msg0 =
         new LogMessage(
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             "INFO",
             "0",
             Map.of(
@@ -128,7 +128,7 @@ public class FieldConflictsTest {
 
     LogMessage msg1 =
         new LogMessage(
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             "INFO",
             "1",
             Map.of(
@@ -146,7 +146,7 @@ public class FieldConflictsTest {
 
     LogMessage msg2 =
         new LogMessage(
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             "INFO",
             "2",
             Map.of(
@@ -172,7 +172,7 @@ public class FieldConflictsTest {
                 assertThat(
                         findAllMessages(
                                 strictLogStore.logSearcher,
-                                MessageUtil.TEST_DATASET_NAME,
+                                MessageUtil.TEST_DATA_SET_NAME,
                                 queryByHost,
                                 1000,
                                 1)
@@ -183,7 +183,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByString =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             conflictingTypeByString,
             1000,
             1);
@@ -193,7 +193,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByExactString =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             conflictingTypeByExactString,
             1000,
             1);
@@ -203,7 +203,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByString1 =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             conflictingTypeByString1,
             1000,
             1);
@@ -213,7 +213,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByExactString1 =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             conflictingTypeByExactString1,
             1000,
             1);
@@ -223,7 +223,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByNumber =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             conflictingTypeByNumber,
             1000,
             1);
@@ -233,7 +233,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByNumberString =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             conflictingTypeByNumberString,
             1000,
             1);

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/FieldConflictsTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/FieldConflictsTest.java
@@ -32,7 +32,7 @@ public class FieldConflictsTest {
 
     LogMessage msg1 =
         new LogMessage(
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "INFO",
             "1",
             Map.of(
@@ -50,7 +50,7 @@ public class FieldConflictsTest {
 
     LogMessage msg2 =
         new LogMessage(
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "INFO",
             "2",
             Map.of(
@@ -76,7 +76,7 @@ public class FieldConflictsTest {
                 assertThat(
                         findAllMessages(
                                 strictLogStore.logSearcher,
-                                MessageUtil.TEST_DATA_SET_NAME,
+                                MessageUtil.TEST_DATASET_NAME,
                                 queryByHost,
                                 1000,
                                 1)
@@ -87,7 +87,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByInt =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             conflictingTypeByNumber,
             1000,
             1);
@@ -97,7 +97,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByNumber =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             conflictingTypeExactMatch,
             1000,
             1);
@@ -110,7 +110,7 @@ public class FieldConflictsTest {
 
     LogMessage msg0 =
         new LogMessage(
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "INFO",
             "0",
             Map.of(
@@ -128,7 +128,7 @@ public class FieldConflictsTest {
 
     LogMessage msg1 =
         new LogMessage(
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "INFO",
             "1",
             Map.of(
@@ -146,7 +146,7 @@ public class FieldConflictsTest {
 
     LogMessage msg2 =
         new LogMessage(
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "INFO",
             "2",
             Map.of(
@@ -172,7 +172,7 @@ public class FieldConflictsTest {
                 assertThat(
                         findAllMessages(
                                 strictLogStore.logSearcher,
-                                MessageUtil.TEST_DATA_SET_NAME,
+                                MessageUtil.TEST_DATASET_NAME,
                                 queryByHost,
                                 1000,
                                 1)
@@ -183,7 +183,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByString =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             conflictingTypeByString,
             1000,
             1);
@@ -193,7 +193,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByExactString =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             conflictingTypeByExactString,
             1000,
             1);
@@ -203,7 +203,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByString1 =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             conflictingTypeByString1,
             1000,
             1);
@@ -213,7 +213,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByExactString1 =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             conflictingTypeByExactString1,
             1000,
             1);
@@ -223,7 +223,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByNumber =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             conflictingTypeByNumber,
             1000,
             1);
@@ -233,7 +233,7 @@ public class FieldConflictsTest {
     Collection<LogMessage> searchByNumberString =
         findAllMessages(
             strictLogStore.logSearcher,
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             conflictingTypeByNumberString,
             1000,
             1);

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
@@ -68,7 +68,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(forgivingLogStore.logStore, 1, 100, true);
       Collection<LogMessage> results =
           findAllMessages(
-              forgivingLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "Message1", 10, 1);
+              forgivingLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 10, 1);
       assertThat(results.size()).isEqualTo(1);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -82,7 +82,7 @@ public class LuceneIndexStoreImplTest {
       // TODO: Use ImmutableMap from Guava instead of Map.of which is Java 9 only?
       LogMessage msg =
           new LogMessage(
-              MessageUtil.TEST_INDEX_NAME,
+              MessageUtil.TEST_DATASET_NAME,
               "INFO",
               "1",
               Map.of(
@@ -101,17 +101,17 @@ public class LuceneIndexStoreImplTest {
 
       SearchResult<LogMessage> result1 =
           forgivingLogStore.logSearcher.search(
-              MessageUtil.TEST_INDEX_NAME, "key1:value1", 0, MAX_TIME, 100, 1);
+              MessageUtil.TEST_DATASET_NAME, "key1:value1", 0, MAX_TIME, 100, 1);
       assertThat(result1.hits.size()).isEqualTo(1);
 
       SearchResult<LogMessage> result2 =
           forgivingLogStore.logSearcher.search(
-              MessageUtil.TEST_INDEX_NAME, "duplicateproperty:duplicate1", 0, MAX_TIME, 100, 1);
+              MessageUtil.TEST_DATASET_NAME, "duplicateproperty:duplicate1", 0, MAX_TIME, 100, 1);
       assertThat(result2.hits.size()).isEqualTo(1);
 
       SearchResult<LogMessage> result3 =
           forgivingLogStore.logSearcher.search(
-              MessageUtil.TEST_INDEX_NAME, "duplicateproperty:2", 0, MAX_TIME, 100, 1);
+              MessageUtil.TEST_DATASET_NAME, "duplicateproperty:2", 0, MAX_TIME, 100, 1);
       assertThat(result3.hits.size()).isEqualTo(1);
     }
 
@@ -120,7 +120,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(forgivingLogStore.logStore, 1, 100, true);
       Collection<LogMessage> results =
           findAllMessages(
-              forgivingLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "identifier", 1000, 1);
+              forgivingLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "identifier", 1000, 1);
       assertThat(results.size()).isEqualTo(100);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -134,7 +134,7 @@ public class LuceneIndexStoreImplTest {
       List<LogMessage> msgs = addMessages(forgivingLogStore.logStore, 1, 100, true);
       List<LogMessage> results =
           findAllMessages(
-              forgivingLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "identifier", 1, 1);
+              forgivingLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "identifier", 1, 1);
       assertThat(results.size()).isEqualTo(1);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -152,7 +152,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(forgivingLogStore.logStore, 1, 99, true);
       Collection<LogMessage> results =
           findAllMessages(
-              forgivingLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "identifier", 1000, 1);
+              forgivingLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "identifier", 1000, 1);
       assertThat(results.size()).isEqualTo(100);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -169,7 +169,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(forgivingLogStore.logStore, 1, 99, true);
       Collection<LogMessage> results =
           findAllMessages(
-              forgivingLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "identifier", 1000, 1);
+              forgivingLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "identifier", 1000, 1);
       assertThat(results.size()).isEqualTo(100);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -194,7 +194,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(strictLogStore.logStore, 1, 99, true);
       Collection<LogMessage> results =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "identifier", 1000, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "identifier", 1000, 1);
       assertThat(results.size()).isEqualTo(99);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -211,7 +211,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(strictLogStore.logStore, 1, 99, true);
       Collection<LogMessage> results =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "identifier", 1000, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "identifier", 1000, 1);
       assertThat(results.size()).isEqualTo(99);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -238,7 +238,7 @@ public class LuceneIndexStoreImplTest {
     public void testFieldSearch() throws InterruptedException {
       LogMessage msg =
           new LogMessage(
-              MessageUtil.TEST_INDEX_NAME,
+              MessageUtil.TEST_DATASET_NAME,
               "INFO",
               "1",
               Map.of(
@@ -257,13 +257,13 @@ public class LuceneIndexStoreImplTest {
 
       Collection<LogMessage> results =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "tag:foo", 1000, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "tag:foo", 1000, 1);
       assertThat(results.size()).isEqualTo(1);
 
       Collection<LogMessage> results2 =
           findAllMessages(
               strictLogStore.logSearcher,
-              MessageUtil.TEST_INDEX_NAME,
+              MessageUtil.TEST_DATASET_NAME,
               "hostname:host1-dc2.abc.com",
               1000,
               1);
@@ -271,28 +271,32 @@ public class LuceneIndexStoreImplTest {
 
       Collection<LogMessage> results3 =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "hostname:xyz", 1000, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "hostname:xyz", 1000, 1);
       assertThat(results3.size()).isEqualTo(0);
 
       Collection<LogMessage> results4 =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "hostname:host2", 1000, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "hostname:host2", 1000, 1);
       assertThat(results4.size()).isEqualTo(0);
 
       Collection<LogMessage> results5 =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "hostname:abc", 1000, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "hostname:abc", 1000, 1);
       assertThat(results5.size()).isEqualTo(0);
 
       Collection<LogMessage> results6 =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "hostname:abc.com", 1000, 1);
+              strictLogStore.logSearcher,
+              MessageUtil.TEST_DATASET_NAME,
+              "hostname:abc.com",
+              1000,
+              1);
       assertThat(results6.size()).isEqualTo(1);
 
       Collection<LogMessage> results7 =
           findAllMessages(
               strictLogStore.logSearcher,
-              MessageUtil.TEST_INDEX_NAME,
+              MessageUtil.TEST_DATASET_NAME,
               "hostname:host1-dc2",
               1000,
               1);
@@ -300,7 +304,11 @@ public class LuceneIndexStoreImplTest {
 
       Collection<LogMessage> results8 =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "hostname:com.abc", 1000, 1);
+              strictLogStore.logSearcher,
+              MessageUtil.TEST_DATASET_NAME,
+              "hostname:com.abc",
+              1000,
+              1);
       assertThat(results8.size()).isEqualTo(0);
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(1);
@@ -324,7 +332,7 @@ public class LuceneIndexStoreImplTest {
       testLogStore.logStore = null;
       Collection<LogMessage> results =
           findAllMessages(
-              testLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "Message1", 100, 1);
+              testLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 100, 1);
       assertThat(results.size()).isEqualTo(1);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, testLogStore.metricsRegistry)).isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, testLogStore.metricsRegistry)).isEqualTo(0);
@@ -359,7 +367,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(logStore, 1, 100, true);
       Collection<LogMessage> results =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "Message1", 100, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 100, 1);
       assertThat(results.size()).isEqualTo(1);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -409,7 +417,7 @@ public class LuceneIndexStoreImplTest {
           new LogIndexSearcherImpl(
               LogIndexSearcherImpl.searcherManagerFromPath(tempFolder.getRoot().toPath()));
       Collection<LogMessage> newResults =
-          findAllMessages(newSearcher, MessageUtil.TEST_INDEX_NAME, "Message1", 100, 1);
+          findAllMessages(newSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 100, 1);
       assertThat(newResults.size()).isEqualTo(1);
 
       // Clean up
@@ -424,7 +432,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(logStore, 1, 100, true);
       Collection<LogMessage> results =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "Message1", 100, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 100, 1);
       assertThat(results.size()).isEqualTo(1);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -452,7 +460,7 @@ public class LuceneIndexStoreImplTest {
               LogIndexSearcherImpl.searcherManagerFromPath(tempFolder.getRoot().toPath()));
 
       Collection<LogMessage> newResults =
-          findAllMessages(newSearcher, MessageUtil.TEST_INDEX_NAME, "Message1", 100, 1);
+          findAllMessages(newSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 100, 1);
       assertThat(newResults.size()).isEqualTo(1);
       logStore.releaseIndexCommit(indexCommit);
       newSearcher.close();
@@ -471,7 +479,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(strictLogStore.logStore, 1, 100, true);
       Collection<LogMessage> results =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "Message1", 100, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 100, 1);
       assertThat(results.size()).isEqualTo(1);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -509,7 +517,8 @@ public class LuceneIndexStoreImplTest {
 
       Thread.sleep(2 * commitDuration.toMillis());
       Collection<LogMessage> results =
-          findAllMessages(testLogStore.logSearcher, MessageUtil.TEST_INDEX_NAME, "Message1", 10, 1);
+          findAllMessages(
+              testLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 10, 1);
       assertThat(results.size()).isEqualTo(1);
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, testLogStore.metricsRegistry)).isEqualTo(100);

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
@@ -68,7 +68,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(forgivingLogStore.logStore, 1, 100, true);
       Collection<LogMessage> results =
           findAllMessages(
-              forgivingLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 10, 1);
+              forgivingLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "Message1", 10, 1);
       assertThat(results.size()).isEqualTo(1);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -82,7 +82,7 @@ public class LuceneIndexStoreImplTest {
       // TODO: Use ImmutableMap from Guava instead of Map.of which is Java 9 only?
       LogMessage msg =
           new LogMessage(
-              MessageUtil.TEST_DATASET_NAME,
+              MessageUtil.TEST_DATA_SET_NAME,
               "INFO",
               "1",
               Map.of(
@@ -101,17 +101,17 @@ public class LuceneIndexStoreImplTest {
 
       SearchResult<LogMessage> result1 =
           forgivingLogStore.logSearcher.search(
-              MessageUtil.TEST_DATASET_NAME, "key1:value1", 0, MAX_TIME, 100, 1);
+              MessageUtil.TEST_DATA_SET_NAME, "key1:value1", 0, MAX_TIME, 100, 1);
       assertThat(result1.hits.size()).isEqualTo(1);
 
       SearchResult<LogMessage> result2 =
           forgivingLogStore.logSearcher.search(
-              MessageUtil.TEST_DATASET_NAME, "duplicateproperty:duplicate1", 0, MAX_TIME, 100, 1);
+              MessageUtil.TEST_DATA_SET_NAME, "duplicateproperty:duplicate1", 0, MAX_TIME, 100, 1);
       assertThat(result2.hits.size()).isEqualTo(1);
 
       SearchResult<LogMessage> result3 =
           forgivingLogStore.logSearcher.search(
-              MessageUtil.TEST_DATASET_NAME, "duplicateproperty:2", 0, MAX_TIME, 100, 1);
+              MessageUtil.TEST_DATA_SET_NAME, "duplicateproperty:2", 0, MAX_TIME, 100, 1);
       assertThat(result3.hits.size()).isEqualTo(1);
     }
 
@@ -120,7 +120,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(forgivingLogStore.logStore, 1, 100, true);
       Collection<LogMessage> results =
           findAllMessages(
-              forgivingLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "identifier", 1000, 1);
+              forgivingLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "identifier", 1000, 1);
       assertThat(results.size()).isEqualTo(100);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -134,7 +134,7 @@ public class LuceneIndexStoreImplTest {
       List<LogMessage> msgs = addMessages(forgivingLogStore.logStore, 1, 100, true);
       List<LogMessage> results =
           findAllMessages(
-              forgivingLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "identifier", 1, 1);
+              forgivingLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "identifier", 1, 1);
       assertThat(results.size()).isEqualTo(1);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -152,7 +152,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(forgivingLogStore.logStore, 1, 99, true);
       Collection<LogMessage> results =
           findAllMessages(
-              forgivingLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "identifier", 1000, 1);
+              forgivingLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "identifier", 1000, 1);
       assertThat(results.size()).isEqualTo(100);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -169,7 +169,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(forgivingLogStore.logStore, 1, 99, true);
       Collection<LogMessage> results =
           findAllMessages(
-              forgivingLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "identifier", 1000, 1);
+              forgivingLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "identifier", 1000, 1);
       assertThat(results.size()).isEqualTo(100);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -194,7 +194,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(strictLogStore.logStore, 1, 99, true);
       Collection<LogMessage> results =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "identifier", 1000, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "identifier", 1000, 1);
       assertThat(results.size()).isEqualTo(99);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -211,7 +211,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(strictLogStore.logStore, 1, 99, true);
       Collection<LogMessage> results =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "identifier", 1000, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "identifier", 1000, 1);
       assertThat(results.size()).isEqualTo(99);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -238,7 +238,7 @@ public class LuceneIndexStoreImplTest {
     public void testFieldSearch() throws InterruptedException {
       LogMessage msg =
           new LogMessage(
-              MessageUtil.TEST_DATASET_NAME,
+              MessageUtil.TEST_DATA_SET_NAME,
               "INFO",
               "1",
               Map.of(
@@ -257,13 +257,13 @@ public class LuceneIndexStoreImplTest {
 
       Collection<LogMessage> results =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "tag:foo", 1000, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "tag:foo", 1000, 1);
       assertThat(results.size()).isEqualTo(1);
 
       Collection<LogMessage> results2 =
           findAllMessages(
               strictLogStore.logSearcher,
-              MessageUtil.TEST_DATASET_NAME,
+              MessageUtil.TEST_DATA_SET_NAME,
               "hostname:host1-dc2.abc.com",
               1000,
               1);
@@ -271,23 +271,27 @@ public class LuceneIndexStoreImplTest {
 
       Collection<LogMessage> results3 =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "hostname:xyz", 1000, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "hostname:xyz", 1000, 1);
       assertThat(results3.size()).isEqualTo(0);
 
       Collection<LogMessage> results4 =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "hostname:host2", 1000, 1);
+              strictLogStore.logSearcher,
+              MessageUtil.TEST_DATA_SET_NAME,
+              "hostname:host2",
+              1000,
+              1);
       assertThat(results4.size()).isEqualTo(0);
 
       Collection<LogMessage> results5 =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "hostname:abc", 1000, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "hostname:abc", 1000, 1);
       assertThat(results5.size()).isEqualTo(0);
 
       Collection<LogMessage> results6 =
           findAllMessages(
               strictLogStore.logSearcher,
-              MessageUtil.TEST_DATASET_NAME,
+              MessageUtil.TEST_DATA_SET_NAME,
               "hostname:abc.com",
               1000,
               1);
@@ -296,7 +300,7 @@ public class LuceneIndexStoreImplTest {
       Collection<LogMessage> results7 =
           findAllMessages(
               strictLogStore.logSearcher,
-              MessageUtil.TEST_DATASET_NAME,
+              MessageUtil.TEST_DATA_SET_NAME,
               "hostname:host1-dc2",
               1000,
               1);
@@ -305,7 +309,7 @@ public class LuceneIndexStoreImplTest {
       Collection<LogMessage> results8 =
           findAllMessages(
               strictLogStore.logSearcher,
-              MessageUtil.TEST_DATASET_NAME,
+              MessageUtil.TEST_DATA_SET_NAME,
               "hostname:com.abc",
               1000,
               1);
@@ -332,7 +336,7 @@ public class LuceneIndexStoreImplTest {
       testLogStore.logStore = null;
       Collection<LogMessage> results =
           findAllMessages(
-              testLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 100, 1);
+              testLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "Message1", 100, 1);
       assertThat(results.size()).isEqualTo(1);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, testLogStore.metricsRegistry)).isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, testLogStore.metricsRegistry)).isEqualTo(0);
@@ -367,7 +371,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(logStore, 1, 100, true);
       Collection<LogMessage> results =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 100, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "Message1", 100, 1);
       assertThat(results.size()).isEqualTo(1);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -417,7 +421,7 @@ public class LuceneIndexStoreImplTest {
           new LogIndexSearcherImpl(
               LogIndexSearcherImpl.searcherManagerFromPath(tempFolder.getRoot().toPath()));
       Collection<LogMessage> newResults =
-          findAllMessages(newSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 100, 1);
+          findAllMessages(newSearcher, MessageUtil.TEST_DATA_SET_NAME, "Message1", 100, 1);
       assertThat(newResults.size()).isEqualTo(1);
 
       // Clean up
@@ -432,7 +436,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(logStore, 1, 100, true);
       Collection<LogMessage> results =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 100, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "Message1", 100, 1);
       assertThat(results.size()).isEqualTo(1);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -460,7 +464,7 @@ public class LuceneIndexStoreImplTest {
               LogIndexSearcherImpl.searcherManagerFromPath(tempFolder.getRoot().toPath()));
 
       Collection<LogMessage> newResults =
-          findAllMessages(newSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 100, 1);
+          findAllMessages(newSearcher, MessageUtil.TEST_DATA_SET_NAME, "Message1", 100, 1);
       assertThat(newResults.size()).isEqualTo(1);
       logStore.releaseIndexCommit(indexCommit);
       newSearcher.close();
@@ -479,7 +483,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(strictLogStore.logStore, 1, 100, true);
       Collection<LogMessage> results =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 100, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "Message1", 100, 1);
       assertThat(results.size()).isEqualTo(1);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -518,7 +522,7 @@ public class LuceneIndexStoreImplTest {
       Thread.sleep(2 * commitDuration.toMillis());
       Collection<LogMessage> results =
           findAllMessages(
-              testLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 10, 1);
+              testLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "Message1", 10, 1);
       assertThat(results.size()).isEqualTo(1);
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, testLogStore.metricsRegistry)).isEqualTo(100);

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
@@ -68,7 +68,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(forgivingLogStore.logStore, 1, 100, true);
       Collection<LogMessage> results =
           findAllMessages(
-              forgivingLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "Message1", 10, 1);
+              forgivingLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 10, 1);
       assertThat(results.size()).isEqualTo(1);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -82,7 +82,7 @@ public class LuceneIndexStoreImplTest {
       // TODO: Use ImmutableMap from Guava instead of Map.of which is Java 9 only?
       LogMessage msg =
           new LogMessage(
-              MessageUtil.TEST_DATA_SET_NAME,
+              MessageUtil.TEST_DATASET_NAME,
               "INFO",
               "1",
               Map.of(
@@ -101,17 +101,17 @@ public class LuceneIndexStoreImplTest {
 
       SearchResult<LogMessage> result1 =
           forgivingLogStore.logSearcher.search(
-              MessageUtil.TEST_DATA_SET_NAME, "key1:value1", 0, MAX_TIME, 100, 1);
+              MessageUtil.TEST_DATASET_NAME, "key1:value1", 0, MAX_TIME, 100, 1);
       assertThat(result1.hits.size()).isEqualTo(1);
 
       SearchResult<LogMessage> result2 =
           forgivingLogStore.logSearcher.search(
-              MessageUtil.TEST_DATA_SET_NAME, "duplicateproperty:duplicate1", 0, MAX_TIME, 100, 1);
+              MessageUtil.TEST_DATASET_NAME, "duplicateproperty:duplicate1", 0, MAX_TIME, 100, 1);
       assertThat(result2.hits.size()).isEqualTo(1);
 
       SearchResult<LogMessage> result3 =
           forgivingLogStore.logSearcher.search(
-              MessageUtil.TEST_DATA_SET_NAME, "duplicateproperty:2", 0, MAX_TIME, 100, 1);
+              MessageUtil.TEST_DATASET_NAME, "duplicateproperty:2", 0, MAX_TIME, 100, 1);
       assertThat(result3.hits.size()).isEqualTo(1);
     }
 
@@ -120,7 +120,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(forgivingLogStore.logStore, 1, 100, true);
       Collection<LogMessage> results =
           findAllMessages(
-              forgivingLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "identifier", 1000, 1);
+              forgivingLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "identifier", 1000, 1);
       assertThat(results.size()).isEqualTo(100);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -134,7 +134,7 @@ public class LuceneIndexStoreImplTest {
       List<LogMessage> msgs = addMessages(forgivingLogStore.logStore, 1, 100, true);
       List<LogMessage> results =
           findAllMessages(
-              forgivingLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "identifier", 1, 1);
+              forgivingLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "identifier", 1, 1);
       assertThat(results.size()).isEqualTo(1);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -152,7 +152,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(forgivingLogStore.logStore, 1, 99, true);
       Collection<LogMessage> results =
           findAllMessages(
-              forgivingLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "identifier", 1000, 1);
+              forgivingLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "identifier", 1000, 1);
       assertThat(results.size()).isEqualTo(100);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -169,7 +169,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(forgivingLogStore.logStore, 1, 99, true);
       Collection<LogMessage> results =
           findAllMessages(
-              forgivingLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "identifier", 1000, 1);
+              forgivingLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "identifier", 1000, 1);
       assertThat(results.size()).isEqualTo(100);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, forgivingLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -194,7 +194,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(strictLogStore.logStore, 1, 99, true);
       Collection<LogMessage> results =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "identifier", 1000, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "identifier", 1000, 1);
       assertThat(results.size()).isEqualTo(99);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -211,7 +211,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(strictLogStore.logStore, 1, 99, true);
       Collection<LogMessage> results =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "identifier", 1000, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "identifier", 1000, 1);
       assertThat(results.size()).isEqualTo(99);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -238,7 +238,7 @@ public class LuceneIndexStoreImplTest {
     public void testFieldSearch() throws InterruptedException {
       LogMessage msg =
           new LogMessage(
-              MessageUtil.TEST_DATA_SET_NAME,
+              MessageUtil.TEST_DATASET_NAME,
               "INFO",
               "1",
               Map.of(
@@ -257,13 +257,13 @@ public class LuceneIndexStoreImplTest {
 
       Collection<LogMessage> results =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "tag:foo", 1000, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "tag:foo", 1000, 1);
       assertThat(results.size()).isEqualTo(1);
 
       Collection<LogMessage> results2 =
           findAllMessages(
               strictLogStore.logSearcher,
-              MessageUtil.TEST_DATA_SET_NAME,
+              MessageUtil.TEST_DATASET_NAME,
               "hostname:host1-dc2.abc.com",
               1000,
               1);
@@ -271,27 +271,23 @@ public class LuceneIndexStoreImplTest {
 
       Collection<LogMessage> results3 =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "hostname:xyz", 1000, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "hostname:xyz", 1000, 1);
       assertThat(results3.size()).isEqualTo(0);
 
       Collection<LogMessage> results4 =
           findAllMessages(
-              strictLogStore.logSearcher,
-              MessageUtil.TEST_DATA_SET_NAME,
-              "hostname:host2",
-              1000,
-              1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "hostname:host2", 1000, 1);
       assertThat(results4.size()).isEqualTo(0);
 
       Collection<LogMessage> results5 =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "hostname:abc", 1000, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "hostname:abc", 1000, 1);
       assertThat(results5.size()).isEqualTo(0);
 
       Collection<LogMessage> results6 =
           findAllMessages(
               strictLogStore.logSearcher,
-              MessageUtil.TEST_DATA_SET_NAME,
+              MessageUtil.TEST_DATASET_NAME,
               "hostname:abc.com",
               1000,
               1);
@@ -300,7 +296,7 @@ public class LuceneIndexStoreImplTest {
       Collection<LogMessage> results7 =
           findAllMessages(
               strictLogStore.logSearcher,
-              MessageUtil.TEST_DATA_SET_NAME,
+              MessageUtil.TEST_DATASET_NAME,
               "hostname:host1-dc2",
               1000,
               1);
@@ -309,7 +305,7 @@ public class LuceneIndexStoreImplTest {
       Collection<LogMessage> results8 =
           findAllMessages(
               strictLogStore.logSearcher,
-              MessageUtil.TEST_DATA_SET_NAME,
+              MessageUtil.TEST_DATASET_NAME,
               "hostname:com.abc",
               1000,
               1);
@@ -336,7 +332,7 @@ public class LuceneIndexStoreImplTest {
       testLogStore.logStore = null;
       Collection<LogMessage> results =
           findAllMessages(
-              testLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "Message1", 100, 1);
+              testLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 100, 1);
       assertThat(results.size()).isEqualTo(1);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, testLogStore.metricsRegistry)).isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, testLogStore.metricsRegistry)).isEqualTo(0);
@@ -371,7 +367,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(logStore, 1, 100, true);
       Collection<LogMessage> results =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "Message1", 100, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 100, 1);
       assertThat(results.size()).isEqualTo(1);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -421,7 +417,7 @@ public class LuceneIndexStoreImplTest {
           new LogIndexSearcherImpl(
               LogIndexSearcherImpl.searcherManagerFromPath(tempFolder.getRoot().toPath()));
       Collection<LogMessage> newResults =
-          findAllMessages(newSearcher, MessageUtil.TEST_DATA_SET_NAME, "Message1", 100, 1);
+          findAllMessages(newSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 100, 1);
       assertThat(newResults.size()).isEqualTo(1);
 
       // Clean up
@@ -436,7 +432,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(logStore, 1, 100, true);
       Collection<LogMessage> results =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "Message1", 100, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 100, 1);
       assertThat(results.size()).isEqualTo(1);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -464,7 +460,7 @@ public class LuceneIndexStoreImplTest {
               LogIndexSearcherImpl.searcherManagerFromPath(tempFolder.getRoot().toPath()));
 
       Collection<LogMessage> newResults =
-          findAllMessages(newSearcher, MessageUtil.TEST_DATA_SET_NAME, "Message1", 100, 1);
+          findAllMessages(newSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 100, 1);
       assertThat(newResults.size()).isEqualTo(1);
       logStore.releaseIndexCommit(indexCommit);
       newSearcher.close();
@@ -483,7 +479,7 @@ public class LuceneIndexStoreImplTest {
       addMessages(strictLogStore.logStore, 1, 100, true);
       Collection<LogMessage> results =
           findAllMessages(
-              strictLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "Message1", 100, 1);
+              strictLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 100, 1);
       assertThat(results.size()).isEqualTo(1);
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry))
           .isEqualTo(100);
@@ -522,7 +518,7 @@ public class LuceneIndexStoreImplTest {
       Thread.sleep(2 * commitDuration.toMillis());
       Collection<LogMessage> results =
           findAllMessages(
-              testLogStore.logSearcher, MessageUtil.TEST_DATA_SET_NAME, "Message1", 10, 1);
+              testLogStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 10, 1);
       assertThat(results.size()).isEqualTo(1);
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, testLogStore.metricsRegistry)).isEqualTo(100);

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/AlreadyClosedLogIndexSearcherImpl.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/AlreadyClosedLogIndexSearcherImpl.java
@@ -6,7 +6,7 @@ import org.apache.lucene.store.AlreadyClosedException;
 public class AlreadyClosedLogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
   @Override
   public SearchResult<LogMessage> search(
-      String indexName, String query, long minTime, long maxTime, int howMany, int bucketCount) {
+          String dataset, String query, long minTime, long maxTime, int howMany, int bucketCount) {
     throw new AlreadyClosedException("Failed to acquire an index searcher");
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/AlreadyClosedLogIndexSearcherImpl.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/AlreadyClosedLogIndexSearcherImpl.java
@@ -6,7 +6,7 @@ import org.apache.lucene.store.AlreadyClosedException;
 public class AlreadyClosedLogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
   @Override
   public SearchResult<LogMessage> search(
-          String dataset, String query, long minTime, long maxTime, int howMany, int bucketCount) {
+      String dataset, String query, long minTime, long maxTime, int howMany, int bucketCount) {
     throw new AlreadyClosedException("Failed to acquire an index searcher");
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/IllegalArgumentLogIndexSearcherImpl.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/IllegalArgumentLogIndexSearcherImpl.java
@@ -5,7 +5,7 @@ import com.slack.kaldb.logstore.LogMessage;
 public class IllegalArgumentLogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
   @Override
   public SearchResult<LogMessage> search(
-      String indexName, String query, long minTime, long maxTime, int howMany, int bucketCount) {
+          String dataset, String query, long minTime, long maxTime, int howMany, int bucketCount) {
     throw new IllegalArgumentException("Failed to acquire an index searcher");
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/IllegalArgumentLogIndexSearcherImpl.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/IllegalArgumentLogIndexSearcherImpl.java
@@ -5,7 +5,7 @@ import com.slack.kaldb.logstore.LogMessage;
 public class IllegalArgumentLogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
   @Override
   public SearchResult<LogMessage> search(
-          String dataset, String query, long minTime, long maxTime, int howMany, int bucketCount) {
+      String dataset, String query, long minTime, long maxTime, int howMany, int bucketCount) {
     throw new IllegalArgumentException("Failed to acquire an index searcher");
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbLocalQueryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbLocalQueryServiceTest.java
@@ -93,7 +93,7 @@ public class KaldbLocalQueryServiceTest {
     KaldbSearch.SearchResult response =
         kaldbLocalQueryService.doSearch(
             searchRequestBuilder
-                .setIndexName(MessageUtil.TEST_INDEX_NAME)
+                .setDataSet(MessageUtil.TEST_DATASET_NAME)
                 .setQueryString("Message100")
                 .setStartTimeEpochMs(chunk1StartTimeMs)
                 .setEndTimeEpochMs(chunk1EndTimeMs)
@@ -116,7 +116,7 @@ public class KaldbLocalQueryServiceTest {
     LogWireMessage hit = JsonUtil.read(hits.get(0).toStringUtf8(), LogWireMessage.class);
     LogMessage m = LogMessage.fromWireMessage(hit);
     assertThat(m.getType()).isEqualTo(MessageUtil.TEST_MESSAGE_TYPE);
-    assertThat(m.getIndex()).isEqualTo(MessageUtil.TEST_INDEX_NAME);
+    assertThat(m.getIndex()).isEqualTo(MessageUtil.TEST_DATASET_NAME);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_LONG_PROPERTY)).isEqualTo(100);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_INT_PROPERTY)).isEqualTo(100);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_FLOAT_PROPERTY)).isEqualTo(100.0);
@@ -158,7 +158,7 @@ public class KaldbLocalQueryServiceTest {
     KaldbSearch.SearchResult response =
         kaldbLocalQueryService.doSearch(
             searchRequestBuilder
-                .setIndexName(MessageUtil.TEST_INDEX_NAME)
+                .setDataSet(MessageUtil.TEST_DATASET_NAME)
                 .setQueryString("blah")
                 .setStartTimeEpochMs(chunk1StartTimeMs)
                 .setEndTimeEpochMs(chunk1EndTimeMs)
@@ -210,7 +210,7 @@ public class KaldbLocalQueryServiceTest {
     KaldbSearch.SearchResult response =
         kaldbLocalQueryService.doSearch(
             searchRequestBuilder
-                .setIndexName(MessageUtil.TEST_INDEX_NAME)
+                .setDataSet(MessageUtil.TEST_DATASET_NAME)
                 .setQueryString("Message1")
                 .setStartTimeEpochMs(chunk1StartTimeMs)
                 .setEndTimeEpochMs(chunk1EndTimeMs)
@@ -261,7 +261,7 @@ public class KaldbLocalQueryServiceTest {
     KaldbSearch.SearchResult response =
         kaldbLocalQueryService.doSearch(
             searchRequestBuilder
-                .setIndexName(MessageUtil.TEST_INDEX_NAME)
+                .setDataSet(MessageUtil.TEST_DATASET_NAME)
                 .setQueryString("Message1")
                 .setStartTimeEpochMs(chunk1StartTimeMs)
                 .setEndTimeEpochMs(chunk1EndTimeMs)
@@ -285,7 +285,7 @@ public class KaldbLocalQueryServiceTest {
     LogWireMessage hit = JsonUtil.read(hits.get(0).toStringUtf8(), LogWireMessage.class);
     LogMessage m = LogMessage.fromWireMessage(hit);
     assertThat(m.getType()).isEqualTo(MessageUtil.TEST_MESSAGE_TYPE);
-    assertThat(m.getIndex()).isEqualTo(MessageUtil.TEST_INDEX_NAME);
+    assertThat(m.getIndex()).isEqualTo(MessageUtil.TEST_DATASET_NAME);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_LONG_PROPERTY)).isEqualTo(1);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_INT_PROPERTY)).isEqualTo(1);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_FLOAT_PROPERTY)).isEqualTo(1.0);
@@ -317,7 +317,7 @@ public class KaldbLocalQueryServiceTest {
 
     kaldbLocalQueryService.doSearch(
         searchRequestBuilder
-            .setIndexName(MessageUtil.TEST_INDEX_NAME)
+            .setDataSet(MessageUtil.TEST_DATASET_NAME)
             .setQueryString("Message1")
             .setStartTimeEpochMs(chunk1StartTimeMs)
             .setEndTimeEpochMs(chunk1EndTimeMs)
@@ -366,7 +366,7 @@ public class KaldbLocalQueryServiceTest {
     KaldbSearch.SearchResult response =
         blockingKaldbClient.search(
             KaldbSearch.SearchRequest.newBuilder()
-                .setIndexName(MessageUtil.TEST_INDEX_NAME)
+                .setDataSet(MessageUtil.TEST_DATASET_NAME)
                 .setQueryString("Message1")
                 .setStartTimeEpochMs(chunk1StartTimeMs)
                 .setEndTimeEpochMs(chunk1EndTimeMs)
@@ -390,7 +390,7 @@ public class KaldbLocalQueryServiceTest {
     LogWireMessage hit = JsonUtil.read(hits.get(0).toStringUtf8(), LogWireMessage.class);
     LogMessage m = LogMessage.fromWireMessage(hit);
     assertThat(m.getType()).isEqualTo(MessageUtil.TEST_MESSAGE_TYPE);
-    assertThat(m.getIndex()).isEqualTo(MessageUtil.TEST_INDEX_NAME);
+    assertThat(m.getIndex()).isEqualTo(MessageUtil.TEST_DATASET_NAME);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_LONG_PROPERTY)).isEqualTo(1);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_INT_PROPERTY)).isEqualTo(1);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_FLOAT_PROPERTY)).isEqualTo(1.0);
@@ -448,7 +448,7 @@ public class KaldbLocalQueryServiceTest {
     KaldbSearch.SearchResult result =
         blockingStub.search(
             KaldbSearch.SearchRequest.newBuilder()
-                .setIndexName(MessageUtil.TEST_INDEX_NAME)
+                .setDataSet(MessageUtil.TEST_DATASET_NAME)
                 .setQueryString("Message1")
                 .setStartTimeEpochMs(chunk1StartTimeMs)
                 .setEndTimeEpochMs(chunk1EndTimeMs)

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbLocalQueryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbLocalQueryServiceTest.java
@@ -93,7 +93,7 @@ public class KaldbLocalQueryServiceTest {
     KaldbSearch.SearchResult response =
         kaldbLocalQueryService.doSearch(
             searchRequestBuilder
-                .setDataSet(MessageUtil.TEST_DATA_SET_NAME)
+                .setDataset(MessageUtil.TEST_DATASET_NAME)
                 .setQueryString("Message100")
                 .setStartTimeEpochMs(chunk1StartTimeMs)
                 .setEndTimeEpochMs(chunk1EndTimeMs)
@@ -116,7 +116,7 @@ public class KaldbLocalQueryServiceTest {
     LogWireMessage hit = JsonUtil.read(hits.get(0).toStringUtf8(), LogWireMessage.class);
     LogMessage m = LogMessage.fromWireMessage(hit);
     assertThat(m.getType()).isEqualTo(MessageUtil.TEST_MESSAGE_TYPE);
-    assertThat(m.getIndex()).isEqualTo(MessageUtil.TEST_DATA_SET_NAME);
+    assertThat(m.getIndex()).isEqualTo(MessageUtil.TEST_DATASET_NAME);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_LONG_PROPERTY)).isEqualTo(100);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_INT_PROPERTY)).isEqualTo(100);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_FLOAT_PROPERTY)).isEqualTo(100.0);
@@ -158,7 +158,7 @@ public class KaldbLocalQueryServiceTest {
     KaldbSearch.SearchResult response =
         kaldbLocalQueryService.doSearch(
             searchRequestBuilder
-                .setDataSet(MessageUtil.TEST_DATA_SET_NAME)
+                .setDataset(MessageUtil.TEST_DATASET_NAME)
                 .setQueryString("blah")
                 .setStartTimeEpochMs(chunk1StartTimeMs)
                 .setEndTimeEpochMs(chunk1EndTimeMs)
@@ -210,7 +210,7 @@ public class KaldbLocalQueryServiceTest {
     KaldbSearch.SearchResult response =
         kaldbLocalQueryService.doSearch(
             searchRequestBuilder
-                .setDataSet(MessageUtil.TEST_DATA_SET_NAME)
+                .setDataset(MessageUtil.TEST_DATASET_NAME)
                 .setQueryString("Message1")
                 .setStartTimeEpochMs(chunk1StartTimeMs)
                 .setEndTimeEpochMs(chunk1EndTimeMs)
@@ -261,7 +261,7 @@ public class KaldbLocalQueryServiceTest {
     KaldbSearch.SearchResult response =
         kaldbLocalQueryService.doSearch(
             searchRequestBuilder
-                .setDataSet(MessageUtil.TEST_DATA_SET_NAME)
+                .setDataset(MessageUtil.TEST_DATASET_NAME)
                 .setQueryString("Message1")
                 .setStartTimeEpochMs(chunk1StartTimeMs)
                 .setEndTimeEpochMs(chunk1EndTimeMs)
@@ -285,7 +285,7 @@ public class KaldbLocalQueryServiceTest {
     LogWireMessage hit = JsonUtil.read(hits.get(0).toStringUtf8(), LogWireMessage.class);
     LogMessage m = LogMessage.fromWireMessage(hit);
     assertThat(m.getType()).isEqualTo(MessageUtil.TEST_MESSAGE_TYPE);
-    assertThat(m.getIndex()).isEqualTo(MessageUtil.TEST_DATA_SET_NAME);
+    assertThat(m.getIndex()).isEqualTo(MessageUtil.TEST_DATASET_NAME);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_LONG_PROPERTY)).isEqualTo(1);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_INT_PROPERTY)).isEqualTo(1);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_FLOAT_PROPERTY)).isEqualTo(1.0);
@@ -317,7 +317,7 @@ public class KaldbLocalQueryServiceTest {
 
     kaldbLocalQueryService.doSearch(
         searchRequestBuilder
-            .setDataSet(MessageUtil.TEST_DATA_SET_NAME)
+            .setDataset(MessageUtil.TEST_DATASET_NAME)
             .setQueryString("Message1")
             .setStartTimeEpochMs(chunk1StartTimeMs)
             .setEndTimeEpochMs(chunk1EndTimeMs)
@@ -366,7 +366,7 @@ public class KaldbLocalQueryServiceTest {
     KaldbSearch.SearchResult response =
         blockingKaldbClient.search(
             KaldbSearch.SearchRequest.newBuilder()
-                .setDataSet(MessageUtil.TEST_DATA_SET_NAME)
+                .setDataset(MessageUtil.TEST_DATASET_NAME)
                 .setQueryString("Message1")
                 .setStartTimeEpochMs(chunk1StartTimeMs)
                 .setEndTimeEpochMs(chunk1EndTimeMs)
@@ -390,7 +390,7 @@ public class KaldbLocalQueryServiceTest {
     LogWireMessage hit = JsonUtil.read(hits.get(0).toStringUtf8(), LogWireMessage.class);
     LogMessage m = LogMessage.fromWireMessage(hit);
     assertThat(m.getType()).isEqualTo(MessageUtil.TEST_MESSAGE_TYPE);
-    assertThat(m.getIndex()).isEqualTo(MessageUtil.TEST_DATA_SET_NAME);
+    assertThat(m.getIndex()).isEqualTo(MessageUtil.TEST_DATASET_NAME);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_LONG_PROPERTY)).isEqualTo(1);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_INT_PROPERTY)).isEqualTo(1);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_FLOAT_PROPERTY)).isEqualTo(1.0);
@@ -448,7 +448,7 @@ public class KaldbLocalQueryServiceTest {
     KaldbSearch.SearchResult result =
         blockingStub.search(
             KaldbSearch.SearchRequest.newBuilder()
-                .setDataSet(MessageUtil.TEST_DATA_SET_NAME)
+                .setDataset(MessageUtil.TEST_DATASET_NAME)
                 .setQueryString("Message1")
                 .setStartTimeEpochMs(chunk1StartTimeMs)
                 .setEndTimeEpochMs(chunk1EndTimeMs)

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbLocalQueryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbLocalQueryServiceTest.java
@@ -93,7 +93,7 @@ public class KaldbLocalQueryServiceTest {
     KaldbSearch.SearchResult response =
         kaldbLocalQueryService.doSearch(
             searchRequestBuilder
-                .setDataSet(MessageUtil.TEST_DATASET_NAME)
+                .setDataSet(MessageUtil.TEST_DATA_SET_NAME)
                 .setQueryString("Message100")
                 .setStartTimeEpochMs(chunk1StartTimeMs)
                 .setEndTimeEpochMs(chunk1EndTimeMs)
@@ -116,7 +116,7 @@ public class KaldbLocalQueryServiceTest {
     LogWireMessage hit = JsonUtil.read(hits.get(0).toStringUtf8(), LogWireMessage.class);
     LogMessage m = LogMessage.fromWireMessage(hit);
     assertThat(m.getType()).isEqualTo(MessageUtil.TEST_MESSAGE_TYPE);
-    assertThat(m.getIndex()).isEqualTo(MessageUtil.TEST_DATASET_NAME);
+    assertThat(m.getIndex()).isEqualTo(MessageUtil.TEST_DATA_SET_NAME);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_LONG_PROPERTY)).isEqualTo(100);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_INT_PROPERTY)).isEqualTo(100);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_FLOAT_PROPERTY)).isEqualTo(100.0);
@@ -158,7 +158,7 @@ public class KaldbLocalQueryServiceTest {
     KaldbSearch.SearchResult response =
         kaldbLocalQueryService.doSearch(
             searchRequestBuilder
-                .setDataSet(MessageUtil.TEST_DATASET_NAME)
+                .setDataSet(MessageUtil.TEST_DATA_SET_NAME)
                 .setQueryString("blah")
                 .setStartTimeEpochMs(chunk1StartTimeMs)
                 .setEndTimeEpochMs(chunk1EndTimeMs)
@@ -210,7 +210,7 @@ public class KaldbLocalQueryServiceTest {
     KaldbSearch.SearchResult response =
         kaldbLocalQueryService.doSearch(
             searchRequestBuilder
-                .setDataSet(MessageUtil.TEST_DATASET_NAME)
+                .setDataSet(MessageUtil.TEST_DATA_SET_NAME)
                 .setQueryString("Message1")
                 .setStartTimeEpochMs(chunk1StartTimeMs)
                 .setEndTimeEpochMs(chunk1EndTimeMs)
@@ -261,7 +261,7 @@ public class KaldbLocalQueryServiceTest {
     KaldbSearch.SearchResult response =
         kaldbLocalQueryService.doSearch(
             searchRequestBuilder
-                .setDataSet(MessageUtil.TEST_DATASET_NAME)
+                .setDataSet(MessageUtil.TEST_DATA_SET_NAME)
                 .setQueryString("Message1")
                 .setStartTimeEpochMs(chunk1StartTimeMs)
                 .setEndTimeEpochMs(chunk1EndTimeMs)
@@ -285,7 +285,7 @@ public class KaldbLocalQueryServiceTest {
     LogWireMessage hit = JsonUtil.read(hits.get(0).toStringUtf8(), LogWireMessage.class);
     LogMessage m = LogMessage.fromWireMessage(hit);
     assertThat(m.getType()).isEqualTo(MessageUtil.TEST_MESSAGE_TYPE);
-    assertThat(m.getIndex()).isEqualTo(MessageUtil.TEST_DATASET_NAME);
+    assertThat(m.getIndex()).isEqualTo(MessageUtil.TEST_DATA_SET_NAME);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_LONG_PROPERTY)).isEqualTo(1);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_INT_PROPERTY)).isEqualTo(1);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_FLOAT_PROPERTY)).isEqualTo(1.0);
@@ -317,7 +317,7 @@ public class KaldbLocalQueryServiceTest {
 
     kaldbLocalQueryService.doSearch(
         searchRequestBuilder
-            .setDataSet(MessageUtil.TEST_DATASET_NAME)
+            .setDataSet(MessageUtil.TEST_DATA_SET_NAME)
             .setQueryString("Message1")
             .setStartTimeEpochMs(chunk1StartTimeMs)
             .setEndTimeEpochMs(chunk1EndTimeMs)
@@ -366,7 +366,7 @@ public class KaldbLocalQueryServiceTest {
     KaldbSearch.SearchResult response =
         blockingKaldbClient.search(
             KaldbSearch.SearchRequest.newBuilder()
-                .setDataSet(MessageUtil.TEST_DATASET_NAME)
+                .setDataSet(MessageUtil.TEST_DATA_SET_NAME)
                 .setQueryString("Message1")
                 .setStartTimeEpochMs(chunk1StartTimeMs)
                 .setEndTimeEpochMs(chunk1EndTimeMs)
@@ -390,7 +390,7 @@ public class KaldbLocalQueryServiceTest {
     LogWireMessage hit = JsonUtil.read(hits.get(0).toStringUtf8(), LogWireMessage.class);
     LogMessage m = LogMessage.fromWireMessage(hit);
     assertThat(m.getType()).isEqualTo(MessageUtil.TEST_MESSAGE_TYPE);
-    assertThat(m.getIndex()).isEqualTo(MessageUtil.TEST_DATASET_NAME);
+    assertThat(m.getIndex()).isEqualTo(MessageUtil.TEST_DATA_SET_NAME);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_LONG_PROPERTY)).isEqualTo(1);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_INT_PROPERTY)).isEqualTo(1);
     assertThat(m.source.get(MessageUtil.TEST_SOURCE_FLOAT_PROPERTY)).isEqualTo(1.0);
@@ -448,7 +448,7 @@ public class KaldbLocalQueryServiceTest {
     KaldbSearch.SearchResult result =
         blockingStub.search(
             KaldbSearch.SearchRequest.newBuilder()
-                .setDataSet(MessageUtil.TEST_DATASET_NAME)
+                .setDataSet(MessageUtil.TEST_DATA_SET_NAME)
                 .setQueryString("Message1")
                 .setStartTimeEpochMs(chunk1StartTimeMs)
                 .setEndTimeEpochMs(chunk1EndTimeMs)

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
@@ -4,7 +4,7 @@ import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.COMMITS_TIMER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_FAILED_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_RECEIVED_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.REFRESHES_TIMER;
-import static com.slack.kaldb.testlib.MessageUtil.TEST_DATASET_NAME;
+import static com.slack.kaldb.testlib.MessageUtil.TEST_DATA_SET_NAME;
 import static com.slack.kaldb.testlib.MessageUtil.makeMessageWithIndexAndTimestamp;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
 import static com.slack.kaldb.testlib.MetricsUtil.getTimerCount;
@@ -41,18 +41,18 @@ public class LogIndexSearcherImplTest {
 
   private void loadTestData(Instant time) {
     strictLogStore.logStore.addMessage(
-        makeMessageWithIndexAndTimestamp(1, "apple", TEST_DATASET_NAME, time));
+        makeMessageWithIndexAndTimestamp(1, "apple", TEST_DATA_SET_NAME, time));
 
     // todo - re-enable when multi-tenancy is supported - slackhq/kaldb/issues/223
     // strictLogStore.logStore.addMessage(
     // makeMessageWithIndexAndTimestamp(2, "baby", "new" + TEST_INDEX_NAME, time.plusSeconds(1)));
     strictLogStore.logStore.addMessage(
-        makeMessageWithIndexAndTimestamp(3, "apple baby", TEST_DATASET_NAME, time.plusSeconds(2)));
+        makeMessageWithIndexAndTimestamp(3, "apple baby", TEST_DATA_SET_NAME, time.plusSeconds(2)));
     strictLogStore.logStore.addMessage(
-        makeMessageWithIndexAndTimestamp(4, "car", TEST_DATASET_NAME, time.plusSeconds(3)));
+        makeMessageWithIndexAndTimestamp(4, "car", TEST_DATA_SET_NAME, time.plusSeconds(3)));
     strictLogStore.logStore.addMessage(
         makeMessageWithIndexAndTimestamp(
-            5, "apple baby car", TEST_DATASET_NAME, time.plusSeconds(4)));
+            5, "apple baby car", TEST_DATA_SET_NAME, time.plusSeconds(4)));
     strictLogStore.logStore.commit();
     strictLogStore.logStore.refresh();
   }
@@ -210,7 +210,7 @@ public class LogIndexSearcherImplTest {
     loadTestData(time);
     SearchResult<LogMessage> babies =
         strictLogStore.logSearcher.search(
-            TEST_DATASET_NAME,
+            TEST_DATA_SET_NAME,
             "baby",
             time.toEpochMilli(),
             time.plusSeconds(2).toEpochMilli(),
@@ -229,7 +229,7 @@ public class LogIndexSearcherImplTest {
 
     SearchResult<LogMessage> apples =
         strictLogStore.logSearcher.search(
-            TEST_DATASET_NAME,
+            TEST_DATA_SET_NAME,
             "apple",
             time.toEpochMilli(),
             time.plusSeconds(100).toEpochMilli(),
@@ -248,15 +248,15 @@ public class LogIndexSearcherImplTest {
     Instant time = Instant.ofEpochSecond(1593365471);
 
     strictLogStore.logStore.addMessage(
-        makeMessageWithIndexAndTimestamp(1, "apple", TEST_DATASET_NAME, time));
+        makeMessageWithIndexAndTimestamp(1, "apple", TEST_DATA_SET_NAME, time));
     strictLogStore.logStore.addMessage(
-        makeMessageWithIndexAndTimestamp(2, "apple baby", TEST_DATASET_NAME, time.plusSeconds(2)));
+        makeMessageWithIndexAndTimestamp(2, "apple baby", TEST_DATA_SET_NAME, time.plusSeconds(2)));
     strictLogStore.logStore.commit();
     strictLogStore.logStore.refresh();
 
     SearchResult<LogMessage> baby =
         strictLogStore.logSearcher.search(
-            TEST_DATASET_NAME,
+            TEST_DATA_SET_NAME,
             "baby",
             time.toEpochMilli(),
             time.plusSeconds(10).toEpochMilli(),
@@ -271,7 +271,7 @@ public class LogIndexSearcherImplTest {
 
     // Add car but don't commit. So, no results for car.
     strictLogStore.logStore.addMessage(
-        makeMessageWithIndexAndTimestamp(3, "car", TEST_DATASET_NAME, time.plusSeconds(3)));
+        makeMessageWithIndexAndTimestamp(3, "car", TEST_DATA_SET_NAME, time.plusSeconds(3)));
 
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(3);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
@@ -280,7 +280,7 @@ public class LogIndexSearcherImplTest {
 
     SearchResult<LogMessage> car =
         strictLogStore.logSearcher.search(
-            TEST_DATASET_NAME,
+            TEST_DATA_SET_NAME,
             "car",
             time.toEpochMilli(),
             time.plusSeconds(10).toEpochMilli(),
@@ -298,7 +298,7 @@ public class LogIndexSearcherImplTest {
 
     SearchResult<LogMessage> carAfterCommit =
         strictLogStore.logSearcher.search(
-            TEST_DATASET_NAME,
+            TEST_DATA_SET_NAME,
             "car",
             time.toEpochMilli(),
             time.plusSeconds(10).toEpochMilli(),
@@ -316,7 +316,7 @@ public class LogIndexSearcherImplTest {
 
     SearchResult<LogMessage> carAfterRefresh =
         strictLogStore.logSearcher.search(
-            TEST_DATASET_NAME,
+            TEST_DATA_SET_NAME,
             "car",
             time.toEpochMilli(),
             time.plusSeconds(10).toEpochMilli(),
@@ -327,7 +327,7 @@ public class LogIndexSearcherImplTest {
     // Add another message to search, refresh but don't commit.
     strictLogStore.logStore.addMessage(
         makeMessageWithIndexAndTimestamp(
-            4, "apple baby car", TEST_DATASET_NAME, time.plusSeconds(4)));
+            4, "apple baby car", TEST_DATA_SET_NAME, time.plusSeconds(4)));
     strictLogStore.logStore.refresh();
 
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(4);
@@ -338,7 +338,7 @@ public class LogIndexSearcherImplTest {
     // Item shows up in search without commit.
     SearchResult<LogMessage> babies =
         strictLogStore.logSearcher.search(
-            TEST_DATASET_NAME,
+            TEST_DATA_SET_NAME,
             "baby",
             time.toEpochMilli(),
             time.plusSeconds(10).toEpochMilli(),
@@ -363,7 +363,7 @@ public class LogIndexSearcherImplTest {
     loadTestData(time);
 
     SearchResult<LogMessage> allIndexItems =
-        strictLogStore.logSearcher.search(TEST_DATASET_NAME, "", 0, MAX_TIME, 1000, 1);
+        strictLogStore.logSearcher.search(TEST_DATA_SET_NAME, "", 0, MAX_TIME, 1000, 1);
 
     assertThat(allIndexItems.hits.size()).isEqualTo(4);
     assertThat(allIndexItems.totalCount).isEqualTo(4);
@@ -376,7 +376,7 @@ public class LogIndexSearcherImplTest {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
 
-    strictLogStore.logSearcher.search(TEST_DATASET_NAME + "miss", null, 0, MAX_TIME, 1000, 1);
+    strictLogStore.logSearcher.search(TEST_DATA_SET_NAME + "miss", null, 0, MAX_TIME, 1000, 1);
   }
 
   @Test
@@ -387,7 +387,7 @@ public class LogIndexSearcherImplTest {
 
     SearchResult<LogMessage> allIndexItems =
         strictLogStore.logSearcher.search(
-            TEST_DATASET_NAME + "miss", "apple", 0, MAX_TIME, 1000, 1);
+            TEST_DATA_SET_NAME + "miss", "apple", 0, MAX_TIME, 1000, 1);
 
     assertThat(allIndexItems.hits.size()).isEqualTo(0);
     assertThat(allIndexItems.totalCount).isEqualTo(0);
@@ -401,7 +401,7 @@ public class LogIndexSearcherImplTest {
     loadTestData(time);
 
     SearchResult<LogMessage> elephants =
-        strictLogStore.logSearcher.search(TEST_DATASET_NAME, "elephant", 0, MAX_TIME, 1000, 1);
+        strictLogStore.logSearcher.search(TEST_DATA_SET_NAME, "elephant", 0, MAX_TIME, 1000, 1);
     assertThat(elephants.hits.size()).isEqualTo(0);
     assertThat(elephants.totalCount).isEqualTo(0);
     assertThat(elephants.buckets.size()).isEqualTo(1);
@@ -414,7 +414,7 @@ public class LogIndexSearcherImplTest {
     loadTestData(time);
     SearchResult<LogMessage> babies =
         strictLogStore.logSearcher.search(
-            TEST_DATASET_NAME,
+            TEST_DATA_SET_NAME,
             "baby",
             time.toEpochMilli(),
             time.plusSeconds(10).toEpochMilli(),
@@ -431,7 +431,7 @@ public class LogIndexSearcherImplTest {
     loadTestData(time);
     SearchResult<LogMessage> babies =
         strictLogStore.logSearcher.search(
-            TEST_DATASET_NAME,
+            TEST_DATA_SET_NAME,
             "baby",
             time.toEpochMilli(),
             time.plusSeconds(10).toEpochMilli(),
@@ -463,14 +463,14 @@ public class LogIndexSearcherImplTest {
   public void testInvalidStartTime() {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
-    strictLogStore.logSearcher.search(TEST_DATASET_NAME, "test", -1L, MAX_TIME, 1000, 1);
+    strictLogStore.logSearcher.search(TEST_DATA_SET_NAME, "test", -1L, MAX_TIME, 1000, 1);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidEndTime() {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
-    strictLogStore.logSearcher.search(TEST_DATASET_NAME, "test", 0, -1L, 1000, 1);
+    strictLogStore.logSearcher.search(TEST_DATA_SET_NAME, "test", 0, -1L, 1000, 1);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -478,7 +478,7 @@ public class LogIndexSearcherImplTest {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
     strictLogStore.logSearcher.search(
-        TEST_DATASET_NAME,
+        TEST_DATA_SET_NAME,
         "test",
         time.toEpochMilli(),
         time.minusSeconds(1).toEpochMilli(),
@@ -491,7 +491,7 @@ public class LogIndexSearcherImplTest {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
     strictLogStore.logSearcher.search(
-        TEST_DATASET_NAME, "test", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), 0, 0);
+        TEST_DATA_SET_NAME, "test", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), 0, 0);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -499,7 +499,7 @@ public class LogIndexSearcherImplTest {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
     strictLogStore.logSearcher.search(
-        TEST_DATASET_NAME, "test", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), -1, 0);
+        TEST_DATA_SET_NAME, "test", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), -1, 0);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -507,7 +507,7 @@ public class LogIndexSearcherImplTest {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
     strictLogStore.logSearcher.search(
-        TEST_DATASET_NAME, "test", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), 1, -2);
+        TEST_DATA_SET_NAME, "test", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), 1, -2);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -515,7 +515,7 @@ public class LogIndexSearcherImplTest {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
     strictLogStore.logSearcher.search(
-        TEST_DATASET_NAME, "/", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), 1, 1);
+        TEST_DATA_SET_NAME, "/", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), 1, 1);
   }
 
   @Test
@@ -533,7 +533,8 @@ public class LogIndexSearcherImplTest {
           for (int i = 0; i < 100; i++) {
             try {
               SearchResult<LogMessage> babies =
-                  strictLogStore.logSearcher.search(TEST_DATASET_NAME, "baby", 0, MAX_TIME, 100, 1);
+                  strictLogStore.logSearcher.search(
+                      TEST_DATA_SET_NAME, "baby", 0, MAX_TIME, 100, 1);
               if (babies.hits.size() != 2) {
                 searchFailures.addAndGet(1);
               } else {

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
@@ -4,7 +4,7 @@ import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.COMMITS_TIMER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_FAILED_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_RECEIVED_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.REFRESHES_TIMER;
-import static com.slack.kaldb.testlib.MessageUtil.TEST_INDEX_NAME;
+import static com.slack.kaldb.testlib.MessageUtil.TEST_DATASET_NAME;
 import static com.slack.kaldb.testlib.MessageUtil.makeMessageWithIndexAndTimestamp;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
 import static com.slack.kaldb.testlib.MetricsUtil.getTimerCount;
@@ -41,18 +41,18 @@ public class LogIndexSearcherImplTest {
 
   private void loadTestData(Instant time) {
     strictLogStore.logStore.addMessage(
-        makeMessageWithIndexAndTimestamp(1, "apple", TEST_INDEX_NAME, time));
+        makeMessageWithIndexAndTimestamp(1, "apple", TEST_DATASET_NAME, time));
 
     // todo - re-enable when multi-tenancy is supported - slackhq/kaldb/issues/223
     // strictLogStore.logStore.addMessage(
     // makeMessageWithIndexAndTimestamp(2, "baby", "new" + TEST_INDEX_NAME, time.plusSeconds(1)));
     strictLogStore.logStore.addMessage(
-        makeMessageWithIndexAndTimestamp(3, "apple baby", TEST_INDEX_NAME, time.plusSeconds(2)));
+        makeMessageWithIndexAndTimestamp(3, "apple baby", TEST_DATASET_NAME, time.plusSeconds(2)));
     strictLogStore.logStore.addMessage(
-        makeMessageWithIndexAndTimestamp(4, "car", TEST_INDEX_NAME, time.plusSeconds(3)));
+        makeMessageWithIndexAndTimestamp(4, "car", TEST_DATASET_NAME, time.plusSeconds(3)));
     strictLogStore.logStore.addMessage(
         makeMessageWithIndexAndTimestamp(
-            5, "apple baby car", TEST_INDEX_NAME, time.plusSeconds(4)));
+            5, "apple baby car", TEST_DATASET_NAME, time.plusSeconds(4)));
     strictLogStore.logStore.commit();
     strictLogStore.logStore.refresh();
   }
@@ -210,7 +210,7 @@ public class LogIndexSearcherImplTest {
     loadTestData(time);
     SearchResult<LogMessage> babies =
         strictLogStore.logSearcher.search(
-            TEST_INDEX_NAME,
+            TEST_DATASET_NAME,
             "baby",
             time.toEpochMilli(),
             time.plusSeconds(2).toEpochMilli(),
@@ -229,7 +229,7 @@ public class LogIndexSearcherImplTest {
 
     SearchResult<LogMessage> apples =
         strictLogStore.logSearcher.search(
-            TEST_INDEX_NAME,
+            TEST_DATASET_NAME,
             "apple",
             time.toEpochMilli(),
             time.plusSeconds(100).toEpochMilli(),
@@ -248,15 +248,15 @@ public class LogIndexSearcherImplTest {
     Instant time = Instant.ofEpochSecond(1593365471);
 
     strictLogStore.logStore.addMessage(
-        makeMessageWithIndexAndTimestamp(1, "apple", TEST_INDEX_NAME, time));
+        makeMessageWithIndexAndTimestamp(1, "apple", TEST_DATASET_NAME, time));
     strictLogStore.logStore.addMessage(
-        makeMessageWithIndexAndTimestamp(2, "apple baby", TEST_INDEX_NAME, time.plusSeconds(2)));
+        makeMessageWithIndexAndTimestamp(2, "apple baby", TEST_DATASET_NAME, time.plusSeconds(2)));
     strictLogStore.logStore.commit();
     strictLogStore.logStore.refresh();
 
     SearchResult<LogMessage> baby =
         strictLogStore.logSearcher.search(
-            TEST_INDEX_NAME,
+            TEST_DATASET_NAME,
             "baby",
             time.toEpochMilli(),
             time.plusSeconds(10).toEpochMilli(),
@@ -271,7 +271,7 @@ public class LogIndexSearcherImplTest {
 
     // Add car but don't commit. So, no results for car.
     strictLogStore.logStore.addMessage(
-        makeMessageWithIndexAndTimestamp(3, "car", TEST_INDEX_NAME, time.plusSeconds(3)));
+        makeMessageWithIndexAndTimestamp(3, "car", TEST_DATASET_NAME, time.plusSeconds(3)));
 
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(3);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
@@ -280,7 +280,12 @@ public class LogIndexSearcherImplTest {
 
     SearchResult<LogMessage> car =
         strictLogStore.logSearcher.search(
-            TEST_INDEX_NAME, "car", time.toEpochMilli(), time.plusSeconds(10).toEpochMilli(), 2, 1);
+            TEST_DATASET_NAME,
+            "car",
+            time.toEpochMilli(),
+            time.plusSeconds(10).toEpochMilli(),
+            2,
+            1);
     assertThat(car.totalCount).isEqualTo(0);
 
     // Commit but no refresh. Item is still not available for search.
@@ -293,7 +298,12 @@ public class LogIndexSearcherImplTest {
 
     SearchResult<LogMessage> carAfterCommit =
         strictLogStore.logSearcher.search(
-            TEST_INDEX_NAME, "car", time.toEpochMilli(), time.plusSeconds(10).toEpochMilli(), 2, 1);
+            TEST_DATASET_NAME,
+            "car",
+            time.toEpochMilli(),
+            time.plusSeconds(10).toEpochMilli(),
+            2,
+            1);
     assertThat(carAfterCommit.totalCount).isEqualTo(0);
 
     // Car can be searched after refresh.
@@ -306,13 +316,18 @@ public class LogIndexSearcherImplTest {
 
     SearchResult<LogMessage> carAfterRefresh =
         strictLogStore.logSearcher.search(
-            TEST_INDEX_NAME, "car", time.toEpochMilli(), time.plusSeconds(10).toEpochMilli(), 2, 1);
+            TEST_DATASET_NAME,
+            "car",
+            time.toEpochMilli(),
+            time.plusSeconds(10).toEpochMilli(),
+            2,
+            1);
     assertThat(carAfterRefresh.totalCount).isEqualTo(1);
 
     // Add another message to search, refresh but don't commit.
     strictLogStore.logStore.addMessage(
         makeMessageWithIndexAndTimestamp(
-            4, "apple baby car", TEST_INDEX_NAME, time.plusSeconds(4)));
+            4, "apple baby car", TEST_DATASET_NAME, time.plusSeconds(4)));
     strictLogStore.logStore.refresh();
 
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(4);
@@ -323,7 +338,7 @@ public class LogIndexSearcherImplTest {
     // Item shows up in search without commit.
     SearchResult<LogMessage> babies =
         strictLogStore.logSearcher.search(
-            TEST_INDEX_NAME,
+            TEST_DATASET_NAME,
             "baby",
             time.toEpochMilli(),
             time.plusSeconds(10).toEpochMilli(),
@@ -348,7 +363,7 @@ public class LogIndexSearcherImplTest {
     loadTestData(time);
 
     SearchResult<LogMessage> allIndexItems =
-        strictLogStore.logSearcher.search(TEST_INDEX_NAME, "", 0, MAX_TIME, 1000, 1);
+        strictLogStore.logSearcher.search(TEST_DATASET_NAME, "", 0, MAX_TIME, 1000, 1);
 
     assertThat(allIndexItems.hits.size()).isEqualTo(4);
     assertThat(allIndexItems.totalCount).isEqualTo(4);
@@ -361,7 +376,7 @@ public class LogIndexSearcherImplTest {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
 
-    strictLogStore.logSearcher.search(TEST_INDEX_NAME + "miss", null, 0, MAX_TIME, 1000, 1);
+    strictLogStore.logSearcher.search(TEST_DATASET_NAME + "miss", null, 0, MAX_TIME, 1000, 1);
   }
 
   @Test
@@ -371,7 +386,8 @@ public class LogIndexSearcherImplTest {
     loadTestData(time);
 
     SearchResult<LogMessage> allIndexItems =
-        strictLogStore.logSearcher.search(TEST_INDEX_NAME + "miss", "apple", 0, MAX_TIME, 1000, 1);
+        strictLogStore.logSearcher.search(
+            TEST_DATASET_NAME + "miss", "apple", 0, MAX_TIME, 1000, 1);
 
     assertThat(allIndexItems.hits.size()).isEqualTo(0);
     assertThat(allIndexItems.totalCount).isEqualTo(0);
@@ -385,7 +401,7 @@ public class LogIndexSearcherImplTest {
     loadTestData(time);
 
     SearchResult<LogMessage> elephants =
-        strictLogStore.logSearcher.search(TEST_INDEX_NAME, "elephant", 0, MAX_TIME, 1000, 1);
+        strictLogStore.logSearcher.search(TEST_DATASET_NAME, "elephant", 0, MAX_TIME, 1000, 1);
     assertThat(elephants.hits.size()).isEqualTo(0);
     assertThat(elephants.totalCount).isEqualTo(0);
     assertThat(elephants.buckets.size()).isEqualTo(1);
@@ -398,7 +414,7 @@ public class LogIndexSearcherImplTest {
     loadTestData(time);
     SearchResult<LogMessage> babies =
         strictLogStore.logSearcher.search(
-            TEST_INDEX_NAME,
+            TEST_DATASET_NAME,
             "baby",
             time.toEpochMilli(),
             time.plusSeconds(10).toEpochMilli(),
@@ -415,7 +431,7 @@ public class LogIndexSearcherImplTest {
     loadTestData(time);
     SearchResult<LogMessage> babies =
         strictLogStore.logSearcher.search(
-            TEST_INDEX_NAME,
+            TEST_DATASET_NAME,
             "baby",
             time.toEpochMilli(),
             time.plusSeconds(10).toEpochMilli(),
@@ -447,14 +463,14 @@ public class LogIndexSearcherImplTest {
   public void testInvalidStartTime() {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
-    strictLogStore.logSearcher.search(TEST_INDEX_NAME, "test", -1L, MAX_TIME, 1000, 1);
+    strictLogStore.logSearcher.search(TEST_DATASET_NAME, "test", -1L, MAX_TIME, 1000, 1);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidEndTime() {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
-    strictLogStore.logSearcher.search(TEST_INDEX_NAME, "test", 0, -1L, 1000, 1);
+    strictLogStore.logSearcher.search(TEST_DATASET_NAME, "test", 0, -1L, 1000, 1);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -462,7 +478,12 @@ public class LogIndexSearcherImplTest {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
     strictLogStore.logSearcher.search(
-        TEST_INDEX_NAME, "test", time.toEpochMilli(), time.minusSeconds(1).toEpochMilli(), 1000, 1);
+        TEST_DATASET_NAME,
+        "test",
+        time.toEpochMilli(),
+        time.minusSeconds(1).toEpochMilli(),
+        1000,
+        1);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -470,7 +491,7 @@ public class LogIndexSearcherImplTest {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
     strictLogStore.logSearcher.search(
-        TEST_INDEX_NAME, "test", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), 0, 0);
+        TEST_DATASET_NAME, "test", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), 0, 0);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -478,7 +499,7 @@ public class LogIndexSearcherImplTest {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
     strictLogStore.logSearcher.search(
-        TEST_INDEX_NAME, "test", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), -1, 0);
+        TEST_DATASET_NAME, "test", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), -1, 0);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -486,7 +507,7 @@ public class LogIndexSearcherImplTest {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
     strictLogStore.logSearcher.search(
-        TEST_INDEX_NAME, "test", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), 1, -2);
+        TEST_DATASET_NAME, "test", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), 1, -2);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -494,7 +515,7 @@ public class LogIndexSearcherImplTest {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
     strictLogStore.logSearcher.search(
-        TEST_INDEX_NAME, "/", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), 1, 1);
+        TEST_DATASET_NAME, "/", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), 1, 1);
   }
 
   @Test
@@ -512,7 +533,7 @@ public class LogIndexSearcherImplTest {
           for (int i = 0; i < 100; i++) {
             try {
               SearchResult<LogMessage> babies =
-                  strictLogStore.logSearcher.search(TEST_INDEX_NAME, "baby", 0, MAX_TIME, 100, 1);
+                  strictLogStore.logSearcher.search(TEST_DATASET_NAME, "baby", 0, MAX_TIME, 100, 1);
               if (babies.hits.size() != 2) {
                 searchFailures.addAndGet(1);
               } else {

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
@@ -4,7 +4,7 @@ import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.COMMITS_TIMER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_FAILED_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_RECEIVED_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.REFRESHES_TIMER;
-import static com.slack.kaldb.testlib.MessageUtil.TEST_DATA_SET_NAME;
+import static com.slack.kaldb.testlib.MessageUtil.TEST_DATASET_NAME;
 import static com.slack.kaldb.testlib.MessageUtil.makeMessageWithIndexAndTimestamp;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
 import static com.slack.kaldb.testlib.MetricsUtil.getTimerCount;
@@ -41,18 +41,18 @@ public class LogIndexSearcherImplTest {
 
   private void loadTestData(Instant time) {
     strictLogStore.logStore.addMessage(
-        makeMessageWithIndexAndTimestamp(1, "apple", TEST_DATA_SET_NAME, time));
+        makeMessageWithIndexAndTimestamp(1, "apple", TEST_DATASET_NAME, time));
 
     // todo - re-enable when multi-tenancy is supported - slackhq/kaldb/issues/223
     // strictLogStore.logStore.addMessage(
     // makeMessageWithIndexAndTimestamp(2, "baby", "new" + TEST_INDEX_NAME, time.plusSeconds(1)));
     strictLogStore.logStore.addMessage(
-        makeMessageWithIndexAndTimestamp(3, "apple baby", TEST_DATA_SET_NAME, time.plusSeconds(2)));
+        makeMessageWithIndexAndTimestamp(3, "apple baby", TEST_DATASET_NAME, time.plusSeconds(2)));
     strictLogStore.logStore.addMessage(
-        makeMessageWithIndexAndTimestamp(4, "car", TEST_DATA_SET_NAME, time.plusSeconds(3)));
+        makeMessageWithIndexAndTimestamp(4, "car", TEST_DATASET_NAME, time.plusSeconds(3)));
     strictLogStore.logStore.addMessage(
         makeMessageWithIndexAndTimestamp(
-            5, "apple baby car", TEST_DATA_SET_NAME, time.plusSeconds(4)));
+            5, "apple baby car", TEST_DATASET_NAME, time.plusSeconds(4)));
     strictLogStore.logStore.commit();
     strictLogStore.logStore.refresh();
   }
@@ -210,7 +210,7 @@ public class LogIndexSearcherImplTest {
     loadTestData(time);
     SearchResult<LogMessage> babies =
         strictLogStore.logSearcher.search(
-            TEST_DATA_SET_NAME,
+            TEST_DATASET_NAME,
             "baby",
             time.toEpochMilli(),
             time.plusSeconds(2).toEpochMilli(),
@@ -229,7 +229,7 @@ public class LogIndexSearcherImplTest {
 
     SearchResult<LogMessage> apples =
         strictLogStore.logSearcher.search(
-            TEST_DATA_SET_NAME,
+            TEST_DATASET_NAME,
             "apple",
             time.toEpochMilli(),
             time.plusSeconds(100).toEpochMilli(),
@@ -248,15 +248,15 @@ public class LogIndexSearcherImplTest {
     Instant time = Instant.ofEpochSecond(1593365471);
 
     strictLogStore.logStore.addMessage(
-        makeMessageWithIndexAndTimestamp(1, "apple", TEST_DATA_SET_NAME, time));
+        makeMessageWithIndexAndTimestamp(1, "apple", TEST_DATASET_NAME, time));
     strictLogStore.logStore.addMessage(
-        makeMessageWithIndexAndTimestamp(2, "apple baby", TEST_DATA_SET_NAME, time.plusSeconds(2)));
+        makeMessageWithIndexAndTimestamp(2, "apple baby", TEST_DATASET_NAME, time.plusSeconds(2)));
     strictLogStore.logStore.commit();
     strictLogStore.logStore.refresh();
 
     SearchResult<LogMessage> baby =
         strictLogStore.logSearcher.search(
-            TEST_DATA_SET_NAME,
+            TEST_DATASET_NAME,
             "baby",
             time.toEpochMilli(),
             time.plusSeconds(10).toEpochMilli(),
@@ -271,7 +271,7 @@ public class LogIndexSearcherImplTest {
 
     // Add car but don't commit. So, no results for car.
     strictLogStore.logStore.addMessage(
-        makeMessageWithIndexAndTimestamp(3, "car", TEST_DATA_SET_NAME, time.plusSeconds(3)));
+        makeMessageWithIndexAndTimestamp(3, "car", TEST_DATASET_NAME, time.plusSeconds(3)));
 
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(3);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(0);
@@ -280,7 +280,7 @@ public class LogIndexSearcherImplTest {
 
     SearchResult<LogMessage> car =
         strictLogStore.logSearcher.search(
-            TEST_DATA_SET_NAME,
+            TEST_DATASET_NAME,
             "car",
             time.toEpochMilli(),
             time.plusSeconds(10).toEpochMilli(),
@@ -298,7 +298,7 @@ public class LogIndexSearcherImplTest {
 
     SearchResult<LogMessage> carAfterCommit =
         strictLogStore.logSearcher.search(
-            TEST_DATA_SET_NAME,
+            TEST_DATASET_NAME,
             "car",
             time.toEpochMilli(),
             time.plusSeconds(10).toEpochMilli(),
@@ -316,7 +316,7 @@ public class LogIndexSearcherImplTest {
 
     SearchResult<LogMessage> carAfterRefresh =
         strictLogStore.logSearcher.search(
-            TEST_DATA_SET_NAME,
+            TEST_DATASET_NAME,
             "car",
             time.toEpochMilli(),
             time.plusSeconds(10).toEpochMilli(),
@@ -327,7 +327,7 @@ public class LogIndexSearcherImplTest {
     // Add another message to search, refresh but don't commit.
     strictLogStore.logStore.addMessage(
         makeMessageWithIndexAndTimestamp(
-            4, "apple baby car", TEST_DATA_SET_NAME, time.plusSeconds(4)));
+            4, "apple baby car", TEST_DATASET_NAME, time.plusSeconds(4)));
     strictLogStore.logStore.refresh();
 
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, strictLogStore.metricsRegistry)).isEqualTo(4);
@@ -338,7 +338,7 @@ public class LogIndexSearcherImplTest {
     // Item shows up in search without commit.
     SearchResult<LogMessage> babies =
         strictLogStore.logSearcher.search(
-            TEST_DATA_SET_NAME,
+            TEST_DATASET_NAME,
             "baby",
             time.toEpochMilli(),
             time.plusSeconds(10).toEpochMilli(),
@@ -363,7 +363,7 @@ public class LogIndexSearcherImplTest {
     loadTestData(time);
 
     SearchResult<LogMessage> allIndexItems =
-        strictLogStore.logSearcher.search(TEST_DATA_SET_NAME, "", 0, MAX_TIME, 1000, 1);
+        strictLogStore.logSearcher.search(TEST_DATASET_NAME, "", 0, MAX_TIME, 1000, 1);
 
     assertThat(allIndexItems.hits.size()).isEqualTo(4);
     assertThat(allIndexItems.totalCount).isEqualTo(4);
@@ -376,7 +376,7 @@ public class LogIndexSearcherImplTest {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
 
-    strictLogStore.logSearcher.search(TEST_DATA_SET_NAME + "miss", null, 0, MAX_TIME, 1000, 1);
+    strictLogStore.logSearcher.search(TEST_DATASET_NAME + "miss", null, 0, MAX_TIME, 1000, 1);
   }
 
   @Test
@@ -387,7 +387,7 @@ public class LogIndexSearcherImplTest {
 
     SearchResult<LogMessage> allIndexItems =
         strictLogStore.logSearcher.search(
-            TEST_DATA_SET_NAME + "miss", "apple", 0, MAX_TIME, 1000, 1);
+            TEST_DATASET_NAME + "miss", "apple", 0, MAX_TIME, 1000, 1);
 
     assertThat(allIndexItems.hits.size()).isEqualTo(0);
     assertThat(allIndexItems.totalCount).isEqualTo(0);
@@ -401,7 +401,7 @@ public class LogIndexSearcherImplTest {
     loadTestData(time);
 
     SearchResult<LogMessage> elephants =
-        strictLogStore.logSearcher.search(TEST_DATA_SET_NAME, "elephant", 0, MAX_TIME, 1000, 1);
+        strictLogStore.logSearcher.search(TEST_DATASET_NAME, "elephant", 0, MAX_TIME, 1000, 1);
     assertThat(elephants.hits.size()).isEqualTo(0);
     assertThat(elephants.totalCount).isEqualTo(0);
     assertThat(elephants.buckets.size()).isEqualTo(1);
@@ -414,7 +414,7 @@ public class LogIndexSearcherImplTest {
     loadTestData(time);
     SearchResult<LogMessage> babies =
         strictLogStore.logSearcher.search(
-            TEST_DATA_SET_NAME,
+            TEST_DATASET_NAME,
             "baby",
             time.toEpochMilli(),
             time.plusSeconds(10).toEpochMilli(),
@@ -431,7 +431,7 @@ public class LogIndexSearcherImplTest {
     loadTestData(time);
     SearchResult<LogMessage> babies =
         strictLogStore.logSearcher.search(
-            TEST_DATA_SET_NAME,
+            TEST_DATASET_NAME,
             "baby",
             time.toEpochMilli(),
             time.plusSeconds(10).toEpochMilli(),
@@ -463,14 +463,14 @@ public class LogIndexSearcherImplTest {
   public void testInvalidStartTime() {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
-    strictLogStore.logSearcher.search(TEST_DATA_SET_NAME, "test", -1L, MAX_TIME, 1000, 1);
+    strictLogStore.logSearcher.search(TEST_DATASET_NAME, "test", -1L, MAX_TIME, 1000, 1);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidEndTime() {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
-    strictLogStore.logSearcher.search(TEST_DATA_SET_NAME, "test", 0, -1L, 1000, 1);
+    strictLogStore.logSearcher.search(TEST_DATASET_NAME, "test", 0, -1L, 1000, 1);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -478,7 +478,7 @@ public class LogIndexSearcherImplTest {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
     strictLogStore.logSearcher.search(
-        TEST_DATA_SET_NAME,
+        TEST_DATASET_NAME,
         "test",
         time.toEpochMilli(),
         time.minusSeconds(1).toEpochMilli(),
@@ -491,7 +491,7 @@ public class LogIndexSearcherImplTest {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
     strictLogStore.logSearcher.search(
-        TEST_DATA_SET_NAME, "test", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), 0, 0);
+        TEST_DATASET_NAME, "test", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), 0, 0);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -499,7 +499,7 @@ public class LogIndexSearcherImplTest {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
     strictLogStore.logSearcher.search(
-        TEST_DATA_SET_NAME, "test", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), -1, 0);
+        TEST_DATASET_NAME, "test", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), -1, 0);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -507,7 +507,7 @@ public class LogIndexSearcherImplTest {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
     strictLogStore.logSearcher.search(
-        TEST_DATA_SET_NAME, "test", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), 1, -2);
+        TEST_DATASET_NAME, "test", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), 1, -2);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -515,7 +515,7 @@ public class LogIndexSearcherImplTest {
     Instant time = Instant.ofEpochSecond(1593365471);
     loadTestData(time);
     strictLogStore.logSearcher.search(
-        TEST_DATA_SET_NAME, "/", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), 1, 1);
+        TEST_DATASET_NAME, "/", time.toEpochMilli(), time.plusSeconds(1).toEpochMilli(), 1, 1);
   }
 
   @Test
@@ -533,8 +533,7 @@ public class LogIndexSearcherImplTest {
           for (int i = 0; i < 100; i++) {
             try {
               SearchResult<LogMessage> babies =
-                  strictLogStore.logSearcher.search(
-                      TEST_DATA_SET_NAME, "baby", 0, MAX_TIME, 100, 1);
+                  strictLogStore.logSearcher.search(TEST_DATASET_NAME, "baby", 0, MAX_TIME, 100, 1);
               if (babies.hits.size() != 2) {
                 searchFailures.addAndGet(1);
               } else {

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImplTest.java
@@ -70,7 +70,7 @@ public class SearchResultAggregatorImplTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "Message1",
             histogramStartMs,
             histogramEndMs,
@@ -125,7 +125,7 @@ public class SearchResultAggregatorImplTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "Message1",
             histogramStartMs,
             histogramEndMs,
@@ -191,7 +191,7 @@ public class SearchResultAggregatorImplTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "Message1",
             histogramStartMs,
             histogramEndMs,
@@ -240,7 +240,7 @@ public class SearchResultAggregatorImplTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "Message1",
             searchStartMs,
             searchEndMs,
@@ -293,7 +293,7 @@ public class SearchResultAggregatorImplTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "Message1",
             histogramStartMs,
             histogramEndMs,
@@ -341,7 +341,7 @@ public class SearchResultAggregatorImplTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "Message1",
             startTimeMs,
             endTimeMs,
@@ -394,7 +394,7 @@ public class SearchResultAggregatorImplTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_DATA_SET_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "Message1",
             histogramStartMs,
             histogramEndMs,

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImplTest.java
@@ -70,7 +70,7 @@ public class SearchResultAggregatorImplTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_INDEX_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "Message1",
             histogramStartMs,
             histogramEndMs,
@@ -125,7 +125,7 @@ public class SearchResultAggregatorImplTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_INDEX_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "Message1",
             histogramStartMs,
             histogramEndMs,
@@ -191,7 +191,7 @@ public class SearchResultAggregatorImplTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_INDEX_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "Message1",
             histogramStartMs,
             histogramEndMs,
@@ -240,7 +240,7 @@ public class SearchResultAggregatorImplTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_INDEX_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "Message1",
             searchStartMs,
             searchEndMs,
@@ -293,7 +293,7 @@ public class SearchResultAggregatorImplTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_INDEX_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "Message1",
             histogramStartMs,
             histogramEndMs,
@@ -341,7 +341,12 @@ public class SearchResultAggregatorImplTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_INDEX_NAME, "Message1", startTimeMs, endTimeMs, howMany, bucketCount);
+            MessageUtil.TEST_DATASET_NAME,
+            "Message1",
+            startTimeMs,
+            endTimeMs,
+            howMany,
+            bucketCount);
     List<SearchResult<LogMessage>> searchResults = new ArrayList<>(2);
     searchResults.add(searchResult1);
     searchResults.add(searchResult2);
@@ -389,7 +394,7 @@ public class SearchResultAggregatorImplTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_INDEX_NAME,
+            MessageUtil.TEST_DATASET_NAME,
             "Message1",
             histogramStartMs,
             histogramEndMs,

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImplTest.java
@@ -70,7 +70,7 @@ public class SearchResultAggregatorImplTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             "Message1",
             histogramStartMs,
             histogramEndMs,
@@ -125,7 +125,7 @@ public class SearchResultAggregatorImplTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             "Message1",
             histogramStartMs,
             histogramEndMs,
@@ -191,7 +191,7 @@ public class SearchResultAggregatorImplTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             "Message1",
             histogramStartMs,
             histogramEndMs,
@@ -240,7 +240,7 @@ public class SearchResultAggregatorImplTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             "Message1",
             searchStartMs,
             searchEndMs,
@@ -293,7 +293,7 @@ public class SearchResultAggregatorImplTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             "Message1",
             histogramStartMs,
             histogramEndMs,
@@ -341,7 +341,7 @@ public class SearchResultAggregatorImplTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             "Message1",
             startTimeMs,
             endTimeMs,
@@ -394,7 +394,7 @@ public class SearchResultAggregatorImplTest {
 
     SearchQuery searchQuery =
         new SearchQuery(
-            MessageUtil.TEST_DATASET_NAME,
+            MessageUtil.TEST_DATA_SET_NAME,
             "Message1",
             histogramStartMs,
             histogramEndMs,

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/StatsCollectorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/StatsCollectorTest.java
@@ -4,7 +4,7 @@ import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.COMMITS_TIMER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_FAILED_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_RECEIVED_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.REFRESHES_TIMER;
-import static com.slack.kaldb.testlib.MessageUtil.TEST_INDEX_NAME;
+import static com.slack.kaldb.testlib.MessageUtil.TEST_DATASET_NAME;
 import static com.slack.kaldb.testlib.MessageUtil.makeMessageWithIndexAndTimestamp;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
 import static com.slack.kaldb.testlib.MetricsUtil.getTimerCount;
@@ -28,17 +28,17 @@ public class StatsCollectorTest {
   @Test
   public void testStatsCollectorWithPerMinuteMessages() {
     Instant time = Instant.ofEpochSecond(1593365471);
-    LogMessage m1 = makeMessageWithIndexAndTimestamp(1, "apple", TEST_INDEX_NAME, time);
+    LogMessage m1 = makeMessageWithIndexAndTimestamp(1, "apple", TEST_DATASET_NAME, time);
     LogMessage m2 =
-        makeMessageWithIndexAndTimestamp(2, "baby", TEST_INDEX_NAME, time.plusSeconds(60));
+        makeMessageWithIndexAndTimestamp(2, "baby", TEST_DATASET_NAME, time.plusSeconds(60));
     LogMessage m3 =
         makeMessageWithIndexAndTimestamp(
-            3, "apple baby", TEST_INDEX_NAME, time.plusSeconds(2 * 60));
+            3, "apple baby", TEST_DATASET_NAME, time.plusSeconds(2 * 60));
     LogMessage m4 =
-        makeMessageWithIndexAndTimestamp(4, "car", TEST_INDEX_NAME, time.plusSeconds(3 * 60));
+        makeMessageWithIndexAndTimestamp(4, "car", TEST_DATASET_NAME, time.plusSeconds(3 * 60));
     LogMessage m5 =
         makeMessageWithIndexAndTimestamp(
-            5, "apple baby car", TEST_INDEX_NAME, time.plusSeconds(4 * 60));
+            5, "apple baby car", TEST_DATASET_NAME, time.plusSeconds(4 * 60));
     strictLogStore.logStore.addMessage(m1);
     strictLogStore.logStore.addMessage(m2);
     strictLogStore.logStore.addMessage(m3);
@@ -49,7 +49,7 @@ public class StatsCollectorTest {
 
     SearchResult<LogMessage> allIndexItems =
         strictLogStore.logSearcher.search(
-            TEST_INDEX_NAME,
+            TEST_DATASET_NAME,
             "",
             time.toEpochMilli(),
             time.plusSeconds(4 * 60).toEpochMilli(),

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/StatsCollectorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/StatsCollectorTest.java
@@ -4,7 +4,7 @@ import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.COMMITS_TIMER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_FAILED_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_RECEIVED_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.REFRESHES_TIMER;
-import static com.slack.kaldb.testlib.MessageUtil.TEST_DATASET_NAME;
+import static com.slack.kaldb.testlib.MessageUtil.TEST_DATA_SET_NAME;
 import static com.slack.kaldb.testlib.MessageUtil.makeMessageWithIndexAndTimestamp;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
 import static com.slack.kaldb.testlib.MetricsUtil.getTimerCount;
@@ -28,17 +28,17 @@ public class StatsCollectorTest {
   @Test
   public void testStatsCollectorWithPerMinuteMessages() {
     Instant time = Instant.ofEpochSecond(1593365471);
-    LogMessage m1 = makeMessageWithIndexAndTimestamp(1, "apple", TEST_DATASET_NAME, time);
+    LogMessage m1 = makeMessageWithIndexAndTimestamp(1, "apple", TEST_DATA_SET_NAME, time);
     LogMessage m2 =
-        makeMessageWithIndexAndTimestamp(2, "baby", TEST_DATASET_NAME, time.plusSeconds(60));
+        makeMessageWithIndexAndTimestamp(2, "baby", TEST_DATA_SET_NAME, time.plusSeconds(60));
     LogMessage m3 =
         makeMessageWithIndexAndTimestamp(
-            3, "apple baby", TEST_DATASET_NAME, time.plusSeconds(2 * 60));
+            3, "apple baby", TEST_DATA_SET_NAME, time.plusSeconds(2 * 60));
     LogMessage m4 =
-        makeMessageWithIndexAndTimestamp(4, "car", TEST_DATASET_NAME, time.plusSeconds(3 * 60));
+        makeMessageWithIndexAndTimestamp(4, "car", TEST_DATA_SET_NAME, time.plusSeconds(3 * 60));
     LogMessage m5 =
         makeMessageWithIndexAndTimestamp(
-            5, "apple baby car", TEST_DATASET_NAME, time.plusSeconds(4 * 60));
+            5, "apple baby car", TEST_DATA_SET_NAME, time.plusSeconds(4 * 60));
     strictLogStore.logStore.addMessage(m1);
     strictLogStore.logStore.addMessage(m2);
     strictLogStore.logStore.addMessage(m3);
@@ -49,7 +49,7 @@ public class StatsCollectorTest {
 
     SearchResult<LogMessage> allIndexItems =
         strictLogStore.logSearcher.search(
-            TEST_DATASET_NAME,
+            TEST_DATA_SET_NAME,
             "",
             time.toEpochMilli(),
             time.plusSeconds(4 * 60).toEpochMilli(),

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/StatsCollectorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/StatsCollectorTest.java
@@ -4,7 +4,7 @@ import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.COMMITS_TIMER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_FAILED_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_RECEIVED_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.REFRESHES_TIMER;
-import static com.slack.kaldb.testlib.MessageUtil.TEST_DATA_SET_NAME;
+import static com.slack.kaldb.testlib.MessageUtil.TEST_DATASET_NAME;
 import static com.slack.kaldb.testlib.MessageUtil.makeMessageWithIndexAndTimestamp;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
 import static com.slack.kaldb.testlib.MetricsUtil.getTimerCount;
@@ -28,17 +28,17 @@ public class StatsCollectorTest {
   @Test
   public void testStatsCollectorWithPerMinuteMessages() {
     Instant time = Instant.ofEpochSecond(1593365471);
-    LogMessage m1 = makeMessageWithIndexAndTimestamp(1, "apple", TEST_DATA_SET_NAME, time);
+    LogMessage m1 = makeMessageWithIndexAndTimestamp(1, "apple", TEST_DATASET_NAME, time);
     LogMessage m2 =
-        makeMessageWithIndexAndTimestamp(2, "baby", TEST_DATA_SET_NAME, time.plusSeconds(60));
+        makeMessageWithIndexAndTimestamp(2, "baby", TEST_DATASET_NAME, time.plusSeconds(60));
     LogMessage m3 =
         makeMessageWithIndexAndTimestamp(
-            3, "apple baby", TEST_DATA_SET_NAME, time.plusSeconds(2 * 60));
+            3, "apple baby", TEST_DATASET_NAME, time.plusSeconds(2 * 60));
     LogMessage m4 =
-        makeMessageWithIndexAndTimestamp(4, "car", TEST_DATA_SET_NAME, time.plusSeconds(3 * 60));
+        makeMessageWithIndexAndTimestamp(4, "car", TEST_DATASET_NAME, time.plusSeconds(3 * 60));
     LogMessage m5 =
         makeMessageWithIndexAndTimestamp(
-            5, "apple baby car", TEST_DATA_SET_NAME, time.plusSeconds(4 * 60));
+            5, "apple baby car", TEST_DATASET_NAME, time.plusSeconds(4 * 60));
     strictLogStore.logStore.addMessage(m1);
     strictLogStore.logStore.addMessage(m2);
     strictLogStore.logStore.addMessage(m3);
@@ -49,7 +49,7 @@ public class StatsCollectorTest {
 
     SearchResult<LogMessage> allIndexItems =
         strictLogStore.logSearcher.search(
-            TEST_DATA_SET_NAME,
+            TEST_DATASET_NAME,
             "",
             time.toEpochMilli(),
             time.plusSeconds(4 * 60).toEpochMilli(),

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
@@ -75,7 +75,7 @@ public class KaldbTest {
 
     return kaldbService.search(
         KaldbSearch.SearchRequest.newBuilder()
-            .setDataSet(MessageUtil.TEST_DATASET_NAME)
+            .setDataSet(MessageUtil.TEST_DATA_SET_NAME)
             .setQueryString(queryString)
             .setStartTimeEpochMs(startTime)
             .setEndTimeEpochMs(endTime)
@@ -147,7 +147,7 @@ public class KaldbTest {
         new ServicePartitionMetadata(1, Long.MAX_VALUE, List.of("0", "1"));
     final List<ServicePartitionMetadata> partitionConfigs = Collections.singletonList(partition);
     ServiceMetadata serviceMetadata =
-        new ServiceMetadata(MessageUtil.TEST_DATASET_NAME, "serviceOwner", 1000, partitionConfigs);
+        new ServiceMetadata(MessageUtil.TEST_DATA_SET_NAME, "serviceOwner", 1000, partitionConfigs);
     serviceMetadataStore.createSync(serviceMetadata);
     await().until(() -> serviceMetadataStore.listSync().size() == 1);
   }

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
@@ -75,7 +75,7 @@ public class KaldbTest {
 
     return kaldbService.search(
         KaldbSearch.SearchRequest.newBuilder()
-            .setDataSet(MessageUtil.TEST_DATA_SET_NAME)
+            .setDataset(MessageUtil.TEST_DATASET_NAME)
             .setQueryString(queryString)
             .setStartTimeEpochMs(startTime)
             .setEndTimeEpochMs(endTime)
@@ -147,7 +147,7 @@ public class KaldbTest {
         new ServicePartitionMetadata(1, Long.MAX_VALUE, List.of("0", "1"));
     final List<ServicePartitionMetadata> partitionConfigs = Collections.singletonList(partition);
     ServiceMetadata serviceMetadata =
-        new ServiceMetadata(MessageUtil.TEST_DATA_SET_NAME, "serviceOwner", 1000, partitionConfigs);
+        new ServiceMetadata(MessageUtil.TEST_DATASET_NAME, "serviceOwner", 1000, partitionConfigs);
     serviceMetadataStore.createSync(serviceMetadata);
     await().until(() -> serviceMetadataStore.listSync().size() == 1);
   }

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
@@ -75,7 +75,7 @@ public class KaldbTest {
 
     return kaldbService.search(
         KaldbSearch.SearchRequest.newBuilder()
-            .setIndexName(MessageUtil.TEST_INDEX_NAME)
+            .setDataSet(MessageUtil.TEST_DATASET_NAME)
             .setQueryString(queryString)
             .setStartTimeEpochMs(startTime)
             .setEndTimeEpochMs(endTime)
@@ -147,7 +147,7 @@ public class KaldbTest {
         new ServicePartitionMetadata(1, Long.MAX_VALUE, List.of("0", "1"));
     final List<ServicePartitionMetadata> partitionConfigs = Collections.singletonList(partition);
     ServiceMetadata serviceMetadata =
-        new ServiceMetadata(MessageUtil.TEST_INDEX_NAME, "serviceOwner", 1000, partitionConfigs);
+        new ServiceMetadata(MessageUtil.TEST_DATASET_NAME, "serviceOwner", 1000, partitionConfigs);
     serviceMetadataStore.createSync(serviceMetadata);
     await().until(() -> serviceMetadataStore.listSync().size() == 1);
   }

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/MessageUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/MessageUtil.java
@@ -18,7 +18,7 @@ public class MessageUtil {
   // TODO: Add Timer
 
   public static final String DEFAULT_MESSAGE_PREFIX = "Message";
-  public static final String TEST_DATA_SET_NAME = "testDataSet";
+  public static final String TEST_DATASET_NAME = "testDataSet";
   public static final String TEST_MESSAGE_TYPE = "INFO";
   public static final String TEST_SOURCE_INT_PROPERTY = "intproperty";
   public static final String TEST_SOURCE_LONG_PROPERTY = "longproperty";
@@ -42,7 +42,7 @@ public class MessageUtil {
     String id = DEFAULT_MESSAGE_PREFIX + i;
     Map<String, Object> fieldMap = new HashMap<>();
     fieldMap.put("type", TEST_MESSAGE_TYPE);
-    fieldMap.put("index", TEST_DATA_SET_NAME);
+    fieldMap.put("index", TEST_DATASET_NAME);
     fieldMap.put("id", id);
 
     Map<String, Object> sourceFieldMap = new HashMap<>();
@@ -68,7 +68,7 @@ public class MessageUtil {
     fieldMap.put(TEST_SOURCE_LONG_PROPERTY, (long) i);
     fieldMap.put(TEST_SOURCE_DOUBLE_PROPERTY, (double) i);
     fieldMap.put(TEST_SOURCE_FLOAT_PROPERTY, (float) i);
-    return new LogWireMessage(TEST_DATA_SET_NAME, TEST_MESSAGE_TYPE, id, fieldMap);
+    return new LogWireMessage(TEST_DATASET_NAME, TEST_MESSAGE_TYPE, id, fieldMap);
   }
 
   public static LogMessage makeMessageWithIndexAndTimestamp(
@@ -103,7 +103,7 @@ public class MessageUtil {
   }
 
   public static String makeSerializedBadMessage(int i) {
-    LogWireMessage msg = new LogWireMessage(TEST_DATA_SET_NAME, null, "Message" + i, null);
+    LogWireMessage msg = new LogWireMessage(TEST_DATASET_NAME, null, "Message" + i, null);
     try {
       return JsonUtil.writeAsString(msg);
     } catch (JsonProcessingException e) {

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/MessageUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/MessageUtil.java
@@ -18,7 +18,7 @@ public class MessageUtil {
   // TODO: Add Timer
 
   public static final String DEFAULT_MESSAGE_PREFIX = "Message";
-  public static final String TEST_INDEX_NAME = "testindex";
+  public static final String TEST_DATASET_NAME = "testDataSet";
   public static final String TEST_MESSAGE_TYPE = "INFO";
   public static final String TEST_SOURCE_INT_PROPERTY = "intproperty";
   public static final String TEST_SOURCE_LONG_PROPERTY = "longproperty";
@@ -42,7 +42,7 @@ public class MessageUtil {
     String id = DEFAULT_MESSAGE_PREFIX + i;
     Map<String, Object> fieldMap = new HashMap<>();
     fieldMap.put("type", TEST_MESSAGE_TYPE);
-    fieldMap.put("index", TEST_INDEX_NAME);
+    fieldMap.put("index", TEST_DATASET_NAME);
     fieldMap.put("id", id);
 
     Map<String, Object> sourceFieldMap = new HashMap<>();
@@ -68,7 +68,7 @@ public class MessageUtil {
     fieldMap.put(TEST_SOURCE_LONG_PROPERTY, (long) i);
     fieldMap.put(TEST_SOURCE_DOUBLE_PROPERTY, (double) i);
     fieldMap.put(TEST_SOURCE_FLOAT_PROPERTY, (float) i);
-    return new LogWireMessage(TEST_INDEX_NAME, TEST_MESSAGE_TYPE, id, fieldMap);
+    return new LogWireMessage(TEST_DATASET_NAME, TEST_MESSAGE_TYPE, id, fieldMap);
   }
 
   public static LogMessage makeMessageWithIndexAndTimestamp(
@@ -103,7 +103,7 @@ public class MessageUtil {
   }
 
   public static String makeSerializedBadMessage(int i) {
-    LogWireMessage msg = new LogWireMessage(TEST_INDEX_NAME, null, "Message" + i, null);
+    LogWireMessage msg = new LogWireMessage(TEST_DATASET_NAME, null, "Message" + i, null);
     try {
       return JsonUtil.writeAsString(msg);
     } catch (JsonProcessingException e) {

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/MessageUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/MessageUtil.java
@@ -18,7 +18,7 @@ public class MessageUtil {
   // TODO: Add Timer
 
   public static final String DEFAULT_MESSAGE_PREFIX = "Message";
-  public static final String TEST_DATASET_NAME = "testDataSet";
+  public static final String TEST_DATA_SET_NAME = "testDataSet";
   public static final String TEST_MESSAGE_TYPE = "INFO";
   public static final String TEST_SOURCE_INT_PROPERTY = "intproperty";
   public static final String TEST_SOURCE_LONG_PROPERTY = "longproperty";
@@ -42,7 +42,7 @@ public class MessageUtil {
     String id = DEFAULT_MESSAGE_PREFIX + i;
     Map<String, Object> fieldMap = new HashMap<>();
     fieldMap.put("type", TEST_MESSAGE_TYPE);
-    fieldMap.put("index", TEST_DATASET_NAME);
+    fieldMap.put("index", TEST_DATA_SET_NAME);
     fieldMap.put("id", id);
 
     Map<String, Object> sourceFieldMap = new HashMap<>();
@@ -68,7 +68,7 @@ public class MessageUtil {
     fieldMap.put(TEST_SOURCE_LONG_PROPERTY, (long) i);
     fieldMap.put(TEST_SOURCE_DOUBLE_PROPERTY, (double) i);
     fieldMap.put(TEST_SOURCE_FLOAT_PROPERTY, (float) i);
-    return new LogWireMessage(TEST_DATASET_NAME, TEST_MESSAGE_TYPE, id, fieldMap);
+    return new LogWireMessage(TEST_DATA_SET_NAME, TEST_MESSAGE_TYPE, id, fieldMap);
   }
 
   public static LogMessage makeMessageWithIndexAndTimestamp(
@@ -103,7 +103,7 @@ public class MessageUtil {
   }
 
   public static String makeSerializedBadMessage(int i) {
-    LogWireMessage msg = new LogWireMessage(TEST_DATASET_NAME, null, "Message" + i, null);
+    LogWireMessage msg = new LogWireMessage(TEST_DATA_SET_NAME, null, "Message" + i, null);
     try {
       return JsonUtil.writeAsString(msg);
     } catch (JsonProcessingException e) {

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/TemporaryLogStoreAndSearcherRule.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/TemporaryLogStoreAndSearcherRule.java
@@ -37,9 +37,9 @@ public class TemporaryLogStoreAndSearcherRule implements TestRule {
   }
 
   public static List<LogMessage> findAllMessages(
-      LogIndexSearcherImpl searcher, String indexName, String query, int howMany, int bucketCount) {
+      LogIndexSearcherImpl searcher, String dataset, String query, int howMany, int bucketCount) {
     SearchResult<LogMessage> results =
-        searcher.search(indexName, query, 0, MAX_TIME, howMany, bucketCount);
+        searcher.search(dataset, query, 0, MAX_TIME, howMany, bucketCount);
     return results.hits;
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/TestKafkaServer.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/TestKafkaServer.java
@@ -89,7 +89,7 @@ public class TestKafkaServer {
     String jsonStr = JsonUtil.writeAsString(message.source);
     return Murron.MurronMessage.newBuilder()
         .setTimestamp(message.timeSinceEpochMilli * 1000 * 1000)
-        .setType(MessageUtil.TEST_DATA_SET_NAME)
+        .setType(MessageUtil.TEST_DATASET_NAME)
         .setHost("localhost")
         .setPid(100)
         .setOffset(offset)

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/TestKafkaServer.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/TestKafkaServer.java
@@ -89,7 +89,7 @@ public class TestKafkaServer {
     String jsonStr = JsonUtil.writeAsString(message.source);
     return Murron.MurronMessage.newBuilder()
         .setTimestamp(message.timeSinceEpochMilli * 1000 * 1000)
-        .setType(MessageUtil.TEST_INDEX_NAME)
+        .setType(MessageUtil.TEST_DATASET_NAME)
         .setHost("localhost")
         .setPid(100)
         .setOffset(offset)

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/TestKafkaServer.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/TestKafkaServer.java
@@ -89,7 +89,7 @@ public class TestKafkaServer {
     String jsonStr = JsonUtil.writeAsString(message.source);
     return Murron.MurronMessage.newBuilder()
         .setTimestamp(message.timeSinceEpochMilli * 1000 * 1000)
-        .setType(MessageUtil.TEST_DATASET_NAME)
+        .setType(MessageUtil.TEST_DATA_SET_NAME)
         .setHost("localhost")
         .setPid(100)
         .setOffset(offset)

--- a/kaldb/src/test/java/com/slack/kaldb/writer/LogMessageWriterImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/LogMessageWriterImplTest.java
@@ -4,7 +4,7 @@ import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_FAILED_COUN
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_RECEIVED_COUNTER;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static com.slack.kaldb.testlib.ChunkManagerUtil.makeChunkManagerUtil;
-import static com.slack.kaldb.testlib.MessageUtil.TEST_INDEX_NAME;
+import static com.slack.kaldb.testlib.MessageUtil.TEST_DATASET_NAME;
 import static com.slack.kaldb.testlib.MessageUtil.getCurrentLogDate;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
 import static com.slack.kaldb.testlib.SpanUtil.makeSpan;
@@ -95,13 +95,14 @@ public class LogMessageWriterImplTest {
     chunkManagerUtil.chunkManager.getActiveChunk().commit();
 
     // Search
-    assertThat(searchChunkManager(TEST_INDEX_NAME, "").hits.size()).isEqualTo(1);
-    assertThat(searchChunkManager(TEST_INDEX_NAME, "Message1").hits.size()).isEqualTo(1);
-    assertThat(searchChunkManager(TEST_INDEX_NAME, "Message2").hits.size()).isEqualTo(0);
-    assertThat(searchChunkManager(TEST_INDEX_NAME, "id:Message1").hits.size()).isEqualTo(1);
-    assertThat(searchChunkManager(TEST_INDEX_NAME, "intproperty:1").hits.size()).isEqualTo(1);
-    assertThat(searchChunkManager(TEST_INDEX_NAME, "intproperty:2").hits.size()).isEqualTo(0);
-    assertThat(searchChunkManager(TEST_INDEX_NAME, "longproperty:1 AND intproperty:1").hits.size())
+    assertThat(searchChunkManager(TEST_DATASET_NAME, "").hits.size()).isEqualTo(1);
+    assertThat(searchChunkManager(TEST_DATASET_NAME, "Message1").hits.size()).isEqualTo(1);
+    assertThat(searchChunkManager(TEST_DATASET_NAME, "Message2").hits.size()).isEqualTo(0);
+    assertThat(searchChunkManager(TEST_DATASET_NAME, "id:Message1").hits.size()).isEqualTo(1);
+    assertThat(searchChunkManager(TEST_DATASET_NAME, "intproperty:1").hits.size()).isEqualTo(1);
+    assertThat(searchChunkManager(TEST_DATASET_NAME, "intproperty:2").hits.size()).isEqualTo(0);
+    assertThat(
+            searchChunkManager(TEST_DATASET_NAME, "longproperty:1 AND intproperty:1").hits.size())
         .isEqualTo(1);
   }
 
@@ -114,7 +115,7 @@ public class LogMessageWriterImplTest {
     Map<String, Object> fieldMap = Maps.newHashMap();
     String id = "1";
     fieldMap.put("id", id);
-    fieldMap.put("index", TEST_INDEX_NAME);
+    fieldMap.put("index", TEST_DATASET_NAME);
     Map<String, Object> sourceFieldMap = new HashMap<>();
     sourceFieldMap.put(LogMessage.ReservedField.TIMESTAMP.fieldName, getCurrentLogDate());
     String message = String.format("The identifier in this message is %s", id);

--- a/kaldb/src/test/java/com/slack/kaldb/writer/LogMessageWriterImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/LogMessageWriterImplTest.java
@@ -4,7 +4,7 @@ import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_FAILED_COUN
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_RECEIVED_COUNTER;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static com.slack.kaldb.testlib.ChunkManagerUtil.makeChunkManagerUtil;
-import static com.slack.kaldb.testlib.MessageUtil.TEST_DATASET_NAME;
+import static com.slack.kaldb.testlib.MessageUtil.TEST_DATA_SET_NAME;
 import static com.slack.kaldb.testlib.MessageUtil.getCurrentLogDate;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
 import static com.slack.kaldb.testlib.SpanUtil.makeSpan;
@@ -95,14 +95,14 @@ public class LogMessageWriterImplTest {
     chunkManagerUtil.chunkManager.getActiveChunk().commit();
 
     // Search
-    assertThat(searchChunkManager(TEST_DATASET_NAME, "").hits.size()).isEqualTo(1);
-    assertThat(searchChunkManager(TEST_DATASET_NAME, "Message1").hits.size()).isEqualTo(1);
-    assertThat(searchChunkManager(TEST_DATASET_NAME, "Message2").hits.size()).isEqualTo(0);
-    assertThat(searchChunkManager(TEST_DATASET_NAME, "id:Message1").hits.size()).isEqualTo(1);
-    assertThat(searchChunkManager(TEST_DATASET_NAME, "intproperty:1").hits.size()).isEqualTo(1);
-    assertThat(searchChunkManager(TEST_DATASET_NAME, "intproperty:2").hits.size()).isEqualTo(0);
+    assertThat(searchChunkManager(TEST_DATA_SET_NAME, "").hits.size()).isEqualTo(1);
+    assertThat(searchChunkManager(TEST_DATA_SET_NAME, "Message1").hits.size()).isEqualTo(1);
+    assertThat(searchChunkManager(TEST_DATA_SET_NAME, "Message2").hits.size()).isEqualTo(0);
+    assertThat(searchChunkManager(TEST_DATA_SET_NAME, "id:Message1").hits.size()).isEqualTo(1);
+    assertThat(searchChunkManager(TEST_DATA_SET_NAME, "intproperty:1").hits.size()).isEqualTo(1);
+    assertThat(searchChunkManager(TEST_DATA_SET_NAME, "intproperty:2").hits.size()).isEqualTo(0);
     assertThat(
-            searchChunkManager(TEST_DATASET_NAME, "longproperty:1 AND intproperty:1").hits.size())
+            searchChunkManager(TEST_DATA_SET_NAME, "longproperty:1 AND intproperty:1").hits.size())
         .isEqualTo(1);
   }
 
@@ -115,7 +115,7 @@ public class LogMessageWriterImplTest {
     Map<String, Object> fieldMap = Maps.newHashMap();
     String id = "1";
     fieldMap.put("id", id);
-    fieldMap.put("index", TEST_DATASET_NAME);
+    fieldMap.put("index", TEST_DATA_SET_NAME);
     Map<String, Object> sourceFieldMap = new HashMap<>();
     sourceFieldMap.put(LogMessage.ReservedField.TIMESTAMP.fieldName, getCurrentLogDate());
     String message = String.format("The identifier in this message is %s", id);

--- a/kaldb/src/test/java/com/slack/kaldb/writer/LogMessageWriterImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/LogMessageWriterImplTest.java
@@ -4,7 +4,7 @@ import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_FAILED_COUN
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_RECEIVED_COUNTER;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static com.slack.kaldb.testlib.ChunkManagerUtil.makeChunkManagerUtil;
-import static com.slack.kaldb.testlib.MessageUtil.TEST_DATA_SET_NAME;
+import static com.slack.kaldb.testlib.MessageUtil.TEST_DATASET_NAME;
 import static com.slack.kaldb.testlib.MessageUtil.getCurrentLogDate;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
 import static com.slack.kaldb.testlib.SpanUtil.makeSpan;
@@ -95,14 +95,14 @@ public class LogMessageWriterImplTest {
     chunkManagerUtil.chunkManager.getActiveChunk().commit();
 
     // Search
-    assertThat(searchChunkManager(TEST_DATA_SET_NAME, "").hits.size()).isEqualTo(1);
-    assertThat(searchChunkManager(TEST_DATA_SET_NAME, "Message1").hits.size()).isEqualTo(1);
-    assertThat(searchChunkManager(TEST_DATA_SET_NAME, "Message2").hits.size()).isEqualTo(0);
-    assertThat(searchChunkManager(TEST_DATA_SET_NAME, "id:Message1").hits.size()).isEqualTo(1);
-    assertThat(searchChunkManager(TEST_DATA_SET_NAME, "intproperty:1").hits.size()).isEqualTo(1);
-    assertThat(searchChunkManager(TEST_DATA_SET_NAME, "intproperty:2").hits.size()).isEqualTo(0);
+    assertThat(searchChunkManager(TEST_DATASET_NAME, "").hits.size()).isEqualTo(1);
+    assertThat(searchChunkManager(TEST_DATASET_NAME, "Message1").hits.size()).isEqualTo(1);
+    assertThat(searchChunkManager(TEST_DATASET_NAME, "Message2").hits.size()).isEqualTo(0);
+    assertThat(searchChunkManager(TEST_DATASET_NAME, "id:Message1").hits.size()).isEqualTo(1);
+    assertThat(searchChunkManager(TEST_DATASET_NAME, "intproperty:1").hits.size()).isEqualTo(1);
+    assertThat(searchChunkManager(TEST_DATASET_NAME, "intproperty:2").hits.size()).isEqualTo(0);
     assertThat(
-            searchChunkManager(TEST_DATA_SET_NAME, "longproperty:1 AND intproperty:1").hits.size())
+            searchChunkManager(TEST_DATASET_NAME, "longproperty:1 AND intproperty:1").hits.size())
         .isEqualTo(1);
   }
 
@@ -115,7 +115,7 @@ public class LogMessageWriterImplTest {
     Map<String, Object> fieldMap = Maps.newHashMap();
     String id = "1";
     fieldMap.put("id", id);
-    fieldMap.put("index", TEST_DATA_SET_NAME);
+    fieldMap.put("index", TEST_DATASET_NAME);
     Map<String, Object> sourceFieldMap = new HashMap<>();
     sourceFieldMap.put(LogMessage.ReservedField.TIMESTAMP.fieldName, getCurrentLogDate());
     String message = String.format("The identifier in this message is %s", id);


### PR DESCRIPTION
Rename index_name field to data_set in SearchRequest so we can better clarify the intent of the field.