### PR TITLE
allow for all dataset matching

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetPartitionMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetPartitionMetadata.java
@@ -96,11 +96,12 @@ public class DatasetPartitionMetadata {
       DatasetMetadataStore datasetMetadataStore,
       long startTimeEpochMs,
       long endTimeEpochMs,
-      String indexName) {
+      String dataset) {
+    boolean skipDatasetFilter = (dataset.equals("*") || dataset.equals("_all"));
     return datasetMetadataStore
         .getCached()
         .stream()
-        .filter(serviceMetadata -> serviceMetadata.name.equals(indexName))
+        .filter(serviceMetadata -> skipDatasetFilter || serviceMetadata.name.equals(dataset))
         .flatMap(
             serviceMetadata -> serviceMetadata.partitionConfigs.stream()) // will always return one
         .filter(


### PR DESCRIPTION
Allow for `_all` and `*` to match all datasets. This ensures we can search for different "datasets" within the same cluster