### PR TITLE
use actions/setup-java v3

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: '11'
-        distribution: 'temurin'
+        distribution: 'corretto'
         cache: 'maven'
     - name: Ensure code is formatted
       run: mvn com.coveo:fmt-maven-plugin:check --file kaldb/pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,18 +16,13 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '11'
-        distribution: 'adopt'
-    - name: Cache Maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
+        distribution: 'temurin'
+        cache: 'maven'
     - name: Ensure code is formatted
       run: mvn com.coveo:fmt-maven-plugin:check --file kaldb/pom.xml
     - name: Ensure jmh benchmark code is formatted


### PR DESCRIPTION
- use actions/setup-java v3
- this comes with caching in the syntax so we can move to that
- adopt JDK isn't a thing anymore ( more https://github.com/marketplace/actions/setup-java-jdk ) so we use the new project name `temurin`