### PR TITLE
Add `isRestored` to `ReplicaMetadata`

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaCreationService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaCreationService.java
@@ -226,11 +226,17 @@ public class ReplicaCreationService extends AbstractScheduledService {
   }
 
   public static ReplicaMetadata replicaMetadataFromSnapshotId(
-      String snapshotId, Instant expireAfter) {
+      String snapshotId, Instant expireAfter, boolean isRestored) {
     return new ReplicaMetadata(
         String.format("%s-%s", snapshotId, UUID.randomUUID()),
         snapshotId,
         Instant.now().toEpochMilli(),
-        expireAfter.toEpochMilli());
+        expireAfter.toEpochMilli(),
+        isRestored);
+  }
+
+  public static ReplicaMetadata replicaMetadataFromSnapshotId(
+      String snapshotId, Instant expireAfter) {
+    return replicaMetadataFromSnapshotId(snapshotId, expireAfter, false);
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadata.java
@@ -15,9 +15,19 @@ public class ReplicaMetadata extends KaldbMetadata {
   public final String snapshotId;
   public final long createdTimeEpochMs;
   public final long expireAfterEpochMs;
+  public boolean isRestored;
 
   public ReplicaMetadata(
       String name, String snapshotId, long createdTimeEpochMs, long expireAfterEpochMs) {
+    this(name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, false);
+  }
+
+  public ReplicaMetadata(
+      String name,
+      String snapshotId,
+      long createdTimeEpochMs,
+      long expireAfterEpochMs,
+      boolean isRestored) {
     super(name);
     checkArgument(createdTimeEpochMs > 0, "Created time must be greater than 0");
     checkArgument(expireAfterEpochMs >= 0, "Expiration time must be greater than or equal to 0");
@@ -27,6 +37,7 @@ public class ReplicaMetadata extends KaldbMetadata {
     this.snapshotId = snapshotId;
     this.createdTimeEpochMs = createdTimeEpochMs;
     this.expireAfterEpochMs = expireAfterEpochMs;
+    this.isRestored = isRestored;
   }
 
   public String getSnapshotId() {
@@ -39,6 +50,10 @@ public class ReplicaMetadata extends KaldbMetadata {
 
   public long getExpireAfterEpochMs() {
     return expireAfterEpochMs;
+  }
+
+  public boolean getIsRestored() {
+    return isRestored;
   }
 
   @Override
@@ -70,6 +85,8 @@ public class ReplicaMetadata extends KaldbMetadata {
         + createdTimeEpochMs
         + ", expireAfterEpochMs="
         + expireAfterEpochMs
+        + ", isRestored="
+        + isRestored
         + '}';
   }
 }

--- a/kaldb/src/main/proto/metadata.proto
+++ b/kaldb/src/main/proto/metadata.proto
@@ -39,6 +39,8 @@ message ReplicaMetadata {
 
   // Timestamp after which this replica can be deleted
   int64 expire_after_epoch_ms = 5;
+
+  bool isRestored = 6;
 }
 
 message SnapshotMetadata {


### PR DESCRIPTION
Add a `isRestored` value to `ReplicaMetadata` in order to determine which Replicas are created from the restore API