### PR TITLE
use standard span field names in the proto definition 

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/writer/MurronLogFormatter.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/MurronLogFormatter.java
@@ -81,8 +81,8 @@ public class MurronLogFormatter {
     String traceId = (String) jsonMsgMap.getOrDefault(traceIdFieldName, "");
     spanBuilder.setTraceId(ByteString.copyFrom(traceId.getBytes()));
 
-    spanBuilder.setStartTimestampMicros(murronMsg.getTimestamp() / 1000);
-    spanBuilder.setDurationMicros(
+    spanBuilder.setTimestamp(murronMsg.getTimestamp() / 1000);
+    spanBuilder.setDuration(
         Long.parseLong(String.valueOf(jsonMsgMap.getOrDefault(durationField, "1")))
             * durationTimeMuiltiplier);
 

--- a/kaldb/src/main/java/com/slack/kaldb/writer/SpanFormatter.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/SpanFormatter.java
@@ -44,10 +44,10 @@ public class SpanFormatter {
     jsonMap.put(LogMessage.ReservedField.PARENT_ID.fieldName, span.getParentId().toStringUtf8());
     jsonMap.put(LogMessage.ReservedField.TRACE_ID.fieldName, span.getTraceId().toStringUtf8());
     jsonMap.put(LogMessage.ReservedField.NAME.fieldName, span.getName());
-    jsonMap.put(LogMessage.ReservedField.DURATION_MS.fieldName, span.getDurationMicros());
+    jsonMap.put(LogMessage.ReservedField.DURATION_MS.fieldName, span.getDuration());
 
     // TODO: Use a microsecond resolution, instead of millisecond resolution.
-    Instant timestamp = Instant.ofEpochMilli(span.getStartTimestampMicros() / (1000));
+    Instant timestamp = Instant.ofEpochMilli(span.getTimestamp() / (1000));
     jsonMap.put(LogMessage.ReservedField.TIMESTAMP.fieldName, timestamp.toString());
 
     String indexName = "";

--- a/kaldb/src/main/proto/trace.proto
+++ b/kaldb/src/main/proto/trace.proto
@@ -57,12 +57,12 @@ message Span {
   // For example: a value of 1551849569000000 represents March 6, 2019 5:19:29 UTC.
   // We use fixed64 since it is more wire efficient for than int64 for larger numbers.
   // This field is required.
-  fixed64 start_timestamp_micros = 5;
+  fixed64 timestamp = 5;
 
   // This field stored the duration in microseconds for the event in the critical path.
   // For example 150 milliseconds is 150000 microseconds.
   // This field is required.
-  uint64 duration_micros = 6;
+  uint64 duration = 6;
 
   // A list of key value pairs.
   repeated KeyValue tags = 7;

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/KaldbSerdesTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/KaldbSerdesTest.java
@@ -65,8 +65,8 @@ public class KaldbSerdesTest {
             .setId(ByteString.copyFromUtf8(id))
             .setTraceId(ByteString.copyFromUtf8(traceId))
             .setName(name)
-            .setStartTimestampMicros(timestamp)
-            .setDurationMicros(duration)
+            .setTimestamp(timestamp)
+            .setDuration(duration)
             .build();
     Trace.ListOfSpans listOfSpans = Trace.ListOfSpans.newBuilder().addSpans(span).build();
 
@@ -82,9 +82,9 @@ public class KaldbSerdesTest {
     assertThat(deserializedMessage.getSpansList().get(0).getTraceId())
         .isEqualTo(ByteString.copyFromUtf8(traceId));
     assertThat(deserializedMessage.getSpansList().get(0).getName()).isEqualTo(name);
-    assertThat(deserializedMessage.getSpansList().get(0).getStartTimestampMicros())
+    assertThat(deserializedMessage.getSpansList().get(0).getTimestamp())
         .isEqualTo(timestamp);
-    assertThat(deserializedMessage.getSpansList().get(0).getDurationMicros()).isEqualTo(duration);
+    assertThat(deserializedMessage.getSpansList().get(0).getDuration()).isEqualTo(duration);
     assertThat(deserializedMessage.getSpansList().get(0).getTagsList().size()).isEqualTo(0);
   }
 
@@ -114,8 +114,8 @@ public class KaldbSerdesTest {
             .setId(ByteString.copyFromUtf8(id))
             .setTraceId(ByteString.copyFromUtf8(traceId))
             .setName(name)
-            .setStartTimestampMicros(timestamp)
-            .setDurationMicros(duration)
+            .setTimestamp(timestamp)
+            .setDuration(duration)
             .build();
 
     byte[] serializedBytes = serdes.serializer().serialize(topic, span);
@@ -124,8 +124,8 @@ public class KaldbSerdesTest {
     assertThat(deserializedMessage.getId()).isEqualTo(ByteString.copyFromUtf8(id));
     assertThat(deserializedMessage.getTraceId()).isEqualTo(ByteString.copyFromUtf8(traceId));
     assertThat(deserializedMessage.getName()).isEqualTo(name);
-    assertThat(deserializedMessage.getStartTimestampMicros()).isEqualTo(timestamp);
-    assertThat(deserializedMessage.getDurationMicros()).isEqualTo(duration);
+    assertThat(deserializedMessage.getTimestamp()).isEqualTo(timestamp);
+    assertThat(deserializedMessage.getDuration()).isEqualTo(duration);
     assertThat(deserializedMessage.getTagsList().size()).isEqualTo(0);
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/KaldbSerdesTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/KaldbSerdesTest.java
@@ -82,8 +82,7 @@ public class KaldbSerdesTest {
     assertThat(deserializedMessage.getSpansList().get(0).getTraceId())
         .isEqualTo(ByteString.copyFromUtf8(traceId));
     assertThat(deserializedMessage.getSpansList().get(0).getName()).isEqualTo(name);
-    assertThat(deserializedMessage.getSpansList().get(0).getTimestamp())
-        .isEqualTo(timestamp);
+    assertThat(deserializedMessage.getSpansList().get(0).getTimestamp()).isEqualTo(timestamp);
     assertThat(deserializedMessage.getSpansList().get(0).getDuration()).isEqualTo(duration);
     assertThat(deserializedMessage.getSpansList().get(0).getTagsList().size()).isEqualTo(0);
   }

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorValueMapperTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorValueMapperTest.java
@@ -39,8 +39,8 @@ public class PreprocessorValueMapperTest {
     Iterator<Trace.Span> spanIterator = spanIterable.iterator();
     Trace.Span span = spanIterator.next();
 
-    assertThat(span.getStartTimestampMicros()).isEqualTo(timestamp / 1000);
-    assertThat(span.getDurationMicros()).isEqualTo(1);
+    assertThat(span.getTimestamp()).isEqualTo(timestamp / 1000);
+    assertThat(span.getDuration()).isEqualTo(1);
 
     assertThat(span.getTagsList().size()).isEqualTo(6);
     assertThat(
@@ -106,8 +106,8 @@ public class PreprocessorValueMapperTest {
     Iterator<Trace.Span> spanIterator = spanIterable.iterator();
     Trace.Span mappedSpan = spanIterator.next();
 
-    assertThat(mappedSpan.getStartTimestampMicros()).isEqualTo(timestampMicros);
-    assertThat(mappedSpan.getDurationMicros()).isEqualTo(durationMicros);
+    assertThat(mappedSpan.getTimestamp()).isEqualTo(timestampMicros);
+    assertThat(mappedSpan.getDuration()).isEqualTo(durationMicros);
 
     assertThat(mappedSpan.getTagsList().size()).isEqualTo(8);
     assertThat(

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/SpanUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/SpanUtil.java
@@ -38,8 +38,8 @@ public class SpanUtil {
     spanBuilder.setTraceId(ByteString.copyFrom(traceId.getBytes()));
     spanBuilder.setId(ByteString.copyFrom(id.getBytes()));
     spanBuilder.setParentId(ByteString.copyFrom(parentId.getBytes()));
-    spanBuilder.setStartTimestampMicros(timestampMicros);
-    spanBuilder.setDurationMicros(durationMicros);
+    spanBuilder.setTimestamp(timestampMicros);
+    spanBuilder.setDuration(durationMicros);
     spanBuilder.setName(name);
 
     List<Trace.KeyValue> tags = new ArrayList<>();

--- a/kaldb/src/test/java/com/slack/kaldb/writer/MurronLogFormatterTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/MurronLogFormatterTest.java
@@ -57,12 +57,12 @@ public class MurronLogFormatterTest {
     Murron.MurronMessage testMurronMsg = testMurronMsgBuilder.build();
 
     Trace.Span apiSpan = MurronLogFormatter.fromApiLog(testMurronMsg);
-    assertThat(apiSpan.getDurationMicros()).isEqualTo(1418L);
+    assertThat(apiSpan.getDuration()).isEqualTo(1418L);
     assertThat(apiSpan.getName()).isEqualTo(indexName);
     assertThat(apiSpan.getId().toString().contains(host)).isTrue();
     assertThat(apiSpan.getTraceId().isEmpty()).isTrue();
     assertThat(apiSpan.getParentId().isEmpty()).isTrue();
-    assertThat(apiSpan.getStartTimestampMicros()).isEqualTo(timestamp / 1000);
+    assertThat(apiSpan.getTimestamp()).isEqualTo(timestamp / 1000);
     List<Trace.KeyValue> tags = apiSpan.getTagsList();
     assertThat(getTagValue(tags, "http_method")).isEqualTo("POST");
     assertThat(getTagValue(tags, "mysql_conns_count")).isEqualTo(0L);
@@ -94,11 +94,11 @@ public class MurronLogFormatterTest {
 
     Trace.Span apiSpan = MurronLogFormatter.fromApiLog(testMurronMsg);
     assertThat(apiSpan.getName()).isEqualTo("api_log");
-    assertThat(apiSpan.getDurationMicros()).isEqualTo(14168L);
+    assertThat(apiSpan.getDuration()).isEqualTo(14168L);
     assertThat(apiSpan.getId().toString().contains(host)).isTrue();
     assertThat(apiSpan.getTraceId().toStringUtf8()).isEqualTo("123");
     assertThat(apiSpan.getParentId().toStringUtf8()).isEqualTo("4567");
-    assertThat(apiSpan.getStartTimestampMicros()).isEqualTo(timestamp / 1000);
+    assertThat(apiSpan.getTimestamp()).isEqualTo(timestamp / 1000);
     List<Trace.KeyValue> tags = apiSpan.getTagsList();
     assertThat(getTagValue(tags, "http_method")).isEqualTo("POST");
     assertThat(getTagValue(tags, "mysql_conns_count")).isEqualTo(0L);
@@ -151,11 +151,11 @@ public class MurronLogFormatterTest {
 
     Trace.Span apiSpan = MurronLogFormatter.fromEnvoyLog(testMurronMsg);
     assertThat(apiSpan.getName()).isEqualTo(indexName);
-    assertThat(apiSpan.getDurationMicros()).isEqualTo(36000L);
+    assertThat(apiSpan.getDuration()).isEqualTo(36000L);
     assertThat(apiSpan.getId().toStringUtf8()).isEqualTo(requestId);
     assertThat(apiSpan.getTraceId().toStringUtf8()).isEqualTo(requestId);
     assertThat(apiSpan.getParentId().toStringUtf8()).isEmpty();
-    assertThat(apiSpan.getStartTimestampMicros()).isEqualTo(timestamp / 1000);
+    assertThat(apiSpan.getTimestamp()).isEqualTo(timestamp / 1000);
     List<Trace.KeyValue> tags = apiSpan.getTagsList();
     assertThat(getTagValue(tags, "tcpip_remote_ip")).isEqualTo("10.232.200.31");
     assertThat(getTagValue(tags, "req_method")).isEqualTo("POST");


### PR DESCRIPTION
While @shellywu815  was working on https://github.com/slackhq/kaldb/pull/348 , she had to add `ZipkinSpan` to the trace.proto . Ideally we should be able to use the Span proto that exists

So here are two changes to variable names to the Span proto that don't conform to the standard. Using different variable names causes frontend applications ( in our case Grafana ) to not be able to render the timestamp and duration correctly.

