### PR TITLE
Add endpoint to restore replica from Snapshot ID

### DIFF
--- a/kaldb/src/main/proto/manager_api.proto
+++ b/kaldb/src/main/proto/manager_api.proto
@@ -22,6 +22,7 @@ service ManagerApiService {
   rpc UpdatePartitionAssignment(UpdatePartitionAssignmentRequest) returns (UpdatePartitionAssignmentResponse) {}
 
   rpc RestoreReplica(RestoreReplicaRequest) returns (RestoreReplicaResponse) {}
+  rpc RestoreReplicaIds(RestoreReplicaIdsRequest) returns (RestoreReplicaIdsResponse) {}
 }
 
 // CreateDatasetMetadataRequest represents a new dataset with uninitialized thoughput and partition assignments
@@ -78,5 +79,13 @@ message RestoreReplicaRequest {
 }
 
 message RestoreReplicaResponse {
+  string status = 1;
+}
+
+message RestoreReplicaIdsRequest {
+  repeated string ids_to_restore = 1;
+}
+
+message RestoreReplicaIdsResponse {
   string status = 1;
 }

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaRestoreServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaRestoreServiceTest.java
@@ -5,7 +5,8 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 
 import brave.Tracing;
 import com.slack.kaldb.metadata.replica.ReplicaMetadata;


### PR DESCRIPTION
* Add new endpoint on ManagerApiGrpc to restore replicas from specific Snapshot IDs
* Add new test, `shouldRestoreGivenSnapshotIds`, to test the new endpoint
* Refactor ManagerApiGrpc and ReplicaRestoreService code to use snapshot IDs exclusively (previously it was using SnapshotMetadatas)