### PR TITLE
Add `managerConnectString` to query service config

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -44,6 +44,7 @@ queryConfig:
     serverAddress: ${KALDB_QUERY_SERVER_ADDRESS:-localhost}
     requestTimeoutMs: ${KALDB_QUERY_REQUEST_TIMEOUT_MS:-5000}
   defaultQueryTimeoutMs: ${KALDB_QUERY_DEFAULT_QUERY_TIMEOUT_MS:-3000}
+  managerConnectString: ${KALDB_MANAGER_CONNECTION_STRING:-localhost:8083}
 
 metadataStoreConfig:
   zookeeperConfig:

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -84,6 +84,7 @@ message TracingConfig {
 message QueryServiceConfig {
   ServerConfig server_config = 1;
   int32 default_query_timeout_ms = 2;
+  string managerConnectString = 3;
 }
 
 // Configuration for the indexer.

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
@@ -207,6 +207,7 @@ public class KaldbConfigTest {
     final KaldbConfigs.QueryServiceConfig queryServiceConfig = config.getQueryConfig();
     assertThat(queryServiceConfig.getServerConfig().getServerPort()).isEqualTo(8081);
     assertThat(queryServiceConfig.getServerConfig().getServerAddress()).isEqualTo("1.2.3.4");
+    assertThat(queryServiceConfig.getManagerConnectString()).isEqualTo("localhost:8083");
 
     final KaldbConfigs.MetadataStoreConfig metadataStoreConfig = config.getMetadataStoreConfig();
     final KaldbConfigs.ZookeeperConfig zookeeperConfig = metadataStoreConfig.getZookeeperConfig();
@@ -350,6 +351,7 @@ public class KaldbConfigTest {
     final KaldbConfigs.QueryServiceConfig readConfig = config.getQueryConfig();
     assertThat(readConfig.getServerConfig().getServerPort()).isEqualTo(8081);
     assertThat(readConfig.getServerConfig().getServerAddress()).isEqualTo("1.2.3.4");
+    assertThat(readConfig.getManagerConnectString()).isEqualTo("localhost:8083");
 
     final KaldbConfigs.MetadataStoreConfig metadataStoreConfig = config.getMetadataStoreConfig();
     final KaldbConfigs.ZookeeperConfig zookeeperConfig = metadataStoreConfig.getZookeeperConfig();
@@ -507,6 +509,7 @@ public class KaldbConfigTest {
     final KaldbConfigs.QueryServiceConfig queryServiceConfig = config.getQueryConfig();
     assertThat(queryServiceConfig.getServerConfig().getServerPort()).isZero();
     assertThat(queryServiceConfig.getServerConfig().getServerAddress()).isEmpty();
+    assertThat(queryServiceConfig.getManagerConnectString()).isEmpty();
 
     final KaldbConfigs.MetadataStoreConfig metadataStoreConfig = config.getMetadataStoreConfig();
     final KaldbConfigs.ZookeeperConfig zookeeperConfig = metadataStoreConfig.getZookeeperConfig();
@@ -641,6 +644,7 @@ public class KaldbConfigTest {
     final KaldbConfigs.QueryServiceConfig queryServiceConfig = config.getQueryConfig();
     assertThat(queryServiceConfig.getServerConfig().getServerPort()).isZero();
     assertThat(queryServiceConfig.getServerConfig().getServerAddress()).isEmpty();
+    assertThat(queryServiceConfig.getManagerConnectString()).isEmpty();
 
     final KaldbConfigs.MetadataStoreConfig metadataStoreConfig = config.getMetadataStoreConfig();
     final KaldbConfigs.ZookeeperConfig zookeeperConfig = metadataStoreConfig.getZookeeperConfig();

--- a/kaldb/src/test/resources/test_config.json
+++ b/kaldb/src/test/resources/test_config.json
@@ -51,7 +51,8 @@
       "serverAddress": "1.2.3.4",
       "requestTimeoutMs": 3000
     },
-    "defaultQueryTimeoutMs": 1500
+    "defaultQueryTimeoutMs": 1500,
+    "managerConnectString": "localhost:8083"
   },
   "metadataStoreConfig": {
     "zookeeperConfig": {

--- a/kaldb/src/test/resources/test_config.yaml
+++ b/kaldb/src/test/resources/test_config.yaml
@@ -22,6 +22,7 @@ queryConfig:
     serverAddress: "1.2.3.4"
     requestTimeoutMs: 3000
   defaultQueryTimeoutMs: 2500
+  managerConnectString: localhost:8083
 
 kafkaConfig:
   kafkaTopic: ${KAFKA_TOPIC:-test-topic}


### PR DESCRIPTION
Add `managerConnectString` to query service config.
To be used by the query service for connections to the manager.