### PR TITLE
Add `ReplicaRestoreService`

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -78,6 +78,10 @@ managerConfig:
   snapshotDeletionServiceConfig:
     schedulePeriodMins: ${KALDB_MANAGER_SNAPSHOT_DELETE_PERIOD_MINS:-15}
     snapshotLifespanMins: ${KALDB_MANAGER_SNAPSHOT_LIFESPAN_MINS:-10080}
+  replicaRestoreServiceConfig:
+    schedulePeriodMins: ${KALDB_MANAGER_REPLICA_RESTORE_PERIOD_MINS:-15}
+    maxReplicasPerRequest: ${KALDB_MANAGER_REPLICA_RESTORE_MAX_REPLICAS_PER_REQUEST:-200}
+    replicaLifespanMins: ${KALDB_MANAGER_REPLICA_RESTORE_LIFESPAN_MINS:-60}
 
 clusterConfig:
   clusterName: ${KALDB_CLUSTER_NAME:-kaldb_local}

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaRestoreService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaRestoreService.java
@@ -1,0 +1,177 @@
+package com.slack.kaldb.clusterManager;
+
+import static com.slack.kaldb.clusterManager.ReplicaCreationService.replicaMetadataFromSnapshotId;
+
+import com.google.common.util.concurrent.AbstractScheduledService;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.slack.kaldb.metadata.replica.ReplicaMetadata;
+import com.slack.kaldb.metadata.replica.ReplicaMetadataStore;
+import com.slack.kaldb.metadata.snapshot.SnapshotMetadata;
+import com.slack.kaldb.proto.config.KaldbConfigs;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import javax.naming.SizeLimitExceededException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Scheduled service responsible for restoring user requested Snapshots that have expired. Users can
+ * call the queueSnapshotsForRestoration to queue Snapshots for restoration in the future. This
+ * service will automatically handle de-duping, ensuring that no Snapshot is restored more than
+ * once. Additionally, the maximum number of Snapshots that can be requested at once is also
+ * configurable to prevent overwhelming the service.
+ */
+public class ReplicaRestoreService extends AbstractScheduledService {
+  private ScheduledFuture<?> pendingTask;
+  private final KaldbConfigs.ManagerConfig managerConfig;
+  private final ScheduledExecutorService executorService =
+      Executors.newSingleThreadScheduledExecutor(
+          new ThreadFactoryBuilder().setNameFormat("replica-restore-service-%d").build());
+  private final BlockingQueue<SnapshotMetadata> queue = new LinkedBlockingQueue<>();
+  private final ReplicaMetadataStore replicaMetadataStore;
+  private final MeterRegistry meterRegistry;
+  private final Counter successfullyCreatedReplicas;
+  private final Counter failedReplicas;
+  private final Counter skippedReplicas;
+  private final Timer restoreTimer;
+  protected static final Logger LOG = LoggerFactory.getLogger(ReplicaCreationService.class);
+  public static String REPLICAS_CREATED = "replicas_created";
+  public static String REPLICAS_FAILED = "replicas_failed";
+  public static String REPLICAS_SKIPPED = "replicas_skipped";
+  public static String REPLICAS_RESTORE_TIMER = "replicas_restore_timer";
+
+  public ReplicaRestoreService(
+      ReplicaMetadataStore replicaMetadataStore,
+      MeterRegistry meterRegistry,
+      KaldbConfigs.ManagerConfig managerConfig) {
+    this.managerConfig = managerConfig;
+    this.replicaMetadataStore = replicaMetadataStore;
+    this.meterRegistry = meterRegistry;
+    this.skippedReplicas = meterRegistry.counter(REPLICAS_SKIPPED);
+    this.successfullyCreatedReplicas = meterRegistry.counter(REPLICAS_CREATED);
+    this.failedReplicas = meterRegistry.counter(REPLICAS_FAILED);
+    this.restoreTimer = meterRegistry.timer(REPLICAS_RESTORE_TIMER);
+  }
+
+  @Override
+  protected void runOneIteration() {
+    if (pendingTask == null || pendingTask.getDelay(TimeUnit.SECONDS) <= 0) {
+      pendingTask =
+          executorService.schedule(
+              this::restoreQueuedSnapshots,
+              managerConfig.getEventAggregationSecs(),
+              TimeUnit.SECONDS);
+    } else {
+      LOG.info(
+          "Replica restore task already scheduled, will run in {} ms",
+          pendingTask.getDelay(TimeUnit.MILLISECONDS));
+    }
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    LOG.info("Starting replica restore service");
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    LOG.info("Closing replica restore service");
+    executorService.shutdownNow();
+    LOG.info("Closed replica restore service");
+  }
+
+  @Override
+  protected Scheduler scheduler() {
+    return Scheduler.newFixedRateSchedule(
+        managerConfig.getScheduleInitialDelayMins(),
+        managerConfig.getReplicaRestoreServiceConfig().getSchedulePeriodMins(),
+        TimeUnit.MINUTES);
+  }
+
+  /**
+   * Queues Snapshots to have replicas created for them in the future. If the number of Snapshots
+   * exceeds the maximum limit per request, a SizeLimitExceededException will be thrown.
+   *
+   * @throws SizeLimitExceededException Thrown when the number of Snapshots queued in one call
+   *     exceeds maxReplicasPerRequest
+   * @param snapshotsToRestore List of Snapshots to be queued for restoration
+   */
+  public synchronized void queueSnapshotsForRestoration(List<SnapshotMetadata> snapshotsToRestore)
+      throws SizeLimitExceededException {
+    if (snapshotsToRestore.size()
+        >= managerConfig.getReplicaRestoreServiceConfig().getMaxReplicasPerRequest()) {
+      throw new SizeLimitExceededException(
+          "Number of replicas requested exceeds maxReplicasPerRequest limit");
+    }
+    queue.addAll(snapshotsToRestore);
+    LOG.info("Current size of Snapshot restoration queue: " + queue.size());
+    runOneIteration();
+  }
+
+  /** Drains the current queue and creates replicas as required. Called by scheduler. */
+  private void restoreQueuedSnapshots() {
+    if (queue.isEmpty()) {
+      return;
+    }
+
+    Timer.Sample restoreReplicasTimer = Timer.start(meterRegistry);
+
+    List<SnapshotMetadata> snapshotsToRestore = new ArrayList<>();
+    Set<String> createdReplicas = new HashSet<>();
+
+    for (ReplicaMetadata replicaMetadata : replicaMetadataStore.getCached()) {
+      createdReplicas.add(replicaMetadata.snapshotId);
+    }
+
+    queue.drainTo(snapshotsToRestore);
+
+    for (SnapshotMetadata snapshotMetadata : snapshotsToRestore) {
+      try {
+        restoreOrSkipSnapshot(snapshotMetadata, createdReplicas);
+        createdReplicas.add(snapshotMetadata.snapshotId);
+      } catch (InterruptedException e) {
+        LOG.error("Something went wrong dequeueing snapshot ID {}", snapshotMetadata.snapshotId, e);
+        failedReplicas.increment();
+      }
+    }
+    restoreReplicasTimer.stop(restoreTimer);
+  }
+
+  /** Creates replica from given snapshot if its ID doesn't already exist in createdReplicas */
+  private void restoreOrSkipSnapshot(SnapshotMetadata snapshot, Set<String> createdReplicas)
+      throws InterruptedException {
+    if (!createdReplicas.contains(snapshot.snapshotId)) {
+      LOG.info("Restoring replica with ID {}", snapshot.snapshotId);
+
+      try {
+        replicaMetadataStore.createSync(
+            replicaMetadataFromSnapshotId(
+                snapshot.snapshotId,
+                Instant.now()
+                    .plus(
+                        managerConfig.getReplicaRestoreServiceConfig().getReplicaLifespanMins(),
+                        ChronoUnit.MINUTES)));
+      } catch (Exception e) {
+        LOG.error("Error restoring replica for snapshot {}", snapshot.snapshotId, e);
+      }
+      createdReplicas.add(snapshot.snapshotId);
+      successfullyCreatedReplicas.increment();
+    } else {
+      LOG.info("Skipping Snapshot ID {} ", snapshot.snapshotId);
+      skippedReplicas.increment();
+    }
+  }
+}

