### PR TITLE
Upgrade errorprone to 2.16

### DIFF
--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -25,7 +25,7 @@
         <curator.version>5.2.1</curator.version>
         <log4j.version>2.17.2</log4j.version>
         <aws.sdk.version>2.17.209</aws.sdk.version>
-        <error.prone.version>2.15.0</error.prone.version>
+        <error.prone.version>2.16</error.prone.version>
     </properties>
 
     <repositories>

--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorValueMapper.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorValueMapper.java
@@ -77,7 +77,7 @@ public class PreprocessorValueMapper {
       String dataTransformer) {
     Preconditions.checkArgument(
         PRE_PROCESSOR_DATA_TRANSFORMER_MAP.containsKey(dataTransformer),
-        "Invalid data transformer provided, must be one of {}",
+        "Invalid data transformer provided, must be one of %s",
         PRE_PROCESSOR_DATA_TRANSFORMER_MAP.toString());
     return messageBytes -> {
       try {


### PR DESCRIPTION
This version includes the fix for https://github.com/google/error-prone/issues/3092, an issue we were occasionally experiencing.
