### PR TITLE
Improve unit test stability

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,12 +16,13 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'temurin'
+        cache: 'maven'
     - name: Ensure code is formatted
       run: mvn com.coveo:fmt-maven-plugin:check --file kaldb/pom.xml
     - name: Ensure jmh benchmark code is formatted

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,18 +16,13 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '11'
-        distribution: 'adopt'
-    - name: Cache Maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
+        distribution: 'temurin'
+        cache: 'maven'
     - name: Ensure code is formatted
       run: mvn com.coveo:fmt-maven-plugin:check --file kaldb/pom.xml
     - name: Ensure jmh benchmark code is formatted

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,13 +16,12 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v2
       with:
         java-version: '11'
-        distribution: 'temurin'
-        cache: 'maven'
+        distribution: 'adopt'
     - name: Ensure code is formatted
       run: mvn com.coveo:fmt-maven-plugin:check --file kaldb/pom.xml
     - name: Ensure jmh benchmark code is formatted

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,12 +22,6 @@ jobs:
       with:
         java-version: '11'
         distribution: 'adopt'
-    - name: Cache Maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
     - name: Ensure code is formatted
       run: mvn com.coveo:fmt-maven-plugin:check --file kaldb/pom.xml
     - name: Ensure jmh benchmark code is formatted

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,13 +16,18 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-        cache: 'maven'
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
     - name: Ensure code is formatted
       run: mvn com.coveo:fmt-maven-plugin:check --file kaldb/pom.xml
     - name: Ensure jmh benchmark code is formatted

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,6 +22,12 @@ jobs:
       with:
         java-version: '11'
         distribution: 'adopt'
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
     - name: Ensure code is formatted
       run: mvn com.coveo:fmt-maven-plugin:check --file kaldb/pom.xml
     - name: Ensure jmh benchmark code is formatted

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,18 +16,18 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-      - name: Cache Maven packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
     - name: Ensure code is formatted
       run: mvn com.coveo:fmt-maven-plugin:check --file kaldb/pom.xml
     - name: Ensure jmh benchmark code is formatted

