### PR TITLE
Add an indexType field to `SnapshotMetadata` and `ReplicaMetadata`

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ChunkInfo.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ChunkInfo.java
@@ -42,7 +42,7 @@ public class ChunkInfo {
         chunkInfo.getDataEndTimeEpochMs(),
         chunkInfo.maxOffset,
         chunkInfo.kafkaPartitionId,
-        Metadata.IndexType.LUCENE_REGULAR);
+        Metadata.IndexType.LOGS_LUCENE9);
   }
 
   /* A unique identifier for a the chunk. */

--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ChunkInfo.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ChunkInfo.java
@@ -3,6 +3,7 @@ package com.slack.kaldb.chunk;
 import static com.slack.kaldb.util.ArgValidationUtils.ensureTrue;
 
 import com.slack.kaldb.metadata.snapshot.SnapshotMetadata;
+import com.slack.kaldb.proto.metadata.Metadata;
 import java.util.Objects;
 
 /**
@@ -40,7 +41,8 @@ public class ChunkInfo {
         chunkInfo.getDataStartTimeEpochMs(),
         chunkInfo.getDataEndTimeEpochMs(),
         chunkInfo.maxOffset,
-        chunkInfo.kafkaPartitionId);
+        chunkInfo.kafkaPartitionId,
+        Metadata.IndexType.LUCENE_REGULAR);
   }
 
   /* A unique identifier for a the chunk. */

--- a/kaldb/src/main/java/com/slack/kaldb/chunk/IndexingChunkImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/IndexingChunkImpl.java
@@ -76,7 +76,7 @@ public class IndexingChunkImpl<T> extends ReadWriteChunk<T> {
             chunkInfo.getDataEndTimeEpochMs(),
             chunkInfo.getMaxOffset(),
             chunkInfo.getKafkaPartitionId(),
-            Metadata.IndexType.LUCENE_REGULAR);
+            Metadata.IndexType.LOGS_LUCENE9);
     snapshotMetadataStore.updateSync(updatedSnapshotMetadata);
     liveSnapshotMetadata = updatedSnapshotMetadata;
 

--- a/kaldb/src/main/java/com/slack/kaldb/chunk/IndexingChunkImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/IndexingChunkImpl.java
@@ -6,6 +6,7 @@ import com.slack.kaldb.logstore.LogStore;
 import com.slack.kaldb.metadata.search.SearchMetadataStore;
 import com.slack.kaldb.metadata.snapshot.SnapshotMetadata;
 import com.slack.kaldb.metadata.snapshot.SnapshotMetadataStore;
+import com.slack.kaldb.proto.metadata.Metadata;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,7 +75,8 @@ public class IndexingChunkImpl<T> extends ReadWriteChunk<T> {
             chunkInfo.getDataStartTimeEpochMs(),
             chunkInfo.getDataEndTimeEpochMs(),
             chunkInfo.getMaxOffset(),
-            chunkInfo.getKafkaPartitionId());
+            chunkInfo.getKafkaPartitionId(),
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.updateSync(updatedSnapshotMetadata);
     liveSnapshotMetadata = updatedSnapshotMetadata;
 

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaCreationService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaCreationService.java
@@ -15,6 +15,7 @@ import com.slack.kaldb.metadata.replica.ReplicaMetadataStore;
 import com.slack.kaldb.metadata.snapshot.SnapshotMetadata;
 import com.slack.kaldb.metadata.snapshot.SnapshotMetadataStore;
 import com.slack.kaldb.proto.config.KaldbConfigs;
+import com.slack.kaldb.proto.metadata.Metadata;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
@@ -233,6 +234,7 @@ public class ReplicaCreationService extends AbstractScheduledService {
         snapshotId,
         Instant.now().toEpochMilli(),
         expireAfter.toEpochMilli(),
-        isRestored);
+        isRestored,
+        Metadata.IndexType.LUCENE_REGULAR);
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaCreationService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaCreationService.java
@@ -235,6 +235,6 @@ public class ReplicaCreationService extends AbstractScheduledService {
         Instant.now().toEpochMilli(),
         expireAfter.toEpochMilli(),
         isRestored,
-        Metadata.IndexType.LUCENE_REGULAR);
+        Metadata.IndexType.LOGS_LUCENE9);
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializer.java
@@ -13,7 +13,8 @@ public class ReplicaMetadataSerializer implements MetadataSerializer<ReplicaMeta
         replicaMetadataProto.getSnapshotId(),
         replicaMetadataProto.getCreatedTimeEpochMs(),
         replicaMetadataProto.getExpireAfterEpochMs(),