--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -233,10 +233,16 @@ public class Kaldb {
           new CacheSlotMetadataStore(metadataStore, true);
       DatasetMetadataStore datasetMetadataStore = new DatasetMetadataStore(metadataStore, true);
 
+      ReplicaRestoreService replicaRestoreService =
+          new ReplicaRestoreService(replicaMetadataStore, meterRegistry, managerConfig);
+      services.add(replicaRestoreService);
+
       ArmeriaService armeriaService =
           new ArmeriaService.Builder(serverPort, "kalDbManager", meterRegistry)
               .withTracing(kaldbConfig.getTracingConfig())
-              .withGrpcService(new ManagerApiGrpc(datasetMetadataStore))
+              .withGrpcService(
+                  new ManagerApiGrpc(
+                      datasetMetadataStore, snapshotMetadataStore, replicaRestoreService))
               .build();
       services.add(armeriaService);
 

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -160,6 +160,12 @@ message ManagerConfig {
     int32 snapshot_lifespan_mins = 2;
   }
 
+  message ReplicaRestoreServiceConfig {
+    int32 schedule_period_mins = 1;
+    int32 max_replicas_per_request = 2;
+    int32 replica_lifespan_mins = 3;
+  }
+
   // Event aggregation secs is a de-bounce setting. It's the time
   // a service waits to take an action after a zk notification.
   int32 event_aggregation_secs = 1;
@@ -176,6 +182,7 @@ message ManagerConfig {
   RecoveryTaskAssignmentServiceConfig
       recovery_task_assignment_service_config = 8;
   SnapshotDeletionServiceConfig snapshot_deletion_service_config = 9;
+  ReplicaRestoreServiceConfig replica_restore_service_config = 10;
 }
 
 // Config for the recovery node.

--- a/kaldb/src/main/proto/manager_api.proto
+++ b/kaldb/src/main/proto/manager_api.proto
@@ -20,6 +20,8 @@ service ManagerApiService {
   //
   // In the future if only a rate is provided with an empty list the allocation will be automatically assigned.
   rpc UpdatePartitionAssignment(UpdatePartitionAssignmentRequest) returns (UpdatePartitionAssignmentResponse) {}
+
+  rpc RestoreReplica(RestoreReplicaRequest) returns (RestoreReplicaResponse) {}
 }
 
 // CreateDatasetMetadataRequest represents a new dataset with uninitialized thoughput and partition assignments
@@ -67,4 +69,14 @@ message UpdatePartitionAssignmentRequest {
 message UpdatePartitionAssignmentResponse {
   // The assigned partition IDs
   repeated string assigned_partition_ids = 1;
+}
+
+message RestoreReplicaRequest {
+  string service_name = 1;
+  int64 start_time_epoch_ms = 2;
+  int64 end_time_epoch_ms = 3;
+}
+
+message RestoreReplicaResponse {
+  string status = 1;
 }

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaRestoreServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaRestoreServiceTest.java
@@ -1,0 +1,228 @@
+package com.slack.kaldb.clusterManager;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import brave.Tracing;
+import com.slack.kaldb.metadata.replica.ReplicaMetadata;
+import com.slack.kaldb.metadata.replica.ReplicaMetadataStore;
+import com.slack.kaldb.metadata.snapshot.SnapshotMetadata;
+import com.slack.kaldb.metadata.zookeeper.MetadataStore;
+import com.slack.kaldb.metadata.zookeeper.ZookeeperMetadataStoreImpl;
+import com.slack.kaldb.proto.config.KaldbConfigs;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import javax.naming.SizeLimitExceededException;
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ReplicaRestoreServiceTest {
+
+  private TestingServer testingServer;
+  private MeterRegistry meterRegistry;
+  private MetadataStore metadataStore;
+  private KaldbConfigs.ManagerConfig managerConfig;
+  private ReplicaMetadataStore replicaMetadataStore;
+
+  @Before
+  public void setUp() throws Exception {
+    Tracing.newBuilder().build();
+    meterRegistry = new SimpleMeterRegistry();
+    testingServer = new TestingServer();
+
+    com.slack.kaldb.proto.config.KaldbConfigs.ZookeeperConfig zkConfig =
+        com.slack.kaldb.proto.config.KaldbConfigs.ZookeeperConfig.newBuilder()
+            .setZkConnectString(testingServer.getConnectString())
+            .setZkPathPrefix("ReplicaRestoreServiceTest")
+            .setZkSessionTimeoutMs(1000)
+            .setZkConnectionTimeoutMs(1000)
+            .setSleepBetweenRetriesMs(1000)
+            .build();
+
+    KaldbConfigs.ManagerConfig.ReplicaRestoreServiceConfig replicaRecreationServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaRestoreServiceConfig.newBuilder()
+            .setMaxReplicasPerRequest(200)
+            .setReplicaLifespanMins(60)
+            .setSchedulePeriodMins(30)
+            .build();
+
+    managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setEventAggregationSecs(2)
+            .setReplicaRestoreServiceConfig(replicaRecreationServiceConfig)
+            .build();
+
+    metadataStore = ZookeeperMetadataStoreImpl.fromConfig(meterRegistry, zkConfig);
+    replicaMetadataStore = spy(new ReplicaMetadataStore(metadataStore, true));
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    meterRegistry.close();
+    testingServer.close();
+    metadataStore.close();
+  }
+
+  @Test
+  public void shouldHandleDrainingAndAdding() throws Exception {
+    doAnswer(
+            invocationOnMock -> {
+              Thread.sleep(100);
+              return invocationOnMock.callRealMethod();
+            })
+        .when(replicaMetadataStore)
+        .createSync(any(ReplicaMetadata.class));
+
+    ReplicaRestoreService replicaRestoreService =
+        new ReplicaRestoreService(replicaMetadataStore, meterRegistry, managerConfig);
+
+    for (int i = 0; i < 10; i++) {
+      long now = Instant.now().toEpochMilli();
+      String id = "loop" + i;
+      SnapshotMetadata snapshotIncluded = new SnapshotMetadata(id, id, now + 10, now + 15, 0, id);
+      replicaRestoreService.queueSnapshotsForRestoration(List.of(snapshotIncluded));
+      Thread.sleep(300);
+    }
+
+    await().until(() -> replicaMetadataStore.getCached().size() == 7);
+    assertThat(meterRegistry.timer(ReplicaRestoreService.REPLICAS_RESTORE_TIMER).count())
+        .isEqualTo(1);
+
+    await().until(() -> replicaMetadataStore.getCached().size() == 10);
+    assertThat(meterRegistry.timer(ReplicaRestoreService.REPLICAS_RESTORE_TIMER).count())
+        .isEqualTo(2);
+  }
+
+  @Test
+  public void shouldHandleMultipleSimultaneousRequests() {
+    doAnswer(
+            invocationOnMock -> {
+              Thread.sleep(100);
+              return invocationOnMock.callRealMethod();
+            })
+        .when(replicaMetadataStore)
+        .createSync(any(ReplicaMetadata.class));
+
+    ReplicaRestoreService replicaRestoreService =
+        new ReplicaRestoreService(replicaMetadataStore, meterRegistry, managerConfig);
+    ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+    for (int i = 0; i < 2; i++) {
+      executorService.submit(
+          () -> {
+            for (int j = 0; j < 10; j++) {
+              long now = Instant.now().toEpochMilli();
+              String id = "loop" + UUID.randomUUID();
+              SnapshotMetadata snapshotIncluded =
+                  new SnapshotMetadata(id, id, now + 10, now + 15, 0, id);
+              try {
+                replicaRestoreService.queueSnapshotsForRestoration(List.of(snapshotIncluded));
+                Thread.sleep(300);
+              } catch (Exception e) {
+                fail();
+              }
+            }
+          });
+    }
+
+    await().until(() -> replicaMetadataStore.getCached().size() == 14);
+    assertThat(meterRegistry.timer(ReplicaRestoreService.REPLICAS_RESTORE_TIMER).count())
+        .isEqualTo(1);
+
+    await().until(() -> replicaMetadataStore.getCached().size() == 20);
+    assertThat(meterRegistry.timer(ReplicaRestoreService.REPLICAS_RESTORE_TIMER).count())
+        .isEqualTo(2);
+
+    executorService.shutdown();
+  }
+
+  @Test
+  public void shouldRemoveDuplicates() throws Exception {
+    KaldbConfigs.ManagerConfig.ReplicaRestoreServiceConfig replicaRecreationServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaRestoreServiceConfig.newBuilder()
+            .setMaxReplicasPerRequest(200)
+            .setReplicaLifespanMins(60)
+            .setSchedulePeriodMins(30)
+            .build();
+
+    managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaRestoreServiceConfig(replicaRecreationServiceConfig)
+            .build();
+
+    ReplicaRestoreService replicaRestoreService =
+        new ReplicaRestoreService(replicaMetadataStore, meterRegistry, managerConfig);
+
+    long now = Instant.now().toEpochMilli();
+    List<SnapshotMetadata> duplicateSnapshots = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      String id = "duplicate";
+      duplicateSnapshots.add(new SnapshotMetadata(id, id, now + 10, now + 15, 0, id));
+    }
+
+    replicaRestoreService.queueSnapshotsForRestoration(duplicateSnapshots);
+
+    await().until(() -> replicaMetadataStore.getCached().size() == 1);
+    assertThat(meterRegistry.counter(ReplicaRestoreService.REPLICAS_SKIPPED).count()).isEqualTo(9);
+    assertThat(meterRegistry.counter(ReplicaRestoreService.REPLICAS_CREATED).count()).isEqualTo(1);
+
+    List<SnapshotMetadata> snapshots = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      now = Instant.now().toEpochMilli();
+      String id = "loop" + i;
+      snapshots.add(new SnapshotMetadata(id, id, now + 10, now + 15, 0, id));
+    }
+
+    replicaRestoreService.queueSnapshotsForRestoration(snapshots);
+    replicaRestoreService.queueSnapshotsForRestoration(duplicateSnapshots);
+
+    await().until(() -> replicaMetadataStore.getCached().size() == 4);
+    assertThat(meterRegistry.counter(ReplicaRestoreService.REPLICAS_SKIPPED).count()).isEqualTo(19);
+    assertThat(meterRegistry.counter(ReplicaRestoreService.REPLICAS_CREATED).count()).isEqualTo(4);
+  }
+
+  @Test
+  public void shouldNotQueueIfFull() {
+    int MAX_QUEUE_SIZE = 5;
+    KaldbConfigs.ManagerConfig.ReplicaRestoreServiceConfig replicaRecreationServiceConfig =
+        KaldbConfigs.ManagerConfig.ReplicaRestoreServiceConfig.newBuilder()
+            .setMaxReplicasPerRequest(MAX_QUEUE_SIZE)
+            .setReplicaLifespanMins(60)
+            .setSchedulePeriodMins(30)
+            .build();
+
+    managerConfig =
+        KaldbConfigs.ManagerConfig.newBuilder()
+            .setReplicaRestoreServiceConfig(replicaRecreationServiceConfig)
+            .build();
+
+    ReplicaRestoreService replicaRestoreService =
+        new ReplicaRestoreService(replicaMetadataStore, meterRegistry, managerConfig);
+
+    List<SnapshotMetadata> snapshots = new ArrayList<>();
+    for (int i = 0; i < MAX_QUEUE_SIZE; i++) {
+      long now = Instant.now().toEpochMilli();
+      String id = "loop" + i;
+      snapshots.add(new SnapshotMetadata(id, id, now + 10, now + 15, 0, id));
+    }
+
+    assertThrows(
+        SizeLimitExceededException.class,
+        () -> {
+          replicaRestoreService.queueSnapshotsForRestoration(snapshots);
+        });
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
@@ -245,6 +245,12 @@ public class KaldbConfigTest {
     assertThat(snapshotDeletionServiceConfig.getSchedulePeriodMins()).isEqualTo(15);
     assertThat(snapshotDeletionServiceConfig.getSnapshotLifespanMins()).isEqualTo(10080);
 
+    final KaldbConfigs.ManagerConfig.ReplicaRestoreServiceConfig replicaRestoreServiceConfig =
+        managerConfig.getReplicaRestoreServiceConfig();
+    assertThat(replicaRestoreServiceConfig.getSchedulePeriodMins()).isEqualTo(15);
+    assertThat(replicaRestoreServiceConfig.getMaxReplicasPerRequest()).isEqualTo(200);
+    assertThat(replicaRestoreServiceConfig.getReplicaLifespanMins()).isEqualTo(60);
+
     final KaldbConfigs.ServerConfig managerServerConfig = managerConfig.getServerConfig();
     assertThat(managerServerConfig.getServerPort()).isEqualTo(8083);
     assertThat(managerServerConfig.getServerAddress()).isEqualTo("localhost");
@@ -381,6 +387,12 @@ public class KaldbConfigTest {
     final KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig replicaAssignmentServiceConfig =
         managerConfig.getReplicaAssignmentServiceConfig();
     assertThat(replicaAssignmentServiceConfig.getSchedulePeriodMins()).isEqualTo(10);
+
+    final KaldbConfigs.ManagerConfig.ReplicaRestoreServiceConfig replicaRestoreServiceConfig =
+        managerConfig.getReplicaRestoreServiceConfig();
+    assertThat(replicaRestoreServiceConfig.getSchedulePeriodMins()).isEqualTo(15);
+    assertThat(replicaRestoreServiceConfig.getMaxReplicasPerRequest()).isEqualTo(200);
+    assertThat(replicaRestoreServiceConfig.getReplicaLifespanMins()).isEqualTo(60);
 
     final KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig snapshotDeletionServiceConfig =
         managerConfig.getSnapshotDeletionServiceConfig();
@@ -526,6 +538,12 @@ public class KaldbConfigTest {
     assertThat(clusterConfig.getClusterName()).isEmpty();
     assertThat(clusterConfig.getEnv()).isEmpty();
 
+    final KaldbConfigs.ManagerConfig.ReplicaRestoreServiceConfig replicaRestoreServiceConfig =
+        managerConfig.getReplicaRestoreServiceConfig();
+    assertThat(replicaRestoreServiceConfig.getSchedulePeriodMins()).isZero();
+    assertThat(replicaRestoreServiceConfig.getMaxReplicasPerRequest()).isZero();
+    assertThat(replicaRestoreServiceConfig.getReplicaLifespanMins()).isZero();
+
     final KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig snapshotDeletionServiceConfig =
         managerConfig.getSnapshotDeletionServiceConfig();
     assertThat(snapshotDeletionServiceConfig.getSchedulePeriodMins()).isZero();
@@ -645,6 +663,12 @@ public class KaldbConfigTest {
     final KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig replicaAssignmentServiceConfig =
         managerConfig.getReplicaAssignmentServiceConfig();
     assertThat(replicaAssignmentServiceConfig.getSchedulePeriodMins()).isZero();
+
+    final KaldbConfigs.ManagerConfig.ReplicaRestoreServiceConfig replicaRestoreServiceConfig =
+        managerConfig.getReplicaRestoreServiceConfig();
+    assertThat(replicaRestoreServiceConfig.getSchedulePeriodMins()).isZero();
+    assertThat(replicaRestoreServiceConfig.getMaxReplicasPerRequest()).isZero();
+    assertThat(replicaRestoreServiceConfig.getReplicaLifespanMins()).isZero();
 
     final KaldbConfigs.ManagerConfig.SnapshotDeletionServiceConfig snapshotDeletionServiceConfig =
         managerConfig.getSnapshotDeletionServiceConfig();

--- a/kaldb/src/test/resources/test_config.json
+++ b/kaldb/src/test/resources/test_config.json
@@ -94,6 +94,11 @@
     "snapshotDeletionServiceConfig": {
       "schedulePeriodMins": 15,
       "snapshotLifespanMins": 10080
+    },
+    "replicaRestoreServiceConfig": {
+      "schedulePeriodMins": 15,
+      "maxReplicasPerRequest": 200,
+      "replicaLifespanMins": 60
     }
   },
   "recoveryConfig": {

--- a/kaldb/src/test/resources/test_config.yaml
+++ b/kaldb/src/test/resources/test_config.yaml
@@ -77,6 +77,10 @@ managerConfig:
   snapshotDeletionServiceConfig:
     schedulePeriodMins: 15
     snapshotLifespanMins: 10080
+  replicaRestoreServiceConfig:
+    schedulePeriodMins: 15
+    maxReplicasPerRequest: 200
+    replicaLifespanMins: 60
 
 recoveryConfig:
   serverConfig:


### PR DESCRIPTION
* Add a new service, `ReplicaRestoreService`, responsible for rehydrating Snapshots
* Add tests for said service
* Hook up the new `ReplicaRestoreService` to the `restoreSnapshots` GRPC endpoint in the manager API