--- a/kaldb/src/test/java/com/slack/kaldb/blobfs/s3/S3BlobFsTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/blobfs/s3/S3BlobFsTest.java
@@ -45,7 +45,9 @@ public class S3BlobFsTest {
 
   @After
   public void tearDown() throws IOException {
-    s3BlobFs.close();
+    if (s3BlobFs != null) {
+      s3BlobFs.close();
+    }
   }
 
   private void createEmptyFile(String folderName, String fileName) {

--- a/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
@@ -73,11 +73,21 @@ public class RecoveryServiceTest {
     if (metadataStore != null) {
       metadataStore.close();
     }
-    blobFs.close();
-    kafkaServer.close();
-    zkServer.close();
-    meterRegistry.close();
-    s3Client.close();
+    if (blobFs != null) {
+      blobFs.close();
+    }
+    if (kafkaServer != null) {
+      kafkaServer.close();
+    }
+    if (zkServer != null) {
+      zkServer.close();
+    }
+    if (meterRegistry != null) {
+      meterRegistry.close();
+    }
+    if (s3Client != null) {
+      s3Client.close();
+    }
   }
 
   @SuppressWarnings("OptionalGetWithoutIsPresent")

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -409,7 +409,6 @@ public class KaldbIndexerTest {
   }
 
   @Test
-  @Ignore
   public void testIndexerShutdownTwice() throws Exception {
     startKafkaServer();
     assertThat(snapshotMetadataStore.listSync()).isEmpty();
@@ -472,7 +471,6 @@ public class KaldbIndexerTest {
   }
 
   @Test
-  @Ignore
   public void testIndexerRestart() throws Exception {
     startKafkaServer();
     assertThat(snapshotMetadataStore.listSync()).isEmpty();

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -125,16 +125,28 @@ public class KaldbIndexerTest {
 
   @After
   public void tearDown() throws Exception {
-    chunkManagerUtil.close();
+    if (chunkManagerUtil != null) {
+      chunkManagerUtil.close();
+    }
     if (kaldbIndexer != null) {
       kaldbIndexer.stopAsync();
       kaldbIndexer.awaitTerminated(DEFAULT_START_STOP_DURATION);
     }
-    kafkaServer.close();
-    snapshotMetadataStore.close();
-    recoveryTaskStore.close();
-    zkMetadataStore.close();
-    testZKServer.close();
+    if (kafkaServer != null) {
+      kafkaServer.close();
+    }
+    if (snapshotMetadataStore != null) {
+      snapshotMetadataStore.close();
+    }
+    if (recoveryTaskStore != null) {
+      recoveryTaskStore.close();
+    }
+    if (zkMetadataStore != null) {
+      zkMetadataStore.close();
+    }
+    if (testZKServer != null) {
+      testZKServer.close();
+    }
   }
 
   @Test
@@ -455,6 +467,7 @@ public class KaldbIndexerTest {
   }
 
   @Test
+  @Ignore
   public void testIndexerRestart() throws Exception {
     startKafkaServer();
     assertThat(snapshotMetadataStore.listSync()).isEmpty();

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -408,6 +408,7 @@ public class KaldbIndexerTest {
   }
 
   @Test
+  @Ignore
   public void testIndexerShutdownTwice() throws Exception {
     startKafkaServer();
     assertThat(snapshotMetadataStore.listSync()).isEmpty();
@@ -447,6 +448,9 @@ public class KaldbIndexerTest {
     kaldbIndexer.startAsync();
     kaldbIndexer.awaitRunning(DEFAULT_START_STOP_DURATION);
     await().until(() -> kafkaServer.getConnectedConsumerGroups() == 1);
+
+    // Produce more messages since the recovery task is created for head.
+    produceMessagesToKafka(kafkaServer.getBroker(), startTime);
 
     consumeMessagesAndSearchMessagesTest(100, 1);
 

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -43,11 +43,7 @@ import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
 import org.apache.curator.test.TestingServer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -439,9 +435,6 @@ public class KaldbIndexerTest {
     kaldbIndexer.startAsync();
     kaldbIndexer.awaitRunning(DEFAULT_START_STOP_DURATION);
     await().until(() -> kafkaServer.getConnectedConsumerGroups() == 1);
-
-    // Produce more messages since the recovery task is created for head.
-    produceMessagesToKafka(kafkaServer.getBroker(), startTime);
 
     consumeMessagesAndSearchMessagesTest(100, 1);
 

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -587,7 +587,6 @@ public class KaldbIndexerTest {
 
     await().until(() -> getCount(MESSAGES_RECEIVED_COUNTER, metricsRegistry) == messagesReceived);
     assertThat(chunkManagerUtil.chunkManager.getChunkList().size()).isEqualTo(1);
-
     assertThat(getCount(MESSAGES_FAILED_COUNTER, metricsRegistry)).isEqualTo(0);
     if (rolloversCompleted > 0) {
       assertThat(getCount(RollOverChunkTask.ROLLOVERS_INITIATED, metricsRegistry))

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -35,7 +35,6 @@ import com.slack.kaldb.proto.config.KaldbConfigs;
 import com.slack.kaldb.testlib.ChunkManagerUtil;
 import com.slack.kaldb.testlib.TestKafkaServer;
 import com.slack.kaldb.writer.kafka.KaldbKafkaConsumer;
-import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.time.Instant;
@@ -586,25 +585,9 @@ public class KaldbIndexerTest {
       activeChunk.commit();
     }
 
-    await()
-        .until(
-            () -> {
-              try {
-                double count = getCount(MESSAGES_RECEIVED_COUNTER, metricsRegistry);
-                LOG.debug(
-                    "MESSAGES_RECEIVED_COUNTER current_count={} total_count={}",
-                    count,
-                    messagesReceived);
-                return count == messagesReceived;
-              } catch (MeterNotFoundException e) {
-                // this is key, otherwise the first time this is called the meter has not beein
-                // initialized
-                // this causes MeterNotFoundException and for some reason doesn't get bubbled up in
-                // the unit test case
-                return false;
-              }
-            });
+    await().until(() -> getCount(MESSAGES_RECEIVED_COUNTER, metricsRegistry) == messagesReceived);
     assertThat(chunkManagerUtil.chunkManager.getChunkList().size()).isEqualTo(1);
+
     assertThat(getCount(MESSAGES_FAILED_COUNTER, metricsRegistry)).isEqualTo(0);
     if (rolloversCompleted > 0) {
       assertThat(getCount(RollOverChunkTask.ROLLOVERS_INITIATED, metricsRegistry))

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
@@ -23,7 +23,6 @@ import com.slack.kaldb.proto.service.KaldbSearch;
 import com.slack.kaldb.testlib.KaldbConfigUtil;
 import com.slack.kaldb.testlib.MessageUtil;
 import com.slack.kaldb.testlib.TestKafkaServer;
-import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import java.io.IOException;
@@ -215,15 +214,8 @@ public class KaldbTest {
 
     await()
         .until(
-            () -> {
-              try {
-                double count = getCount(MESSAGES_RECEIVED_COUNTER, indexerMeterRegistry);
-                LOG.debug("Registry1 current_count={} total_count={}", count, indexedMessagesCount);
-                return count == indexedMessagesCount;
-              } catch (MeterNotFoundException e) {
-                return false;
-              }
-            });
+            () ->
+                getCount(MESSAGES_RECEIVED_COUNTER, indexerMeterRegistry) == indexedMessagesCount);
 
     await().until(() -> getCount(RollOverChunkTask.ROLLOVERS_COMPLETED, indexerMeterRegistry) == 1);
     assertThat(getCount(RollOverChunkTask.ROLLOVERS_FAILED, indexerMeterRegistry)).isZero();

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
@@ -131,11 +131,21 @@ public class KaldbTest {
 
   @After
   public void teardown() throws Exception {
-    kafkaServer.close();
-    meterRegistry.close();
-    datasetMetadataStore.close();
-    zkMetadataStore.close();
-    zkServer.close();
+    if (kafkaServer != null) {
+      kafkaServer.close();
+    }
+    if (meterRegistry != null) {
+      meterRegistry.close();
+    }
+    if (datasetMetadataStore != null) {
+      datasetMetadataStore.close();
+    }
+    if (zkMetadataStore != null) {
+      zkMetadataStore.close();
+    }
+    if (zkServer != null) {
+      zkServer.close();
+    }
   }
 
   private KaldbConfigs.KaldbConfig makeKaldbConfig(

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -69,11 +69,21 @@ public class RecoveryTaskCreatorTest {
 
   @After
   public void shutdown() throws IOException {
-    recoveryTaskStore.close();
-    snapshotMetadataStore.close();
-    zkMetadataStore.close();
-    testingServer.close();
-    meterRegistry.close();
+    if (recoveryTaskStore != null) {
+      recoveryTaskStore.close();
+    }
+    if (snapshotMetadataStore != null) {
+      snapshotMetadataStore.close();
+    }
+    if (zkMetadataStore != null) {
+      zkMetadataStore.close();
+    }
+    if (testingServer != null) {
+      testingServer.close();
+    }
+    if (meterRegistry != null) {
+      meterRegistry.close();
+    }
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceTest.java
@@ -24,7 +24,6 @@ import com.slack.kaldb.proto.config.KaldbConfigs;
 import com.slack.kaldb.proto.service.KaldbSearch;
 import com.slack.kaldb.testlib.KaldbConfigUtil;
 import com.slack.kaldb.testlib.TestKafkaServer;
-import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import java.nio.charset.StandardCharsets;
@@ -224,15 +223,8 @@ public class ZipkinServiceTest {
 
     await()
         .until(
-            () -> {
-              try {
-                double count = getCount(MESSAGES_RECEIVED_COUNTER, indexerMeterRegistry);
-                LOG.debug("Registry1 current_count={} total_count={}", count, indexedMessagesCount);
-                return count == indexedMessagesCount;
-              } catch (MeterNotFoundException e) {
-                return false;
-              }
-            });
+            () ->
+                getCount(MESSAGES_RECEIVED_COUNTER, indexerMeterRegistry) == indexedMessagesCount);
 
     await().until(() -> getCount(RollOverChunkTask.ROLLOVERS_COMPLETED, indexerMeterRegistry) == 1);
     assertThat(getCount(RollOverChunkTask.ROLLOVERS_FAILED, indexerMeterRegistry)).isZero();

--- a/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceTest.java
@@ -90,11 +90,21 @@ public class ZipkinServiceTest {
 
   @After
   public void teardown() throws Exception {
-    kafkaServer.close();
-    meterRegistry.close();
-    datasetMetadataStore.close();
-    zkMetadataStore.close();
-    zkServer.close();
+    if (kafkaServer != null) {
+      kafkaServer.close();
+    }
+    if (meterRegistry != null) {
+      meterRegistry.close();
+    }
+    if (datasetMetadataStore != null) {
+      datasetMetadataStore.close();
+    }
+    if (zkMetadataStore != null) {
+      zkMetadataStore.close();
+    }
+    if (zkServer != null) {
+      zkServer.close();
+    }
   }
 
   public static LogWireMessage makeWireMessageForSpans(

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/MetricsUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/MetricsUtil.java
@@ -1,6 +1,5 @@
 package com.slack.kaldb.testlib;
 
-import com.slack.kaldb.server.Kaldb;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
 import org.slf4j.Logger;

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/MetricsUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/MetricsUtil.java
@@ -32,10 +32,10 @@ public class MetricsUtil {
     try {
       return metricsRegistry.get(counterName).counter().count();
     } catch (MeterNotFoundException e) {
-      LOG.error("Metric not found", e);
+      LOG.warn("Metric not found", e);
       return 0;
     } catch (Exception e) {
-      LOG.error("Error while getting metric", e);
+      LOG.warn("Error while getting metric", e);
       throw e;
     }
   }
@@ -44,10 +44,10 @@ public class MetricsUtil {
     try {
       return metricsRegistry.get(guageName).gauge().value();
     } catch (MeterNotFoundException e) {
-      LOG.error("Metric not found", e);
+      LOG.warn("Metric not found", e);
       return 0;
     } catch (Exception e) {
-      LOG.error("Error while getting metric", e);
+      LOG.warn("Error while getting metric", e);
       throw e;
     }
   }
@@ -56,10 +56,10 @@ public class MetricsUtil {
     try {
       return metricsRegistry.get(timerName).timer().count();
     } catch (MeterNotFoundException e) {
-      LOG.error("Metric not found", e);
+      LOG.warn("Metric not found", e);
       return 0;
     } catch (Exception e) {
-      LOG.error("Error while getting metric", e);
+      LOG.warn("Error while getting metric", e);
       throw e;
     }
   }

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/MetricsUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/MetricsUtil.java
@@ -33,10 +33,18 @@ public class MetricsUtil {
   }
 
   public static double getValue(String guageName, MeterRegistry metricsRegistry) {
-    return metricsRegistry.get(guageName).gauge().value();
+    try {
+      return metricsRegistry.get(guageName).gauge().value();
+    } catch (MeterNotFoundException e) {
+      return 0;
+    }
   }
 
-  public static double getTimerCount(String timerName, MeterRegistry meterRegistry) {
-    return meterRegistry.get(timerName).timer().count();
+  public static double getTimerCount(String timerName, MeterRegistry metricsRegistry) {
+    try {
+      return metricsRegistry.get(timerName).timer().count();
+    } catch (MeterNotFoundException e) {
+      return 0;
+    }
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/MetricsUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/MetricsUtil.java
@@ -1,14 +1,20 @@
 package com.slack.kaldb.testlib;
 
+import com.slack.kaldb.server.Kaldb;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MetricsUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MetricsUtil.class);
 
   public static double getCount(String counterName, MeterRegistry metricsRegistry) {
     try {
       return metricsRegistry.get(counterName).counter().count();
-    } catch (MeterNotFoundException e) {
+    } catch (Exception e) {
+      LOG.info("Metric not found");
       // most likely we'll be calling getCount from a await() and waiting for the counter to match
       // expected value
       // Now the thing is, when the meter has not been initialized we want await() to actually wait
@@ -35,7 +41,7 @@ public class MetricsUtil {
   public static double getValue(String guageName, MeterRegistry metricsRegistry) {
     try {
       return metricsRegistry.get(guageName).gauge().value();
-    } catch (MeterNotFoundException e) {
+    } catch (Exception e) {
       return 0;
     }
   }
@@ -43,7 +49,7 @@ public class MetricsUtil {
   public static double getTimerCount(String timerName, MeterRegistry metricsRegistry) {
     try {
       return metricsRegistry.get(timerName).timer().count();
-    } catch (MeterNotFoundException e) {
+    } catch (Exception e) {
       return 0;
     }
   }

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/MetricsUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/MetricsUtil.java
@@ -1,10 +1,35 @@
 package com.slack.kaldb.testlib;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
 
 public class MetricsUtil {
+
   public static double getCount(String counterName, MeterRegistry metricsRegistry) {
-    return metricsRegistry.get(counterName).counter().count();
+    try {
+      return metricsRegistry.get(counterName).counter().count();
+    } catch (MeterNotFoundException e) {
+      // most likely we'll be calling getCount from a await() and waiting for the counter to match
+      // expected value
+      // Now the thing is, when the meter has not been initialized we want await() to actually wait
+      // till the code initializes the meter
+      // if we don't add this catch block we'll throw MeterNotFoundException and await() code needs
+      // special handling to ensure the excpeiton is dealt with
+      // so instead of every called doing something like the example snippet below we just return 0
+      //      await()
+      //              .until(
+      //                      () -> {
+      //                        try {
+      //                          double count = getCount(METRIC_NAME, meterRegistry);
+      //                          LOG.debug("METRIC_NAME current_count={} total_count={}", count,
+      // meterRegistry);
+      //                          return count == <count_expected>;
+      //                        } catch (MeterNotFoundException e) {
+      //                          return false;
+      //                        }
+      //                      });
+      return 0;
+    }
   }
 
   public static double getValue(String guageName, MeterRegistry metricsRegistry) {

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/MetricsUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/MetricsUtil.java
@@ -6,6 +6,25 @@ import io.micrometer.core.instrument.search.MeterNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+// The get*() functions do some exception handling.
+// most likely we'll be calling getCount from an await() and waiting for the counter to match
+// expected value. When the meter has not been initialized we want await() to actually wait
+// till the code initializes the meter.
+// If we don't add a catch block we'll throw MeterNotFoundException and await() code needs
+// special handling to ensure the exception is dealt with
+// so instead of every called doing something like this below we just return 0
+//      await()
+//              .until(
+//                      () -> {
+//                        try {
+//                          double count = getCount(METRIC_NAME, meterRegistry);
+//                          LOG.debug("METRIC_NAME current_count={} total_count={}", count,
+// meterRegistry);
+//                          return count == <count_expected>;
+//                        } catch (MeterNotFoundException e) {
+//                          return false;
+//                        }
+//                      });
 public class MetricsUtil {
 
   private static final Logger LOG = LoggerFactory.getLogger(MetricsUtil.class);
@@ -13,44 +32,36 @@ public class MetricsUtil {
   public static double getCount(String counterName, MeterRegistry metricsRegistry) {
     try {
       return metricsRegistry.get(counterName).counter().count();
-    } catch (Exception e) {
-      LOG.info("Metric not found");
-      // most likely we'll be calling getCount from a await() and waiting for the counter to match
-      // expected value
-      // Now the thing is, when the meter has not been initialized we want await() to actually wait
-      // till the code initializes the meter
-      // if we don't add this catch block we'll throw MeterNotFoundException and await() code needs
-      // special handling to ensure the excpeiton is dealt with
-      // so instead of every called doing something like the example snippet below we just return 0
-      //      await()
-      //              .until(
-      //                      () -> {
-      //                        try {
-      //                          double count = getCount(METRIC_NAME, meterRegistry);
-      //                          LOG.debug("METRIC_NAME current_count={} total_count={}", count,
-      // meterRegistry);
-      //                          return count == <count_expected>;
-      //                        } catch (MeterNotFoundException e) {
-      //                          return false;
-      //                        }
-      //                      });
+    } catch (MeterNotFoundException e) {
+      LOG.error("Metric not found", e);
       return 0;
+    } catch (Exception e) {
+      LOG.error("Error while getting metric", e);
+      throw e;
     }
   }
 
   public static double getValue(String guageName, MeterRegistry metricsRegistry) {
     try {
       return metricsRegistry.get(guageName).gauge().value();
-    } catch (Exception e) {
+    } catch (MeterNotFoundException e) {
+      LOG.error("Metric not found", e);
       return 0;
+    } catch (Exception e) {
+      LOG.error("Error while getting metric", e);
+      throw e;
     }
   }
 
   public static double getTimerCount(String timerName, MeterRegistry metricsRegistry) {
     try {
       return metricsRegistry.get(timerName).timer().count();
-    } catch (Exception e) {
+    } catch (MeterNotFoundException e) {
+      LOG.error("Metric not found", e);
       return 0;
+    } catch (Exception e) {
+      LOG.error("Error while getting metric", e);
+      throw e;
     }
   }
 }


### PR DESCRIPTION
- KaldbIndexerTest should wait till the documents have been indexed ( we make changes to the await and more details in the comments )
- Close tests properly i.e do null checks so that all resources close. Otherwise on a test failure , all subsequent tests fail with `java.util.concurrent.ExecutionException: io.netty.channel.unix.Errors$NativeIoException: bind(..) failed: Address already in use`