### PR TITLE
Reenable error-prone and fix associated problems

### DIFF
--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -25,6 +25,7 @@
         <curator.version>5.2.1</curator.version>
         <log4j.version>2.17.2</log4j.version>
         <aws.sdk.version>2.17.209</aws.sdk.version>
+        <error.prone.version>2.15.0</error.prone.version>
     </properties>
 
     <repositories>
@@ -488,6 +489,7 @@
                     <fork>true</fork>
                     <compilerArgs>
                         <arg>-XDcompilePolicy=simple</arg>
+                        <arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode -XepExcludedPaths:.*/protobuf/.*</arg>
                         <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                         <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
                         <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
@@ -499,6 +501,13 @@
                         <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
                         <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
                     </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.google.errorprone</groupId>
+                            <artifactId>error_prone_core</artifactId>
+                            <version>${error.prone.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                  </configuration>
             </plugin>
             <plugin>

--- a/kaldb/src/main/java/com/slack/kaldb/blobfs/s3/S3BlobFs.java
+++ b/kaldb/src/main/java/com/slack/kaldb/blobfs/s3/S3BlobFs.java
@@ -68,7 +68,7 @@ public class S3BlobFs extends BlobFs {
     AwsCredentialsProvider awsCredentialsProvider;
     try {
 
-      if (!isNullOrEmpty(config.getS3AccessKey()) && !isNullOrEmpty(config.getS3AccessKey())) {
+      if (!isNullOrEmpty(config.getS3AccessKey()) && !isNullOrEmpty(config.getS3SecretKey())) {
         String accessKey = config.getS3AccessKey();
         String secretKey = config.getS3SecretKey();
         AwsBasicCredentials awsBasicCredentials = AwsBasicCredentials.create(accessKey, secretKey);

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetMetadataTest.java
@@ -53,6 +53,7 @@ public class DatasetMetadataTest {
   }
 
   @Test
+  @SuppressWarnings("DoNotCall")
   public void testServiceMetadataImmutableList() {
     final String name = "testService";
     final String owner = "serviceOwner";


### PR DESCRIPTION
Reenables the error-prone plugin during the build process, excludes all generated code from checks, and fixes one spot in `S3BlobFs`  that looked like a bug.
