### PR TITLE
Restore replicas upon query

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -44,7 +44,7 @@ queryConfig:
     serverAddress: ${KALDB_QUERY_SERVER_ADDRESS:-localhost}
     requestTimeoutMs: ${KALDB_QUERY_REQUEST_TIMEOUT_MS:-5000}
   defaultQueryTimeoutMs: ${KALDB_QUERY_DEFAULT_QUERY_TIMEOUT_MS:-3000}
-  managerConnectString: ${KALDB_MANAGER_CONNECTION_STRING:-localhost:8083}
+  managerConnectString: ${KALDB_MANAGER_CONNECTION_STRING:-http://localhost:8083}
 
 metadataStoreConfig:
   zookeeperConfig:

--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -201,7 +201,8 @@ public class Kaldb {
               datasetMetadataStore,
               meterRegistry,
               requestTimeout,
-              Duration.ofMillis(kaldbConfig.getQueryConfig().getDefaultQueryTimeoutMs()));
+              Duration.ofMillis(kaldbConfig.getQueryConfig().getDefaultQueryTimeoutMs()),
+              kaldbConfig.getQueryConfig());
       final int serverPort = kaldbConfig.getQueryConfig().getServerConfig().getServerPort();
 
       ArmeriaService armeriaService =

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
@@ -521,6 +521,7 @@ public class KaldbDistributedQueryServiceTest {
             queryEndTimeEpochMs,
             dataset);
 
-    return getMatchingSearchMetadata(searchMetadataStore, snapshotsToSearch);
+    return new HashSet<>(
+        getMatchingSearchMetadata(searchMetadataStore, snapshotsToSearch).values());
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
@@ -207,7 +207,7 @@ public class KaldbConfigTest {
     final KaldbConfigs.QueryServiceConfig queryServiceConfig = config.getQueryConfig();
     assertThat(queryServiceConfig.getServerConfig().getServerPort()).isEqualTo(8081);
     assertThat(queryServiceConfig.getServerConfig().getServerAddress()).isEqualTo("1.2.3.4");
-    assertThat(queryServiceConfig.getManagerConnectString()).isEqualTo("localhost:8083");
+    assertThat(queryServiceConfig.getManagerConnectString()).isEqualTo("http://localhost:8083");
 
     final KaldbConfigs.MetadataStoreConfig metadataStoreConfig = config.getMetadataStoreConfig();
     final KaldbConfigs.ZookeeperConfig zookeeperConfig = metadataStoreConfig.getZookeeperConfig();
@@ -351,7 +351,7 @@ public class KaldbConfigTest {
     final KaldbConfigs.QueryServiceConfig readConfig = config.getQueryConfig();
     assertThat(readConfig.getServerConfig().getServerPort()).isEqualTo(8081);
     assertThat(readConfig.getServerConfig().getServerAddress()).isEqualTo("1.2.3.4");
-    assertThat(readConfig.getManagerConnectString()).isEqualTo("localhost:8083");
+    assertThat(readConfig.getManagerConnectString()).isEqualTo("http://localhost:8083");
 
     final KaldbConfigs.MetadataStoreConfig metadataStoreConfig = config.getMetadataStoreConfig();
     final KaldbConfigs.ZookeeperConfig zookeeperConfig = metadataStoreConfig.getZookeeperConfig();

--- a/kaldb/src/test/resources/test_config.json
+++ b/kaldb/src/test/resources/test_config.json
@@ -52,7 +52,7 @@
       "requestTimeoutMs": 3000
     },
     "defaultQueryTimeoutMs": 1500,
-    "managerConnectString": "localhost:8083"
+    "managerConnectString": "http://localhost:8083"
   },
   "metadataStoreConfig": {
     "zookeeperConfig": {

--- a/kaldb/src/test/resources/test_config.yaml
+++ b/kaldb/src/test/resources/test_config.yaml
@@ -22,7 +22,7 @@ queryConfig:
     serverAddress: "1.2.3.4"
     requestTimeoutMs: 3000
   defaultQueryTimeoutMs: 2500
-  managerConnectString: localhost:8083
+  managerConnectString: "http://localhost:8083"
 
 kafkaConfig:
   kafkaTopic: ${KAFKA_TOPIC:-test-topic}


### PR DESCRIPTION
Automatically call the restore API when any `Snapshots` that need to be searched cannot be found