-        replicaMetadataProto.getIsRestored());
+        replicaMetadataProto.getIsRestored(),
+        Metadata.IndexType.LUCENE_REGULAR);
   }
 
   private static Metadata.ReplicaMetadata toReplicaMetadataProto(ReplicaMetadata metadata) {
@@ -23,6 +24,7 @@ public class ReplicaMetadataSerializer implements MetadataSerializer<ReplicaMeta
         .setCreatedTimeEpochMs(metadata.createdTimeEpochMs)
         .setExpireAfterEpochMs(metadata.expireAfterEpochMs)
         .setIsRestored(metadata.isRestored)
+        .setIndexType(metadata.indexType)
         .build();
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializer.java
@@ -14,7 +14,7 @@ public class ReplicaMetadataSerializer implements MetadataSerializer<ReplicaMeta
         replicaMetadataProto.getCreatedTimeEpochMs(),
         replicaMetadataProto.getExpireAfterEpochMs(),
         replicaMetadataProto.getIsRestored(),
-        Metadata.IndexType.LUCENE_REGULAR);
+        Metadata.IndexType.LOGS_LUCENE9);
   }
 
   private static Metadata.ReplicaMetadata toReplicaMetadataProto(ReplicaMetadata metadata) {

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadata.java
@@ -3,6 +3,7 @@ package com.slack.kaldb.metadata.snapshot;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.slack.kaldb.metadata.core.KaldbMetadata;
+import com.slack.kaldb.proto.metadata.Metadata;
 
 /**
  * The SnapshotMetadata class contains all the metadata related to a snapshot.
@@ -30,6 +31,7 @@ public class SnapshotMetadata extends KaldbMetadata {
   public final long endTimeEpochMs;
   public final long maxOffset;
   public final String partitionId;
+  public final Metadata.IndexType indexType;
 
   public SnapshotMetadata(
       String snapshotId,
@@ -37,7 +39,8 @@ public class SnapshotMetadata extends KaldbMetadata {
       long startTimeEpochMs,
       long endTimeEpochMs,
       long maxOffset,
-      String partitionId) {
+      String partitionId,
+      Metadata.IndexType indexType) {
     this(
         snapshotId,
         snapshotPath,
@@ -45,7 +48,8 @@ public class SnapshotMetadata extends KaldbMetadata {
         startTimeEpochMs,
         endTimeEpochMs,
         maxOffset,
-        partitionId);
+        partitionId,
+        indexType);
   }
 
   private SnapshotMetadata(
@@ -55,7 +59,8 @@ public class SnapshotMetadata extends KaldbMetadata {
       long startTimeEpochMs,
       long endTimeEpochMs,
       long maxOffset,
-      String partitionId) {
+      String partitionId,
+      Metadata.IndexType indexType) {
     super(name);
     checkArgument(snapshotId != null && !snapshotId.isEmpty(), "snapshotId can't be null or empty");
     checkArgument(startTimeEpochMs > 0, "start time should be greater than zero.");
@@ -75,6 +80,7 @@ public class SnapshotMetadata extends KaldbMetadata {
     this.endTimeEpochMs = endTimeEpochMs;
     this.maxOffset = maxOffset;
     this.partitionId = partitionId;
+    this.indexType = indexType;
   }
 
   @Override
@@ -88,20 +94,25 @@ public class SnapshotMetadata extends KaldbMetadata {
     if (startTimeEpochMs != that.startTimeEpochMs) return false;
     if (endTimeEpochMs != that.endTimeEpochMs) return false;
     if (maxOffset != that.maxOffset) return false;
-    if (!snapshotPath.equals(that.snapshotPath)) return false;
-    if (!snapshotId.equals(that.snapshotId)) return false;
-    return partitionId.equals(that.partitionId);
+    if (snapshotPath != null ? !snapshotPath.equals(that.snapshotPath) : that.snapshotPath != null)
+      return false;
+    if (snapshotId != null ? !snapshotId.equals(that.snapshotId) : that.snapshotId != null)
+      return false;
+    if (partitionId != null ? !partitionId.equals(that.partitionId) : that.partitionId != null)
+      return false;
+    return indexType == that.indexType;
   }
 
   @Override
   public int hashCode() {
     int result = super.hashCode();
-    result = 31 * result + snapshotPath.hashCode();
-    result = 31 * result + snapshotId.hashCode();
+    result = 31 * result + (snapshotPath != null ? snapshotPath.hashCode() : 0);
+    result = 31 * result + (snapshotId != null ? snapshotId.hashCode() : 0);
     result = 31 * result + (int) (startTimeEpochMs ^ (startTimeEpochMs >>> 32));
     result = 31 * result + (int) (endTimeEpochMs ^ (endTimeEpochMs >>> 32));
     result = 31 * result + (int) (maxOffset ^ (maxOffset >>> 32));
-    result = 31 * result + partitionId.hashCode();
+    result = 31 * result + (partitionId != null ? partitionId.hashCode() : 0);
+    result = 31 * result + (indexType != null ? indexType.hashCode() : 0);
     return result;
   }
 
@@ -127,6 +138,8 @@ public class SnapshotMetadata extends KaldbMetadata {
         + ", partitionId='"
         + partitionId
         + '\''
+        + ", indexType="
+        + indexType
         + '}';
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataSerializer.java
@@ -29,7 +29,7 @@ public class SnapshotMetadataSerializer implements MetadataSerializer<SnapshotMe
         protoSnapshotMetadata.getEndTimeEpochMs(),
         protoSnapshotMetadata.getMaxOffset(),
         protoSnapshotMetadata.getPartitionId(),
-        Metadata.IndexType.LUCENE_REGULAR);
+        Metadata.IndexType.LOGS_LUCENE9);
   }
 
   @Override

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataSerializer.java
@@ -16,6 +16,7 @@ public class SnapshotMetadataSerializer implements MetadataSerializer<SnapshotMe
         .setEndTimeEpochMs(snapshotMetadata.endTimeEpochMs)
         .setPartitionId(snapshotMetadata.partitionId)
         .setMaxOffset(snapshotMetadata.maxOffset)
+        .setIndexType(snapshotMetadata.indexType)
         .build();
   }
 
@@ -27,7 +28,8 @@ public class SnapshotMetadataSerializer implements MetadataSerializer<SnapshotMe
         protoSnapshotMetadata.getStartTimeEpochMs(),
         protoSnapshotMetadata.getEndTimeEpochMs(),
         protoSnapshotMetadata.getMaxOffset(),
-        protoSnapshotMetadata.getPartitionId());
+        protoSnapshotMetadata.getPartitionId(),
+        Metadata.IndexType.LUCENE_REGULAR);
   }
 
   @Override

--- a/kaldb/src/main/proto/metadata.proto
+++ b/kaldb/src/main/proto/metadata.proto
@@ -4,8 +4,8 @@ package slack.proto.kaldb;
 
 option java_package = "com.slack.kaldb.proto.metadata";
 
-enum DataType {
-  LUCENE_BASIC = 0;
+enum IndexType {
+  LUCENE_REGULAR = 0;
 };
 
 message CacheSlotMetadata {
@@ -45,6 +45,9 @@ message ReplicaMetadata {
   int64 expire_after_epoch_ms = 5;
 
   bool isRestored = 6;
+
+  // Add the index type of the replica metadata.
+  IndexType index_type = 7;
 }
 
 message SnapshotMetadata {
@@ -67,8 +70,8 @@ message SnapshotMetadata {
   // Kafka offset when this snapshot was taken for that partition.
   int64 max_offset = 6;
 
-  // The type of data contained in the snapshot
-  DataType data_type = 8;
+  // The index used to store the data.
+  IndexType index_type = 8;
 }
 
 message SearchMetadata {

--- a/kaldb/src/main/proto/metadata.proto
+++ b/kaldb/src/main/proto/metadata.proto
@@ -4,6 +4,10 @@ package slack.proto.kaldb;
 
 option java_package = "com.slack.kaldb.proto.metadata";
 
+enum DataType {
+  LUCENE_BASIC = 0;
+};
+
 message CacheSlotMetadata {
   enum CacheSlotState {
     FREE = 0;
@@ -62,6 +66,9 @@ message SnapshotMetadata {
   string partition_id = 7;
   // Kafka offset when this snapshot was taken for that partition.
   int64 max_offset = 6;
+
+  // The type of data contained in the snapshot
+  DataType data_type = 8;
 }
 
 message SearchMetadata {

--- a/kaldb/src/main/proto/metadata.proto
+++ b/kaldb/src/main/proto/metadata.proto
@@ -5,7 +5,7 @@ package slack.proto.kaldb;
 option java_package = "com.slack.kaldb.proto.metadata";
 
 enum IndexType {
-  LUCENE_REGULAR = 0;
+  LOGS_LUCENE9 = 0;
 };
 
 message CacheSlotMetadata {

--- a/kaldb/src/main/proto/metadata.proto
+++ b/kaldb/src/main/proto/metadata.proto
@@ -46,7 +46,6 @@ message ReplicaMetadata {
 
   bool isRestored = 6;
 
-  // Add the index type of the replica metadata.
   IndexType index_type = 7;
 }
 
@@ -70,7 +69,7 @@ message SnapshotMetadata {
   // Kafka offset when this snapshot was taken for that partition.
   int64 max_offset = 6;
 
-  // The index used to store the data.
+  // The type of index used to store this data.
   IndexType index_type = 8;
 }
 

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -7,7 +7,7 @@ import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.COMMITS_TIMER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_FAILED_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_RECEIVED_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.REFRESHES_TIMER;
-import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LOGS_LUCENE9;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
 import static com.slack.kaldb.testlib.MetricsUtil.getTimerCount;
 import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.addMessages;
@@ -467,7 +467,7 @@ public class ReadOnlyChunkImplTest {
                 Instant.now().toEpochMilli(),
                 1,
                 "partitionId",
-                LUCENE_REGULAR))
+                LOGS_LUCENE9))
         .get(5, TimeUnit.SECONDS);
   }
 
@@ -482,7 +482,7 @@ public class ReadOnlyChunkImplTest {
                 Instant.now().toEpochMilli(),
                 Instant.now().plusSeconds(60).toEpochMilli(),
                 false,
-                LUCENE_REGULAR))
+                LOGS_LUCENE9))
         .get(5, TimeUnit.SECONDS);
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -7,6 +7,7 @@ import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.COMMITS_TIMER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_FAILED_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_RECEIVED_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.REFRESHES_TIMER;
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
 import static com.slack.kaldb.testlib.MetricsUtil.getTimerCount;
 import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.addMessages;
@@ -466,7 +467,7 @@ public class ReadOnlyChunkImplTest {
                 Instant.now().toEpochMilli(),
                 1,
                 "partitionId",
-                Metadata.IndexType.LUCENE_REGULAR))
+                LUCENE_REGULAR))
         .get(5, TimeUnit.SECONDS);
   }
 
@@ -480,7 +481,8 @@ public class ReadOnlyChunkImplTest {
                 snapshotId,
                 Instant.now().toEpochMilli(),
                 Instant.now().plusSeconds(60).toEpochMilli(),
-                false))
+                false,
+                LUCENE_REGULAR))
         .get(5, TimeUnit.SECONDS);
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -465,7 +465,8 @@ public class ReadOnlyChunkImplTest {
                 Instant.now().minus(1, ChronoUnit.MINUTES).toEpochMilli(),
                 Instant.now().toEpochMilli(),
                 1,
-                "partitionId"))
+                "partitionId",
+                Metadata.IndexType.LUCENE_REGULAR))
         .get(5, TimeUnit.SECONDS);
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
@@ -98,9 +98,15 @@ public class DiskOrMessageCountBasedRolloverStrategyTest {
       chunkManager.stopAsync();
       chunkManager.awaitTerminated(DEFAULT_START_STOP_DURATION);
     }
-    metadataStore.close();
-    s3Client.close();
-    localZkServer.stop();
+    if (metadataStore != null) {
+      metadataStore.close();
+    }
+    if (s3Client != null) {
+      s3Client.close();
+    }
+    if (localZkServer != null) {
+      localZkServer.stop();
+    }
   }
 
   private void initChunkManager(

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
@@ -1,5 +1,6 @@
 package com.slack.kaldb.clusterManager;
 
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -172,7 +173,8 @@ public class ReplicaAssignmentServiceTest {
               UUID.randomUUID().toString(),
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
-              false);
+              false,
+              LUCENE_REGULAR);
       replicaMetadataList.add(replicaMetadata);
       replicaMetadataStore.create(replicaMetadata);
     }
@@ -279,7 +281,8 @@ public class ReplicaAssignmentServiceTest {
               UUID.randomUUID().toString(),
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
-              false);
+              false,
+              LUCENE_REGULAR);
       replicaMetadataList.add(replicaMetadata);
       replicaMetadataStore.create(replicaMetadata);
     }
@@ -357,7 +360,8 @@ public class ReplicaAssignmentServiceTest {
               UUID.randomUUID().toString(),
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
-              false);
+              false,
+              LUCENE_REGULAR);
       replicaMetadataList.add(replicaMetadata);
       replicaMetadataStore.create(replicaMetadata);
     }
@@ -459,7 +463,8 @@ public class ReplicaAssignmentServiceTest {
               UUID.randomUUID().toString(),
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
-              false);
+              false,
+              LUCENE_REGULAR);
       replicaMetadataList.add(replicaMetadata);
       replicaMetadataStore.create(replicaMetadata);
     }
@@ -526,7 +531,8 @@ public class ReplicaAssignmentServiceTest {
               UUID.randomUUID().toString(),
               Instant.now().minus(1500, ChronoUnit.MINUTES).toEpochMilli(),
               Instant.now().minusSeconds(60).toEpochMilli(),
-              false);
+              false,
+              LUCENE_REGULAR);
       replicaMetadataExpiredList.add(replicaMetadata);
       replicaMetadataStore.create(replicaMetadata);
     }
@@ -538,7 +544,8 @@ public class ReplicaAssignmentServiceTest {
             UUID.randomUUID().toString(),
             Instant.now().minus(1500, ChronoUnit.MINUTES).toEpochMilli(),
             0,
-            false);
+            false,
+            LUCENE_REGULAR);
     replicaMetadataExpiredList.add(replicaMetadataZero);
     replicaMetadataStore.create(replicaMetadataZero);
 
@@ -549,7 +556,8 @@ public class ReplicaAssignmentServiceTest {
               UUID.randomUUID().toString(),
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
-              false);
+              false,
+              LUCENE_REGULAR);
       replicaMetadataStore.create(replicaMetadata);
     }
 
@@ -642,7 +650,8 @@ public class ReplicaAssignmentServiceTest {
               UUID.randomUUID().toString(),
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
-              false);
+              false,
+              LUCENE_REGULAR);
       replicaMetadataStore.create(replicaMetadata);
     }
 
@@ -765,7 +774,8 @@ public class ReplicaAssignmentServiceTest {
               UUID.randomUUID().toString(),
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
-              false);
+              false,
+              LUCENE_REGULAR);
       replicaMetadataStore.create(replicaMetadata);
     }
 
@@ -863,7 +873,8 @@ public class ReplicaAssignmentServiceTest {
               UUID.randomUUID().toString(),
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
-              false);
+              false,
+              LUCENE_REGULAR);
       replicaMetadataStore.create(replicaMetadata);
     }
 
@@ -975,7 +986,8 @@ public class ReplicaAssignmentServiceTest {
               UUID.randomUUID().toString(),
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
-              false);
+              false,
+              LUCENE_REGULAR);
       replicaMetadataStore.create(replicaMetadata);
     }
 
@@ -1047,7 +1059,8 @@ public class ReplicaAssignmentServiceTest {
               UUID.randomUUID().toString(),
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
-              false);
+              false,
+              LUCENE_REGULAR);
       replicaMetadataList.add(replicaMetadata);
       replicaMetadataStore.create(replicaMetadata);
     }
@@ -1123,7 +1136,8 @@ public class ReplicaAssignmentServiceTest {
             UUID.randomUUID().toString(),
             now.minus(1, ChronoUnit.HOURS).toEpochMilli(),
             now.plusSeconds(60).toEpochMilli(),
-            false);
+            false,
+            LUCENE_REGULAR);
     replicaMetadataStore.create(olderReplicaMetadata);
 
     ReplicaMetadata newerReplicaMetadata =
@@ -1132,7 +1146,8 @@ public class ReplicaAssignmentServiceTest {
             UUID.randomUUID().toString(),
             now.toEpochMilli(),
             now.plusSeconds(60).toEpochMilli(),
-            false);
+            false,
+            LUCENE_REGULAR);
     replicaMetadataStore.create(newerReplicaMetadata);
 
     await().until(() -> replicaMetadataStore.getCached().size() == 2);

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
@@ -1,6 +1,6 @@
 package com.slack.kaldb.clusterManager;
 
-import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LOGS_LUCENE9;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -174,7 +174,7 @@ public class ReplicaAssignmentServiceTest {
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
               false,
-              LUCENE_REGULAR);
+              LOGS_LUCENE9);
       replicaMetadataList.add(replicaMetadata);
       replicaMetadataStore.create(replicaMetadata);
     }
@@ -282,7 +282,7 @@ public class ReplicaAssignmentServiceTest {
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
               false,
-              LUCENE_REGULAR);
+              LOGS_LUCENE9);
       replicaMetadataList.add(replicaMetadata);
       replicaMetadataStore.create(replicaMetadata);
     }
@@ -361,7 +361,7 @@ public class ReplicaAssignmentServiceTest {
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
               false,
-              LUCENE_REGULAR);
+              LOGS_LUCENE9);
       replicaMetadataList.add(replicaMetadata);
       replicaMetadataStore.create(replicaMetadata);
     }
@@ -464,7 +464,7 @@ public class ReplicaAssignmentServiceTest {
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
               false,
-              LUCENE_REGULAR);
+              LOGS_LUCENE9);
       replicaMetadataList.add(replicaMetadata);
       replicaMetadataStore.create(replicaMetadata);
     }
@@ -532,7 +532,7 @@ public class ReplicaAssignmentServiceTest {
               Instant.now().minus(1500, ChronoUnit.MINUTES).toEpochMilli(),
               Instant.now().minusSeconds(60).toEpochMilli(),
               false,
-              LUCENE_REGULAR);
+              LOGS_LUCENE9);
       replicaMetadataExpiredList.add(replicaMetadata);
       replicaMetadataStore.create(replicaMetadata);
     }
@@ -545,7 +545,7 @@ public class ReplicaAssignmentServiceTest {
             Instant.now().minus(1500, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             false,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     replicaMetadataExpiredList.add(replicaMetadataZero);
     replicaMetadataStore.create(replicaMetadataZero);
 
@@ -557,7 +557,7 @@ public class ReplicaAssignmentServiceTest {
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
               false,
-              LUCENE_REGULAR);
+              LOGS_LUCENE9);
       replicaMetadataStore.create(replicaMetadata);
     }
 
@@ -651,7 +651,7 @@ public class ReplicaAssignmentServiceTest {
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
               false,
-              LUCENE_REGULAR);
+              LOGS_LUCENE9);
       replicaMetadataStore.create(replicaMetadata);
     }
 
@@ -775,7 +775,7 @@ public class ReplicaAssignmentServiceTest {
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
               false,
-              LUCENE_REGULAR);
+              LOGS_LUCENE9);
       replicaMetadataStore.create(replicaMetadata);
     }
 
@@ -874,7 +874,7 @@ public class ReplicaAssignmentServiceTest {
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
               false,
-              LUCENE_REGULAR);
+              LOGS_LUCENE9);
       replicaMetadataStore.create(replicaMetadata);
     }
 
@@ -987,7 +987,7 @@ public class ReplicaAssignmentServiceTest {
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
               false,
-              LUCENE_REGULAR);
+              LOGS_LUCENE9);
       replicaMetadataStore.create(replicaMetadata);
     }
 
@@ -1060,7 +1060,7 @@ public class ReplicaAssignmentServiceTest {
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
               false,
-              LUCENE_REGULAR);
+              LOGS_LUCENE9);
       replicaMetadataList.add(replicaMetadata);
       replicaMetadataStore.create(replicaMetadata);
     }
@@ -1137,7 +1137,7 @@ public class ReplicaAssignmentServiceTest {
             now.minus(1, ChronoUnit.HOURS).toEpochMilli(),
             now.plusSeconds(60).toEpochMilli(),
             false,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     replicaMetadataStore.create(olderReplicaMetadata);
 
     ReplicaMetadata newerReplicaMetadata =
@@ -1147,7 +1147,7 @@ public class ReplicaAssignmentServiceTest {
             now.toEpochMilli(),
             now.plusSeconds(60).toEpochMilli(),
             false,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     replicaMetadataStore.create(newerReplicaMetadata);
 
     await().until(() -> replicaMetadataStore.getCached().size() == 2);

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaCreationServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaCreationServiceTest.java
@@ -16,6 +16,7 @@ import com.slack.kaldb.metadata.snapshot.SnapshotMetadataStore;
 import com.slack.kaldb.metadata.zookeeper.MetadataStore;
 import com.slack.kaldb.metadata.zookeeper.ZookeeperMetadataStoreImpl;
 import com.slack.kaldb.proto.config.KaldbConfigs;
+import com.slack.kaldb.proto.metadata.Metadata;
 import com.slack.kaldb.testlib.MetricsUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -83,7 +84,13 @@ public class ReplicaCreationServiceTest {
 
     SnapshotMetadata snapshotA =
         new SnapshotMetadata(
-            "a", "a", Instant.now().toEpochMilli() - 1, Instant.now().toEpochMilli(), 0, "a");
+            "a",
+            "a",
+            Instant.now().toEpochMilli() - 1,
+            Instant.now().toEpochMilli(),
+            0,
+            "a",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(snapshotA);
 
     replicaMetadataStore.createSync(
@@ -128,7 +135,13 @@ public class ReplicaCreationServiceTest {
   public void shouldCreateZeroReplicasNoneConfigured() throws Exception {
     SnapshotMetadata snapshotA =
         new SnapshotMetadata(
-            "a", "a", Instant.now().toEpochMilli() - 1, Instant.now().toEpochMilli(), 0, "a");
+            "a",
+            "a",
+            Instant.now().toEpochMilli() - 1,
+            Instant.now().toEpochMilli(),
+            0,
+            "a",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(snapshotA);
 
     KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
@@ -166,7 +179,13 @@ public class ReplicaCreationServiceTest {
   public void shouldCreateFourReplicasIfNoneExist() throws Exception {
     SnapshotMetadata snapshotA =
         new SnapshotMetadata(
-            "a", "a", Instant.now().toEpochMilli() - 1, Instant.now().toEpochMilli(), 0, "a");
+            "a",
+            "a",
+            Instant.now().toEpochMilli() - 1,
+            Instant.now().toEpochMilli(),
+            0,
+            "a",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(snapshotA);
 
     KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
@@ -215,7 +234,13 @@ public class ReplicaCreationServiceTest {
   public void shouldNotCreateReplicasForLiveSnapshots() {
     SnapshotMetadata snapshotNotLive =
         new SnapshotMetadata(
-            "a", "a", Instant.now().toEpochMilli() - 1, Instant.now().toEpochMilli(), 0, "a");
+            "a",
+            "a",
+            Instant.now().toEpochMilli() - 1,
+            Instant.now().toEpochMilli(),
+            0,
+            "a",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(snapshotNotLive);
 
     SnapshotMetadata snapshotLive =
@@ -225,7 +250,8 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli() - 1,
             Instant.now().toEpochMilli(),
             0,
-            "b");
+            "b",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(snapshotLive);
 
     KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
@@ -308,7 +334,8 @@ public class ReplicaCreationServiceTest {
                       Instant.now().minus(1450, ChronoUnit.MINUTES).toEpochMilli(),
                       Instant.now().minus(1441, ChronoUnit.MINUTES).toEpochMilli(),
                       0,
-                      snapshotId);
+                      snapshotId,
+                      Metadata.IndexType.LUCENE_REGULAR);
               snapshotList.add(snapshot);
             });
 
@@ -323,7 +350,8 @@ public class ReplicaCreationServiceTest {
                       Instant.now().toEpochMilli() - 1,
                       Instant.now().toEpochMilli(),
                       0,
-                      snapshotId);
+                      snapshotId,
+                      Metadata.IndexType.LUCENE_REGULAR);
               snapshotList.add(snapshot);
             });
 
@@ -339,7 +367,8 @@ public class ReplicaCreationServiceTest {
                       Instant.now().toEpochMilli() - 1,
                       Instant.now().toEpochMilli(),
                       0,
-                      snapshotId);
+                      snapshotId,
+                      Metadata.IndexType.LUCENE_REGULAR);
               eligibleSnapshots.add(snapshot);
             });
     snapshotList.addAll(eligibleSnapshots);
@@ -418,7 +447,13 @@ public class ReplicaCreationServiceTest {
     // EventAggregationSecs duration, attempt to create the replicas
     SnapshotMetadata snapshotA =
         new SnapshotMetadata(
-            "a", "a", Instant.now().toEpochMilli() - 1, Instant.now().toEpochMilli(), 0, "a");
+            "a",
+            "a",
+            Instant.now().toEpochMilli() - 1,
+            Instant.now().toEpochMilli(),
+            0,
+            "a",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(snapshotA);
 
     await().until(() -> replicaMetadataStore.getCached().size() == 2);
@@ -480,7 +515,13 @@ public class ReplicaCreationServiceTest {
     // attempt to create the replicas
     SnapshotMetadata snapshotA =
         new SnapshotMetadata(
-            "a", "a", Instant.now().toEpochMilli() - 1, Instant.now().toEpochMilli(), 0, "a");
+            "a",
+            "a",
+            Instant.now().toEpochMilli() - 1,
+            Instant.now().toEpochMilli(),
+            0,
+            "a",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(snapshotA);
 
     await()
@@ -527,7 +568,13 @@ public class ReplicaCreationServiceTest {
   public void shouldHandleFailedCreateFutures() {
     SnapshotMetadata snapshotA =
         new SnapshotMetadata(
-            "a", "a", Instant.now().toEpochMilli() - 1, Instant.now().toEpochMilli(), 0, "a");
+            "a",
+            "a",
+            Instant.now().toEpochMilli() - 1,
+            Instant.now().toEpochMilli(),
+            0,
+            "a",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(snapshotA);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
 
@@ -569,7 +616,13 @@ public class ReplicaCreationServiceTest {
   public void shouldHandleMixOfSuccessfulFailedZkFutures() {
     SnapshotMetadata snapshotA =
         new SnapshotMetadata(
-            "a", "a", Instant.now().toEpochMilli() - 1, Instant.now().toEpochMilli(), 0, "a");
+            "a",
+            "a",
+            Instant.now().toEpochMilli() - 1,
+            Instant.now().toEpochMilli(),
+            0,
+            "a",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(snapshotA);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
 

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaCreationServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaCreationServiceTest.java
@@ -1,5 +1,6 @@
 package com.slack.kaldb.clusterManager;
 
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -16,7 +17,6 @@ import com.slack.kaldb.metadata.snapshot.SnapshotMetadataStore;
 import com.slack.kaldb.metadata.zookeeper.MetadataStore;
 import com.slack.kaldb.metadata.zookeeper.ZookeeperMetadataStoreImpl;
 import com.slack.kaldb.proto.config.KaldbConfigs;
-import com.slack.kaldb.proto.metadata.Metadata;
 import com.slack.kaldb.testlib.MetricsUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -90,7 +90,7 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(snapshotA);
 
     replicaMetadataStore.createSync(
@@ -141,7 +141,7 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(snapshotA);
 
     KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
@@ -185,7 +185,7 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(snapshotA);
 
     KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
@@ -240,7 +240,7 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(snapshotNotLive);
 
     SnapshotMetadata snapshotLive =
@@ -251,7 +251,7 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "b",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(snapshotLive);
 
     KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
@@ -335,7 +335,7 @@ public class ReplicaCreationServiceTest {
                       Instant.now().minus(1441, ChronoUnit.MINUTES).toEpochMilli(),
                       0,
                       snapshotId,
-                      Metadata.IndexType.LUCENE_REGULAR);
+                      LUCENE_REGULAR);
               snapshotList.add(snapshot);
             });
 
@@ -351,7 +351,7 @@ public class ReplicaCreationServiceTest {
                       Instant.now().toEpochMilli(),
                       0,
                       snapshotId,
-                      Metadata.IndexType.LUCENE_REGULAR);
+                      LUCENE_REGULAR);
               snapshotList.add(snapshot);
             });
 
@@ -368,7 +368,7 @@ public class ReplicaCreationServiceTest {
                       Instant.now().toEpochMilli(),
                       0,
                       snapshotId,
-                      Metadata.IndexType.LUCENE_REGULAR);
+                      LUCENE_REGULAR);
               eligibleSnapshots.add(snapshot);
             });
     snapshotList.addAll(eligibleSnapshots);
@@ -453,7 +453,7 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(snapshotA);
 
     await().until(() -> replicaMetadataStore.getCached().size() == 2);
@@ -521,7 +521,7 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(snapshotA);
 
     await()
@@ -574,7 +574,7 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(snapshotA);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
 
@@ -622,7 +622,7 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(snapshotA);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
 

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaCreationServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaCreationServiceTest.java
@@ -1,6 +1,6 @@
 package com.slack.kaldb.clusterManager;
 
-import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LOGS_LUCENE9;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -90,7 +90,7 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(snapshotA);
 
     replicaMetadataStore.createSync(
@@ -141,7 +141,7 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(snapshotA);
 
     KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
@@ -185,7 +185,7 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(snapshotA);
 
     KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
@@ -240,7 +240,7 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(snapshotNotLive);
 
     SnapshotMetadata snapshotLive =
@@ -251,7 +251,7 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "b",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(snapshotLive);
 
     KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
@@ -335,7 +335,7 @@ public class ReplicaCreationServiceTest {
                       Instant.now().minus(1441, ChronoUnit.MINUTES).toEpochMilli(),
                       0,
                       snapshotId,
-                      LUCENE_REGULAR);
+                      LOGS_LUCENE9);
               snapshotList.add(snapshot);
             });
 
@@ -351,7 +351,7 @@ public class ReplicaCreationServiceTest {
                       Instant.now().toEpochMilli(),
                       0,
                       snapshotId,
-                      LUCENE_REGULAR);
+                      LOGS_LUCENE9);
               snapshotList.add(snapshot);
             });
 
@@ -368,7 +368,7 @@ public class ReplicaCreationServiceTest {
                       Instant.now().toEpochMilli(),
                       0,
                       snapshotId,
-                      LUCENE_REGULAR);
+                      LOGS_LUCENE9);
               eligibleSnapshots.add(snapshot);
             });
     snapshotList.addAll(eligibleSnapshots);
@@ -453,7 +453,7 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(snapshotA);
 
     await().until(() -> replicaMetadataStore.getCached().size() == 2);
@@ -521,7 +521,7 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(snapshotA);
 
     await()
@@ -574,7 +574,7 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(snapshotA);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
 
@@ -622,7 +622,7 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(snapshotA);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
 

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaDeletionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaDeletionServiceTest.java
@@ -1,6 +1,6 @@
 package com.slack.kaldb.clusterManager;
 
-import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LOGS_LUCENE9;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -140,7 +140,7 @@ public class ReplicaDeletionServiceTest {
             Instant.now().minusSeconds(30).toEpochMilli(),
             Instant.now().minusSeconds(10).toEpochMilli(),
             false,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     replicaMetadataStore.create(replicaMetadata);
 
     CacheSlotMetadata cacheSlotMetadata =
@@ -195,7 +195,7 @@ public class ReplicaDeletionServiceTest {
               Instant.now().minusSeconds(30).toEpochMilli(),
               Instant.now().minusSeconds(10).toEpochMilli(),
               false,
-              LUCENE_REGULAR);
+              LOGS_LUCENE9);
       replicaMetadataList.add(replicaMetadata);
       replicaMetadataStore.create(replicaMetadata);
     }
@@ -269,7 +269,7 @@ public class ReplicaDeletionServiceTest {
             Instant.now().minusSeconds(30).toEpochMilli(),
             Instant.now().plusSeconds(30).toEpochMilli(),
             false,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     replicaMetadataStore.create(replicaMetadata);
 
     CacheSlotMetadata cacheSlotMetadata =
@@ -322,7 +322,7 @@ public class ReplicaDeletionServiceTest {
             Instant.now().minusSeconds(30).toEpochMilli(),
             Instant.now().minusSeconds(10).toEpochMilli(),
             false,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     replicaMetadataStore.create(replicaMetadata);
 
     CacheSlotMetadata cacheSlotMetadata =
@@ -397,7 +397,7 @@ public class ReplicaDeletionServiceTest {
               Instant.now().minusSeconds(30).toEpochMilli(),
               Instant.now().minusSeconds(10).toEpochMilli(),
               false,
-              LUCENE_REGULAR);
+              LOGS_LUCENE9);
       replicaMetadataStore.create(replicaMetadata);
     }
 
@@ -491,7 +491,7 @@ public class ReplicaDeletionServiceTest {
             Instant.now().minusSeconds(30).toEpochMilli(),
             Instant.now().minusSeconds(10).toEpochMilli(),
             false,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     replicaMetadataStore.create(replicaMetadataUnassigned);
 
     ReplicaMetadata replicaMetadataAssigned =
@@ -501,7 +501,7 @@ public class ReplicaDeletionServiceTest {
             Instant.now().minusSeconds(30).toEpochMilli(),
             Instant.now().minusSeconds(10).toEpochMilli(),
             false,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     replicaMetadataStore.create(replicaMetadataAssigned);
 
     CacheSlotMetadata cacheSlotMetadataUnassigned =

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaDeletionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaDeletionServiceTest.java
@@ -1,5 +1,6 @@
 package com.slack.kaldb.clusterManager;
 
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -138,7 +139,8 @@ public class ReplicaDeletionServiceTest {
             UUID.randomUUID().toString(),
             Instant.now().minusSeconds(30).toEpochMilli(),
             Instant.now().minusSeconds(10).toEpochMilli(),
-            false);
+            false,
+            LUCENE_REGULAR);
     replicaMetadataStore.create(replicaMetadata);
 
     CacheSlotMetadata cacheSlotMetadata =
@@ -192,7 +194,8 @@ public class ReplicaDeletionServiceTest {
               UUID.randomUUID().toString(),
               Instant.now().minusSeconds(30).toEpochMilli(),
               Instant.now().minusSeconds(10).toEpochMilli(),
-              false);
+              false,
+              LUCENE_REGULAR);
       replicaMetadataList.add(replicaMetadata);
       replicaMetadataStore.create(replicaMetadata);
     }
@@ -265,7 +268,8 @@ public class ReplicaDeletionServiceTest {
             UUID.randomUUID().toString(),
             Instant.now().minusSeconds(30).toEpochMilli(),
             Instant.now().plusSeconds(30).toEpochMilli(),
-            false);
+            false,
+            LUCENE_REGULAR);
     replicaMetadataStore.create(replicaMetadata);
 
     CacheSlotMetadata cacheSlotMetadata =
@@ -317,7 +321,8 @@ public class ReplicaDeletionServiceTest {
             UUID.randomUUID().toString(),
             Instant.now().minusSeconds(30).toEpochMilli(),
             Instant.now().minusSeconds(10).toEpochMilli(),
-            false);
+            false,
+            LUCENE_REGULAR);
     replicaMetadataStore.create(replicaMetadata);
 
     CacheSlotMetadata cacheSlotMetadata =
@@ -391,7 +396,8 @@ public class ReplicaDeletionServiceTest {
               UUID.randomUUID().toString(),
               Instant.now().minusSeconds(30).toEpochMilli(),
               Instant.now().minusSeconds(10).toEpochMilli(),
-              false);
+              false,
+              LUCENE_REGULAR);
       replicaMetadataStore.create(replicaMetadata);
     }
 
@@ -484,7 +490,8 @@ public class ReplicaDeletionServiceTest {
             UUID.randomUUID().toString(),
             Instant.now().minusSeconds(30).toEpochMilli(),
             Instant.now().minusSeconds(10).toEpochMilli(),
-            false);
+            false,
+            LUCENE_REGULAR);
     replicaMetadataStore.create(replicaMetadataUnassigned);
 
     ReplicaMetadata replicaMetadataAssigned =
@@ -493,7 +500,8 @@ public class ReplicaDeletionServiceTest {
             UUID.randomUUID().toString(),
             Instant.now().minusSeconds(30).toEpochMilli(),
             Instant.now().minusSeconds(10).toEpochMilli(),
-            false);
+            false,
+            LUCENE_REGULAR);
     replicaMetadataStore.create(replicaMetadataAssigned);
 
     CacheSlotMetadata cacheSlotMetadataUnassigned =

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
@@ -1,6 +1,6 @@
 package com.slack.kaldb.clusterManager;
 
-import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LOGS_LUCENE9;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -155,7 +155,7 @@ public class ReplicaEvictionServiceTest {
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
               false,
-              LUCENE_REGULAR);
+              LOGS_LUCENE9);
       replicas.add(replicaMetadata);
       replicaMetadataStore.create(replicaMetadata);
     }
@@ -235,7 +235,7 @@ public class ReplicaEvictionServiceTest {
             Instant.now().toEpochMilli(),
             Instant.now().minusSeconds(60).toEpochMilli(),
             false,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     replicaMetadataStore.create(replicaMetadata);
 
     CacheSlotMetadata cacheSlotMetadata =
@@ -310,7 +310,7 @@ public class ReplicaEvictionServiceTest {
             Instant.now().toEpochMilli(),
             0,
             false,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     replicaMetadataStore.create(replicaMetadata);
 
     CacheSlotMetadata cacheSlotMetadata =
@@ -385,7 +385,7 @@ public class ReplicaEvictionServiceTest {
             Instant.now().toEpochMilli(),
             Instant.now().minusSeconds(60).toEpochMilli(),
             false,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     replicaMetadataStore.create(replicaMetadata);
 
     CacheSlotMetadata cacheSlotMetadata =
@@ -443,7 +443,7 @@ public class ReplicaEvictionServiceTest {
             Instant.now().toEpochMilli(),
             Instant.now().minusSeconds(60).toEpochMilli(),
             false,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     replicaMetadataStore.create(replicaMetadata);
 
     CacheSlotMetadata cacheSlotMetadata =
@@ -501,7 +501,7 @@ public class ReplicaEvictionServiceTest {
             Instant.now().toEpochMilli(),
             Instant.now().minusSeconds(60).toEpochMilli(),
             false,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     replicaMetadataStore.create(replicaMetadata);
 
     CacheSlotMetadata cacheSlotMetadata =
@@ -604,7 +604,7 @@ public class ReplicaEvictionServiceTest {
               Instant.now().toEpochMilli(),
               Instant.now().minusSeconds(60).toEpochMilli(),
               false,
-              LUCENE_REGULAR);
+              LOGS_LUCENE9);
       replicas.add(replicaMetadata);
       replicaMetadataStore.create(replicaMetadata);
     }
@@ -735,7 +735,7 @@ public class ReplicaEvictionServiceTest {
             Instant.now().toEpochMilli(),
             Instant.now().minusSeconds(60).toEpochMilli(),
             false,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     replicaMetadataStore.create(replicaMetadataExpiredOne);
     CacheSlotMetadata cacheSlotReplicaExpiredOne =
         new CacheSlotMetadata(
@@ -752,7 +752,7 @@ public class ReplicaEvictionServiceTest {
             Instant.now().toEpochMilli(),
             Instant.now().minusSeconds(60).toEpochMilli(),
             false,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     replicaMetadataStore.create(replicaMetadataExpiredTwo);
     CacheSlotMetadata cacheSlotReplicaExpireTwo =
         new CacheSlotMetadata(
@@ -769,7 +769,7 @@ public class ReplicaEvictionServiceTest {
             Instant.now().toEpochMilli(),
             Instant.now().plusSeconds(360).toEpochMilli(),
             false,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     replicaMetadataStore.create(replicaMetadataUnexpiredOne);
     CacheSlotMetadata cacheSlotReplicaUnexpiredOne =
         new CacheSlotMetadata(
@@ -786,7 +786,7 @@ public class ReplicaEvictionServiceTest {
             Instant.now().toEpochMilli(),
             Instant.now().plusSeconds(360).toEpochMilli(),
             false,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     replicaMetadataStore.create(replicaMetadataUnexpiredTwo);
     CacheSlotMetadata cacheSlotFree =
         new CacheSlotMetadata(

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
@@ -1,5 +1,6 @@
 package com.slack.kaldb.clusterManager;
 
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -153,7 +154,8 @@ public class ReplicaEvictionServiceTest {
               UUID.randomUUID().toString(),
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
-              false);
+              false,
+              LUCENE_REGULAR);
       replicas.add(replicaMetadata);
       replicaMetadataStore.create(replicaMetadata);
     }
@@ -232,7 +234,8 @@ public class ReplicaEvictionServiceTest {
             UUID.randomUUID().toString(),
             Instant.now().toEpochMilli(),
             Instant.now().minusSeconds(60).toEpochMilli(),
-            false);
+            false,
+            LUCENE_REGULAR);
     replicaMetadataStore.create(replicaMetadata);
 
     CacheSlotMetadata cacheSlotMetadata =
@@ -306,7 +309,8 @@ public class ReplicaEvictionServiceTest {
             UUID.randomUUID().toString(),
             Instant.now().toEpochMilli(),
             0,
-            false);
+            false,
+            LUCENE_REGULAR);
     replicaMetadataStore.create(replicaMetadata);
 
     CacheSlotMetadata cacheSlotMetadata =
@@ -380,7 +384,8 @@ public class ReplicaEvictionServiceTest {
             UUID.randomUUID().toString(),
             Instant.now().toEpochMilli(),
             Instant.now().minusSeconds(60).toEpochMilli(),
-            false);
+            false,
+            LUCENE_REGULAR);
     replicaMetadataStore.create(replicaMetadata);
 
     CacheSlotMetadata cacheSlotMetadata =
@@ -437,7 +442,8 @@ public class ReplicaEvictionServiceTest {
             UUID.randomUUID().toString(),
             Instant.now().toEpochMilli(),
             Instant.now().minusSeconds(60).toEpochMilli(),
-            false);
+            false,
+            LUCENE_REGULAR);
     replicaMetadataStore.create(replicaMetadata);
 
     CacheSlotMetadata cacheSlotMetadata =
@@ -494,7 +500,8 @@ public class ReplicaEvictionServiceTest {
             UUID.randomUUID().toString(),
             Instant.now().toEpochMilli(),
             Instant.now().minusSeconds(60).toEpochMilli(),
-            false);
+            false,
+            LUCENE_REGULAR);
     replicaMetadataStore.create(replicaMetadata);
 
     CacheSlotMetadata cacheSlotMetadata =
@@ -596,7 +603,8 @@ public class ReplicaEvictionServiceTest {
               UUID.randomUUID().toString(),
               Instant.now().toEpochMilli(),
               Instant.now().minusSeconds(60).toEpochMilli(),
-              false);
+              false,
+              LUCENE_REGULAR);
       replicas.add(replicaMetadata);
       replicaMetadataStore.create(replicaMetadata);
     }
@@ -726,7 +734,8 @@ public class ReplicaEvictionServiceTest {
             UUID.randomUUID().toString(),
             Instant.now().toEpochMilli(),
             Instant.now().minusSeconds(60).toEpochMilli(),
-            false);
+            false,
+            LUCENE_REGULAR);
     replicaMetadataStore.create(replicaMetadataExpiredOne);
     CacheSlotMetadata cacheSlotReplicaExpiredOne =
         new CacheSlotMetadata(
@@ -742,7 +751,8 @@ public class ReplicaEvictionServiceTest {
             UUID.randomUUID().toString(),
             Instant.now().toEpochMilli(),
             Instant.now().minusSeconds(60).toEpochMilli(),
-            false);
+            false,
+            LUCENE_REGULAR);
     replicaMetadataStore.create(replicaMetadataExpiredTwo);
     CacheSlotMetadata cacheSlotReplicaExpireTwo =
         new CacheSlotMetadata(
@@ -758,7 +768,8 @@ public class ReplicaEvictionServiceTest {
             UUID.randomUUID().toString(),
             Instant.now().toEpochMilli(),
             Instant.now().plusSeconds(360).toEpochMilli(),
-            false);
+            false,
+            LUCENE_REGULAR);
     replicaMetadataStore.create(replicaMetadataUnexpiredOne);
     CacheSlotMetadata cacheSlotReplicaUnexpiredOne =
         new CacheSlotMetadata(
@@ -774,7 +785,8 @@ public class ReplicaEvictionServiceTest {
             UUID.randomUUID().toString(),
             Instant.now().toEpochMilli(),
             Instant.now().plusSeconds(360).toEpochMilli(),
-            false);
+            false,
+            LUCENE_REGULAR);
     replicaMetadataStore.create(replicaMetadataUnexpiredTwo);
     CacheSlotMetadata cacheSlotFree =
         new CacheSlotMetadata(

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaRestoreServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaRestoreServiceTest.java
@@ -15,6 +15,7 @@ import com.slack.kaldb.metadata.snapshot.SnapshotMetadata;
 import com.slack.kaldb.metadata.zookeeper.MetadataStore;
 import com.slack.kaldb.metadata.zookeeper.ZookeeperMetadataStoreImpl;
 import com.slack.kaldb.proto.config.KaldbConfigs;
+import com.slack.kaldb.proto.metadata.Metadata;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
@@ -93,7 +94,9 @@ public class ReplicaRestoreServiceTest {
     for (int i = 0; i < 10; i++) {
       long now = Instant.now().toEpochMilli();
       String id = "loop" + i;
-      SnapshotMetadata snapshotIncluded = new SnapshotMetadata(id, id, now + 10, now + 15, 0, id);
+      SnapshotMetadata snapshotIncluded =
+          new SnapshotMetadata(
+              id, id, now + 10, now + 15, 0, id, Metadata.IndexType.LUCENE_REGULAR);
       replicaRestoreService.queueSnapshotsForRestoration(List.of(snapshotIncluded));
       Thread.sleep(300);
     }
@@ -128,7 +131,8 @@ public class ReplicaRestoreServiceTest {
               long now = Instant.now().toEpochMilli();
               String id = "loop" + UUID.randomUUID();
               SnapshotMetadata snapshotIncluded =
-                  new SnapshotMetadata(id, id, now + 10, now + 15, 0, id);
+                  new SnapshotMetadata(
+                      id, id, now + 10, now + 15, 0, id, Metadata.IndexType.LUCENE_REGULAR);
               try {
                 replicaRestoreService.queueSnapshotsForRestoration(List.of(snapshotIncluded));
                 Thread.sleep(300);
@@ -171,7 +175,9 @@ public class ReplicaRestoreServiceTest {
     List<SnapshotMetadata> duplicateSnapshots = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
       String id = "duplicate";
-      duplicateSnapshots.add(new SnapshotMetadata(id, id, now + 10, now + 15, 0, id));
+      duplicateSnapshots.add(
+          new SnapshotMetadata(
+              id, id, now + 10, now + 15, 0, id, Metadata.IndexType.LUCENE_REGULAR));
     }
 
     replicaRestoreService.queueSnapshotsForRestoration(duplicateSnapshots);
@@ -184,7 +190,9 @@ public class ReplicaRestoreServiceTest {
     for (int i = 0; i < 3; i++) {
       now = Instant.now().toEpochMilli();
       String id = "loop" + i;
-      snapshots.add(new SnapshotMetadata(id, id, now + 10, now + 15, 0, id));
+      snapshots.add(
+          new SnapshotMetadata(
+              id, id, now + 10, now + 15, 0, id, Metadata.IndexType.LUCENE_REGULAR));
     }
 
     replicaRestoreService.queueSnapshotsForRestoration(snapshots);
@@ -219,7 +227,9 @@ public class ReplicaRestoreServiceTest {
     for (int i = 0; i < MAX_QUEUE_SIZE; i++) {
       long now = Instant.now().toEpochMilli();
       String id = "loop" + i;
-      snapshots.add(new SnapshotMetadata(id, id, now + 10, now + 15, 0, id));
+      snapshots.add(
+          new SnapshotMetadata(
+              id, id, now + 10, now + 15, 0, id, Metadata.IndexType.LUCENE_REGULAR));
     }
 
     assertThrows(

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaRestoreServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaRestoreServiceTest.java
@@ -1,5 +1,6 @@
 package com.slack.kaldb.clusterManager;
 
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertThrows;
@@ -15,7 +16,6 @@ import com.slack.kaldb.metadata.snapshot.SnapshotMetadata;
 import com.slack.kaldb.metadata.zookeeper.MetadataStore;
 import com.slack.kaldb.metadata.zookeeper.ZookeeperMetadataStoreImpl;
 import com.slack.kaldb.proto.config.KaldbConfigs;
-import com.slack.kaldb.proto.metadata.Metadata;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
@@ -95,8 +95,7 @@ public class ReplicaRestoreServiceTest {
       long now = Instant.now().toEpochMilli();
       String id = "loop" + i;
       SnapshotMetadata snapshotIncluded =
-          new SnapshotMetadata(
-              id, id, now + 10, now + 15, 0, id, Metadata.IndexType.LUCENE_REGULAR);
+          new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LUCENE_REGULAR);
       replicaRestoreService.queueSnapshotsForRestoration(List.of(snapshotIncluded));
       Thread.sleep(300);
     }
@@ -131,8 +130,7 @@ public class ReplicaRestoreServiceTest {
               long now = Instant.now().toEpochMilli();
               String id = "loop" + UUID.randomUUID();
               SnapshotMetadata snapshotIncluded =
-                  new SnapshotMetadata(
-                      id, id, now + 10, now + 15, 0, id, Metadata.IndexType.LUCENE_REGULAR);
+                  new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LUCENE_REGULAR);
               try {
                 replicaRestoreService.queueSnapshotsForRestoration(List.of(snapshotIncluded));
                 Thread.sleep(300);
@@ -176,8 +174,7 @@ public class ReplicaRestoreServiceTest {
     for (int i = 0; i < 10; i++) {
       String id = "duplicate";
       duplicateSnapshots.add(
-          new SnapshotMetadata(
-              id, id, now + 10, now + 15, 0, id, Metadata.IndexType.LUCENE_REGULAR));
+          new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LUCENE_REGULAR));
     }
 
     replicaRestoreService.queueSnapshotsForRestoration(duplicateSnapshots);
@@ -190,9 +187,7 @@ public class ReplicaRestoreServiceTest {
     for (int i = 0; i < 3; i++) {
       now = Instant.now().toEpochMilli();
       String id = "loop" + i;
-      snapshots.add(
-          new SnapshotMetadata(
-              id, id, now + 10, now + 15, 0, id, Metadata.IndexType.LUCENE_REGULAR));
+      snapshots.add(new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LUCENE_REGULAR));
     }
 
     replicaRestoreService.queueSnapshotsForRestoration(snapshots);
@@ -227,9 +222,7 @@ public class ReplicaRestoreServiceTest {
     for (int i = 0; i < MAX_QUEUE_SIZE; i++) {
       long now = Instant.now().toEpochMilli();
       String id = "loop" + i;
-      snapshots.add(
-          new SnapshotMetadata(
-              id, id, now + 10, now + 15, 0, id, Metadata.IndexType.LUCENE_REGULAR));
+      snapshots.add(new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LUCENE_REGULAR));
     }
 
     assertThrows(

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaRestoreServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaRestoreServiceTest.java
@@ -1,6 +1,6 @@
 package com.slack.kaldb.clusterManager;
 
-import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LOGS_LUCENE9;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertThrows;
@@ -95,7 +95,7 @@ public class ReplicaRestoreServiceTest {
       long now = Instant.now().toEpochMilli();
       String id = "loop" + i;
       SnapshotMetadata snapshotIncluded =
-          new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LUCENE_REGULAR);
+          new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LOGS_LUCENE9);
       replicaRestoreService.queueSnapshotsForRestoration(List.of(snapshotIncluded));
       Thread.sleep(300);
     }
@@ -130,7 +130,7 @@ public class ReplicaRestoreServiceTest {
               long now = Instant.now().toEpochMilli();
               String id = "loop" + UUID.randomUUID();
               SnapshotMetadata snapshotIncluded =
-                  new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LUCENE_REGULAR);
+                  new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LOGS_LUCENE9);
               try {
                 replicaRestoreService.queueSnapshotsForRestoration(List.of(snapshotIncluded));
                 Thread.sleep(300);
@@ -173,8 +173,7 @@ public class ReplicaRestoreServiceTest {
     List<SnapshotMetadata> duplicateSnapshots = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
       String id = "duplicate";
-      duplicateSnapshots.add(
-          new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LUCENE_REGULAR));
+      duplicateSnapshots.add(new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LOGS_LUCENE9));
     }
 
     replicaRestoreService.queueSnapshotsForRestoration(duplicateSnapshots);
@@ -187,7 +186,7 @@ public class ReplicaRestoreServiceTest {
     for (int i = 0; i < 3; i++) {
       now = Instant.now().toEpochMilli();
       String id = "loop" + i;
-      snapshots.add(new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LUCENE_REGULAR));
+      snapshots.add(new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LOGS_LUCENE9));
     }
 
     replicaRestoreService.queueSnapshotsForRestoration(snapshots);
@@ -222,7 +221,7 @@ public class ReplicaRestoreServiceTest {
     for (int i = 0; i < MAX_QUEUE_SIZE; i++) {
       long now = Instant.now().toEpochMilli();
       String id = "loop" + i;
-      snapshots.add(new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LUCENE_REGULAR));
+      snapshots.add(new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LOGS_LUCENE9));
     }
 
     assertThrows(

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/SnapshotDeletionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/SnapshotDeletionServiceTest.java
@@ -1,6 +1,7 @@
 package com.slack.kaldb.clusterManager;
 
 import static com.slack.kaldb.logstore.BlobFsUtils.createURI;
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -26,7 +27,6 @@ import com.slack.kaldb.metadata.zookeeper.InternalMetadataStoreException;
 import com.slack.kaldb.metadata.zookeeper.MetadataStore;
 import com.slack.kaldb.metadata.zookeeper.ZookeeperMetadataStoreImpl;
 import com.slack.kaldb.proto.config.KaldbConfigs;
-import com.slack.kaldb.proto.metadata.Metadata;
 import com.slack.kaldb.testlib.MetricsUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -153,7 +153,7 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.create(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
 
@@ -209,7 +209,7 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.create(snapshotMetadata);
 
     ReplicaMetadata replicaMetadata =
@@ -218,7 +218,8 @@ public class SnapshotDeletionServiceTest {
             snapshotMetadata.name,
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             Instant.now().minus(500, ChronoUnit.MINUTES).toEpochMilli(),
-            false);
+            false,
+            LUCENE_REGULAR);
     replicaMetadataStore.create(replicaMetadata);
 
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
@@ -320,7 +321,7 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(500, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.create(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
     String[] s3BlobFsFiles = s3BlobFs.listFiles(directoryPath, true);
@@ -380,7 +381,7 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.create(snapshotMetadata);
 
     // replica is also expired
@@ -390,7 +391,8 @@ public class SnapshotDeletionServiceTest {
             snapshotMetadata.name,
             Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
-            false);
+            false,
+            LUCENE_REGULAR);
     replicaMetadataStore.create(replicaMetadata);
 
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
@@ -453,7 +455,7 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.create(snapshotMetadata);
 
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
@@ -511,7 +513,7 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.create(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
 
@@ -573,7 +575,7 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.create(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
 
@@ -630,7 +632,7 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.create(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
 
@@ -724,7 +726,7 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.create(snapshotMetadata);
 
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
@@ -797,7 +799,7 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.create(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
 

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/SnapshotDeletionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/SnapshotDeletionServiceTest.java
@@ -26,6 +26,7 @@ import com.slack.kaldb.metadata.zookeeper.InternalMetadataStoreException;
 import com.slack.kaldb.metadata.zookeeper.MetadataStore;
 import com.slack.kaldb.metadata.zookeeper.ZookeeperMetadataStoreImpl;
 import com.slack.kaldb.proto.config.KaldbConfigs;
+import com.slack.kaldb.proto.metadata.Metadata;
 import com.slack.kaldb.testlib.MetricsUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -151,7 +152,8 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
-            "1");
+            "1",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.create(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
 
@@ -206,7 +208,8 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
-            "1");
+            "1",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.create(snapshotMetadata);
 
     ReplicaMetadata replicaMetadata =
@@ -316,7 +319,8 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
             Instant.now().minus(500, ChronoUnit.MINUTES).toEpochMilli(),
             0,
-            "1");
+            "1",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.create(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
     String[] s3BlobFsFiles = s3BlobFs.listFiles(directoryPath, true);
@@ -375,7 +379,8 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
-            "1");
+            "1",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.create(snapshotMetadata);
 
     // replica is also expired
@@ -447,7 +452,8 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
-            "1");
+            "1",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.create(snapshotMetadata);
 
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
@@ -504,7 +510,8 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
-            "1");
+            "1",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.create(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
 
@@ -565,7 +572,8 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
-            "1");
+            "1",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.create(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
 
@@ -621,7 +629,8 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
-            "1");
+            "1",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.create(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
 
@@ -714,7 +723,8 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
-            "1");
+            "1",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.create(snapshotMetadata);
 
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
@@ -786,7 +796,8 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
-            "1");
+            "1",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.create(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
 

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/SnapshotDeletionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/SnapshotDeletionServiceTest.java
@@ -1,7 +1,7 @@
 package com.slack.kaldb.clusterManager;
 
 import static com.slack.kaldb.logstore.BlobFsUtils.createURI;
-import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LOGS_LUCENE9;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -153,7 +153,7 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.create(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
 
@@ -209,7 +209,7 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.create(snapshotMetadata);
 
     ReplicaMetadata replicaMetadata =
@@ -219,7 +219,7 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             Instant.now().minus(500, ChronoUnit.MINUTES).toEpochMilli(),
             false,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     replicaMetadataStore.create(replicaMetadata);
 
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
@@ -321,7 +321,7 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(500, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.create(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
     String[] s3BlobFsFiles = s3BlobFs.listFiles(directoryPath, true);
@@ -381,7 +381,7 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.create(snapshotMetadata);
 
     // replica is also expired
@@ -392,7 +392,7 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             false,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     replicaMetadataStore.create(replicaMetadata);
 
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
@@ -455,7 +455,7 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.create(snapshotMetadata);
 
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
@@ -513,7 +513,7 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.create(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
 
@@ -575,7 +575,7 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.create(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
 
@@ -632,7 +632,7 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.create(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
 
@@ -726,7 +726,7 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.create(snapshotMetadata);
 
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
@@ -799,7 +799,7 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.create(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.getCached().size() == 1);
 

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
@@ -15,6 +15,7 @@ import com.slack.kaldb.metadata.zookeeper.MetadataStore;
 import com.slack.kaldb.metadata.zookeeper.NoNodeException;
 import com.slack.kaldb.metadata.zookeeper.NodeExistsException;
 import com.slack.kaldb.metadata.zookeeper.ZookeeperMetadataStoreImpl;
+import com.slack.kaldb.proto.metadata.Metadata;
 import com.slack.kaldb.util.CountingFatalErrorHandler;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -52,7 +53,13 @@ public class KaldbMetadataStoreTest {
     final String partitionId = "1";
 
     return new SnapshotMetadata(
-        name, snapshotPath, startTimeUtc, endTimeUtc, maxOffset, partitionId);
+        name,
+        snapshotPath,
+        startTimeUtc,
+        endTimeUtc,
+        maxOffset,
+        partitionId,
+        Metadata.IndexType.LUCENE_REGULAR);
   }
 
   public static class TestPersistentCreatableUpdatableCacheableMetadataStore {
@@ -130,7 +137,13 @@ public class KaldbMetadataStoreTest {
 
       final SnapshotMetadata snapshot =
           new SnapshotMetadata(
-              name, snapshotPath, startTimeUtc, endTimeUtc, maxOffset, partitionId);
+              name,
+              snapshotPath,
+              startTimeUtc,
+              endTimeUtc,
+              maxOffset,
+              partitionId,
+              Metadata.IndexType.LUCENE_REGULAR);
 
       assertThat(store.list().get()).isEmpty();
       assertThat(store.create(snapshot).get()).isNull();
@@ -148,7 +161,13 @@ public class KaldbMetadataStoreTest {
 
       final SnapshotMetadata newSnapshot =
           new SnapshotMetadata(
-              name, snapshotPath, startTimeUtc + 1, endTimeUtc + 1, maxOffset + 100, partitionId);
+              name,
+              snapshotPath,
+              startTimeUtc + 1,
+              endTimeUtc + 1,
+              maxOffset + 100,
+              partitionId,
+              Metadata.IndexType.LUCENE_REGULAR);
       assertThat(store.update(newSnapshot).get()).isNull();
       assertThat(store.list().get().size()).isEqualTo(1);
       assertThat(store.list().get()).containsOnly(newSnapshot);
@@ -210,7 +229,13 @@ public class KaldbMetadataStoreTest {
 
       final SnapshotMetadata testSnapshot =
           new SnapshotMetadata(
-              name, snapshotPath, startTimeUtc, endTimeUtc, maxOffset, partitionId);
+              name,
+              snapshotPath,
+              startTimeUtc,
+              endTimeUtc,
+              maxOffset,
+              partitionId,
+              Metadata.IndexType.LUCENE_REGULAR);
       assertThat(store.create(testSnapshot).get()).isNull();
 
       SnapshotMetadata metadata = store.getNode(name).get();
@@ -868,7 +893,13 @@ public class KaldbMetadataStoreTest {
 
       final SnapshotMetadata snapshot =
           new SnapshotMetadata(
-              name, snapshotPath, startTimeUtc, endTimeUtc, maxOffset, partitionId);
+              name,
+              snapshotPath,
+              startTimeUtc,
+              endTimeUtc,
+              maxOffset,
+              partitionId,
+              Metadata.IndexType.LUCENE_REGULAR);
 
       assertThat(store.list().get()).isEmpty();
       assertThat(store.create(snapshot).get()).isNull();
@@ -886,7 +917,13 @@ public class KaldbMetadataStoreTest {
 
       final SnapshotMetadata newSnapshot =
           new SnapshotMetadata(
-              name, snapshotPath, startTimeUtc + 1, endTimeUtc + 1, maxOffset + 100, partitionId);
+              name,
+              snapshotPath,
+              startTimeUtc + 1,
+              endTimeUtc + 1,
+              maxOffset + 100,
+              partitionId,
+              Metadata.IndexType.LUCENE_REGULAR);
       assertThat(store.update(newSnapshot).get()).isNull();
       assertThat(store.list().get().size()).isEqualTo(1);
       assertThat(store.list().get()).containsOnly(newSnapshot);
@@ -948,7 +985,13 @@ public class KaldbMetadataStoreTest {
 
       final SnapshotMetadata testSnapshot =
           new SnapshotMetadata(
-              name, snapshotPath, startTimeUtc, endTimeUtc, maxOffset, partitionId);
+              name,
+              snapshotPath,
+              startTimeUtc,
+              endTimeUtc,
+              maxOffset,
+              partitionId,
+              Metadata.IndexType.LUCENE_REGULAR);
       assertThat(store.create(testSnapshot).get()).isNull();
 
       SnapshotMetadata metadata = store.getNode(name).get();

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
@@ -2,6 +2,7 @@ package com.slack.kaldb.metadata.core;
 
 import static com.slack.kaldb.metadata.snapshot.SnapshotMetadataStore.SNAPSHOT_METADATA_STORE_ZK_PATH;
 import static com.slack.kaldb.metadata.zookeeper.ZookeeperCachedMetadataStoreImpl.CACHE_ERROR_COUNTER;
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
 import static com.slack.kaldb.testlib.ZkUtils.closeZookeeperClientConnection;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,7 +16,6 @@ import com.slack.kaldb.metadata.zookeeper.MetadataStore;
 import com.slack.kaldb.metadata.zookeeper.NoNodeException;
 import com.slack.kaldb.metadata.zookeeper.NodeExistsException;
 import com.slack.kaldb.metadata.zookeeper.ZookeeperMetadataStoreImpl;
-import com.slack.kaldb.proto.metadata.Metadata;
 import com.slack.kaldb.util.CountingFatalErrorHandler;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -53,13 +53,7 @@ public class KaldbMetadataStoreTest {
     final String partitionId = "1";
 
     return new SnapshotMetadata(
-        name,
-        snapshotPath,
-        startTimeUtc,
-        endTimeUtc,
-        maxOffset,
-        partitionId,
-        Metadata.IndexType.LUCENE_REGULAR);
+        name, snapshotPath, startTimeUtc, endTimeUtc, maxOffset, partitionId, LUCENE_REGULAR);
   }
 
   public static class TestPersistentCreatableUpdatableCacheableMetadataStore {
@@ -137,13 +131,7 @@ public class KaldbMetadataStoreTest {
 
       final SnapshotMetadata snapshot =
           new SnapshotMetadata(
-              name,
-              snapshotPath,
-              startTimeUtc,
-              endTimeUtc,
-              maxOffset,
-              partitionId,
-              Metadata.IndexType.LUCENE_REGULAR);
+              name, snapshotPath, startTimeUtc, endTimeUtc, maxOffset, partitionId, LUCENE_REGULAR);
 
       assertThat(store.list().get()).isEmpty();
       assertThat(store.create(snapshot).get()).isNull();
@@ -167,7 +155,7 @@ public class KaldbMetadataStoreTest {
               endTimeUtc + 1,
               maxOffset + 100,
               partitionId,
-              Metadata.IndexType.LUCENE_REGULAR);
+              LUCENE_REGULAR);
       assertThat(store.update(newSnapshot).get()).isNull();
       assertThat(store.list().get().size()).isEqualTo(1);
       assertThat(store.list().get()).containsOnly(newSnapshot);
@@ -229,13 +217,7 @@ public class KaldbMetadataStoreTest {
 
       final SnapshotMetadata testSnapshot =
           new SnapshotMetadata(
-              name,
-              snapshotPath,
-              startTimeUtc,
-              endTimeUtc,
-              maxOffset,
-              partitionId,
-              Metadata.IndexType.LUCENE_REGULAR);
+              name, snapshotPath, startTimeUtc, endTimeUtc, maxOffset, partitionId, LUCENE_REGULAR);
       assertThat(store.create(testSnapshot).get()).isNull();
 
       SnapshotMetadata metadata = store.getNode(name).get();
@@ -893,13 +875,7 @@ public class KaldbMetadataStoreTest {
 
       final SnapshotMetadata snapshot =
           new SnapshotMetadata(
-              name,
-              snapshotPath,
-              startTimeUtc,
-              endTimeUtc,
-              maxOffset,
-              partitionId,
-              Metadata.IndexType.LUCENE_REGULAR);
+              name, snapshotPath, startTimeUtc, endTimeUtc, maxOffset, partitionId, LUCENE_REGULAR);
 
       assertThat(store.list().get()).isEmpty();
       assertThat(store.create(snapshot).get()).isNull();
@@ -923,7 +899,7 @@ public class KaldbMetadataStoreTest {
               endTimeUtc + 1,
               maxOffset + 100,
               partitionId,
-              Metadata.IndexType.LUCENE_REGULAR);
+              LUCENE_REGULAR);
       assertThat(store.update(newSnapshot).get()).isNull();
       assertThat(store.list().get().size()).isEqualTo(1);
       assertThat(store.list().get()).containsOnly(newSnapshot);
@@ -985,13 +961,7 @@ public class KaldbMetadataStoreTest {
 
       final SnapshotMetadata testSnapshot =
           new SnapshotMetadata(
-              name,
-              snapshotPath,
-              startTimeUtc,
-              endTimeUtc,
-              maxOffset,
-              partitionId,
-              Metadata.IndexType.LUCENE_REGULAR);
+              name, snapshotPath, startTimeUtc, endTimeUtc, maxOffset, partitionId, LUCENE_REGULAR);
       assertThat(store.create(testSnapshot).get()).isNull();
 
       SnapshotMetadata metadata = store.getNode(name).get();

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
@@ -2,7 +2,7 @@ package com.slack.kaldb.metadata.core;
 
 import static com.slack.kaldb.metadata.snapshot.SnapshotMetadataStore.SNAPSHOT_METADATA_STORE_ZK_PATH;
 import static com.slack.kaldb.metadata.zookeeper.ZookeeperCachedMetadataStoreImpl.CACHE_ERROR_COUNTER;
-import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LOGS_LUCENE9;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
 import static com.slack.kaldb.testlib.ZkUtils.closeZookeeperClientConnection;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -53,7 +53,7 @@ public class KaldbMetadataStoreTest {
     final String partitionId = "1";
 
     return new SnapshotMetadata(
-        name, snapshotPath, startTimeUtc, endTimeUtc, maxOffset, partitionId, LUCENE_REGULAR);
+        name, snapshotPath, startTimeUtc, endTimeUtc, maxOffset, partitionId, LOGS_LUCENE9);
   }
 
   public static class TestPersistentCreatableUpdatableCacheableMetadataStore {
@@ -131,7 +131,7 @@ public class KaldbMetadataStoreTest {
 
       final SnapshotMetadata snapshot =
           new SnapshotMetadata(
-              name, snapshotPath, startTimeUtc, endTimeUtc, maxOffset, partitionId, LUCENE_REGULAR);
+              name, snapshotPath, startTimeUtc, endTimeUtc, maxOffset, partitionId, LOGS_LUCENE9);
 
       assertThat(store.list().get()).isEmpty();
       assertThat(store.create(snapshot).get()).isNull();
@@ -155,7 +155,7 @@ public class KaldbMetadataStoreTest {
               endTimeUtc + 1,
               maxOffset + 100,
               partitionId,
-              LUCENE_REGULAR);
+              LOGS_LUCENE9);
       assertThat(store.update(newSnapshot).get()).isNull();
       assertThat(store.list().get().size()).isEqualTo(1);
       assertThat(store.list().get()).containsOnly(newSnapshot);
@@ -217,7 +217,7 @@ public class KaldbMetadataStoreTest {
 
       final SnapshotMetadata testSnapshot =
           new SnapshotMetadata(
-              name, snapshotPath, startTimeUtc, endTimeUtc, maxOffset, partitionId, LUCENE_REGULAR);
+              name, snapshotPath, startTimeUtc, endTimeUtc, maxOffset, partitionId, LOGS_LUCENE9);
       assertThat(store.create(testSnapshot).get()).isNull();
 
       SnapshotMetadata metadata = store.getNode(name).get();
@@ -875,7 +875,7 @@ public class KaldbMetadataStoreTest {
 
       final SnapshotMetadata snapshot =
           new SnapshotMetadata(
-              name, snapshotPath, startTimeUtc, endTimeUtc, maxOffset, partitionId, LUCENE_REGULAR);
+              name, snapshotPath, startTimeUtc, endTimeUtc, maxOffset, partitionId, LOGS_LUCENE9);
 
       assertThat(store.list().get()).isEmpty();
       assertThat(store.create(snapshot).get()).isNull();
@@ -899,7 +899,7 @@ public class KaldbMetadataStoreTest {
               endTimeUtc + 1,
               maxOffset + 100,
               partitionId,
-              LUCENE_REGULAR);
+              LOGS_LUCENE9);
       assertThat(store.update(newSnapshot).get()).isNull();
       assertThat(store.list().get().size()).isEqualTo(1);
       assertThat(store.list().get()).containsOnly(newSnapshot);
@@ -961,7 +961,7 @@ public class KaldbMetadataStoreTest {
 
       final SnapshotMetadata testSnapshot =
           new SnapshotMetadata(
-              name, snapshotPath, startTimeUtc, endTimeUtc, maxOffset, partitionId, LUCENE_REGULAR);
+              name, snapshotPath, startTimeUtc, endTimeUtc, maxOffset, partitionId, LOGS_LUCENE9);
       assertThat(store.create(testSnapshot).get()).isNull();
 
       SnapshotMetadata metadata = store.getNode(name).get();

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializerTest.java
@@ -1,5 +1,6 @@
 package com.slack.kaldb.metadata.replica;
 
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
@@ -18,7 +19,8 @@ public class ReplicaMetadataSerializerTest {
     long expireAfterEpochMs = Instant.now().plusSeconds(60).toEpochMilli();
 
     ReplicaMetadata replicaMetadata =
-        new ReplicaMetadata(name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, true);
+        new ReplicaMetadata(
+            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, true, LUCENE_REGULAR);
 
     String serializedReplicaMetadata = serDe.toJsonStr(replicaMetadata);
     assertThat(serializedReplicaMetadata).isNotEmpty();
@@ -31,6 +33,7 @@ public class ReplicaMetadataSerializerTest {
     assertThat(deserializedReplicaMetadata.createdTimeEpochMs).isEqualTo(createdTimeEpochMs);
     assertThat(deserializedReplicaMetadata.expireAfterEpochMs).isEqualTo(expireAfterEpochMs);
     assertThat(deserializedReplicaMetadata.isRestored).isTrue();
+    assertThat(deserializedReplicaMetadata.indexType).isEqualTo(LUCENE_REGULAR);
   }
 
   @Test
@@ -50,6 +53,7 @@ public class ReplicaMetadataSerializerTest {
     assertThat(deserializedReplicaMetadata.createdTimeEpochMs).isEqualTo(1639677020380L);
     assertThat(deserializedReplicaMetadata.expireAfterEpochMs).isEqualTo(0L);
     assertThat(deserializedReplicaMetadata.isRestored).isFalse();
+    assertThat(deserializedReplicaMetadata.indexType).isEqualTo(LUCENE_REGULAR);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializerTest.java
@@ -1,6 +1,6 @@
 package com.slack.kaldb.metadata.replica;
 
-import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LOGS_LUCENE9;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
@@ -20,7 +20,7 @@ public class ReplicaMetadataSerializerTest {
 
     ReplicaMetadata replicaMetadata =
         new ReplicaMetadata(
-            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, true, LUCENE_REGULAR);
+            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, true, LOGS_LUCENE9);
 
     String serializedReplicaMetadata = serDe.toJsonStr(replicaMetadata);
     assertThat(serializedReplicaMetadata).isNotEmpty();
@@ -33,7 +33,7 @@ public class ReplicaMetadataSerializerTest {
     assertThat(deserializedReplicaMetadata.createdTimeEpochMs).isEqualTo(createdTimeEpochMs);
     assertThat(deserializedReplicaMetadata.expireAfterEpochMs).isEqualTo(expireAfterEpochMs);
     assertThat(deserializedReplicaMetadata.isRestored).isTrue();
-    assertThat(deserializedReplicaMetadata.indexType).isEqualTo(LUCENE_REGULAR);
+    assertThat(deserializedReplicaMetadata.indexType).isEqualTo(LOGS_LUCENE9);
   }
 
   @Test
@@ -53,7 +53,7 @@ public class ReplicaMetadataSerializerTest {
     assertThat(deserializedReplicaMetadata.createdTimeEpochMs).isEqualTo(1639677020380L);
     assertThat(deserializedReplicaMetadata.expireAfterEpochMs).isEqualTo(0L);
     assertThat(deserializedReplicaMetadata.isRestored).isFalse();
-    assertThat(deserializedReplicaMetadata.indexType).isEqualTo(LUCENE_REGULAR);
+    assertThat(deserializedReplicaMetadata.indexType).isEqualTo(LOGS_LUCENE9);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataTest.java
@@ -1,5 +1,6 @@
 package com.slack.kaldb.metadata.replica;
 
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
@@ -16,22 +17,26 @@ public class ReplicaMetadataTest {
     long expireAfterEpochMs = Instant.now().toEpochMilli();
 
     ReplicaMetadata replicaMetadata =
-        new ReplicaMetadata(name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, false);
+        new ReplicaMetadata(
+            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, false, LUCENE_REGULAR);
 
     assertThat(replicaMetadata.name).isEqualTo(name);
     assertThat(replicaMetadata.snapshotId).isEqualTo(snapshotId);
     assertThat(replicaMetadata.createdTimeEpochMs).isEqualTo(createdTimeEpochMs);
     assertThat(replicaMetadata.expireAfterEpochMs).isEqualTo(expireAfterEpochMs);
     assertThat(replicaMetadata.isRestored).isFalse();
+    assertThat(replicaMetadata.indexType).isEqualTo(LUCENE_REGULAR);
 
     ReplicaMetadata restoredReplicaMetadata =
-        new ReplicaMetadata(name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, true);
+        new ReplicaMetadata(
+            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, true, LUCENE_REGULAR);
 
     assertThat(restoredReplicaMetadata.name).isEqualTo(name);
     assertThat(restoredReplicaMetadata.snapshotId).isEqualTo(snapshotId);
     assertThat(restoredReplicaMetadata.createdTimeEpochMs).isEqualTo(createdTimeEpochMs);
     assertThat(restoredReplicaMetadata.expireAfterEpochMs).isEqualTo(expireAfterEpochMs);
     assertThat(restoredReplicaMetadata.isRestored).isTrue();
+    assertThat(restoredReplicaMetadata.indexType).isEqualTo(LUCENE_REGULAR);
   }
 
   @Test
@@ -42,15 +47,20 @@ public class ReplicaMetadataTest {
     long expireAfterEpochMs = Instant.now().toEpochMilli();
 
     ReplicaMetadata replicaMetadataA =
-        new ReplicaMetadata(name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, true);
+        new ReplicaMetadata(
+            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, true, LUCENE_REGULAR);
     ReplicaMetadata replicaMetadataB =
-        new ReplicaMetadata(name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, true);
+        new ReplicaMetadata(
+            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, true, LUCENE_REGULAR);
     ReplicaMetadata replicaMetadataC =
-        new ReplicaMetadata("nameC", snapshotId, createdTimeEpochMs, expireAfterEpochMs, true);
+        new ReplicaMetadata(
+            "nameC", snapshotId, createdTimeEpochMs, expireAfterEpochMs, true, LUCENE_REGULAR);
     ReplicaMetadata replicaMetadataD =
-        new ReplicaMetadata(name, snapshotId, createdTimeEpochMs + 1, expireAfterEpochMs, false);
+        new ReplicaMetadata(
+            name, snapshotId, createdTimeEpochMs + 1, expireAfterEpochMs, false, LUCENE_REGULAR);
     ReplicaMetadata replicaMetadataE =
-        new ReplicaMetadata(name, snapshotId, createdTimeEpochMs, expireAfterEpochMs + 1, false);
+        new ReplicaMetadata(
+            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs + 1, false, LUCENE_REGULAR);
 
     assertThat(replicaMetadataA).isEqualTo(replicaMetadataB);
     assertThat(replicaMetadataA).isNotEqualTo(replicaMetadataC);
@@ -69,7 +79,12 @@ public class ReplicaMetadataTest {
         .isThrownBy(
             () ->
                 new ReplicaMetadata(
-                    "name", "", Instant.now().toEpochMilli(), Instant.now().toEpochMilli(), false));
+                    "name",
+                    "",
+                    Instant.now().toEpochMilli(),
+                    Instant.now().toEpochMilli(),
+                    false,
+                    LUCENE_REGULAR));
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
@@ -78,12 +93,17 @@ public class ReplicaMetadataTest {
                     null,
                     Instant.now().toEpochMilli(),
                     Instant.now().toEpochMilli(),
-                    true));
+                    true,
+                    LUCENE_REGULAR));
     assertThatIllegalArgumentException()
         .isThrownBy(
-            () -> new ReplicaMetadata("name", "123", 0, Instant.now().toEpochMilli(), false));
+            () ->
+                new ReplicaMetadata(
+                    "name", "123", 0, Instant.now().toEpochMilli(), false, LUCENE_REGULAR));
     assertThatIllegalArgumentException()
         .isThrownBy(
-            () -> new ReplicaMetadata("name", "123", Instant.now().toEpochMilli(), -1, true));
+            () ->
+                new ReplicaMetadata(
+                    "name", "123", Instant.now().toEpochMilli(), -1, true, LUCENE_REGULAR));
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataTest.java
@@ -1,6 +1,6 @@
 package com.slack.kaldb.metadata.replica;
 
-import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LOGS_LUCENE9;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
@@ -18,25 +18,25 @@ public class ReplicaMetadataTest {
 
     ReplicaMetadata replicaMetadata =
         new ReplicaMetadata(
-            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, false, LUCENE_REGULAR);
+            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, false, LOGS_LUCENE9);
 
     assertThat(replicaMetadata.name).isEqualTo(name);
     assertThat(replicaMetadata.snapshotId).isEqualTo(snapshotId);
     assertThat(replicaMetadata.createdTimeEpochMs).isEqualTo(createdTimeEpochMs);
     assertThat(replicaMetadata.expireAfterEpochMs).isEqualTo(expireAfterEpochMs);
     assertThat(replicaMetadata.isRestored).isFalse();
-    assertThat(replicaMetadata.indexType).isEqualTo(LUCENE_REGULAR);
+    assertThat(replicaMetadata.indexType).isEqualTo(LOGS_LUCENE9);
 
     ReplicaMetadata restoredReplicaMetadata =
         new ReplicaMetadata(
-            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, true, LUCENE_REGULAR);
+            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, true, LOGS_LUCENE9);
 
     assertThat(restoredReplicaMetadata.name).isEqualTo(name);
     assertThat(restoredReplicaMetadata.snapshotId).isEqualTo(snapshotId);
     assertThat(restoredReplicaMetadata.createdTimeEpochMs).isEqualTo(createdTimeEpochMs);
     assertThat(restoredReplicaMetadata.expireAfterEpochMs).isEqualTo(expireAfterEpochMs);
     assertThat(restoredReplicaMetadata.isRestored).isTrue();
-    assertThat(restoredReplicaMetadata.indexType).isEqualTo(LUCENE_REGULAR);
+    assertThat(restoredReplicaMetadata.indexType).isEqualTo(LOGS_LUCENE9);
   }
 
   @Test
@@ -48,19 +48,19 @@ public class ReplicaMetadataTest {
 
     ReplicaMetadata replicaMetadataA =
         new ReplicaMetadata(
-            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, true, LUCENE_REGULAR);
+            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, true, LOGS_LUCENE9);
     ReplicaMetadata replicaMetadataB =
         new ReplicaMetadata(
-            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, true, LUCENE_REGULAR);
+            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, true, LOGS_LUCENE9);
     ReplicaMetadata replicaMetadataC =
         new ReplicaMetadata(
-            "nameC", snapshotId, createdTimeEpochMs, expireAfterEpochMs, true, LUCENE_REGULAR);
+            "nameC", snapshotId, createdTimeEpochMs, expireAfterEpochMs, true, LOGS_LUCENE9);
     ReplicaMetadata replicaMetadataD =
         new ReplicaMetadata(
-            name, snapshotId, createdTimeEpochMs + 1, expireAfterEpochMs, false, LUCENE_REGULAR);
+            name, snapshotId, createdTimeEpochMs + 1, expireAfterEpochMs, false, LOGS_LUCENE9);
     ReplicaMetadata replicaMetadataE =
         new ReplicaMetadata(
-            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs + 1, false, LUCENE_REGULAR);
+            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs + 1, false, LOGS_LUCENE9);
 
     assertThat(replicaMetadataA).isEqualTo(replicaMetadataB);
     assertThat(replicaMetadataA).isNotEqualTo(replicaMetadataC);
@@ -84,7 +84,7 @@ public class ReplicaMetadataTest {
                     Instant.now().toEpochMilli(),
                     Instant.now().toEpochMilli(),
                     false,
-                    LUCENE_REGULAR));
+                    LOGS_LUCENE9));
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
@@ -94,16 +94,16 @@ public class ReplicaMetadataTest {
                     Instant.now().toEpochMilli(),
                     Instant.now().toEpochMilli(),
                     true,
-                    LUCENE_REGULAR));
+                    LOGS_LUCENE9));
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
                 new ReplicaMetadata(
-                    "name", "123", 0, Instant.now().toEpochMilli(), false, LUCENE_REGULAR));
+                    "name", "123", 0, Instant.now().toEpochMilli(), false, LOGS_LUCENE9));
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
                 new ReplicaMetadata(
-                    "name", "123", Instant.now().toEpochMilli(), -1, true, LUCENE_REGULAR));
+                    "name", "123", Instant.now().toEpochMilli(), -1, true, LOGS_LUCENE9));
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataSerializerTest.java
@@ -1,5 +1,6 @@
 package com.slack.kaldb.metadata.snapshot;
 
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -18,7 +19,8 @@ public class SnapshotMetadataSerializerTest {
     final String partitionId = "1";
 
     SnapshotMetadata snapshotMetadata =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId);
+        new SnapshotMetadata(
+            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
 
     String serializedSnapshot = serDe.toJsonStr(snapshotMetadata);
     assertThat(serializedSnapshot).isNotEmpty();
@@ -33,6 +35,7 @@ public class SnapshotMetadataSerializerTest {
     assertThat(deserializedSnapshotMetadata.endTimeEpochMs).isEqualTo(endTime);
     assertThat(deserializedSnapshotMetadata.maxOffset).isEqualTo(maxOffset);
     assertThat(deserializedSnapshotMetadata.partitionId).isEqualTo(partitionId);
+    assertThat(deserializedSnapshotMetadata.indexType).isEqualTo(LUCENE_REGULAR);
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataSerializerTest.java
@@ -1,6 +1,6 @@
 package com.slack.kaldb.metadata.snapshot;
 
-import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LOGS_LUCENE9;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -19,8 +19,7 @@ public class SnapshotMetadataSerializerTest {
     final String partitionId = "1";
 
     SnapshotMetadata snapshotMetadata =
-        new SnapshotMetadata(
-            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
 
     String serializedSnapshot = serDe.toJsonStr(snapshotMetadata);
     assertThat(serializedSnapshot).isNotEmpty();
@@ -35,7 +34,7 @@ public class SnapshotMetadataSerializerTest {
     assertThat(deserializedSnapshotMetadata.endTimeEpochMs).isEqualTo(endTime);
     assertThat(deserializedSnapshotMetadata.maxOffset).isEqualTo(maxOffset);
     assertThat(deserializedSnapshotMetadata.partitionId).isEqualTo(partitionId);
-    assertThat(deserializedSnapshotMetadata.indexType).isEqualTo(LUCENE_REGULAR);
+    assertThat(deserializedSnapshotMetadata.indexType).isEqualTo(LOGS_LUCENE9);
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataTest.java
@@ -1,7 +1,7 @@
 package com.slack.kaldb.metadata.snapshot;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
+import static org.assertj.core.api.Assertions.*;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -19,7 +19,8 @@ public class SnapshotMetadataTest {
     final String partitionId = "1";
 
     SnapshotMetadata snapshotMetadata =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId);
+        new SnapshotMetadata(
+            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
 
     assertThat(snapshotMetadata.name).isEqualTo(name);
     assertThat(snapshotMetadata.snapshotPath).isEqualTo(path);
@@ -28,6 +29,7 @@ public class SnapshotMetadataTest {
     assertThat(snapshotMetadata.endTimeEpochMs).isEqualTo(endTime);
     assertThat(snapshotMetadata.maxOffset).isEqualTo(maxOffset);
     assertThat(snapshotMetadata.partitionId).isEqualTo(partitionId);
+    assertThat(snapshotMetadata.indexType).isEqualTo(LUCENE_REGULAR);
   }
 
   @Test
@@ -40,9 +42,11 @@ public class SnapshotMetadataTest {
     final String partitionId = "1";
 
     SnapshotMetadata snapshot1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId);
+        new SnapshotMetadata(
+            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
     SnapshotMetadata snapshot2 =
-        new SnapshotMetadata(name + "2", path, startTime, endTime, maxOffset, partitionId);
+        new SnapshotMetadata(
+            name + "2", path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
 
     assertThat(snapshot1).isEqualTo(snapshot1);
     // Ensure the name field from super class is included.
@@ -65,34 +69,53 @@ public class SnapshotMetadataTest {
 
     assertThatIllegalArgumentException()
         .isThrownBy(
-            () -> new SnapshotMetadata("", path, startTime, endTime, maxOffset, partitionId));
+            () ->
+                new SnapshotMetadata(
+                    "", path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR));
 
     assertThatIllegalArgumentException()
         .isThrownBy(
-            () -> new SnapshotMetadata(name, "", startTime, endTime, maxOffset, partitionId));
+            () ->
+                new SnapshotMetadata(
+                    name, "", startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR));
 
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new SnapshotMetadata(name, path, 0, endTime, maxOffset, partitionId));
+        .isThrownBy(
+            () ->
+                new SnapshotMetadata(
+                    name, path, 0, endTime, maxOffset, partitionId, LUCENE_REGULAR));
 
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new SnapshotMetadata(name, path, startTime, 0, maxOffset, partitionId));
+        .isThrownBy(
+            () ->
+                new SnapshotMetadata(
+                    name, path, startTime, 0, maxOffset, partitionId, LUCENE_REGULAR));
 
     // Start time < end time
     assertThatIllegalArgumentException()
         .isThrownBy(
-            () -> new SnapshotMetadata(name, path, endTime, startTime, maxOffset, partitionId));
+            () ->
+                new SnapshotMetadata(
+                    name, path, endTime, startTime, maxOffset, partitionId, LUCENE_REGULAR));
 
     // Start time same as end time.
     assertThat(
-            new SnapshotMetadata(name, path, startTime, startTime, maxOffset, partitionId)
+            new SnapshotMetadata(
+                    name, path, startTime, startTime, maxOffset, partitionId, LUCENE_REGULAR)
                 .endTimeEpochMs)
         .isEqualTo(startTime);
 
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new SnapshotMetadata(name, path, startTime, endTime, -1, partitionId));
+        .isThrownBy(
+            () ->
+                new SnapshotMetadata(
+                    name, path, startTime, endTime, -1, partitionId, LUCENE_REGULAR));
 
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new SnapshotMetadata(name, path, startTime, endTime, maxOffset, ""));
+        .isThrownBy(
+            () ->
+                new SnapshotMetadata(
+                    name, path, startTime, endTime, maxOffset, "", LUCENE_REGULAR));
   }
 
   @Test
@@ -105,12 +128,19 @@ public class SnapshotMetadataTest {
     final String partitionId = "1";
 
     SnapshotMetadata nonLiveSnapshot =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId);
+        new SnapshotMetadata(
+            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
     assertThat(SnapshotMetadata.isLive(nonLiveSnapshot)).isFalse();
 
     SnapshotMetadata liveSnapshot =
         new SnapshotMetadata(
-            name, SnapshotMetadata.LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, partitionId);
+            name,
+            SnapshotMetadata.LIVE_SNAPSHOT_PATH,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            LUCENE_REGULAR);
     assertThat(SnapshotMetadata.isLive(liveSnapshot)).isTrue();
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataTest.java
@@ -1,6 +1,6 @@
 package com.slack.kaldb.metadata.snapshot;
 
-import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LOGS_LUCENE9;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.HashSet;
@@ -19,8 +19,7 @@ public class SnapshotMetadataTest {
     final String partitionId = "1";
 
     SnapshotMetadata snapshotMetadata =
-        new SnapshotMetadata(
-            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
 
     assertThat(snapshotMetadata.name).isEqualTo(name);
     assertThat(snapshotMetadata.snapshotPath).isEqualTo(path);
@@ -29,7 +28,7 @@ public class SnapshotMetadataTest {
     assertThat(snapshotMetadata.endTimeEpochMs).isEqualTo(endTime);
     assertThat(snapshotMetadata.maxOffset).isEqualTo(maxOffset);
     assertThat(snapshotMetadata.partitionId).isEqualTo(partitionId);
-    assertThat(snapshotMetadata.indexType).isEqualTo(LUCENE_REGULAR);
+    assertThat(snapshotMetadata.indexType).isEqualTo(LOGS_LUCENE9);
   }
 
   @Test
@@ -42,11 +41,10 @@ public class SnapshotMetadataTest {
     final String partitionId = "1";
 
     SnapshotMetadata snapshot1 =
-        new SnapshotMetadata(
-            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     SnapshotMetadata snapshot2 =
         new SnapshotMetadata(
-            name + "2", path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
+            name + "2", path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
 
     assertThat(snapshot1).isEqualTo(snapshot1);
     // Ensure the name field from super class is included.
@@ -71,37 +69,36 @@ public class SnapshotMetadataTest {
         .isThrownBy(
             () ->
                 new SnapshotMetadata(
-                    "", path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR));
+                    "", path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9));
 
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
                 new SnapshotMetadata(
-                    name, "", startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR));
+                    name, "", startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9));
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                new SnapshotMetadata(name, path, 0, endTime, maxOffset, partitionId, LOGS_LUCENE9));
 
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
                 new SnapshotMetadata(
-                    name, path, 0, endTime, maxOffset, partitionId, LUCENE_REGULAR));
-
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () ->
-                new SnapshotMetadata(
-                    name, path, startTime, 0, maxOffset, partitionId, LUCENE_REGULAR));
+                    name, path, startTime, 0, maxOffset, partitionId, LOGS_LUCENE9));
 
     // Start time < end time
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
                 new SnapshotMetadata(
-                    name, path, endTime, startTime, maxOffset, partitionId, LUCENE_REGULAR));
+                    name, path, endTime, startTime, maxOffset, partitionId, LOGS_LUCENE9));
 
     // Start time same as end time.
     assertThat(
             new SnapshotMetadata(
-                    name, path, startTime, startTime, maxOffset, partitionId, LUCENE_REGULAR)
+                    name, path, startTime, startTime, maxOffset, partitionId, LOGS_LUCENE9)
                 .endTimeEpochMs)
         .isEqualTo(startTime);
 
@@ -109,13 +106,12 @@ public class SnapshotMetadataTest {
         .isThrownBy(
             () ->
                 new SnapshotMetadata(
-                    name, path, startTime, endTime, -1, partitionId, LUCENE_REGULAR));
+                    name, path, startTime, endTime, -1, partitionId, LOGS_LUCENE9));
 
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
-                new SnapshotMetadata(
-                    name, path, startTime, endTime, maxOffset, "", LUCENE_REGULAR));
+                new SnapshotMetadata(name, path, startTime, endTime, maxOffset, "", LOGS_LUCENE9));
   }
 
   @Test
@@ -128,8 +124,7 @@ public class SnapshotMetadataTest {
     final String partitionId = "1";
 
     SnapshotMetadata nonLiveSnapshot =
-        new SnapshotMetadata(
-            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     assertThat(SnapshotMetadata.isLive(nonLiveSnapshot)).isFalse();
 
     SnapshotMetadata liveSnapshot =
@@ -140,7 +135,7 @@ public class SnapshotMetadataTest {
             endTime,
             maxOffset,
             partitionId,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     assertThat(SnapshotMetadata.isLive(liveSnapshot)).isTrue();
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -3,7 +3,7 @@ package com.slack.kaldb.server;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_FAILED_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_RECEIVED_COUNTER;
 import static com.slack.kaldb.metadata.snapshot.SnapshotMetadata.LIVE_SNAPSHOT_PATH;
-import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LOGS_LUCENE9;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static com.slack.kaldb.testlib.ChunkManagerUtil.*;
 import static com.slack.kaldb.testlib.KaldbConfigUtil.*;
@@ -196,7 +196,7 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "0",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition1);
     assertThat(snapshotMetadataStore.listSync()).containsOnly(livePartition1);
 
@@ -240,7 +240,7 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "0",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
@@ -251,7 +251,7 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "1",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition1);
     assertThat(snapshotMetadataStore.listSync()).containsOnly(livePartition1, livePartition0);
 
@@ -291,7 +291,7 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "0",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
@@ -302,7 +302,7 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "1",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition1);
     assertThat(snapshotMetadataStore.listSync()).containsOnly(livePartition1, livePartition0);
 
@@ -347,7 +347,7 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "0",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
@@ -358,11 +358,11 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "1",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition1);
 
     final SnapshotMetadata partition0 =
-        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition0);
 
     assertThat(snapshotMetadataStore.listSync())
@@ -411,7 +411,7 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "0",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
@@ -422,11 +422,11 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "1",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition1);
 
     final SnapshotMetadata partition0 =
-        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition0);
 
     assertThat(snapshotMetadataStore.listSync())
@@ -482,7 +482,7 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "0",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
@@ -493,11 +493,11 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "1",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition1);
 
     final SnapshotMetadata partition0 =
-        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition0);
 
     assertThat(snapshotMetadataStore.listSync())
@@ -557,7 +557,7 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "0",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
@@ -568,11 +568,11 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "1",
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition1);
 
     final SnapshotMetadata partition0 =
-        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition0);
 
     assertThat(snapshotMetadataStore.listSync())

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -3,6 +3,7 @@ package com.slack.kaldb.server;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_FAILED_COUNTER;
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_RECEIVED_COUNTER;
 import static com.slack.kaldb.metadata.snapshot.SnapshotMetadata.LIVE_SNAPSHOT_PATH;
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static com.slack.kaldb.testlib.ChunkManagerUtil.*;
 import static com.slack.kaldb.testlib.KaldbConfigUtil.*;
@@ -32,7 +33,6 @@ import com.slack.kaldb.metadata.snapshot.SnapshotMetadataStore;
 import com.slack.kaldb.metadata.zookeeper.MetadataStore;
 import com.slack.kaldb.metadata.zookeeper.ZookeeperMetadataStoreImpl;
 import com.slack.kaldb.proto.config.KaldbConfigs;
-import com.slack.kaldb.proto.metadata.Metadata;
 import com.slack.kaldb.testlib.ChunkManagerUtil;
 import com.slack.kaldb.testlib.TestKafkaServer;
 import com.slack.kaldb.writer.kafka.KaldbKafkaConsumer;
@@ -188,7 +188,7 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "0",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition1);
     assertThat(snapshotMetadataStore.listSync()).containsOnly(livePartition1);
 
@@ -232,7 +232,7 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "0",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
@@ -243,7 +243,7 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "1",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition1);
     assertThat(snapshotMetadataStore.listSync()).containsOnly(livePartition1, livePartition0);
 
@@ -283,7 +283,7 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "0",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
@@ -294,7 +294,7 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "1",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition1);
     assertThat(snapshotMetadataStore.listSync()).containsOnly(livePartition1, livePartition0);
 
@@ -339,7 +339,7 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "0",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
@@ -350,12 +350,11 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "1",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition1);
 
     final SnapshotMetadata partition0 =
-        new SnapshotMetadata(
-            name, path, startTimeMs, endTimeMs, maxOffset, "0", Metadata.IndexType.LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition0);
 
     assertThat(snapshotMetadataStore.listSync())
@@ -404,7 +403,7 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "0",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
@@ -415,12 +414,11 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "1",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition1);
 
     final SnapshotMetadata partition0 =
-        new SnapshotMetadata(
-            name, path, startTimeMs, endTimeMs, maxOffset, "0", Metadata.IndexType.LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition0);
 
     assertThat(snapshotMetadataStore.listSync())
@@ -476,7 +474,7 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "0",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
@@ -487,12 +485,11 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "1",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition1);
 
     final SnapshotMetadata partition0 =
-        new SnapshotMetadata(
-            name, path, startTimeMs, endTimeMs, maxOffset, "0", Metadata.IndexType.LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition0);
 
     assertThat(snapshotMetadataStore.listSync())
@@ -552,7 +549,7 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "0",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
@@ -563,12 +560,11 @@ public class KaldbIndexerTest {
             endTimeMs,
             maxOffset,
             "1",
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition1);
 
     final SnapshotMetadata partition0 =
-        new SnapshotMetadata(
-            name, path, startTimeMs, endTimeMs, maxOffset, "0", Metadata.IndexType.LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition0);
 
     assertThat(snapshotMetadataStore.listSync())

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -32,6 +32,7 @@ import com.slack.kaldb.metadata.snapshot.SnapshotMetadataStore;
 import com.slack.kaldb.metadata.zookeeper.MetadataStore;
 import com.slack.kaldb.metadata.zookeeper.ZookeeperMetadataStoreImpl;
 import com.slack.kaldb.proto.config.KaldbConfigs;
+import com.slack.kaldb.proto.metadata.Metadata;
 import com.slack.kaldb.testlib.ChunkManagerUtil;
 import com.slack.kaldb.testlib.TestKafkaServer;
 import com.slack.kaldb.writer.kafka.KaldbKafkaConsumer;
@@ -181,7 +182,13 @@ public class KaldbIndexerTest {
     final long maxOffset = 50;
     SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
-            name + "live1", LIVE_SNAPSHOT_PATH, startTimeMs, endTimeMs, maxOffset, "0");
+            name + "live1",
+            LIVE_SNAPSHOT_PATH,
+            startTimeMs,
+            endTimeMs,
+            maxOffset,
+            "0",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition1);
     assertThat(snapshotMetadataStore.listSync()).containsOnly(livePartition1);
 
@@ -219,12 +226,24 @@ public class KaldbIndexerTest {
     final long maxOffset = 50;
     SnapshotMetadata livePartition0 =
         new SnapshotMetadata(
-            name + "live0", LIVE_SNAPSHOT_PATH, startTimeMs, endTimeMs, maxOffset, "0");
+            name + "live0",
+            LIVE_SNAPSHOT_PATH,
+            startTimeMs,
+            endTimeMs,
+            maxOffset,
+            "0",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
-            name + "live1", LIVE_SNAPSHOT_PATH, startTimeMs, endTimeMs, maxOffset, "1");
+            name + "live1",
+            LIVE_SNAPSHOT_PATH,
+            startTimeMs,
+            endTimeMs,
+            maxOffset,
+            "1",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition1);
     assertThat(snapshotMetadataStore.listSync()).containsOnly(livePartition1, livePartition0);
 
@@ -258,12 +277,24 @@ public class KaldbIndexerTest {
     final long maxOffset = 50;
     SnapshotMetadata livePartition0 =
         new SnapshotMetadata(
-            name + "live0", LIVE_SNAPSHOT_PATH, startTimeMs, endTimeMs, maxOffset, "0");
+            name + "live0",
+            LIVE_SNAPSHOT_PATH,
+            startTimeMs,
+            endTimeMs,
+            maxOffset,
+            "0",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
-            name + "live1", LIVE_SNAPSHOT_PATH, startTimeMs, endTimeMs, maxOffset, "1");
+            name + "live1",
+            LIVE_SNAPSHOT_PATH,
+            startTimeMs,
+            endTimeMs,
+            maxOffset,
+            "1",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition1);
     assertThat(snapshotMetadataStore.listSync()).containsOnly(livePartition1, livePartition0);
 
@@ -302,16 +333,29 @@ public class KaldbIndexerTest {
     final long maxOffset = 50;
     SnapshotMetadata livePartition0 =
         new SnapshotMetadata(
-            name + "live0", LIVE_SNAPSHOT_PATH, startTimeMs, endTimeMs, maxOffset, "0");
+            name + "live0",
+            LIVE_SNAPSHOT_PATH,
+            startTimeMs,
+            endTimeMs,
+            maxOffset,
+            "0",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
-            name + "live1", LIVE_SNAPSHOT_PATH, startTimeMs, endTimeMs, maxOffset, "1");
+            name + "live1",
+            LIVE_SNAPSHOT_PATH,
+            startTimeMs,
+            endTimeMs,
+            maxOffset,
+            "1",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition1);
 
     final SnapshotMetadata partition0 =
-        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0");
+        new SnapshotMetadata(
+            name, path, startTimeMs, endTimeMs, maxOffset, "0", Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition0);
 
     assertThat(snapshotMetadataStore.listSync())
@@ -354,16 +398,29 @@ public class KaldbIndexerTest {
     final long maxOffset = 30;
     SnapshotMetadata livePartition0 =
         new SnapshotMetadata(
-            name + "live0", LIVE_SNAPSHOT_PATH, startTimeMs, endTimeMs, maxOffset, "0");
+            name + "live0",
+            LIVE_SNAPSHOT_PATH,
+            startTimeMs,
+            endTimeMs,
+            maxOffset,
+            "0",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
-            name + "live1", LIVE_SNAPSHOT_PATH, startTimeMs, endTimeMs, maxOffset, "1");
+            name + "live1",
+            LIVE_SNAPSHOT_PATH,
+            startTimeMs,
+            endTimeMs,
+            maxOffset,
+            "1",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition1);
 
     final SnapshotMetadata partition0 =
-        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0");
+        new SnapshotMetadata(
+            name, path, startTimeMs, endTimeMs, maxOffset, "0", Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition0);
 
     assertThat(snapshotMetadataStore.listSync())
@@ -413,16 +470,29 @@ public class KaldbIndexerTest {
     final long maxOffset = 30;
     SnapshotMetadata livePartition0 =
         new SnapshotMetadata(
-            name + "live0", LIVE_SNAPSHOT_PATH, startTimeMs, endTimeMs, maxOffset, "0");
+            name + "live0",
+            LIVE_SNAPSHOT_PATH,
+            startTimeMs,
+            endTimeMs,
+            maxOffset,
+            "0",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
-            name + "live1", LIVE_SNAPSHOT_PATH, startTimeMs, endTimeMs, maxOffset, "1");
+            name + "live1",
+            LIVE_SNAPSHOT_PATH,
+            startTimeMs,
+            endTimeMs,
+            maxOffset,
+            "1",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition1);
 
     final SnapshotMetadata partition0 =
-        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0");
+        new SnapshotMetadata(
+            name, path, startTimeMs, endTimeMs, maxOffset, "0", Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition0);
 
     assertThat(snapshotMetadataStore.listSync())
@@ -476,16 +546,29 @@ public class KaldbIndexerTest {
     final long maxOffset = 30;
     SnapshotMetadata livePartition0 =
         new SnapshotMetadata(
-            name + "live0", LIVE_SNAPSHOT_PATH, startTimeMs, endTimeMs, maxOffset, "0");
+            name + "live0",
+            LIVE_SNAPSHOT_PATH,
+            startTimeMs,
+            endTimeMs,
+            maxOffset,
+            "0",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
-            name + "live1", LIVE_SNAPSHOT_PATH, startTimeMs, endTimeMs, maxOffset, "1");
+            name + "live1",
+            LIVE_SNAPSHOT_PATH,
+            startTimeMs,
+            endTimeMs,
+            maxOffset,
+            "1",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition1);
 
     final SnapshotMetadata partition0 =
-        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0");
+        new SnapshotMetadata(
+            name, path, startTimeMs, endTimeMs, maxOffset, "0", Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition0);
 
     assertThat(snapshotMetadataStore.listSync())

--- a/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
@@ -500,29 +500,39 @@ public class ManagerApiGrpcTest {
     long end = startTime + 10;
 
     SnapshotMetadata overlapsStartTimeIncluded =
-        new SnapshotMetadata("a", "a", startTime, startTime + 6, 0, "a");
+        new SnapshotMetadata(
+            "a", "a", startTime, startTime + 6, 0, "a", Metadata.IndexType.LUCENE_REGULAR);
     SnapshotMetadata overlapsStartTimeExcluded =
-        new SnapshotMetadata("b", "b", startTime, startTime + 6, 0, "b");
+        new SnapshotMetadata(
+            "b", "b", startTime, startTime + 6, 0, "b", Metadata.IndexType.LUCENE_REGULAR);
 
     SnapshotMetadata fullyOverlapsStartEndTimeIncluded =
-        new SnapshotMetadata("c", "c", startTime + 4, startTime + 11, 0, "a");
+        new SnapshotMetadata(
+            "c", "c", startTime + 4, startTime + 11, 0, "a", Metadata.IndexType.LUCENE_REGULAR);
     SnapshotMetadata fullyOverlapsStartEndTimeExcluded =
-        new SnapshotMetadata("d", "d", startTime + 4, startTime + 11, 0, "b");
+        new SnapshotMetadata(
+            "d", "d", startTime + 4, startTime + 11, 0, "b", Metadata.IndexType.LUCENE_REGULAR);
 
     SnapshotMetadata partiallyOverlapsStartEndTimeIncluded =
-        new SnapshotMetadata("e", "e", startTime + 4, startTime + 5, 0, "a");
+        new SnapshotMetadata(
+            "e", "e", startTime + 4, startTime + 5, 0, "a", Metadata.IndexType.LUCENE_REGULAR);
     SnapshotMetadata partiallyOverlapsStartEndTimeExcluded =
-        new SnapshotMetadata("f", "f", startTime + 4, startTime + 5, 0, "b");
+        new SnapshotMetadata(
+            "f", "f", startTime + 4, startTime + 5, 0, "b", Metadata.IndexType.LUCENE_REGULAR);
 
     SnapshotMetadata overlapsEndTimeIncluded =
-        new SnapshotMetadata("g", "g", startTime + 10, startTime + 15, 0, "a");
+        new SnapshotMetadata(
+            "g", "g", startTime + 10, startTime + 15, 0, "a", Metadata.IndexType.LUCENE_REGULAR);
     SnapshotMetadata overlapsEndTimeExcluded =
-        new SnapshotMetadata("h", "h", startTime + 10, startTime + 15, 0, "b");
+        new SnapshotMetadata(
+            "h", "h", startTime + 10, startTime + 15, 0, "b", Metadata.IndexType.LUCENE_REGULAR);
 
     SnapshotMetadata notWithinStartEndTimeExcluded1 =
-        new SnapshotMetadata("i", "i", startTime, startTime + 4, 0, "a");
+        new SnapshotMetadata(
+            "i", "i", startTime, startTime + 4, 0, "a", Metadata.IndexType.LUCENE_REGULAR);
     SnapshotMetadata notWithinStartEndTimeExcluded2 =
-        new SnapshotMetadata("j", "j", startTime + 11, startTime + 15, 0, "a");
+        new SnapshotMetadata(
+            "j", "j", startTime + 11, startTime + 15, 0, "a", Metadata.IndexType.LUCENE_REGULAR);
 
     DatasetMetadata datasetWithDataInPartitionA =
         new DatasetMetadata(
@@ -571,9 +581,11 @@ public class ManagerApiGrpcTest {
     long end = startTime + 10;
 
     SnapshotMetadata snapshotIncluded =
-        new SnapshotMetadata("g", "g", startTime + 10, startTime + 15, 0, "a");
+        new SnapshotMetadata(
+            "g", "g", startTime + 10, startTime + 15, 0, "a", Metadata.IndexType.LUCENE_REGULAR);
     SnapshotMetadata snapshotExcluded =
-        new SnapshotMetadata("h", "h", startTime + 10, startTime + 15, 0, "b");
+        new SnapshotMetadata(
+            "h", "h", startTime + 10, startTime + 15, 0, "b", Metadata.IndexType.LUCENE_REGULAR);
 
     snapshotMetadataStore.createSync(snapshotIncluded);
     snapshotMetadataStore.createSync(snapshotExcluded);
@@ -612,11 +624,14 @@ public class ManagerApiGrpcTest {
     long end = startTime + 10;
 
     SnapshotMetadata snapshotIncluded =
-        new SnapshotMetadata("a", "a", startTime + 10, startTime + 15, 0, "a");
+        new SnapshotMetadata(
+            "a", "a", startTime + 10, startTime + 15, 0, "a", Metadata.IndexType.LUCENE_REGULAR);
     SnapshotMetadata snapshotIncluded2 =
-        new SnapshotMetadata("b", "b", startTime + 10, startTime + 15, 0, "b");
+        new SnapshotMetadata(
+            "b", "b", startTime + 10, startTime + 15, 0, "b", Metadata.IndexType.LUCENE_REGULAR);
     SnapshotMetadata snapshotExcluded =
-        new SnapshotMetadata("c", "c", startTime + 10, startTime + 15, 0, "c");
+        new SnapshotMetadata(
+            "c", "c", startTime + 10, startTime + 15, 0, "c", Metadata.IndexType.LUCENE_REGULAR);
 
     snapshotMetadataStore.createSync(snapshotIncluded);
     snapshotMetadataStore.createSync(snapshotIncluded2);
@@ -658,11 +673,14 @@ public class ManagerApiGrpcTest {
     long startTime = Instant.now().toEpochMilli();
 
     SnapshotMetadata snapshotFoo =
-        new SnapshotMetadata("foo", "a", startTime + 10, startTime + 15, 0, "a");
+        new SnapshotMetadata(
+            "foo", "a", startTime + 10, startTime + 15, 0, "a", Metadata.IndexType.LUCENE_REGULAR);
     SnapshotMetadata snapshotBar =
-        new SnapshotMetadata("bar", "b", startTime + 10, startTime + 15, 0, "b");
+        new SnapshotMetadata(
+            "bar", "b", startTime + 10, startTime + 15, 0, "b", Metadata.IndexType.LUCENE_REGULAR);
     SnapshotMetadata snapshotBaz =
-        new SnapshotMetadata("baz", "c", startTime + 10, startTime + 15, 0, "c");
+        new SnapshotMetadata(
+            "baz", "c", startTime + 10, startTime + 15, 0, "c", Metadata.IndexType.LUCENE_REGULAR);
 
     snapshotMetadataStore.createSync(snapshotFoo);
     snapshotMetadataStore.createSync(snapshotBar);

--- a/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
@@ -501,38 +501,38 @@ public class ManagerApiGrpcTest {
 
     SnapshotMetadata overlapsStartTimeIncluded =
         new SnapshotMetadata(
-            "a", "a", startTime, startTime + 6, 0, "a", Metadata.IndexType.LUCENE_REGULAR);
+            "a", "a", startTime, startTime + 6, 0, "a", Metadata.IndexType.LOGS_LUCENE9);
     SnapshotMetadata overlapsStartTimeExcluded =
         new SnapshotMetadata(
-            "b", "b", startTime, startTime + 6, 0, "b", Metadata.IndexType.LUCENE_REGULAR);
+            "b", "b", startTime, startTime + 6, 0, "b", Metadata.IndexType.LOGS_LUCENE9);
 
     SnapshotMetadata fullyOverlapsStartEndTimeIncluded =
         new SnapshotMetadata(
-            "c", "c", startTime + 4, startTime + 11, 0, "a", Metadata.IndexType.LUCENE_REGULAR);
+            "c", "c", startTime + 4, startTime + 11, 0, "a", Metadata.IndexType.LOGS_LUCENE9);
     SnapshotMetadata fullyOverlapsStartEndTimeExcluded =
         new SnapshotMetadata(
-            "d", "d", startTime + 4, startTime + 11, 0, "b", Metadata.IndexType.LUCENE_REGULAR);
+            "d", "d", startTime + 4, startTime + 11, 0, "b", Metadata.IndexType.LOGS_LUCENE9);
 
     SnapshotMetadata partiallyOverlapsStartEndTimeIncluded =
         new SnapshotMetadata(
-            "e", "e", startTime + 4, startTime + 5, 0, "a", Metadata.IndexType.LUCENE_REGULAR);
+            "e", "e", startTime + 4, startTime + 5, 0, "a", Metadata.IndexType.LOGS_LUCENE9);
     SnapshotMetadata partiallyOverlapsStartEndTimeExcluded =
         new SnapshotMetadata(
-            "f", "f", startTime + 4, startTime + 5, 0, "b", Metadata.IndexType.LUCENE_REGULAR);
+            "f", "f", startTime + 4, startTime + 5, 0, "b", Metadata.IndexType.LOGS_LUCENE9);
 
     SnapshotMetadata overlapsEndTimeIncluded =
         new SnapshotMetadata(
-            "g", "g", startTime + 10, startTime + 15, 0, "a", Metadata.IndexType.LUCENE_REGULAR);
+            "g", "g", startTime + 10, startTime + 15, 0, "a", Metadata.IndexType.LOGS_LUCENE9);
     SnapshotMetadata overlapsEndTimeExcluded =
         new SnapshotMetadata(
-            "h", "h", startTime + 10, startTime + 15, 0, "b", Metadata.IndexType.LUCENE_REGULAR);
+            "h", "h", startTime + 10, startTime + 15, 0, "b", Metadata.IndexType.LOGS_LUCENE9);
 
     SnapshotMetadata notWithinStartEndTimeExcluded1 =
         new SnapshotMetadata(
-            "i", "i", startTime, startTime + 4, 0, "a", Metadata.IndexType.LUCENE_REGULAR);
+            "i", "i", startTime, startTime + 4, 0, "a", Metadata.IndexType.LOGS_LUCENE9);
     SnapshotMetadata notWithinStartEndTimeExcluded2 =
         new SnapshotMetadata(
-            "j", "j", startTime + 11, startTime + 15, 0, "a", Metadata.IndexType.LUCENE_REGULAR);
+            "j", "j", startTime + 11, startTime + 15, 0, "a", Metadata.IndexType.LOGS_LUCENE9);
 
     DatasetMetadata datasetWithDataInPartitionA =
         new DatasetMetadata(
@@ -582,10 +582,10 @@ public class ManagerApiGrpcTest {
 
     SnapshotMetadata snapshotIncluded =
         new SnapshotMetadata(
-            "g", "g", startTime + 10, startTime + 15, 0, "a", Metadata.IndexType.LUCENE_REGULAR);
+            "g", "g", startTime + 10, startTime + 15, 0, "a", Metadata.IndexType.LOGS_LUCENE9);
     SnapshotMetadata snapshotExcluded =
         new SnapshotMetadata(
-            "h", "h", startTime + 10, startTime + 15, 0, "b", Metadata.IndexType.LUCENE_REGULAR);
+            "h", "h", startTime + 10, startTime + 15, 0, "b", Metadata.IndexType.LOGS_LUCENE9);
 
     snapshotMetadataStore.createSync(snapshotIncluded);
     snapshotMetadataStore.createSync(snapshotExcluded);
@@ -625,13 +625,13 @@ public class ManagerApiGrpcTest {
 
     SnapshotMetadata snapshotIncluded =
         new SnapshotMetadata(
-            "a", "a", startTime + 10, startTime + 15, 0, "a", Metadata.IndexType.LUCENE_REGULAR);
+            "a", "a", startTime + 10, startTime + 15, 0, "a", Metadata.IndexType.LOGS_LUCENE9);
     SnapshotMetadata snapshotIncluded2 =
         new SnapshotMetadata(
-            "b", "b", startTime + 10, startTime + 15, 0, "b", Metadata.IndexType.LUCENE_REGULAR);
+            "b", "b", startTime + 10, startTime + 15, 0, "b", Metadata.IndexType.LOGS_LUCENE9);
     SnapshotMetadata snapshotExcluded =
         new SnapshotMetadata(
-            "c", "c", startTime + 10, startTime + 15, 0, "c", Metadata.IndexType.LUCENE_REGULAR);
+            "c", "c", startTime + 10, startTime + 15, 0, "c", Metadata.IndexType.LOGS_LUCENE9);
 
     snapshotMetadataStore.createSync(snapshotIncluded);
     snapshotMetadataStore.createSync(snapshotIncluded2);
@@ -674,13 +674,13 @@ public class ManagerApiGrpcTest {
 
     SnapshotMetadata snapshotFoo =
         new SnapshotMetadata(
-            "foo", "a", startTime + 10, startTime + 15, 0, "a", Metadata.IndexType.LUCENE_REGULAR);
+            "foo", "a", startTime + 10, startTime + 15, 0, "a", Metadata.IndexType.LOGS_LUCENE9);
     SnapshotMetadata snapshotBar =
         new SnapshotMetadata(
-            "bar", "b", startTime + 10, startTime + 15, 0, "b", Metadata.IndexType.LUCENE_REGULAR);
+            "bar", "b", startTime + 10, startTime + 15, 0, "b", Metadata.IndexType.LOGS_LUCENE9);
     SnapshotMetadata snapshotBaz =
         new SnapshotMetadata(
-            "baz", "c", startTime + 10, startTime + 15, 0, "c", Metadata.IndexType.LUCENE_REGULAR);
+            "baz", "c", startTime + 10, startTime + 15, 0, "c", Metadata.IndexType.LOGS_LUCENE9);
 
     snapshotMetadataStore.createSync(snapshotFoo);
     snapshotMetadataStore.createSync(snapshotBar);

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -1,6 +1,7 @@
 package com.slack.kaldb.server;
 
 import static com.slack.kaldb.metadata.snapshot.SnapshotMetadata.LIVE_SNAPSHOT_PATH;
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
 import static com.slack.kaldb.server.RecoveryTaskCreator.RECOVERY_TASKS_CREATED;
 import static com.slack.kaldb.server.RecoveryTaskCreator.STALE_SNAPSHOT_DELETE_SUCCESS;
 import static com.slack.kaldb.server.RecoveryTaskCreator.getHighestDurableOffsetForPartition;
@@ -23,7 +24,6 @@ import com.slack.kaldb.metadata.recovery.RecoveryTaskMetadataStore;
 import com.slack.kaldb.metadata.snapshot.SnapshotMetadata;
 import com.slack.kaldb.metadata.snapshot.SnapshotMetadataStore;
 import com.slack.kaldb.metadata.zookeeper.ZookeeperMetadataStoreImpl;
-import com.slack.kaldb.proto.metadata.Metadata;
 import com.slack.kaldb.util.CountingFatalErrorHandler;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
@@ -87,13 +87,7 @@ public class RecoveryTaskCreatorTest {
 
     SnapshotMetadata partition1 =
         new SnapshotMetadata(
-            name,
-            path,
-            startTime,
-            endTime,
-            maxOffset,
-            partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
     SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
             name + "1",
@@ -102,7 +96,7 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     SnapshotMetadata livePartition11 =
         new SnapshotMetadata(
             name + "11",
@@ -111,25 +105,12 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     SnapshotMetadata livePartition2 =
         new SnapshotMetadata(
-            name + "2",
-            LIVE_SNAPSHOT_PATH,
-            startTime,
-            endTime,
-            maxOffset,
-            "2",
-            Metadata.IndexType.LUCENE_REGULAR);
+            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2", LUCENE_REGULAR);
     SnapshotMetadata partition2 =
-        new SnapshotMetadata(
-            name + "3",
-            path,
-            startTime,
-            endTime,
-            maxOffset,
-            "2",
-            Metadata.IndexType.LUCENE_REGULAR);
+        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2", LUCENE_REGULAR);
 
     assertThat(getStaleLiveSnapshots(List.of(partition1), partitionId)).isEmpty();
     assertThat(getStaleLiveSnapshots(List.of(partition2), partitionId)).isEmpty();
@@ -166,13 +147,7 @@ public class RecoveryTaskCreatorTest {
 
     SnapshotMetadata partition1 =
         new SnapshotMetadata(
-            name,
-            path,
-            startTime,
-            endTime,
-            maxOffset,
-            partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
     SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
             name + "1",
@@ -181,7 +156,7 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     SnapshotMetadata livePartition11 =
         new SnapshotMetadata(
             name + "11",
@@ -190,25 +165,12 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     SnapshotMetadata livePartition2 =
         new SnapshotMetadata(
-            name + "2",
-            LIVE_SNAPSHOT_PATH,
-            startTime,
-            endTime,
-            maxOffset,
-            "2",
-            Metadata.IndexType.LUCENE_REGULAR);
+            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2", LUCENE_REGULAR);
     SnapshotMetadata partition2 =
-        new SnapshotMetadata(
-            name + "3",
-            path,
-            startTime,
-            endTime,
-            maxOffset,
-            "2",
-            Metadata.IndexType.LUCENE_REGULAR);
+        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2", LUCENE_REGULAR);
 
     testDeleteSnapshots(List.of(partition1), 0, List.of(partition1));
     testDeleteSnapshots(List.of(partition2), 0, List.of(partition2));
@@ -267,13 +229,7 @@ public class RecoveryTaskCreatorTest {
 
     SnapshotMetadata partition1 =
         new SnapshotMetadata(
-            name,
-            path,
-            startTime,
-            endTime,
-            maxOffset,
-            partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
     SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
             name + "1",
@@ -282,7 +238,7 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     SnapshotMetadata livePartition11 =
         new SnapshotMetadata(
             name + "11",
@@ -291,25 +247,12 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     SnapshotMetadata livePartition2 =
         new SnapshotMetadata(
-            name + "2",
-            LIVE_SNAPSHOT_PATH,
-            startTime,
-            endTime,
-            maxOffset,
-            "2",
-            Metadata.IndexType.LUCENE_REGULAR);
+            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2", LUCENE_REGULAR);
     SnapshotMetadata partition2 =
-        new SnapshotMetadata(
-            name + "3",
-            path,
-            startTime,
-            endTime,
-            maxOffset,
-            "2",
-            Metadata.IndexType.LUCENE_REGULAR);
+        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2", LUCENE_REGULAR);
 
     testDeleteSnapshotsTimeouts(List.of(partition1), List.of(partition1), false);
     testDeleteSnapshotsTimeouts(List.of(livePartition1), List.of(livePartition1), true);
@@ -377,13 +320,7 @@ public class RecoveryTaskCreatorTest {
 
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(
-            name,
-            path,
-            startTime,
-            endTime,
-            maxOffset,
-            partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
     final SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
             name + "1",
@@ -392,7 +329,7 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     final SnapshotMetadata livePartition11 =
         new SnapshotMetadata(
             name + "11",
@@ -401,25 +338,12 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     final SnapshotMetadata livePartition2 =
         new SnapshotMetadata(
-            name + "2",
-            LIVE_SNAPSHOT_PATH,
-            startTime,
-            endTime,
-            maxOffset,
-            "2",
-            Metadata.IndexType.LUCENE_REGULAR);
+            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2", LUCENE_REGULAR);
     final SnapshotMetadata partition2 =
-        new SnapshotMetadata(
-            name + "3",
-            path,
-            startTime,
-            endTime,
-            maxOffset,
-            "2",
-            Metadata.IndexType.LUCENE_REGULAR);
+        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2", LUCENE_REGULAR);
 
     List<SnapshotMetadata> snapshots =
         List.of(partition1, livePartition1, livePartition11, partition2, livePartition2);
@@ -481,22 +405,10 @@ public class RecoveryTaskCreatorTest {
 
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(
-            name,
-            path,
-            startTime,
-            endTime,
-            maxOffset,
-            partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
     final SnapshotMetadata partition11 =
         new SnapshotMetadata(
-            name + "1",
-            path,
-            endTime + 1,
-            endTime * 2,
-            maxOffset * 2,
-            partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            name + "1", path, endTime + 1, endTime * 2, maxOffset * 2, partitionId, LUCENE_REGULAR);
     final SnapshotMetadata partition12 =
         new SnapshotMetadata(
             name + "12",
@@ -505,19 +417,13 @@ public class RecoveryTaskCreatorTest {
             endTime * 3,
             maxOffset * 3,
             partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
 
     final String partitionId2 = "2";
     final long partition2Offset = maxOffset * 10;
     final SnapshotMetadata partition2 =
         new SnapshotMetadata(
-            name + "2",
-            path,
-            startTime,
-            endTime,
-            partition2Offset,
-            partitionId2,
-            Metadata.IndexType.LUCENE_REGULAR);
+            name + "2", path, startTime, endTime, partition2Offset, partitionId2, LUCENE_REGULAR);
     final SnapshotMetadata partition21 =
         new SnapshotMetadata(
             name + "21",
@@ -526,7 +432,7 @@ public class RecoveryTaskCreatorTest {
             endTime * 2,
             partition2Offset * 2,
             partitionId2,
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     final SnapshotMetadata partition22 =
         new SnapshotMetadata(
             name + "22",
@@ -535,7 +441,7 @@ public class RecoveryTaskCreatorTest {
             endTime * 3,
             partition2Offset * 3,
             partitionId2,
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
 
     // empty results
     assertThat(
@@ -770,21 +676,14 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(
-            name, path, startTime, endTime, maxOffset, "2", Metadata.IndexType.LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, "2", LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(recoveryTaskCreator.determineStartingOffset(0)).isNegative();
 
     final SnapshotMetadata partition11 =
         new SnapshotMetadata(
-            name + "1",
-            path,
-            endTime + 1,
-            endTime * 2,
-            maxOffset * 2,
-            "2",
-            Metadata.IndexType.LUCENE_REGULAR);
+            name + "1", path, endTime + 1, endTime * 2, maxOffset * 2, "2", LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition11);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1, partition11);
     assertThat(recoveryTaskCreator.determineStartingOffset(0)).isNegative();
@@ -1046,13 +945,7 @@ public class RecoveryTaskCreatorTest {
 
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(
-            name,
-            path,
-            startTime,
-            endTime,
-            maxOffset,
-            partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(
@@ -1072,7 +965,7 @@ public class RecoveryTaskCreatorTest {
             endTime * 2,
             maxOffset * 2,
             partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
 
     snapshotMetadataStore.createSync(partition11);
     assertThat(snapshotMetadataStore.listSync()).containsExactlyInAnyOrder(partition1, partition11);
@@ -1093,7 +986,7 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1, partition11, livePartition1);
     assertThat(recoveryTaskCreator.determineStartingOffset(250)).isEqualTo(201);
@@ -1112,7 +1005,7 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition11);
     assertThat(snapshotMetadataStore.listSync())
         .contains(partition1, partition11, livePartition1, livePartition11);
@@ -1127,13 +1020,7 @@ public class RecoveryTaskCreatorTest {
     snapshotMetadataStore.createSync(livePartition11);
     SnapshotMetadata livePartition2 =
         new SnapshotMetadata(
-            name + "2",
-            LIVE_SNAPSHOT_PATH,
-            startTime,
-            endTime,
-            maxOffset * 5,
-            "2",
-            Metadata.IndexType.LUCENE_REGULAR);
+            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset * 5, "2", LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition2);
     assertThat(snapshotMetadataStore.listSync())
         .contains(partition1, partition11, livePartition1, livePartition2);
@@ -1149,13 +1036,7 @@ public class RecoveryTaskCreatorTest {
     snapshotMetadataStore.createSync(livePartition11);
     SnapshotMetadata partition2 =
         new SnapshotMetadata(
-            name + "3",
-            path,
-            startTime,
-            endTime,
-            maxOffset * 3,
-            "2",
-            Metadata.IndexType.LUCENE_REGULAR);
+            name + "3", path, startTime, endTime, maxOffset * 3, "2", LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition2);
     assertThat(snapshotMetadataStore.listSync())
         .contains(partition1, partition11, livePartition1, livePartition2, partition2);
@@ -1192,13 +1073,7 @@ public class RecoveryTaskCreatorTest {
 
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(
-            name,
-            path,
-            startTime,
-            endTime,
-            maxOffset,
-            partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(
@@ -1227,7 +1102,7 @@ public class RecoveryTaskCreatorTest {
             endTime * 2,
             maxOffset * 2,
             partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
 
     snapshotMetadataStore.createSync(partition11);
     assertThat(snapshotMetadataStore.listSync()).containsExactlyInAnyOrder(partition1, partition11);
@@ -1255,7 +1130,7 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition1);
     assertThat(recoveryTaskStore.listSync()).containsExactly(recoveryTask1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1, partition11, livePartition1);
@@ -1285,7 +1160,7 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition11);
     assertThat(snapshotMetadataStore.listSync())
         .contains(partition1, partition11, livePartition1, livePartition11);
@@ -1316,13 +1191,7 @@ public class RecoveryTaskCreatorTest {
     snapshotMetadataStore.createSync(livePartition11);
     SnapshotMetadata livePartition2 =
         new SnapshotMetadata(
-            name + "2",
-            LIVE_SNAPSHOT_PATH,
-            startTime,
-            endTime,
-            maxOffset * 5,
-            "2",
-            Metadata.IndexType.LUCENE_REGULAR);
+            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset * 5, "2", LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition2);
     assertThat(snapshotMetadataStore.listSync())
         .contains(partition1, partition11, livePartition1, livePartition2);
@@ -1356,13 +1225,7 @@ public class RecoveryTaskCreatorTest {
     snapshotMetadataStore.createSync(livePartition11);
     SnapshotMetadata partition2 =
         new SnapshotMetadata(
-            name + "3",
-            path,
-            startTime,
-            endTime,
-            maxOffset * 3,
-            "2",
-            Metadata.IndexType.LUCENE_REGULAR);
+            name + "3", path, startTime, endTime, maxOffset * 3, "2", LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition2);
     assertThat(snapshotMetadataStore.listSync())
         .contains(partition1, partition11, livePartition1, livePartition2, partition2);
@@ -1425,13 +1288,7 @@ public class RecoveryTaskCreatorTest {
 
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(
-            name,
-            path,
-            startTime,
-            endTime,
-            maxOffset,
-            partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(
@@ -1481,13 +1338,7 @@ public class RecoveryTaskCreatorTest {
 
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(
-            name,
-            path,
-            startTime,
-            endTime,
-            maxOffset,
-            partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(
@@ -1537,13 +1388,7 @@ public class RecoveryTaskCreatorTest {
 
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(
-            name,
-            path,
-            startTime,
-            endTime,
-            maxOffset,
-            partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(
@@ -1593,13 +1438,7 @@ public class RecoveryTaskCreatorTest {
 
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(
-            name,
-            path,
-            startTime,
-            endTime,
-            maxOffset,
-            partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(
@@ -1624,7 +1463,7 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition1);
     assertThat(snapshotMetadataStore.list().get())
         .containsExactlyInAnyOrder(partition1, livePartition1);
@@ -1757,13 +1596,7 @@ public class RecoveryTaskCreatorTest {
 
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(
-            name,
-            path,
-            startTime,
-            endTime,
-            maxOffset,
-            partitionId,
-            Metadata.IndexType.LUCENE_REGULAR);
+            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -1,7 +1,7 @@
 package com.slack.kaldb.server;
 
 import static com.slack.kaldb.metadata.snapshot.SnapshotMetadata.LIVE_SNAPSHOT_PATH;
-import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LUCENE_REGULAR;
+import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LOGS_LUCENE9;
 import static com.slack.kaldb.server.RecoveryTaskCreator.RECOVERY_TASKS_CREATED;
 import static com.slack.kaldb.server.RecoveryTaskCreator.STALE_SNAPSHOT_DELETE_SUCCESS;
 import static com.slack.kaldb.server.RecoveryTaskCreator.getHighestDurableOffsetForPartition;
@@ -96,8 +96,7 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 123;
 
     SnapshotMetadata partition1 =
-        new SnapshotMetadata(
-            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
             name + "1",
@@ -106,7 +105,7 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     SnapshotMetadata livePartition11 =
         new SnapshotMetadata(
             name + "11",
@@ -115,12 +114,12 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     SnapshotMetadata livePartition2 =
         new SnapshotMetadata(
-            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2", LUCENE_REGULAR);
+            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2", LOGS_LUCENE9);
     SnapshotMetadata partition2 =
-        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2", LUCENE_REGULAR);
+        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2", LOGS_LUCENE9);
 
     assertThat(getStaleLiveSnapshots(List.of(partition1), partitionId)).isEmpty();
     assertThat(getStaleLiveSnapshots(List.of(partition2), partitionId)).isEmpty();
@@ -156,8 +155,7 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 123;
 
     SnapshotMetadata partition1 =
-        new SnapshotMetadata(
-            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
             name + "1",
@@ -166,7 +164,7 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     SnapshotMetadata livePartition11 =
         new SnapshotMetadata(
             name + "11",
@@ -175,12 +173,12 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     SnapshotMetadata livePartition2 =
         new SnapshotMetadata(
-            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2", LUCENE_REGULAR);
+            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2", LOGS_LUCENE9);
     SnapshotMetadata partition2 =
-        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2", LUCENE_REGULAR);
+        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2", LOGS_LUCENE9);
 
     testDeleteSnapshots(List.of(partition1), 0, List.of(partition1));
     testDeleteSnapshots(List.of(partition2), 0, List.of(partition2));
@@ -238,8 +236,7 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 123;
 
     SnapshotMetadata partition1 =
-        new SnapshotMetadata(
-            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
             name + "1",
@@ -248,7 +245,7 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     SnapshotMetadata livePartition11 =
         new SnapshotMetadata(
             name + "11",
@@ -257,12 +254,12 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     SnapshotMetadata livePartition2 =
         new SnapshotMetadata(
-            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2", LUCENE_REGULAR);
+            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2", LOGS_LUCENE9);
     SnapshotMetadata partition2 =
-        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2", LUCENE_REGULAR);
+        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2", LOGS_LUCENE9);
 
     testDeleteSnapshotsTimeouts(List.of(partition1), List.of(partition1), false);
     testDeleteSnapshotsTimeouts(List.of(livePartition1), List.of(livePartition1), true);
@@ -329,8 +326,7 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 123;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(
-            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     final SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
             name + "1",
@@ -339,7 +335,7 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     final SnapshotMetadata livePartition11 =
         new SnapshotMetadata(
             name + "11",
@@ -348,12 +344,12 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     final SnapshotMetadata livePartition2 =
         new SnapshotMetadata(
-            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2", LUCENE_REGULAR);
+            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2", LOGS_LUCENE9);
     final SnapshotMetadata partition2 =
-        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2", LUCENE_REGULAR);
+        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2", LOGS_LUCENE9);
 
     List<SnapshotMetadata> snapshots =
         List.of(partition1, livePartition1, livePartition11, partition2, livePartition2);
@@ -414,11 +410,10 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(
-            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     final SnapshotMetadata partition11 =
         new SnapshotMetadata(
-            name + "1", path, endTime + 1, endTime * 2, maxOffset * 2, partitionId, LUCENE_REGULAR);
+            name + "1", path, endTime + 1, endTime * 2, maxOffset * 2, partitionId, LOGS_LUCENE9);
     final SnapshotMetadata partition12 =
         new SnapshotMetadata(
             name + "12",
@@ -427,13 +422,13 @@ public class RecoveryTaskCreatorTest {
             endTime * 3,
             maxOffset * 3,
             partitionId,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
 
     final String partitionId2 = "2";
     final long partition2Offset = maxOffset * 10;
     final SnapshotMetadata partition2 =
         new SnapshotMetadata(
-            name + "2", path, startTime, endTime, partition2Offset, partitionId2, LUCENE_REGULAR);
+            name + "2", path, startTime, endTime, partition2Offset, partitionId2, LOGS_LUCENE9);
     final SnapshotMetadata partition21 =
         new SnapshotMetadata(
             name + "21",
@@ -442,7 +437,7 @@ public class RecoveryTaskCreatorTest {
             endTime * 2,
             partition2Offset * 2,
             partitionId2,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     final SnapshotMetadata partition22 =
         new SnapshotMetadata(
             name + "22",
@@ -451,7 +446,7 @@ public class RecoveryTaskCreatorTest {
             endTime * 3,
             partition2Offset * 3,
             partitionId2,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
 
     // empty results
     assertThat(
@@ -686,14 +681,14 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, "2", LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, "2", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(recoveryTaskCreator.determineStartingOffset(0)).isNegative();
 
     final SnapshotMetadata partition11 =
         new SnapshotMetadata(
-            name + "1", path, endTime + 1, endTime * 2, maxOffset * 2, "2", LUCENE_REGULAR);
+            name + "1", path, endTime + 1, endTime * 2, maxOffset * 2, "2", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition11);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1, partition11);
     assertThat(recoveryTaskCreator.determineStartingOffset(0)).isNegative();
@@ -954,8 +949,7 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(
-            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(
@@ -969,13 +963,7 @@ public class RecoveryTaskCreatorTest {
 
     final SnapshotMetadata partition11 =
         new SnapshotMetadata(
-            name + "11",
-            path,
-            endTime + 1,
-            endTime * 2,
-            maxOffset * 2,
-            partitionId,
-            LUCENE_REGULAR);
+            name + "11", path, endTime + 1, endTime * 2, maxOffset * 2, partitionId, LOGS_LUCENE9);
 
     snapshotMetadataStore.createSync(partition11);
     assertThat(snapshotMetadataStore.listSync()).containsExactlyInAnyOrder(partition1, partition11);
@@ -996,7 +984,7 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1, partition11, livePartition1);
     assertThat(recoveryTaskCreator.determineStartingOffset(250)).isEqualTo(201);
@@ -1015,7 +1003,7 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition11);
     assertThat(snapshotMetadataStore.listSync())
         .contains(partition1, partition11, livePartition1, livePartition11);
@@ -1030,7 +1018,7 @@ public class RecoveryTaskCreatorTest {
     snapshotMetadataStore.createSync(livePartition11);
     SnapshotMetadata livePartition2 =
         new SnapshotMetadata(
-            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset * 5, "2", LUCENE_REGULAR);
+            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset * 5, "2", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition2);
     assertThat(snapshotMetadataStore.listSync())
         .contains(partition1, partition11, livePartition1, livePartition2);
@@ -1046,7 +1034,7 @@ public class RecoveryTaskCreatorTest {
     snapshotMetadataStore.createSync(livePartition11);
     SnapshotMetadata partition2 =
         new SnapshotMetadata(
-            name + "3", path, startTime, endTime, maxOffset * 3, "2", LUCENE_REGULAR);
+            name + "3", path, startTime, endTime, maxOffset * 3, "2", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition2);
     assertThat(snapshotMetadataStore.listSync())
         .contains(partition1, partition11, livePartition1, livePartition2, partition2);
@@ -1082,8 +1070,7 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(
-            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(
@@ -1106,13 +1093,7 @@ public class RecoveryTaskCreatorTest {
 
     final SnapshotMetadata partition11 =
         new SnapshotMetadata(
-            name + "11",
-            path,
-            endTime + 1,
-            endTime * 2,
-            maxOffset * 2,
-            partitionId,
-            LUCENE_REGULAR);
+            name + "11", path, endTime + 1, endTime * 2, maxOffset * 2, partitionId, LOGS_LUCENE9);
 
     snapshotMetadataStore.createSync(partition11);
     assertThat(snapshotMetadataStore.listSync()).containsExactlyInAnyOrder(partition1, partition11);
@@ -1140,7 +1121,7 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition1);
     assertThat(recoveryTaskStore.listSync()).containsExactly(recoveryTask1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1, partition11, livePartition1);
@@ -1170,7 +1151,7 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition11);
     assertThat(snapshotMetadataStore.listSync())
         .contains(partition1, partition11, livePartition1, livePartition11);
@@ -1201,7 +1182,7 @@ public class RecoveryTaskCreatorTest {
     snapshotMetadataStore.createSync(livePartition11);
     SnapshotMetadata livePartition2 =
         new SnapshotMetadata(
-            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset * 5, "2", LUCENE_REGULAR);
+            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset * 5, "2", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition2);
     assertThat(snapshotMetadataStore.listSync())
         .contains(partition1, partition11, livePartition1, livePartition2);
@@ -1235,7 +1216,7 @@ public class RecoveryTaskCreatorTest {
     snapshotMetadataStore.createSync(livePartition11);
     SnapshotMetadata partition2 =
         new SnapshotMetadata(
-            name + "3", path, startTime, endTime, maxOffset * 3, "2", LUCENE_REGULAR);
+            name + "3", path, startTime, endTime, maxOffset * 3, "2", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition2);
     assertThat(snapshotMetadataStore.listSync())
         .contains(partition1, partition11, livePartition1, livePartition2, partition2);
@@ -1297,8 +1278,7 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(
-            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(
@@ -1347,8 +1327,7 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(
-            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(
@@ -1397,8 +1376,7 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(
-            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(
@@ -1447,8 +1425,7 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(
-            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(
@@ -1473,7 +1450,7 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LUCENE_REGULAR);
+            LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition1);
     assertThat(snapshotMetadataStore.list().get())
         .containsExactlyInAnyOrder(partition1, livePartition1);
@@ -1605,8 +1582,7 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(
-            name, path, startTime, endTime, maxOffset, partitionId, LUCENE_REGULAR);
+        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -23,6 +23,7 @@ import com.slack.kaldb.metadata.recovery.RecoveryTaskMetadataStore;
 import com.slack.kaldb.metadata.snapshot.SnapshotMetadata;
 import com.slack.kaldb.metadata.snapshot.SnapshotMetadataStore;
 import com.slack.kaldb.metadata.zookeeper.ZookeeperMetadataStoreImpl;
+import com.slack.kaldb.proto.metadata.Metadata;
 import com.slack.kaldb.util.CountingFatalErrorHandler;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
@@ -85,17 +86,50 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 123;
 
     SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId);
+        new SnapshotMetadata(
+            name,
+            path,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
-            name + "1", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, partitionId);
+            name + "1",
+            LIVE_SNAPSHOT_PATH,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     SnapshotMetadata livePartition11 =
         new SnapshotMetadata(
-            name + "11", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, partitionId);
+            name + "11",
+            LIVE_SNAPSHOT_PATH,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     SnapshotMetadata livePartition2 =
-        new SnapshotMetadata(name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2");
+        new SnapshotMetadata(
+            name + "2",
+            LIVE_SNAPSHOT_PATH,
+            startTime,
+            endTime,
+            maxOffset,
+            "2",
+            Metadata.IndexType.LUCENE_REGULAR);
     SnapshotMetadata partition2 =
-        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2");
+        new SnapshotMetadata(
+            name + "3",
+            path,
+            startTime,
+            endTime,
+            maxOffset,
+            "2",
+            Metadata.IndexType.LUCENE_REGULAR);
 
     assertThat(getStaleLiveSnapshots(List.of(partition1), partitionId)).isEmpty();
     assertThat(getStaleLiveSnapshots(List.of(partition2), partitionId)).isEmpty();
@@ -131,17 +165,50 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 123;
 
     SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId);
+        new SnapshotMetadata(
+            name,
+            path,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
-            name + "1", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, partitionId);
+            name + "1",
+            LIVE_SNAPSHOT_PATH,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     SnapshotMetadata livePartition11 =
         new SnapshotMetadata(
-            name + "11", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, partitionId);
+            name + "11",
+            LIVE_SNAPSHOT_PATH,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     SnapshotMetadata livePartition2 =
-        new SnapshotMetadata(name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2");
+        new SnapshotMetadata(
+            name + "2",
+            LIVE_SNAPSHOT_PATH,
+            startTime,
+            endTime,
+            maxOffset,
+            "2",
+            Metadata.IndexType.LUCENE_REGULAR);
     SnapshotMetadata partition2 =
-        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2");
+        new SnapshotMetadata(
+            name + "3",
+            path,
+            startTime,
+            endTime,
+            maxOffset,
+            "2",
+            Metadata.IndexType.LUCENE_REGULAR);
 
     testDeleteSnapshots(List.of(partition1), 0, List.of(partition1));
     testDeleteSnapshots(List.of(partition2), 0, List.of(partition2));
@@ -199,17 +266,50 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 123;
 
     SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId);
+        new SnapshotMetadata(
+            name,
+            path,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
-            name + "1", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, partitionId);
+            name + "1",
+            LIVE_SNAPSHOT_PATH,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     SnapshotMetadata livePartition11 =
         new SnapshotMetadata(
-            name + "11", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, partitionId);
+            name + "11",
+            LIVE_SNAPSHOT_PATH,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     SnapshotMetadata livePartition2 =
-        new SnapshotMetadata(name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2");
+        new SnapshotMetadata(
+            name + "2",
+            LIVE_SNAPSHOT_PATH,
+            startTime,
+            endTime,
+            maxOffset,
+            "2",
+            Metadata.IndexType.LUCENE_REGULAR);
     SnapshotMetadata partition2 =
-        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2");
+        new SnapshotMetadata(
+            name + "3",
+            path,
+            startTime,
+            endTime,
+            maxOffset,
+            "2",
+            Metadata.IndexType.LUCENE_REGULAR);
 
     testDeleteSnapshotsTimeouts(List.of(partition1), List.of(partition1), false);
     testDeleteSnapshotsTimeouts(List.of(livePartition1), List.of(livePartition1), true);
@@ -276,17 +376,50 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 123;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId);
+        new SnapshotMetadata(
+            name,
+            path,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     final SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
-            name + "1", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, partitionId);
+            name + "1",
+            LIVE_SNAPSHOT_PATH,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     final SnapshotMetadata livePartition11 =
         new SnapshotMetadata(
-            name + "11", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, partitionId);
+            name + "11",
+            LIVE_SNAPSHOT_PATH,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     final SnapshotMetadata livePartition2 =
-        new SnapshotMetadata(name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2");
+        new SnapshotMetadata(
+            name + "2",
+            LIVE_SNAPSHOT_PATH,
+            startTime,
+            endTime,
+            maxOffset,
+            "2",
+            Metadata.IndexType.LUCENE_REGULAR);
     final SnapshotMetadata partition2 =
-        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2");
+        new SnapshotMetadata(
+            name + "3",
+            path,
+            startTime,
+            endTime,
+            maxOffset,
+            "2",
+            Metadata.IndexType.LUCENE_REGULAR);
 
     List<SnapshotMetadata> snapshots =
         List.of(partition1, livePartition1, livePartition11, partition2, livePartition2);
@@ -347,24 +480,62 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId);
+        new SnapshotMetadata(
+            name,
+            path,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     final SnapshotMetadata partition11 =
         new SnapshotMetadata(
-            name + "1", path, endTime + 1, endTime * 2, maxOffset * 2, partitionId);
+            name + "1",
+            path,
+            endTime + 1,
+            endTime * 2,
+            maxOffset * 2,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     final SnapshotMetadata partition12 =
         new SnapshotMetadata(
-            name + "12", path, endTime * 2 + 1, endTime * 3, maxOffset * 3, partitionId);
+            name + "12",
+            path,
+            endTime * 2 + 1,
+            endTime * 3,
+            maxOffset * 3,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
 
     final String partitionId2 = "2";
     final long partition2Offset = maxOffset * 10;
     final SnapshotMetadata partition2 =
-        new SnapshotMetadata(name + "2", path, startTime, endTime, partition2Offset, partitionId2);
+        new SnapshotMetadata(
+            name + "2",
+            path,
+            startTime,
+            endTime,
+            partition2Offset,
+            partitionId2,
+            Metadata.IndexType.LUCENE_REGULAR);
     final SnapshotMetadata partition21 =
         new SnapshotMetadata(
-            name + "21", path, endTime + 1, endTime * 2, partition2Offset * 2, partitionId2);
+            name + "21",
+            path,
+            endTime + 1,
+            endTime * 2,
+            partition2Offset * 2,
+            partitionId2,
+            Metadata.IndexType.LUCENE_REGULAR);
     final SnapshotMetadata partition22 =
         new SnapshotMetadata(
-            name + "22", path, endTime * 2 + 1, endTime * 3, partition2Offset * 3, partitionId2);
+            name + "22",
+            path,
+            endTime * 2 + 1,
+            endTime * 3,
+            partition2Offset * 3,
+            partitionId2,
+            Metadata.IndexType.LUCENE_REGULAR);
 
     // empty results
     assertThat(
@@ -599,13 +770,21 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, "2");
+        new SnapshotMetadata(
+            name, path, startTime, endTime, maxOffset, "2", Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(recoveryTaskCreator.determineStartingOffset(0)).isNegative();
 
     final SnapshotMetadata partition11 =
-        new SnapshotMetadata(name + "1", path, endTime + 1, endTime * 2, maxOffset * 2, "2");
+        new SnapshotMetadata(
+            name + "1",
+            path,
+            endTime + 1,
+            endTime * 2,
+            maxOffset * 2,
+            "2",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition11);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1, partition11);
     assertThat(recoveryTaskCreator.determineStartingOffset(0)).isNegative();
@@ -866,7 +1045,14 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId);
+        new SnapshotMetadata(
+            name,
+            path,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(
@@ -880,7 +1066,13 @@ public class RecoveryTaskCreatorTest {
 
     final SnapshotMetadata partition11 =
         new SnapshotMetadata(
-            name + "11", path, endTime + 1, endTime * 2, maxOffset * 2, partitionId);
+            name + "11",
+            path,
+            endTime + 1,
+            endTime * 2,
+            maxOffset * 2,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
 
     snapshotMetadataStore.createSync(partition11);
     assertThat(snapshotMetadataStore.listSync()).containsExactlyInAnyOrder(partition1, partition11);
@@ -895,7 +1087,13 @@ public class RecoveryTaskCreatorTest {
     // Live partition is cleaned up, no delay.
     SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
-            name + "live1", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, partitionId);
+            name + "live1",
+            LIVE_SNAPSHOT_PATH,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1, partition11, livePartition1);
     assertThat(recoveryTaskCreator.determineStartingOffset(250)).isEqualTo(201);
@@ -908,7 +1106,13 @@ public class RecoveryTaskCreatorTest {
     snapshotMetadataStore.createSync(livePartition1);
     SnapshotMetadata livePartition11 =
         new SnapshotMetadata(
-            name + "live11", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, partitionId);
+            name + "live11",
+            LIVE_SNAPSHOT_PATH,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition11);
     assertThat(snapshotMetadataStore.listSync())
         .contains(partition1, partition11, livePartition1, livePartition11);
@@ -923,7 +1127,13 @@ public class RecoveryTaskCreatorTest {
     snapshotMetadataStore.createSync(livePartition11);
     SnapshotMetadata livePartition2 =
         new SnapshotMetadata(
-            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset * 5, "2");
+            name + "2",
+            LIVE_SNAPSHOT_PATH,
+            startTime,
+            endTime,
+            maxOffset * 5,
+            "2",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition2);
     assertThat(snapshotMetadataStore.listSync())
         .contains(partition1, partition11, livePartition1, livePartition2);
@@ -938,7 +1148,14 @@ public class RecoveryTaskCreatorTest {
     snapshotMetadataStore.createSync(livePartition1);
     snapshotMetadataStore.createSync(livePartition11);
     SnapshotMetadata partition2 =
-        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset * 3, "2");
+        new SnapshotMetadata(
+            name + "3",
+            path,
+            startTime,
+            endTime,
+            maxOffset * 3,
+            "2",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition2);
     assertThat(snapshotMetadataStore.listSync())
         .contains(partition1, partition11, livePartition1, livePartition2, partition2);
@@ -974,7 +1191,14 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId);
+        new SnapshotMetadata(
+            name,
+            path,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(
@@ -997,7 +1221,13 @@ public class RecoveryTaskCreatorTest {
 
     final SnapshotMetadata partition11 =
         new SnapshotMetadata(
-            name + "11", path, endTime + 1, endTime * 2, maxOffset * 2, partitionId);
+            name + "11",
+            path,
+            endTime + 1,
+            endTime * 2,
+            maxOffset * 2,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
 
     snapshotMetadataStore.createSync(partition11);
     assertThat(snapshotMetadataStore.listSync()).containsExactlyInAnyOrder(partition1, partition11);
@@ -1019,7 +1249,13 @@ public class RecoveryTaskCreatorTest {
     // Live partition is cleaned up, new recovery task is created.
     SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
-            name + "live1", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, partitionId);
+            name + "live1",
+            LIVE_SNAPSHOT_PATH,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition1);
     assertThat(recoveryTaskStore.listSync()).containsExactly(recoveryTask1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1, partition11, livePartition1);
@@ -1043,7 +1279,13 @@ public class RecoveryTaskCreatorTest {
     snapshotMetadataStore.createSync(livePartition1);
     SnapshotMetadata livePartition11 =
         new SnapshotMetadata(
-            name + "live11", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, partitionId);
+            name + "live11",
+            LIVE_SNAPSHOT_PATH,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition11);
     assertThat(snapshotMetadataStore.listSync())
         .contains(partition1, partition11, livePartition1, livePartition11);
@@ -1074,7 +1316,13 @@ public class RecoveryTaskCreatorTest {
     snapshotMetadataStore.createSync(livePartition11);
     SnapshotMetadata livePartition2 =
         new SnapshotMetadata(
-            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset * 5, "2");
+            name + "2",
+            LIVE_SNAPSHOT_PATH,
+            startTime,
+            endTime,
+            maxOffset * 5,
+            "2",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition2);
     assertThat(snapshotMetadataStore.listSync())
         .contains(partition1, partition11, livePartition1, livePartition2);
@@ -1107,7 +1355,14 @@ public class RecoveryTaskCreatorTest {
     snapshotMetadataStore.createSync(livePartition1);
     snapshotMetadataStore.createSync(livePartition11);
     SnapshotMetadata partition2 =
-        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset * 3, "2");
+        new SnapshotMetadata(
+            name + "3",
+            path,
+            startTime,
+            endTime,
+            maxOffset * 3,
+            "2",
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition2);
     assertThat(snapshotMetadataStore.listSync())
         .contains(partition1, partition11, livePartition1, livePartition2, partition2);
@@ -1169,7 +1424,14 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId);
+        new SnapshotMetadata(
+            name,
+            path,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(
@@ -1218,7 +1480,14 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId);
+        new SnapshotMetadata(
+            name,
+            path,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(
@@ -1267,7 +1536,14 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId);
+        new SnapshotMetadata(
+            name,
+            path,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(
@@ -1316,7 +1592,14 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId);
+        new SnapshotMetadata(
+            name,
+            path,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(
@@ -1335,7 +1618,13 @@ public class RecoveryTaskCreatorTest {
     // Add a live partition to be deleted.
     SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
-            name + "1", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, partitionId);
+            name + "1",
+            LIVE_SNAPSHOT_PATH,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(livePartition1);
     assertThat(snapshotMetadataStore.list().get())
         .containsExactlyInAnyOrder(partition1, livePartition1);
@@ -1467,7 +1756,14 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId);
+        new SnapshotMetadata(
+            name,
+            path,
+            startTime,
+            endTime,
+            maxOffset,
+            partitionId,
+            Metadata.IndexType.LUCENE_REGULAR);
     snapshotMetadataStore.createSync(partition1);
     assertThat(snapshotMetadataStore.listSync()).contains(partition1);
     assertThat(

--- a/kaldb/src/test/java/com/slack/kaldb/util/SnapshotUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/util/SnapshotUtil.java
@@ -6,12 +6,6 @@ import com.slack.kaldb.proto.metadata.Metadata;
 public class SnapshotUtil {
   public static SnapshotMetadata makeSnapshot(String name) {
     return new SnapshotMetadata(
-        name + "snapshotId",
-        "/testPath_" + name,
-        1,
-        100,
-        1,
-        "1",
-        Metadata.IndexType.LUCENE_REGULAR);
+        name + "snapshotId", "/testPath_" + name, 1, 100, 1, "1", Metadata.IndexType.LOGS_LUCENE9);
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/util/SnapshotUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/util/SnapshotUtil.java
@@ -1,9 +1,17 @@
 package com.slack.kaldb.util;
 
 import com.slack.kaldb.metadata.snapshot.SnapshotMetadata;
+import com.slack.kaldb.proto.metadata.Metadata;
 
 public class SnapshotUtil {
   public static SnapshotMetadata makeSnapshot(String name) {
-    return new SnapshotMetadata(name + "snapshotId", "/testPath_" + name, 1, 100, 1, "1");
+    return new SnapshotMetadata(
+        name + "snapshotId",
+        "/testPath_" + name,
+        1,
+        100,
+        1,
+        "1",
+        Metadata.IndexType.LUCENE_REGULAR);
   }
 }


### PR DESCRIPTION
Add an indexType field to `SnapshotMetadata` and `ReplicaMetadata` to encode the type of index used in replica and snapshots.