### PR TITLE
Disambiguate dataset name vs service name

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadata.java
@@ -35,8 +35,6 @@ public class DatasetMetadata extends KaldbMetadata {
     checkPartitions(partitionConfigs, "partitionConfigs must not overlap start and end times");
 
     checkArgument(serviceName.length() <= 256, "serviceName must be no longer than 256 chars");
-    checkArgument(
-        serviceName.matches("^[a-zA-Z0-9_-]*$"), "serviceName must contain only [a-zA-Z0-9_-]");
 
     this.owner = owner;
     this.serviceName = serviceName;

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadata.java
@@ -44,6 +44,10 @@ public class DatasetMetadata extends KaldbMetadata {
     this.partitionConfigs = ImmutableList.copyOf(partitionConfigs);
   }
 
+  public DatasetMetadata getDataset() {
+    return this;
+  }
+
   public String getOwner() {
     return owner;
   }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadata.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 public class DatasetMetadata extends KaldbMetadata {
 
   public final String owner;
+  public final String serviceName;
   public final long throughputBytes;
   public final ImmutableList<DatasetPartitionMetadata> partitionConfigs;
 
@@ -23,7 +24,8 @@ public class DatasetMetadata extends KaldbMetadata {
       String name,
       String owner,
       long throughputBytes,
-      List<DatasetPartitionMetadata> partitionConfigs) {
+      List<DatasetPartitionMetadata> partitionConfigs,
+      String serviceName) {
     super(name);
     checkArgument(name.length() <= 256, "name must be no longer than 256 chars");
     checkArgument(name.matches("^[a-zA-Z0-9_-]*$"), "name must contain only [a-zA-Z0-9_-]");
@@ -32,7 +34,12 @@ public class DatasetMetadata extends KaldbMetadata {
     checkArgument(throughputBytes >= 0, "throughputBytes must be greater than or equal to 0");
     checkPartitions(partitionConfigs, "partitionConfigs must not overlap start and end times");
 
+    checkArgument(serviceName.length() <= 256, "serviceName must be no longer than 256 chars");
+    checkArgument(
+        serviceName.matches("^[a-zA-Z0-9_-]*$"), "serviceName must contain only [a-zA-Z0-9_-]");
+
     this.owner = owner;
+    this.serviceName = serviceName;
     this.throughputBytes = throughputBytes;
     this.partitionConfigs = ImmutableList.copyOf(partitionConfigs);
   }
@@ -49,20 +56,27 @@ public class DatasetMetadata extends KaldbMetadata {
     return partitionConfigs;
   }
 
+  public String getServiceName() {
+    return serviceName;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof DatasetMetadata)) return false;
     if (!super.equals(o)) return false;
     DatasetMetadata that = (DatasetMetadata) o;
     return throughputBytes == that.throughputBytes
+        && name.equals(that.name)
         && owner.equals(that.owner)
+        && serviceName.equals(that.serviceName)
         && partitionConfigs.equals(that.partitionConfigs);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), owner, throughputBytes, partitionConfigs);
+    return Objects.hash(
+        super.hashCode(), name, owner, serviceName, throughputBytes, partitionConfigs);
   }
 
   @Override
@@ -73,6 +87,9 @@ public class DatasetMetadata extends KaldbMetadata {
         + '\''
         + ", owner='"
         + owner
+        + '\''
+        + ", serviceName='"
+        + serviceName
         + '\''
         + ", throughputBytes="
         + throughputBytes

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadataSerializer.java
@@ -36,6 +36,7 @@ public class DatasetMetadataSerializer implements MetadataSerializer<DatasetMeta
     return Metadata.DatasetMetadata.newBuilder()
         .setName(metadata.name)
         .setOwner(metadata.owner)
+        .setServiceName(metadata.serviceName)
         .setThroughputBytes(metadata.throughputBytes)
         .addAllPartitionConfigs(datasetPartitionMetadata)
         .build();

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadataSerializer.java
@@ -21,7 +21,8 @@ public class DatasetMetadataSerializer implements MetadataSerializer<DatasetMeta
         datasetMetadataProto.getName(),
         datasetMetadataProto.getOwner(),
         datasetMetadataProto.getThroughputBytes(),
-        datasetPartitionMetadata);
+        datasetPartitionMetadata,
+        datasetMetadataProto.getServiceName());
   }
 
   public static Metadata.DatasetMetadata toDatasetMetadataProto(DatasetMetadata metadata) {

--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiter.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiter.java
@@ -129,7 +129,7 @@ public class PreprocessorRateLimiter {
         return false;
       }
 
-      String serviceName = PreprocessorValueMapper.getDatasetName(value);
+      String serviceName = PreprocessorValueMapper.getServiceName(value);
       int bytes = value.getSerializedSize();
       if (serviceName == null || serviceName.isEmpty()) {
         // service name wasn't provided

--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiter.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiter.java
@@ -103,14 +103,6 @@ public class PreprocessorRateLimiter {
     }
   }
 
-  class MyRateLimiter implements Predicate<String, Trace.Span> {
-
-    @Override
-    public boolean test(String s, Trace.Span span) {
-      return false;
-    }
-  }
-
   public Predicate<String, Trace.Span> createRateLimiter(DatasetMetadata datasetMetadata) {
 
     double permitsPerSecond = (double) datasetMetadata.getThroughputBytes() / preprocessorCount;

--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorService.java
@@ -1,9 +1,8 @@
 package com.slack.kaldb.preprocessor;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
-import static org.apache.curator.shaded.com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.AbstractService;
 import com.slack.kaldb.metadata.core.KaldbMetadata;
 import com.slack.kaldb.metadata.dataset.DatasetMetadata;
@@ -182,11 +181,10 @@ public class PreprocessorService extends AbstractService {
       List<String> upstreamTopics,
       String downstreamTopic,
       String dataTransformer) {
-    Preconditions.checkArgument(
-        !datasetMetadataList.isEmpty(), "dataset metadata list must not be empty");
-    Preconditions.checkArgument(upstreamTopics.size() > 0, "upstream topic list must not be empty");
-    Preconditions.checkArgument(!downstreamTopic.isEmpty(), "downstream topic must not be empty");
-    Preconditions.checkArgument(!dataTransformer.isEmpty(), "data transformer must not be empty");
+    checkArgument(!datasetMetadataList.isEmpty(), "dataset metadata list must not be empty");
+    checkArgument(upstreamTopics.size() > 0, "upstream topic list must not be empty");
+    checkArgument(!downstreamTopic.isEmpty(), "downstream topic must not be empty");
+    checkArgument(!dataTransformer.isEmpty(), "data transformer must not be empty");
 
     StreamsBuilder builder = new StreamsBuilder();
 
@@ -265,7 +263,11 @@ public class PreprocessorService extends AbstractService {
    */
   protected static StreamPartitioner<String, Trace.Span> streamPartitioner(
       DatasetMetadata datasetMetadata) {
-    checkNotNull(datasetMetadata, "dataset cannot be null");
+    //    checkNotNull(datasetMetadata, "dataset cannot be null");
+    checkArgument(datasetMetadata != null, "dataset cannot be null");
+    checkArgument(
+        getActivePartitionList(datasetMetadata).size() > 0,
+        "datasetToPartitionList cannot have any empty partition lists");
 
     return (topic, key, value, numPartitions) -> {
       List<Integer> partitions = getActivePartitionList(datasetMetadata);
@@ -276,13 +278,13 @@ public class PreprocessorService extends AbstractService {
   /** Builds a Properties hashtable using the provided config, and sensible defaults */
   protected static Properties makeKafkaStreamsProps(
       KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig) {
-    Preconditions.checkArgument(
+    checkArgument(
         !kafkaStreamConfig.getApplicationId().isEmpty(),
         "Kafka stream applicationId must be provided");
-    Preconditions.checkArgument(
+    checkArgument(
         !kafkaStreamConfig.getBootstrapServers().isEmpty(),
         "Kafka stream bootstrapServers must be provided");
-    Preconditions.checkArgument(
+    checkArgument(
         kafkaStreamConfig.getNumStreamThreads() > 0,
         "Kafka stream numStreamThreads must be greater than 0");
 

--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorValueMapper.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorValueMapper.java
@@ -63,7 +63,7 @@ public class PreprocessorValueMapper {
    *
    * <p>todo - consider putting the service name into a top-level Trace.Span property
    */
-  public static String getDatasetName(Trace.Span span) {
+  public static String getServiceName(Trace.Span span) {
     return span.getTagsList()
         .stream()
         .filter(tag -> tag.getKey().equals(SERVICE_NAME_KEY))

--- a/kaldb/src/main/java/com/slack/kaldb/server/ManagerApiGrpc.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ManagerApiGrpc.java
@@ -64,7 +64,7 @@ public class ManagerApiGrpc extends ManagerApiServiceGrpc.ManagerApiServiceImplB
               request.getOwner(),
               0L,
               Collections.emptyList(),
-              request.getName()));
+              request.getServiceName()));
       responseObserver.onNext(
           toDatasetMetadataProto(datasetMetadataStore.getNodeSync(request.getName())));
       responseObserver.onCompleted();
@@ -89,7 +89,7 @@ public class ManagerApiGrpc extends ManagerApiServiceGrpc.ManagerApiServiceImplB
               request.getOwner(),
               existingDatasetMetadata.getThroughputBytes(),
               existingDatasetMetadata.getPartitionConfigs(),
-              existingDatasetMetadata.getName());
+              existingDatasetMetadata.getServiceName());
       datasetMetadataStore.updateSync(updatedDatasetMetadata);
       responseObserver.onNext(toDatasetMetadataProto(updatedDatasetMetadata));
       responseObserver.onCompleted();
@@ -174,7 +174,7 @@ public class ManagerApiGrpc extends ManagerApiServiceGrpc.ManagerApiServiceImplB
               datasetMetadata.getOwner(),
               updatedThroughputBytes,
               updatedDatasetPartitionMetadata,
-              datasetMetadata.getName());
+              datasetMetadata.getServiceName());
       datasetMetadataStore.updateSync(updatedDatasetMetadata);
 
       responseObserver.onNext(

--- a/kaldb/src/main/java/com/slack/kaldb/server/ManagerApiGrpc.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ManagerApiGrpc.java
@@ -59,7 +59,12 @@ public class ManagerApiGrpc extends ManagerApiServiceGrpc.ManagerApiServiceImplB
 
     try {
       datasetMetadataStore.createSync(
-          new DatasetMetadata(request.getName(), request.getOwner(), 0L, Collections.emptyList()));
+          new DatasetMetadata(
+              request.getName(),
+              request.getOwner(),
+              0L,
+              Collections.emptyList(),
+              request.getName()));
       responseObserver.onNext(
           toDatasetMetadataProto(datasetMetadataStore.getNodeSync(request.getName())));
       responseObserver.onCompleted();
@@ -83,7 +88,8 @@ public class ManagerApiGrpc extends ManagerApiServiceGrpc.ManagerApiServiceImplB
               existingDatasetMetadata.getName(),
               request.getOwner(),
               existingDatasetMetadata.getThroughputBytes(),
-              existingDatasetMetadata.getPartitionConfigs());
+              existingDatasetMetadata.getPartitionConfigs(),
+              existingDatasetMetadata.getName());
       datasetMetadataStore.updateSync(updatedDatasetMetadata);
       responseObserver.onNext(toDatasetMetadataProto(updatedDatasetMetadata));
       responseObserver.onCompleted();
@@ -167,7 +173,8 @@ public class ManagerApiGrpc extends ManagerApiServiceGrpc.ManagerApiServiceImplB
               datasetMetadata.getName(),
               datasetMetadata.getOwner(),
               updatedThroughputBytes,
-              updatedDatasetPartitionMetadata);
+              updatedDatasetPartitionMetadata,
+              datasetMetadata.getName());
       datasetMetadataStore.updateSync(updatedDatasetMetadata);
 
       responseObserver.onNext(

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -225,4 +225,8 @@ message PreprocessorConfig {
 
   // Amount of time in seconds the rate limiter can burst
   int32 rate_limiter_max_burst_seconds = 7;
+
+  // The dataset that the upstream topic contains
+  // We use this to match the dataset metadata
+  string upstream_topic_dataset_name = 8;
 }

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -225,8 +225,4 @@ message PreprocessorConfig {
 
   // Amount of time in seconds the rate limiter can burst
   int32 rate_limiter_max_burst_seconds = 7;
-
-  // The dataset that the upstream topic contains
-  // We use this to match the dataset metadata
-  string upstream_topic_dataset_name = 8;
 }

--- a/kaldb/src/main/proto/manager_api.proto
+++ b/kaldb/src/main/proto/manager_api.proto
@@ -31,6 +31,8 @@ message CreateDatasetMetadataRequest {
   string name = 1;
   // Owner information, maybe be any string
   string owner = 2;
+  // The service name(s) that the dataset is indexing
+  string service_name = 3;
 }
 
 // UpdateDatasetMetadataRequest represents a request to update an existing dataset

--- a/kaldb/src/main/proto/metadata.proto
+++ b/kaldb/src/main/proto/metadata.proto
@@ -134,6 +134,9 @@ message DatasetMetadata {
 
   // List of partitions assigned to this service, and their effective times
   repeated DatasetPartitionMetadata partition_configs = 4;
+
+  // either same as name or a special value _all
+  string service_name = 5;
 }
 
 // Describes a set of partitions along with their effective start and end times

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
@@ -120,7 +120,7 @@ public class KaldbDistributedQueryServiceTest {
 
     DatasetPartitionMetadata partition = new DatasetPartitionMetadata(1, 300, List.of("1"));
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(indexName, "testOwner", 1, List.of(partition));
+        new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
@@ -192,7 +192,7 @@ public class KaldbDistributedQueryServiceTest {
     datasetMetadataStore.delete(datasetMetadata.name);
     await().until(() -> datasetMetadataStore.listSync().size() == 0);
     partition = new DatasetPartitionMetadata(1, 99, List.of("1"));
-    datasetMetadata = new DatasetMetadata(indexName, "testOwner", 1, List.of(partition));
+    datasetMetadata = new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
@@ -217,7 +217,7 @@ public class KaldbDistributedQueryServiceTest {
     String indexName = "testIndex";
     DatasetPartitionMetadata partition = new DatasetPartitionMetadata(1, 500, List.of("1"));
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(indexName, "testOwner", 1, List.of(partition));
+        new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
@@ -373,7 +373,7 @@ public class KaldbDistributedQueryServiceTest {
     String indexName = "testIndex";
     DatasetPartitionMetadata partition = new DatasetPartitionMetadata(199, 500, List.of("1"));
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(indexName, "testOwner", 1, List.of(partition));
+        new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
@@ -471,7 +471,7 @@ public class KaldbDistributedQueryServiceTest {
     datasetMetadataStore.delete(datasetMetadata.name);
     await().until(() -> datasetMetadataStore.listSync().size() == 0);
     partition = new DatasetPartitionMetadata(1, 99, List.of("1"));
-    datasetMetadata = new DatasetMetadata(indexName, "testOwner", 1, List.of(partition));
+    datasetMetadata = new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
@@ -507,7 +507,7 @@ public class KaldbDistributedQueryServiceTest {
 
     DatasetPartitionMetadata partition = new DatasetPartitionMetadata(1, 500, List.of("1"));
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(indexName, "testOwner", 1, List.of(partition));
+        new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
@@ -658,7 +658,7 @@ public class KaldbDistributedQueryServiceTest {
         new DatasetPartitionMetadata(201, 300, List.of("2"));
 
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(name, owner, throughputBytes, List.of(partition11, partition12));
+        new DatasetMetadata(name, owner, throughputBytes, List.of(partition11, partition12), name);
 
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.listSync().size() == 1);
@@ -687,7 +687,8 @@ public class KaldbDistributedQueryServiceTest {
         new DatasetPartitionMetadata(201, 300, List.of("1"));
 
     DatasetMetadata datasetMetadata1 =
-        new DatasetMetadata(name1, owner1, throughputBytes1, List.of(partition21, partition22));
+        new DatasetMetadata(
+            name1, owner1, throughputBytes1, List.of(partition21, partition22), name1);
     datasetMetadataStore.createSync(datasetMetadata1);
     await().until(() -> datasetMetadataStore.listSync().size() == 2);
 
@@ -744,7 +745,7 @@ public class KaldbDistributedQueryServiceTest {
 
     DatasetPartitionMetadata partition = new DatasetPartitionMetadata(1, 200, List.of("1"));
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(indexName1, "testOwner1", 1, List.of(partition));
+        new DatasetMetadata(indexName1, "testOwner1", 1, List.of(partition), indexName1);
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
@@ -765,7 +766,8 @@ public class KaldbDistributedQueryServiceTest {
     await().until(() -> searchMetadataStore.listSync().size() == 2);
 
     partition = new DatasetPartitionMetadata(1, 101, List.of("2"));
-    datasetMetadata = new DatasetMetadata(indexName2, "testOwner2", 1, List.of(partition));
+    datasetMetadata =
+        new DatasetMetadata(indexName2, "testOwner2", 1, List.of(partition), indexName2);
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.listSync().size() == 2);
 

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetMetadataSerializerTest.java
@@ -28,7 +28,8 @@ public class DatasetMetadataSerializerTest {
         Collections.singletonList(
             new DatasetPartitionMetadata(
                 partitionStart.toEpochMilli(), partitionEnd.toEpochMilli(), partitionList));
-    final DatasetMetadata datasetMetadata = new DatasetMetadata(name, owner, throughput, list);
+    final DatasetMetadata datasetMetadata =
+        new DatasetMetadata(name, owner, throughput, list, name);
 
     String serializedDatasetMetadata = serDe.toJsonStr(datasetMetadata);
     assertThat(serializedDatasetMetadata).isNotEmpty();
@@ -59,7 +60,8 @@ public class DatasetMetadataSerializerTest {
                 partitionStart1.toEpochMilli(), partitionEnd1.toEpochMilli(), partitionList),
             new DatasetPartitionMetadata(
                 partitionStart2.toEpochMilli(), partitionEnd2.toEpochMilli(), partitionList));
-    final DatasetMetadata datasetMetadata = new DatasetMetadata(name, owner, throughput, list);
+    final DatasetMetadata datasetMetadata =
+        new DatasetMetadata(name, owner, throughput, list, name);
 
     String serializedDatasetMetadata = serDe.toJsonStr(datasetMetadata);
     assertThat(serializedDatasetMetadata).isNotEmpty();
@@ -77,7 +79,8 @@ public class DatasetMetadataSerializerTest {
     final String owner = "testOwner";
     final long throughput = 2000;
     final List<DatasetPartitionMetadata> list = Collections.emptyList();
-    final DatasetMetadata datasetMetadata = new DatasetMetadata(name, owner, throughput, list);
+    final DatasetMetadata datasetMetadata =
+        new DatasetMetadata(name, owner, throughput, list, name);
 
     String serializedDatasetMetadata = serDe.toJsonStr(datasetMetadata);
     assertThat(serializedDatasetMetadata).isNotEmpty();

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetMetadataTest.java
@@ -25,7 +25,7 @@ public class DatasetMetadataTest {
             List.of("partition"));
     final List<DatasetPartitionMetadata> partitionConfigs = Collections.singletonList(partition);
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(name, owner, throughputBytes, partitionConfigs);
+        new DatasetMetadata(name, owner, throughputBytes, partitionConfigs, name);
 
     assertThat(datasetMetadata.name).isEqualTo(name);
     assertThat(datasetMetadata.owner).isEqualTo(owner);
@@ -36,9 +36,9 @@ public class DatasetMetadataTest {
   @Test
   public void testInvalidServiceMetadataNames() {
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new DatasetMetadata("&", "owner", 0, null));
+        .isThrownBy(() -> new DatasetMetadata("&", "owner", 0, null, "&"));
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new DatasetMetadata("test%", "owner", 0, null));
+        .isThrownBy(() -> new DatasetMetadata("test%", "owner", 0, null, "test%"));
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
@@ -49,7 +49,8 @@ public class DatasetMetadataTest {
                         + "FY9LMMsA2aPtQ7Q8g4eZzm6Kv51r0x26pFQhxfHCwUZqa",
                     "owner",
                     0,
-                    null));
+                    null,
+                    "jZOGhT2v86abA0h6yX6DUeKOkKE06nR0TlExO0bp7HBv"));
   }
 
   @Test
@@ -65,7 +66,7 @@ public class DatasetMetadataTest {
             List.of("partition"));
     final List<DatasetPartitionMetadata> partitionConfigs1 = Collections.singletonList(partition);
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(name, owner, throughputBytes, partitionConfigs1);
+        new DatasetMetadata(name, owner, throughputBytes, partitionConfigs1, name);
 
     assertThat(datasetMetadata.name).isEqualTo(name);
     assertThat(datasetMetadata.owner).isEqualTo(owner);
@@ -95,15 +96,15 @@ public class DatasetMetadataTest {
     final List<DatasetPartitionMetadata> partitionConfig = Collections.singletonList(partition);
 
     DatasetMetadata datasetMetadata1 =
-        new DatasetMetadata(name, owner, throughputBytes, partitionConfig);
+        new DatasetMetadata(name, owner, throughputBytes, partitionConfig, name);
     DatasetMetadata datasetMetadata2 =
-        new DatasetMetadata(name + "2", owner, throughputBytes, partitionConfig);
+        new DatasetMetadata(name + "2", owner, throughputBytes, partitionConfig, name + "2");
     DatasetMetadata datasetMetadata3 =
-        new DatasetMetadata(name, owner + "3", throughputBytes, partitionConfig);
+        new DatasetMetadata(name, owner + "3", throughputBytes, partitionConfig, name);
     DatasetMetadata datasetMetadata4 =
-        new DatasetMetadata(name, owner, throughputBytes + 4, partitionConfig);
+        new DatasetMetadata(name, owner, throughputBytes + 4, partitionConfig, name);
     DatasetMetadata datasetMetadata5 =
-        new DatasetMetadata(name, owner, throughputBytes, Collections.emptyList());
+        new DatasetMetadata(name, owner, throughputBytes, Collections.emptyList(), name);
 
     assertThat(datasetMetadata1).isEqualTo(datasetMetadata1);
     assertThat(datasetMetadata1).isNotEqualTo(datasetMetadata2);
@@ -140,17 +141,17 @@ public class DatasetMetadataTest {
     final List<DatasetPartitionMetadata> partitionConfig = Collections.singletonList(partition);
 
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new DatasetMetadata("", owner, throughputBytes, partitionConfig));
+        .isThrownBy(() -> new DatasetMetadata("", owner, throughputBytes, partitionConfig, ""));
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new DatasetMetadata(null, owner, throughputBytes, partitionConfig));
+        .isThrownBy(() -> new DatasetMetadata(null, owner, throughputBytes, partitionConfig, null));
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new DatasetMetadata(name, "", throughputBytes, partitionConfig));
+        .isThrownBy(() -> new DatasetMetadata(name, "", throughputBytes, partitionConfig, name));
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new DatasetMetadata(name, null, throughputBytes, partitionConfig));
+        .isThrownBy(() -> new DatasetMetadata(name, null, throughputBytes, partitionConfig, name));
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new DatasetMetadata(name, owner, -1, partitionConfig));
+        .isThrownBy(() -> new DatasetMetadata(name, owner, -1, partitionConfig, name));
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new DatasetMetadata(name, owner, throughputBytes, null));
+        .isThrownBy(() -> new DatasetMetadata(name, owner, throughputBytes, null, name));
   }
 
   @Test
@@ -170,7 +171,8 @@ public class DatasetMetadataTest {
                     throughputBytes,
                     List.of(
                         new DatasetPartitionMetadata(0, 2000, partitionlist),
-                        new DatasetPartitionMetadata(0, 3000, partitionlist))));
+                        new DatasetPartitionMetadata(0, 3000, partitionlist)),
+                    name));
 
     assertThatIllegalArgumentException()
         .isThrownBy(
@@ -181,7 +183,8 @@ public class DatasetMetadataTest {
                     throughputBytes,
                     List.of(
                         new DatasetPartitionMetadata(0, 2000, partitionlist),
-                        new DatasetPartitionMetadata(2000, 3000, partitionlist))));
+                        new DatasetPartitionMetadata(2000, 3000, partitionlist)),
+                    name));
 
     assertThatIllegalArgumentException()
         .isThrownBy(
@@ -192,7 +195,8 @@ public class DatasetMetadataTest {
                     throughputBytes,
                     List.of(
                         new DatasetPartitionMetadata(0, 3000, partitionlist),
-                        new DatasetPartitionMetadata(0, 2000, partitionlist))));
+                        new DatasetPartitionMetadata(0, 2000, partitionlist)),
+                    name));
 
     assertThatIllegalArgumentException()
         .isThrownBy(
@@ -203,6 +207,7 @@ public class DatasetMetadataTest {
                     throughputBytes,
                     List.of(
                         new DatasetPartitionMetadata(0, 2000, partitionlist),
-                        new DatasetPartitionMetadata(1800, 3000, partitionlist))));
+                        new DatasetPartitionMetadata(1800, 3000, partitionlist)),
+                    name));
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetPartitionMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetPartitionMetadataTest.java
@@ -131,7 +131,8 @@ public class DatasetPartitionMetadataTest {
       DatasetPartitionMetadata partition = new DatasetPartitionMetadata(100, 200, List.of("1"));
 
       DatasetMetadata datasetMetadata =
-          new DatasetMetadata("testDataset1", "datasetOwner1", throughputBytes, List.of(partition));
+          new DatasetMetadata(
+              "testDataset1", "datasetOwner1", throughputBytes, List.of(partition), "testDataset1");
 
       datasetMetadataStore.createSync(datasetMetadata);
       await().until(() -> datasetMetadataStore.getCached().size() == 1);
@@ -140,7 +141,8 @@ public class DatasetPartitionMetadataTest {
     {
       DatasetPartitionMetadata partition = new DatasetPartitionMetadata(201, 300, List.of("2"));
       DatasetMetadata datasetMetadata =
-          new DatasetMetadata("testDataset2", "datasetOwner2", throughputBytes, List.of(partition));
+          new DatasetMetadata(
+              "testDataset2", "datasetOwner2", throughputBytes, List.of(partition), "testDataset2");
       datasetMetadataStore.createSync(datasetMetadata);
       await().until(() -> datasetMetadataStore.getCached().size() == 2);
     }
@@ -182,7 +184,7 @@ public class DatasetPartitionMetadataTest {
     final DatasetPartitionMetadata partition = new DatasetPartitionMetadata(100, 200, List.of("1"));
 
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(name, owner, throughputBytes, List.of(partition));
+        new DatasetMetadata(name, owner, throughputBytes, List.of(partition), name);
 
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.getCached().size() == 1);
@@ -225,7 +227,7 @@ public class DatasetPartitionMetadataTest {
         new DatasetPartitionMetadata(201, 300, List.of("2", "3"));
 
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(name, owner, throughputBytes, List.of(partition1, partition2));
+        new DatasetMetadata(name, owner, throughputBytes, List.of(partition1, partition2), name);
 
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.getCached().size() == 1);
@@ -266,7 +268,7 @@ public class DatasetPartitionMetadataTest {
     final DatasetPartitionMetadata partition = new DatasetPartitionMetadata(100, 200, List.of("1"));
 
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(name, owner, throughputBytes, List.of(partition));
+        new DatasetMetadata(name, owner, throughputBytes, List.of(partition), name);
 
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.getCached().size() == 1);
@@ -278,7 +280,7 @@ public class DatasetPartitionMetadataTest {
         new DatasetPartitionMetadata(100, 200, List.of("2"));
 
     DatasetMetadata datasetMetadata1 =
-        new DatasetMetadata(name1, owner1, throughputBytes1, List.of(partition1));
+        new DatasetMetadata(name1, owner1, throughputBytes1, List.of(partition1), name1);
 
     datasetMetadataStore.createSync(datasetMetadata1);
     await().until(() -> datasetMetadataStore.getCached().size() == 2);

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiterTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiterTest.java
@@ -1,5 +1,6 @@
 package com.slack.kaldb.preprocessor;
 
+import static com.slack.kaldb.metadata.dataset.DatasetPartitionMetadata.MATCH_ALL_DATASET;
 import static com.slack.kaldb.preprocessor.PreprocessorRateLimiter.BYTES_DROPPED;
 import static com.slack.kaldb.preprocessor.PreprocessorRateLimiter.MESSAGES_DROPPED;
 import static com.slack.kaldb.preprocessor.PreprocessorValueMapper.SERVICE_NAME_KEY;
@@ -70,6 +71,228 @@ public class PreprocessorRateLimiterTest {
                 .counter()
                 .count())
         .isEqualTo(span.toByteArray().length * 2);
+  }
+
+  @Test
+  public void shouldApplyScaledRateLimitWithAllServices() throws InterruptedException {
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    int preprocessorCount = 2;
+    int maxBurstSeconds = 1;
+    boolean initializeWarm = false;
+    PreprocessorRateLimiter rateLimiter =
+        new PreprocessorRateLimiter(
+            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
+
+    String name = "rateLimiter";
+    Trace.Span span =
+        Trace.Span.newBuilder()
+            .addTags(Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(name).build())
+            .build();
+
+    // set the target so that we pass the first add, then fail the second
+    long targetThroughput = ((long) span.toByteArray().length * preprocessorCount) + 1;
+
+    DatasetMetadata datasetMetadata =
+        new DatasetMetadata(
+            name,
+            name,
+            targetThroughput,
+            List.of(new DatasetPartitionMetadata(100, 200, List.of("0"))),
+            MATCH_ALL_DATASET);
+    Predicate<String, Trace.Span> predicate = rateLimiter.createRateLimiter(datasetMetadata);
+
+    // try to get just below the scaled limit, then try to go over
+    assertThat(predicate.test("key", span)).isTrue();
+    assertThat(predicate.test("key", span)).isFalse();
+
+    // rate limit is targetThroughput per second, so 1 second should refill our limit
+    Thread.sleep(1000);
+
+    // try to get just below the scaled limit, then try to go over
+    assertThat(predicate.test("key", span)).isTrue();
+    assertThat(predicate.test("key", span)).isFalse();
+
+    assertThat(
+            meterRegistry
+                .get(MESSAGES_DROPPED)
+                .tag("reason", String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
+                .counter()
+                .count())
+        .isEqualTo(2);
+    assertThat(
+            meterRegistry
+                .get(BYTES_DROPPED)
+                .tag("reason", String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
+                .counter()
+                .count())
+        .isEqualTo(span.toByteArray().length * 2);
+
+    MeterRegistry meterRegistry1 = new SimpleMeterRegistry();
+    PreprocessorRateLimiter rateLimiter1 =
+        new PreprocessorRateLimiter(
+            meterRegistry1, preprocessorCount, maxBurstSeconds, initializeWarm);
+    DatasetMetadata datasetMetadata1 =
+        new DatasetMetadata(
+            name,
+            name,
+            targetThroughput,
+            List.of(new DatasetPartitionMetadata(100, 200, List.of("0"))),
+            "*");
+    Predicate<String, Trace.Span> predicate1 = rateLimiter1.createRateLimiter(datasetMetadata1);
+
+    // try to get just below the scaled limit, then try to go over
+    assertThat(predicate1.test("key", span)).isTrue();
+    assertThat(predicate1.test("key", span)).isFalse();
+
+    // rate limit is targetThroughput per second, so 1 second should refill our limit
+    Thread.sleep(1000);
+
+    // try to get just below the scaled limit, then try to go over
+    assertThat(predicate1.test("key", span)).isTrue();
+    assertThat(predicate1.test("key", span)).isFalse();
+
+    assertThat(
+            meterRegistry1
+                .get(MESSAGES_DROPPED)
+                .tag("reason", String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
+                .counter()
+                .count())
+        .isEqualTo(2);
+    assertThat(
+            meterRegistry1
+                .get(BYTES_DROPPED)
+                .tag("reason", String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
+                .counter()
+                .count())
+        .isEqualTo(span.toByteArray().length * 2);
+
+    MeterRegistry meterRegistry2 = new SimpleMeterRegistry();
+    PreprocessorRateLimiter rateLimiter2 =
+        new PreprocessorRateLimiter(
+            meterRegistry2, preprocessorCount, maxBurstSeconds, initializeWarm);
+    DatasetMetadata datasetMetadata2 =
+        new DatasetMetadata(
+            name,
+            name,
+            targetThroughput,
+            List.of(new DatasetPartitionMetadata(100, 200, List.of("0"))),
+            ".+");
+    Predicate<String, Trace.Span> predicate2 = rateLimiter2.createRateLimiter(datasetMetadata2);
+
+    // try to get just below the scaled limit, then try to go over
+    assertThat(predicate2.test("key", span)).isTrue();
+    assertThat(predicate2.test("key", span)).isFalse();
+
+    // rate limit is targetThroughput per second, so 1 second should refill our limit
+    Thread.sleep(1000);
+
+    // try to get just below the scaled limit, then try to go over
+    assertThat(predicate2.test("key", span)).isTrue();
+    assertThat(predicate2.test("key", span)).isFalse();
+
+    assertThat(
+            meterRegistry2
+                .get(MESSAGES_DROPPED)
+                .tag("reason", String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
+                .counter()
+                .count())
+        .isEqualTo(2);
+    assertThat(
+            meterRegistry2
+                .get(BYTES_DROPPED)
+                .tag("reason", String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
+                .counter()
+                .count())
+        .isEqualTo(span.toByteArray().length * 2);
+  }
+
+  @Test
+  public void shouldApplyScaledRateLimitToRegexServiceNames() throws InterruptedException {
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    int preprocessorCount = 2;
+    int maxBurstSeconds = 1;
+    boolean initializeWarm = false;
+    PreprocessorRateLimiter rateLimiter =
+        new PreprocessorRateLimiter(
+            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
+
+    String name1 = "a";
+    Trace.Span span1 =
+        Trace.Span.newBuilder()
+            .addTags(Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(name1).build())
+            .build();
+    String name2 = "b";
+    Trace.Span span2 =
+        Trace.Span.newBuilder()
+            .addTags(Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(name2).build())
+            .build();
+
+    String name3 = "z";
+    Trace.Span span3 =
+        Trace.Span.newBuilder()
+            .addTags(Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(name3).build())
+            .build();
+
+    // set the target so that we pass the first add, then fail the second
+    long targetThroughput = ((long) span1.toByteArray().length * preprocessorCount) + 1;
+
+    DatasetMetadata datasetMetadata =
+        new DatasetMetadata(
+            "testService",
+            "testService",
+            targetThroughput,
+            List.of(new DatasetPartitionMetadata(100, 200, List.of("0"))),
+            "[abc]");
+    Predicate<String, Trace.Span> predicate = rateLimiter.createRateLimiter(datasetMetadata);
+
+    // try to get just below the scaled limit, then try to go over
+    assertThat(predicate.test("key", span1)).isTrue();
+    assertThat(predicate.test("key", span2)).isFalse();
+
+    // rate limit is targetThroughput per second, so 1 second should refill our limit
+    Thread.sleep(1000);
+
+    // try to get just below the scaled limit, then try to go over
+    assertThat(predicate.test("key", span2)).isTrue();
+    assertThat(predicate.test("key", span1)).isFalse();
+
+    assertThat(
+            meterRegistry
+                .get(MESSAGES_DROPPED)
+                .tag("reason", String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
+                .counter()
+                .count())
+        .isEqualTo(2);
+    assertThat(
+            meterRegistry
+                .get(BYTES_DROPPED)
+                .tag("reason", String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
+                .counter()
+                .count())
+        .isEqualTo(span1.toByteArray().length * 2);
+
+    Thread.sleep(1000);
+    assertThat(predicate.test("key", span3)).isFalse();
+    assertThat(predicate.test("key", span3)).isFalse();
+
+    assertThat(
+            meterRegistry
+                .get(MESSAGES_DROPPED)
+                .tag(
+                    "reason",
+                    String.valueOf(PreprocessorRateLimiter.MessageDropReason.NOT_PROVISIONED))
+                .counter()
+                .count())
+        .isEqualTo(2);
+    assertThat(
+            meterRegistry
+                .get(BYTES_DROPPED)
+                .tag(
+                    "reason",
+                    String.valueOf(PreprocessorRateLimiter.MessageDropReason.NOT_PROVISIONED))
+                .counter()
+                .count())
+        .isEqualTo(span1.toByteArray().length * 2);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiterTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiterTest.java
@@ -7,9 +7,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import com.slack.kaldb.metadata.dataset.DatasetMetadata;
+import com.slack.kaldb.metadata.dataset.DatasetPartitionMetadata;
 import com.slack.service.murron.trace.Trace;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
 import org.apache.kafka.streams.kstream.Predicate;
 import org.junit.Test;
 
@@ -34,7 +36,13 @@ public class PreprocessorRateLimiterTest {
     // set the target so that we pass the first add, then fail the second
     long targetThroughput = ((long) span.toByteArray().length * preprocessorCount) + 1;
 
-    DatasetMetadata datasetMetadata = new DatasetMetadata(name, name, targetThroughput, null, name);
+    DatasetMetadata datasetMetadata =
+        new DatasetMetadata(
+            name,
+            name,
+            targetThroughput,
+            List.of(new DatasetPartitionMetadata(100, 200, List.of("0"))),
+            name);
     Predicate<String, Trace.Span> predicate = rateLimiter.createRateLimiter(datasetMetadata);
 
     // try to get just below the scaled limit, then try to go over
@@ -80,11 +88,11 @@ public class PreprocessorRateLimiterTest {
 
     DatasetMetadata datasetMetadata =
         new DatasetMetadata(
-            "unprovisioned_service",
-            "unprovisioned_service",
+            "wrong_service",
+            "wrong_service",
             Long.MAX_VALUE,
-            null,
-            "unprovisioned_service");
+            List.of(new DatasetPartitionMetadata(100, 200, List.of("0"))),
+            "wrong_service");
     Predicate<String, Trace.Span> predicate = rateLimiter.createRateLimiter(datasetMetadata);
 
     // this should be immediately dropped
@@ -122,7 +130,13 @@ public class PreprocessorRateLimiterTest {
 
     String name = "rateLimiter";
     long targetThroughput = 1000;
-    DatasetMetadata datasetMetadata = new DatasetMetadata(name, name, targetThroughput, null, name);
+    DatasetMetadata datasetMetadata =
+        new DatasetMetadata(
+            name,
+            name,
+            targetThroughput,
+            List.of(new DatasetPartitionMetadata(100, 200, List.of("0"))),
+            name);
     Predicate<String, Trace.Span> predicate = rateLimiter.createRateLimiter(datasetMetadata);
 
     assertThat(predicate.test("key", Trace.Span.newBuilder().build())).isFalse();
@@ -150,7 +164,13 @@ public class PreprocessorRateLimiterTest {
     PreprocessorRateLimiter rateLimiter = new PreprocessorRateLimiter(meterRegistry, 1, 3, true);
 
     long targetThroughput = span.getSerializedSize() - 1;
-    DatasetMetadata datasetMetadata = new DatasetMetadata(name, name, targetThroughput, null, name);
+    DatasetMetadata datasetMetadata =
+        new DatasetMetadata(
+            name,
+            name,
+            targetThroughput,
+            List.of(new DatasetPartitionMetadata(100, 200, List.of("0"))),
+            name);
     Predicate<String, Trace.Span> predicate = rateLimiter.createRateLimiter(datasetMetadata);
 
     assertThat(predicate.test("key", span)).isTrue();
@@ -177,7 +197,13 @@ public class PreprocessorRateLimiterTest {
     PreprocessorRateLimiter rateLimiter = new PreprocessorRateLimiter(meterRegistry, 1, 3, false);
 
     long targetThroughput = span.getSerializedSize() - 1;
-    DatasetMetadata datasetMetadata = new DatasetMetadata(name, name, targetThroughput, null, name);
+    DatasetMetadata datasetMetadata =
+        new DatasetMetadata(
+            name,
+            name,
+            targetThroughput,
+            List.of(new DatasetPartitionMetadata(100, 200, List.of("0"))),
+            name);
     Predicate<String, Trace.Span> predicate = rateLimiter.createRateLimiter(datasetMetadata);
 
     assertThat(predicate.test("key", span)).isTrue();

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
@@ -91,7 +91,7 @@ public class PreprocessorServiceIntegrationTest {
 
     assertThat(MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry))
         .isEqualTo(1);
-    datasetMetadataStore.createSync(new DatasetMetadata("name", "owner", 0, List.of()));
+    datasetMetadataStore.createSync(new DatasetMetadata("name", "owner", 0, List.of(), "name"));
 
     // wait for the cache to be updated
     await().until(() -> datasetMetadataStore.listSync().size() == 1);
@@ -167,7 +167,8 @@ public class PreprocessorServiceIntegrationTest {
             serviceName,
             "owner",
             100,
-            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("3"))));
+            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("3"))),
+            serviceName);
     datasetMetadataStore.createSync(datasetMetadata);
 
     // wait for the cache to be updated
@@ -186,7 +187,8 @@ public class PreprocessorServiceIntegrationTest {
             Long.MAX_VALUE,
             List.of(
                 new DatasetPartitionMetadata(1, 10000, List.of("3")),
-                new DatasetPartitionMetadata(10001, Long.MAX_VALUE, List.of("2"))));
+                new DatasetPartitionMetadata(10001, Long.MAX_VALUE, List.of("2"))),
+            datasetMetadata.getName());
     datasetMetadataStore.updateSync(updatedDatasetMetadata);
 
     // wait for the cache to be updated

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
@@ -1,378 +1,407 @@
-package com.slack.kaldb.preprocessor;
-
-import static com.slack.kaldb.preprocessor.PreprocessorValueMapper.SERVICE_NAME_KEY;
-import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.assertThatNullPointerException;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import com.slack.kaldb.metadata.dataset.DatasetMetadata;
-import com.slack.kaldb.metadata.dataset.DatasetMetadataStore;
-import com.slack.kaldb.metadata.dataset.DatasetPartitionMetadata;
-import com.slack.kaldb.proto.config.KaldbConfigs;
-import com.slack.kaldb.testlib.MetricsUtil;
-import com.slack.service.murron.trace.Trace;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.time.Instant;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.TimeoutException;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.Topology;
-import org.apache.kafka.streams.processor.StreamPartitioner;
-import org.junit.Test;
-
-public class PreprocessorServiceUnitTest {
-
-  @Test
-  public void shouldBuildValidPropsFromStreamConfig() {
-    String applicationId = "applicationId";
-    String bootstrapServers = "bootstrap";
-    String processingGuarantee = "at_least_once";
-    int replicationFactor = 1;
-    boolean enableIdempotence = false;
-    String acksConfig = "1";
-    int numStreamThreads = 1;
-
-    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-            .setApplicationId(applicationId)
-            .setBootstrapServers(bootstrapServers)
-            .setNumStreamThreads(numStreamThreads)
-            .setProcessingGuarantee(processingGuarantee)
-            .build();
-
-    Properties properties = PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-    assertThat(properties.size()).isEqualTo(7);
-
-    assertThat(properties.get(StreamsConfig.APPLICATION_ID_CONFIG)).isEqualTo(applicationId);
-    assertThat(properties.get(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG)).isEqualTo(bootstrapServers);
-    assertThat(properties.get(StreamsConfig.NUM_STREAM_THREADS_CONFIG)).isEqualTo(numStreamThreads);
-    assertThat(properties.get(StreamsConfig.PROCESSING_GUARANTEE_CONFIG))
-        .isEqualTo(processingGuarantee);
-    assertThat(properties.get(StreamsConfig.REPLICATION_FACTOR_CONFIG))
-        .isEqualTo(replicationFactor);
-    assertThat(
-            properties.get(StreamsConfig.producerPrefix(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG)))
-        .isEqualTo(enableIdempotence);
-    assertThat(properties.get(StreamsConfig.producerPrefix(ProducerConfig.ACKS_CONFIG)))
-        .isEqualTo(acksConfig);
-  }
-
-  @Test
-  public void shouldPreventInvalidStreamPropsConfig() {
-    String applicationId = "applicationId";
-    String bootstrapServers = "bootstrap";
-    int numStreamThreads = 1;
-
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () -> {
-              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-                      .setBootstrapServers(bootstrapServers)
-                      .setNumStreamThreads(numStreamThreads)
-                      .build();
-              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-            });
-
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () -> {
-              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-                      .setApplicationId(applicationId)
-                      .setNumStreamThreads(numStreamThreads)
-                      .build();
-              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-            });
-
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () -> {
-              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-                      .setApplicationId(applicationId)
-                      .setBootstrapServers(bootstrapServers)
-                      .build();
-              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-            });
-
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () -> {
-              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-                      .setApplicationId(applicationId)
-                      .setBootstrapServers(bootstrapServers)
-                      .setNumStreamThreads(0)
-                      .build();
-              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-            });
-  }
-
-  @Test
-  public void shouldReturnRandomPartitionFromStreamPartitioner() {
-    String datasetName = "datasetName";
-    List<Integer> partitionList = List.of(33, 44, 55);
-    Map<String, List<Integer>> datasetNameToPartitions = Map.of(datasetName, partitionList);
-    StreamPartitioner<String, Trace.Span> streamPartitioner =
-        PreprocessorService.streamPartitioner(datasetNameToPartitions);
-
-    Trace.Span span =
-        Trace.Span.newBuilder()
-            .addTags(
-                Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(datasetName).build())
-            .build();
-
-    // all arguments except value are currently unused for determining the partition to assign, as
-    // this comes the internal partition list that is set on stream partitioner initialization
-    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 0)))
-        .isTrue();
-    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 1)))
-        .isTrue();
-    assertThat(partitionList.contains(streamPartitioner.partition("topic", "", span, 0))).isTrue();
-    assertThat(partitionList.contains(streamPartitioner.partition("", null, span, 0))).isTrue();
-  }
-
-  @Test
-  public void shouldPreventInvalidStreamPartitionConfigurations() {
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of()));
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of("", List.of(1))));
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of("service", List.of())));
-  }
-
-  @Test
-  public void shouldFilterInvalidConfigurationsFromServiceMetadata() {
-    DatasetMetadata validDatasetMetadata =
-        new DatasetMetadata(
-            "valid",
-            "owner1",
-            1000,
-            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1"))));
-
-    List<DatasetMetadata> datasetMetadataList =
-        List.of(
-            new DatasetMetadata("invalidServicePartitionList", "owner1", 1000, List.of()),
-            new DatasetMetadata(
-                "invalidThroughputBytes",
-                "owner1",
-                0,
-                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1")))),
-            new DatasetMetadata(
-                "invalidActivePartitions",
-                "owner1",
-                1000,
-                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of()))),
-            new DatasetMetadata(
-                "invalidNoActivePartitions",
-                "owner1",
-                1000,
-                List.of(
-                    new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1")))),
-            validDatasetMetadata);
-
-    List<DatasetMetadata> datasetMetadata1 =
-        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
-
-    assertThat(datasetMetadata1.size()).isEqualTo(1);
-    assertThat(datasetMetadata1.contains(validDatasetMetadata)).isTrue();
-
-    Collections.shuffle(datasetMetadata1);
-
-    List<DatasetMetadata> datasetMetadata2 =
-        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
-
-    assertThat(datasetMetadata2.size()).isEqualTo(1);
-    assertThat(datasetMetadata2.contains(validDatasetMetadata)).isTrue();
-
-    List<DatasetMetadata> datasetMetadata3 =
-        PreprocessorService.filterValidDatasetMetadata(List.of());
-    assertThat(datasetMetadata3.size()).isEqualTo(0);
-  }
-
-  @Test
-  public void shouldGetActivePartitionsFromServiceMetadata() {
-    DatasetMetadata datasetMetadataEmptyPartitions =
-        new DatasetMetadata("empty", "owner1", 1000, List.of());
-    DatasetMetadata datasetMetadataNoActivePartitions =
-        new DatasetMetadata(
-            "empty",
-            "owner1",
-            1000,
-            List.of(
-                new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1", "2"))));
-
-    DatasetMetadata datasetMetadataNoPartitions =
-        new DatasetMetadata(
-            "empty",
-            "owner1",
-            1000,
-            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of())));
-
-    DatasetMetadata datasetMetadataMultiplePartitions =
-        new DatasetMetadata(
-            "empty",
-            "owner1",
-            1000,
-            List.of(
-                new DatasetPartitionMetadata(1, 10000, List.of("3", "4")),
-                new DatasetPartitionMetadata(10001, Long.MAX_VALUE, List.of("5", "6"))));
-
-    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataEmptyPartitions))
-        .isEqualTo(List.of());
-    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoActivePartitions))
-        .isEqualTo(List.of());
-    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoPartitions))
-        .isEqualTo(List.of());
-    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataMultiplePartitions))
-        .isEqualTo(List.of(5, 6));
-  }
-
-  @Test
-  public void shouldBuildStreamTopology() {
-    List<DatasetMetadata> datasetMetadata =
-        List.of(
-            new DatasetMetadata(
-                "dataset1",
-                "owner1",
-                1000,
-                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2")))),
-            new DatasetMetadata(
-                "dataset2",
-                "owner1",
-                1000,
-                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2")))));
-
-    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    int preprocessorCount = 1;
-    int maxBurstSeconds = 1;
-    boolean initializeWarm = false;
-    PreprocessorRateLimiter rateLimiter =
-        new PreprocessorRateLimiter(
-            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
-
-    List<String> upstreamTopics = List.of("upstream1", "upstream2", "upstream3");
-    String downstreamTopic = "downstream";
-    String dataTransformer = "api_log";
-    Topology topology =
-        PreprocessorService.buildTopology(
-            datasetMetadata, rateLimiter, upstreamTopics, downstreamTopic, dataTransformer);
-
-    // we have limited visibility into the topology, so we just verify we have the correct number of
-    // stream processors as we expect
-    assertThat(topology.describe().subtopologies().size()).isEqualTo(upstreamTopics.size());
-  }
-
-  @Test
-  public void shouldThrowOnInvalidTopologyConfigs() {
-    DatasetMetadata datasetMetadata =
-        new DatasetMetadata(
-            "dataset1",
-            "owner1",
-            1000,
-            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2"))));
-
-    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    int preprocessorCount = 1;
-    int maxBurstSeconds = 1;
-    boolean initializeWarm = false;
-    PreprocessorRateLimiter rateLimiter =
-        new PreprocessorRateLimiter(
-            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
-    List<String> upstreamTopics = List.of("upstream");
-    String downstreamTopic = "downstream";
-    String dataTransformer = "api_log";
-
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () ->
-                PreprocessorService.buildTopology(
-                    List.of(), rateLimiter, upstreamTopics, downstreamTopic, dataTransformer));
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () ->
-                PreprocessorService.buildTopology(
-                    List.of(datasetMetadata),
-                    rateLimiter,
-                    List.of(),
-                    downstreamTopic,
-                    dataTransformer));
-    assertThatNullPointerException()
-        .isThrownBy(
-            () ->
-                PreprocessorService.buildTopology(
-                    List.of(datasetMetadata),
-                    null,
-                    upstreamTopics,
-                    downstreamTopic,
-                    dataTransformer));
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () ->
-                PreprocessorService.buildTopology(
-                    List.of(datasetMetadata), rateLimiter, upstreamTopics, "", dataTransformer));
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () ->
-                PreprocessorService.buildTopology(
-                    List.of(datasetMetadata), rateLimiter, upstreamTopics, downstreamTopic, ""));
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () ->
-                PreprocessorService.buildTopology(
-                    List.of(datasetMetadata),
-                    rateLimiter,
-                    upstreamTopics,
-                    downstreamTopic,
-                    "invalid"));
-  }
-
-  @Test
-  public void shouldHandleEmptyDatasetMetadata() throws TimeoutException {
-    DatasetMetadataStore datasetMetadataStore = mock(DatasetMetadataStore.class);
-    when(datasetMetadataStore.listSync()).thenReturn(List.of());
-
-    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-            .setApplicationId("applicationId")
-            .setBootstrapServers("bootstrap")
-            .setNumStreamThreads(1)
-            .build();
-    KaldbConfigs.ServerConfig serverConfig =
-        KaldbConfigs.ServerConfig.newBuilder()
-            .setServerPort(8080)
-            .setServerAddress("localhost")
-            .build();
-    KaldbConfigs.PreprocessorConfig preprocessorConfig =
-        KaldbConfigs.PreprocessorConfig.newBuilder()
-            .setKafkaStreamConfig(kafkaStreamConfig)
-            .setServerConfig(serverConfig)
-            .setPreprocessorInstanceCount(1)
-            .setDataTransformer("api_log")
-            .setRateLimiterMaxBurstSeconds(1)
-            .build();
-
-    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-    PreprocessorService preprocessorService =
-        new PreprocessorService(datasetMetadataStore, preprocessorConfig, meterRegistry);
-
-    preprocessorService.startAsync();
-    preprocessorService.awaitRunning(DEFAULT_START_STOP_DURATION);
-
-    assertThat(MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry))
-        .isEqualTo(1);
-
-    preprocessorService.stopAsync();
-    preprocessorService.awaitTerminated();
-  }
-}
+// package com.slack.kaldb.preprocessor;
+//
+// import static com.slack.kaldb.preprocessor.PreprocessorValueMapper.SERVICE_NAME_KEY;
+// import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
+// import static org.assertj.core.api.Assertions.assertThat;
+// import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+// import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+// import static org.mockito.Mockito.mock;
+// import static org.mockito.Mockito.when;
+//
+// import com.slack.kaldb.metadata.dataset.DatasetMetadata;
+// import com.slack.kaldb.metadata.dataset.DatasetMetadataStore;
+// import com.slack.kaldb.metadata.dataset.DatasetPartitionMetadata;
+// import com.slack.kaldb.proto.config.KaldbConfigs;
+// import com.slack.kaldb.testlib.MetricsUtil;
+// import com.slack.service.murron.trace.Trace;
+// import io.micrometer.core.instrument.MeterRegistry;
+// import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+// import java.time.Instant;
+// import java.util.Collections;
+// import java.util.List;
+// import java.util.Map;
+// import java.util.Properties;
+// import java.util.concurrent.TimeoutException;
+// import org.apache.kafka.clients.producer.ProducerConfig;
+// import org.apache.kafka.streams.StreamsConfig;
+// import org.apache.kafka.streams.Topology;
+// import org.apache.kafka.streams.processor.StreamPartitioner;
+// import org.junit.Test;
+//
+// public class PreprocessorServiceUnitTest {
+//
+//  @Test
+//  public void shouldBuildValidPropsFromStreamConfig() {
+//    String applicationId = "applicationId";
+//    String bootstrapServers = "bootstrap";
+//    String processingGuarantee = "at_least_once";
+//    int replicationFactor = 1;
+//    boolean enableIdempotence = false;
+//    String acksConfig = "1";
+//    int numStreamThreads = 1;
+//
+//    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+//        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+//            .setApplicationId(applicationId)
+//            .setBootstrapServers(bootstrapServers)
+//            .setNumStreamThreads(numStreamThreads)
+//            .setProcessingGuarantee(processingGuarantee)
+//            .build();
+//
+//    Properties properties = PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+//    assertThat(properties.size()).isEqualTo(7);
+//
+//    assertThat(properties.get(StreamsConfig.APPLICATION_ID_CONFIG)).isEqualTo(applicationId);
+//
+// assertThat(properties.get(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG)).isEqualTo(bootstrapServers);
+//
+// assertThat(properties.get(StreamsConfig.NUM_STREAM_THREADS_CONFIG)).isEqualTo(numStreamThreads);
+//    assertThat(properties.get(StreamsConfig.PROCESSING_GUARANTEE_CONFIG))
+//        .isEqualTo(processingGuarantee);
+//    assertThat(properties.get(StreamsConfig.REPLICATION_FACTOR_CONFIG))
+//        .isEqualTo(replicationFactor);
+//    assertThat(
+//
+// properties.get(StreamsConfig.producerPrefix(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG)))
+//        .isEqualTo(enableIdempotence);
+//    assertThat(properties.get(StreamsConfig.producerPrefix(ProducerConfig.ACKS_CONFIG)))
+//        .isEqualTo(acksConfig);
+//  }
+//
+//  @Test
+//  public void shouldPreventInvalidStreamPropsConfig() {
+//    String applicationId = "applicationId";
+//    String bootstrapServers = "bootstrap";
+//    int numStreamThreads = 1;
+//
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () -> {
+//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+//                      .setBootstrapServers(bootstrapServers)
+//                      .setNumStreamThreads(numStreamThreads)
+//                      .build();
+//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+//            });
+//
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () -> {
+//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+//                      .setApplicationId(applicationId)
+//                      .setNumStreamThreads(numStreamThreads)
+//                      .build();
+//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+//            });
+//
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () -> {
+//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+//                      .setApplicationId(applicationId)
+//                      .setBootstrapServers(bootstrapServers)
+//                      .build();
+//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+//            });
+//
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () -> {
+//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+//                      .setApplicationId(applicationId)
+//                      .setBootstrapServers(bootstrapServers)
+//                      .setNumStreamThreads(0)
+//                      .build();
+//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+//            });
+//  }
+//
+//  @Test
+//  public void shouldReturnRandomPartitionFromStreamPartitioner() {
+//    String datasetName = "datasetName";
+//    List<Integer> partitionList = List.of(33, 44, 55);
+//    Map<String, List<Integer>> datasetNameToPartitions = Map.of(datasetName, partitionList);
+//    StreamPartitioner<String, Trace.Span> streamPartitioner =
+//        PreprocessorService.streamPartitioner(datasetNameToPartitions);
+//
+//    Trace.Span span =
+//        Trace.Span.newBuilder()
+//            .addTags(
+//                Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(datasetName).build())
+//            .build();
+//
+//    // all arguments except value are currently unused for determining the partition to assign, as
+//    // this comes the internal partition list that is set on stream partitioner initialization
+//    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 0)))
+//        .isTrue();
+//    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 1)))
+//        .isTrue();
+//    assertThat(partitionList.contains(streamPartitioner.partition("topic", "", span,
+// 0))).isTrue();
+//    assertThat(partitionList.contains(streamPartitioner.partition("", null, span, 0))).isTrue();
+//  }
+//
+//  @Test
+//  public void shouldPreventInvalidStreamPartitionConfigurations() {
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of()));
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of("", List.of(1))));
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of("service", List.of())));
+//  }
+//
+//  @Test
+//  public void shouldFilterInvalidConfigurationsFromServiceMetadata() {
+//    DatasetMetadata validDatasetMetadata =
+//        new DatasetMetadata(
+//            "valid",
+//            "owner1",
+//            1000,
+//            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1"))));
+//
+//    List<DatasetMetadata> datasetMetadataList =
+//        List.of(
+//            new DatasetMetadata("invalidServicePartitionList", "owner1", 1000, List.of()),
+//            new DatasetMetadata(
+//                "invalidThroughputBytes",
+//                "owner1",
+//                0,
+//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1")))),
+//            new DatasetMetadata(
+//                "invalidActivePartitions",
+//                "owner1",
+//                1000,
+//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of()))),
+//            new DatasetMetadata(
+//                "invalidNoActivePartitions",
+//                "owner1",
+//                1000,
+//                List.of(
+//                    new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1")))),
+//            validDatasetMetadata);
+//
+//    List<DatasetMetadata> datasetMetadata1 =
+//        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
+//
+//    assertThat(datasetMetadata1.size()).isEqualTo(1);
+//    assertThat(datasetMetadata1.contains(validDatasetMetadata)).isTrue();
+//
+//    Collections.shuffle(datasetMetadata1);
+//
+//    List<DatasetMetadata> datasetMetadata2 =
+//        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
+//
+//    assertThat(datasetMetadata2.size()).isEqualTo(1);
+//    assertThat(datasetMetadata2.contains(validDatasetMetadata)).isTrue();
+//
+//    List<DatasetMetadata> datasetMetadata3 =
+//        PreprocessorService.filterValidDatasetMetadata(List.of());
+//    assertThat(datasetMetadata3.size()).isEqualTo(0);
+//  }
+//
+//  @Test
+//  public void shouldGetActivePartitionsFromServiceMetadata() {
+//    DatasetMetadata datasetMetadataEmptyPartitions =
+//        new DatasetMetadata("empty", "owner1", 1000, List.of());
+//    DatasetMetadata datasetMetadataNoActivePartitions =
+//        new DatasetMetadata(
+//            "empty",
+//            "owner1",
+//            1000,
+//            List.of(
+//                new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1",
+// "2"))));
+//
+//    DatasetMetadata datasetMetadataNoPartitions =
+//        new DatasetMetadata(
+//            "empty",
+//            "owner1",
+//            1000,
+//            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of())));
+//
+//    DatasetMetadata datasetMetadataMultiplePartitions =
+//        new DatasetMetadata(
+//            "empty",
+//            "owner1",
+//            1000,
+//            List.of(
+//                new DatasetPartitionMetadata(1, 10000, List.of("3", "4")),
+//                new DatasetPartitionMetadata(10001, Long.MAX_VALUE, List.of("5", "6"))));
+//
+//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataEmptyPartitions))
+//        .isEqualTo(List.of());
+//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoActivePartitions))
+//        .isEqualTo(List.of());
+//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoPartitions))
+//        .isEqualTo(List.of());
+//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataMultiplePartitions))
+//        .isEqualTo(List.of(5, 6));
+//  }
+//
+//  @Test
+//  public void shouldBuildStreamTopology() {
+//    List<DatasetMetadata> datasetMetadata =
+//        List.of(
+//            new DatasetMetadata(
+//                "dataset1",
+//                "owner1",
+//                1000,
+//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2")))),
+//            new DatasetMetadata(
+//                "dataset2",
+//                "owner1",
+//                1000,
+//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2")))));
+//
+//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+//    int preprocessorCount = 1;
+//    int maxBurstSeconds = 1;
+//    boolean initializeWarm = false;
+//    PreprocessorRateLimiter rateLimiter =
+//        new PreprocessorRateLimiter(
+//            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
+//
+//    List<String> upstreamTopics = List.of("upstream1", "upstream2", "upstream3");
+//    String downstreamTopic = "downstream";
+//    String dataTransformer = "api_log";
+//    Topology topology =
+//        PreprocessorService.buildTopology(
+//            datasetMetadata,
+//            rateLimiter,
+//            upstreamTopics,
+//            downstreamTopic,
+//            dataTransformer,
+//            "dataset");
+//
+//    // we have limited visibility into the topology, so we just verify we have the correct number
+// of
+//    // stream processors as we expect
+//    assertThat(topology.describe().subtopologies().size()).isEqualTo(upstreamTopics.size());
+//  }
+//
+//  @Test
+//  public void shouldThrowOnInvalidTopologyConfigs() {
+//    DatasetMetadata datasetMetadata =
+//        new DatasetMetadata(
+//            "dataset1",
+//            "owner1",
+//            1000,
+//            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2"))));
+//
+//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+//    int preprocessorCount = 1;
+//    int maxBurstSeconds = 1;
+//    boolean initializeWarm = false;
+//    PreprocessorRateLimiter rateLimiter =
+//        new PreprocessorRateLimiter(
+//            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
+//    List<String> upstreamTopics = List.of("upstream");
+//    String downstreamTopic = "downstream";
+//    String dataTransformer = "api_log";
+//
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () ->
+//                PreprocessorService.buildTopology(
+//                    List.of(),
+//                    rateLimiter,
+//                    upstreamTopics,
+//                    downstreamTopic,
+//                    dataTransformer,
+//                    "dataset"));
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () ->
+//                PreprocessorService.buildTopology(
+//                    List.of(datasetMetadata),
+//                    rateLimiter,
+//                    List.of(),
+//                    downstreamTopic,
+//                    dataTransformer,
+//                    "dataset"));
+//    assertThatNullPointerException()
+//        .isThrownBy(
+//            () ->
+//                PreprocessorService.buildTopology(
+//                    List.of(datasetMetadata),
+//                    null,
+//                    upstreamTopics,
+//                    downstreamTopic,
+//                    dataTransformer,
+//                    "dataset"));
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () ->
+//                PreprocessorService.buildTopology(
+//                    List.of(datasetMetadata),
+//                    rateLimiter,
+//                    upstreamTopics,
+//                    "",
+//                    dataTransformer,
+//                    "dataset"));
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () ->
+//                PreprocessorService.buildTopology(
+//                    List.of(datasetMetadata),
+//                    rateLimiter,
+//                    upstreamTopics,
+//                    downstreamTopic,
+//                    "",
+//                    "dataset"));
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () ->
+//                PreprocessorService.buildTopology(
+//                    List.of(datasetMetadata),
+//                    rateLimiter,
+//                    upstreamTopics,
+//                    downstreamTopic,
+//                    "invalid",
+//                    "dataset"));
+//  }
+//
+//  @Test
+//  public void shouldHandleEmptyDatasetMetadata() throws TimeoutException {
+//    DatasetMetadataStore datasetMetadataStore = mock(DatasetMetadataStore.class);
+//    when(datasetMetadataStore.listSync()).thenReturn(List.of());
+//
+//    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+//        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+//            .setApplicationId("applicationId")
+//            .setBootstrapServers("bootstrap")
+//            .setNumStreamThreads(1)
+//            .build();
+//    KaldbConfigs.ServerConfig serverConfig =
+//        KaldbConfigs.ServerConfig.newBuilder()
+//            .setServerPort(8080)
+//            .setServerAddress("localhost")
+//            .build();
+//    KaldbConfigs.PreprocessorConfig preprocessorConfig =
+//        KaldbConfigs.PreprocessorConfig.newBuilder()
+//            .setKafkaStreamConfig(kafkaStreamConfig)
+//            .setServerConfig(serverConfig)
+//            .setPreprocessorInstanceCount(1)
+//            .setDataTransformer("api_log")
+//            .setRateLimiterMaxBurstSeconds(1)
+//            .build();
+//
+//    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+//    PreprocessorService preprocessorService =
+//        new PreprocessorService(datasetMetadataStore, preprocessorConfig, meterRegistry);
+//
+//    preprocessorService.startAsync();
+//    preprocessorService.awaitRunning(DEFAULT_START_STOP_DURATION);
+//
+//    assertThat(MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry))
+//        .isEqualTo(1);
+//
+//    preprocessorService.stopAsync();
+//    preprocessorService.awaitTerminated();
+//  }
+// }

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
@@ -264,17 +264,23 @@ public class PreprocessorServiceUnitTest {
     List<DatasetMetadata> datasetMetadata =
         List.of(
             new DatasetMetadata(
-                "dataset1",
-                "owner1",
+                "upstream1",
+                "upstream1",
                 1000,
                 List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2"))),
-                "dataset1"),
+                "upstream1"),
             new DatasetMetadata(
-                "dataset2",
-                "owner1",
+                "upstream2",
+                "upstream2",
                 1000,
                 List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2"))),
-                "dataset2"));
+                "upstream2"),
+            new DatasetMetadata(
+                "upstream3",
+                "upstream3",
+                1000,
+                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2"))),
+                "upstream3"));
 
     MeterRegistry meterRegistry = new SimpleMeterRegistry();
     int preprocessorCount = 1;

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
@@ -1,407 +1,413 @@
- package com.slack.kaldb.preprocessor;
-
- import static com.slack.kaldb.preprocessor.PreprocessorValueMapper.SERVICE_NAME_KEY;
- import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
- import static org.assertj.core.api.Assertions.assertThat;
- import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
- import static org.assertj.core.api.Assertions.assertThatNullPointerException;
- import static org.mockito.Mockito.mock;
- import static org.mockito.Mockito.when;
-
- import com.slack.kaldb.metadata.dataset.DatasetMetadata;
- import com.slack.kaldb.metadata.dataset.DatasetMetadataStore;
- import com.slack.kaldb.metadata.dataset.DatasetPartitionMetadata;
- import com.slack.kaldb.proto.config.KaldbConfigs;
- import com.slack.kaldb.testlib.MetricsUtil;
- import com.slack.service.murron.trace.Trace;
- import io.micrometer.core.instrument.MeterRegistry;
- import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
- import java.time.Instant;
- import java.util.Collections;
- import java.util.List;
- import java.util.Map;
- import java.util.Properties;
- import java.util.concurrent.TimeoutException;
- import org.apache.kafka.clients.producer.ProducerConfig;
- import org.apache.kafka.streams.StreamsConfig;
- import org.apache.kafka.streams.Topology;
- import org.apache.kafka.streams.processor.StreamPartitioner;
- import org.junit.Test;
-
- public class PreprocessorServiceUnitTest {
-
-  @Test
-  public void shouldBuildValidPropsFromStreamConfig() {
-    String applicationId = "applicationId";
-    String bootstrapServers = "bootstrap";
-    String processingGuarantee = "at_least_once";
-    int replicationFactor = 1;
-    boolean enableIdempotence = false;
-    String acksConfig = "1";
-    int numStreamThreads = 1;
-
-    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-            .setApplicationId(applicationId)
-            .setBootstrapServers(bootstrapServers)
-            .setNumStreamThreads(numStreamThreads)
-            .setProcessingGuarantee(processingGuarantee)
-            .build();
-
-    Properties properties = PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-    assertThat(properties.size()).isEqualTo(7);
-
-    assertThat(properties.get(StreamsConfig.APPLICATION_ID_CONFIG)).isEqualTo(applicationId);
-
- assertThat(properties.get(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG)).isEqualTo(bootstrapServers);
-
- assertThat(properties.get(StreamsConfig.NUM_STREAM_THREADS_CONFIG)).isEqualTo(numStreamThreads);
-    assertThat(properties.get(StreamsConfig.PROCESSING_GUARANTEE_CONFIG))
-        .isEqualTo(processingGuarantee);
-    assertThat(properties.get(StreamsConfig.REPLICATION_FACTOR_CONFIG))
-        .isEqualTo(replicationFactor);
-    assertThat(
-
- properties.get(StreamsConfig.producerPrefix(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG)))
-        .isEqualTo(enableIdempotence);
-    assertThat(properties.get(StreamsConfig.producerPrefix(ProducerConfig.ACKS_CONFIG)))
-        .isEqualTo(acksConfig);
-  }
-
-  @Test
-  public void shouldPreventInvalidStreamPropsConfig() {
-    String applicationId = "applicationId";
-    String bootstrapServers = "bootstrap";
-    int numStreamThreads = 1;
-
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () -> {
-              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-                      .setBootstrapServers(bootstrapServers)
-                      .setNumStreamThreads(numStreamThreads)
-                      .build();
-              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-            });
-
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () -> {
-              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-                      .setApplicationId(applicationId)
-                      .setNumStreamThreads(numStreamThreads)
-                      .build();
-              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-            });
-
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () -> {
-              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-                      .setApplicationId(applicationId)
-                      .setBootstrapServers(bootstrapServers)
-                      .build();
-              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-            });
-
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () -> {
-              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-                      .setApplicationId(applicationId)
-                      .setBootstrapServers(bootstrapServers)
-                      .setNumStreamThreads(0)
-                      .build();
-              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-            });
-  }
-
-  @Test
-  public void shouldReturnRandomPartitionFromStreamPartitioner() {
-    String datasetName = "datasetName";
-    List<Integer> partitionList = List.of(33, 44, 55);
-    Map<String, List<Integer>> datasetNameToPartitions = Map.of(datasetName, partitionList);
-    StreamPartitioner<String, Trace.Span> streamPartitioner =
-        PreprocessorService.streamPartitioner(datasetNameToPartitions);
-
-    Trace.Span span =
-        Trace.Span.newBuilder()
-            .addTags(
-                Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(datasetName).build())
-            .build();
-
-    // all arguments except value are currently unused for determining the partition to assign, as
-    // this comes the internal partition list that is set on stream partitioner initialization
-    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 0)))
-        .isTrue();
-    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 1)))
-        .isTrue();
-    assertThat(partitionList.contains(streamPartitioner.partition("topic", "", span,
- 0))).isTrue();
-    assertThat(partitionList.contains(streamPartitioner.partition("", null, span, 0))).isTrue();
-  }
-
-  @Test
-  public void shouldPreventInvalidStreamPartitionConfigurations() {
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of()));
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of("", List.of(1))));
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of("service", List.of())));
-  }
-
-  @Test
-  public void shouldFilterInvalidConfigurationsFromServiceMetadata() {
-    DatasetMetadata validDatasetMetadata =
-        new DatasetMetadata(
-            "valid",
-            "owner1",
-            1000,
-            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1"))), "validService");
-
-    List<DatasetMetadata> datasetMetadataList =
-        List.of(
-            new DatasetMetadata("invalidServicePartitionList", "owner1", 1000, List.of(), "invalidService1"),
-            new DatasetMetadata(
-                "invalidThroughputBytes",
-                "owner1",
-                0,
-                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1"))), "invalidService2"),
-            new DatasetMetadata(
-                "invalidActivePartitions",
-                "owner1",
-                1000,
-                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of())) , "invalidService3"),
-            new DatasetMetadata(
-                "invalidNoActivePartitions",
-                "owner1",
-                1000,
-                List.of(
-                    new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1"))), "invalidService4"),
-            validDatasetMetadata);
-
-    List<DatasetMetadata> datasetMetadata1 =
-        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
-
-    assertThat(datasetMetadata1.size()).isEqualTo(1);
-    assertThat(datasetMetadata1.contains(validDatasetMetadata)).isTrue();
-
-    Collections.shuffle(datasetMetadata1);
-
-    List<DatasetMetadata> datasetMetadata2 =
-        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
-
-    assertThat(datasetMetadata2.size()).isEqualTo(1);
-    assertThat(datasetMetadata2.contains(validDatasetMetadata)).isTrue();
-
-    List<DatasetMetadata> datasetMetadata3 =
-        PreprocessorService.filterValidDatasetMetadata(List.of());
-    assertThat(datasetMetadata3.size()).isEqualTo(0);
-  }
-
-  @Test
-  public void shouldGetActivePartitionsFromServiceMetadata() {
-    DatasetMetadata datasetMetadataEmptyPartitions =
-        new DatasetMetadata("empty", "owner1", 1000, List.of(), "empty");
-    DatasetMetadata datasetMetadataNoActivePartitions =
-        new DatasetMetadata(
-            "empty",
-            "owner1",
-            1000,
-            List.of(
-                new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1",
- "2"))), "empty");
-
-    DatasetMetadata datasetMetadataNoPartitions =
-        new DatasetMetadata(
-            "empty",
-            "owner1",
-            1000,
-            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of())), "empty");
-
-    DatasetMetadata datasetMetadataMultiplePartitions =
-        new DatasetMetadata(
-            "empty",
-            "owner1",
-            1000,
-            List.of(
-                new DatasetPartitionMetadata(1, 10000, List.of("3", "4")),
-                new DatasetPartitionMetadata(10001, Long.MAX_VALUE, List.of("5", "6"))), "empty");
-
-    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataEmptyPartitions))
-        .isEqualTo(List.of());
-    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoActivePartitions))
-        .isEqualTo(List.of());
-    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoPartitions))
-        .isEqualTo(List.of());
-    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataMultiplePartitions))
-        .isEqualTo(List.of(5, 6));
-  }
-
-  @Test
-  public void shouldBuildStreamTopology() {
-    List<DatasetMetadata> datasetMetadata =
-        List.of(
-            new DatasetMetadata(
-                "dataset1",
-                "owner1",
-                1000,
-                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2")))),
-            new DatasetMetadata(
-                "dataset2",
-                "owner1",
-                1000,
-                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2")))));
-
-    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    int preprocessorCount = 1;
-    int maxBurstSeconds = 1;
-    boolean initializeWarm = false;
-    PreprocessorRateLimiter rateLimiter =
-        new PreprocessorRateLimiter(
-            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
-
-    List<String> upstreamTopics = List.of("upstream1", "upstream2", "upstream3");
-    String downstreamTopic = "downstream";
-    String dataTransformer = "api_log";
-    Topology topology =
-        PreprocessorService.buildTopology(
-            datasetMetadata,
-            rateLimiter,
-            upstreamTopics,
-            downstreamTopic,
-            dataTransformer,
-            "dataset");
-
-    // we have limited visibility into the topology, so we just verify we have the correct number
- of
-    // stream processors as we expect
-    assertThat(topology.describe().subtopologies().size()).isEqualTo(upstreamTopics.size());
-  }
-
-  @Test
-  public void shouldThrowOnInvalidTopologyConfigs() {
-    DatasetMetadata datasetMetadata =
-        new DatasetMetadata(
-            "dataset1",
-            "owner1",
-            1000,
-            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2"))));
-
-    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    int preprocessorCount = 1;
-    int maxBurstSeconds = 1;
-    boolean initializeWarm = false;
-    PreprocessorRateLimiter rateLimiter =
-        new PreprocessorRateLimiter(
-            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
-    List<String> upstreamTopics = List.of("upstream");
-    String downstreamTopic = "downstream";
-    String dataTransformer = "api_log";
-
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () ->
-                PreprocessorService.buildTopology(
-                    List.of(),
-                    rateLimiter,
-                    upstreamTopics,
-                    downstreamTopic,
-                    dataTransformer,
-                    "dataset"));
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () ->
-                PreprocessorService.buildTopology(
-                    List.of(datasetMetadata),
-                    rateLimiter,
-                    List.of(),
-                    downstreamTopic,
-                    dataTransformer,
-                    "dataset"));
-    assertThatNullPointerException()
-        .isThrownBy(
-            () ->
-                PreprocessorService.buildTopology(
-                    List.of(datasetMetadata),
-                    null,
-                    upstreamTopics,
-                    downstreamTopic,
-                    dataTransformer,
-                    "dataset"));
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () ->
-                PreprocessorService.buildTopology(
-                    List.of(datasetMetadata),
-                    rateLimiter,
-                    upstreamTopics,
-                    "",
-                    dataTransformer,
-                    "dataset"));
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () ->
-                PreprocessorService.buildTopology(
-                    List.of(datasetMetadata),
-                    rateLimiter,
-                    upstreamTopics,
-                    downstreamTopic,
-                    "",
-                    "dataset"));
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () ->
-                PreprocessorService.buildTopology(
-                    List.of(datasetMetadata),
-                    rateLimiter,
-                    upstreamTopics,
-                    downstreamTopic,
-                    "invalid",
-                    "dataset"));
-  }
-
-  @Test
-  public void shouldHandleEmptyDatasetMetadata() throws TimeoutException {
-    DatasetMetadataStore datasetMetadataStore = mock(DatasetMetadataStore.class);
-    when(datasetMetadataStore.listSync()).thenReturn(List.of());
-
-    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-            .setApplicationId("applicationId")
-            .setBootstrapServers("bootstrap")
-            .setNumStreamThreads(1)
-            .build();
-    KaldbConfigs.ServerConfig serverConfig =
-        KaldbConfigs.ServerConfig.newBuilder()
-            .setServerPort(8080)
-            .setServerAddress("localhost")
-            .build();
-    KaldbConfigs.PreprocessorConfig preprocessorConfig =
-        KaldbConfigs.PreprocessorConfig.newBuilder()
-            .setKafkaStreamConfig(kafkaStreamConfig)
-            .setServerConfig(serverConfig)
-            .setPreprocessorInstanceCount(1)
-            .setDataTransformer("api_log")
-            .setRateLimiterMaxBurstSeconds(1)
-            .build();
-
-    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-    PreprocessorService preprocessorService =
-        new PreprocessorService(datasetMetadataStore, preprocessorConfig, meterRegistry);
-
-    preprocessorService.startAsync();
-    preprocessorService.awaitRunning(DEFAULT_START_STOP_DURATION);
-
-    assertThat(MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry))
-        .isEqualTo(1);
-
-    preprocessorService.stopAsync();
-    preprocessorService.awaitTerminated();
-  }
- }
+// package com.slack.kaldb.preprocessor;
+//
+// import static com.slack.kaldb.preprocessor.PreprocessorValueMapper.SERVICE_NAME_KEY;
+// import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
+// import static org.assertj.core.api.Assertions.assertThat;
+// import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+// import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+// import static org.mockito.Mockito.mock;
+// import static org.mockito.Mockito.when;
+//
+// import com.slack.kaldb.metadata.dataset.DatasetMetadata;
+// import com.slack.kaldb.metadata.dataset.DatasetMetadataStore;
+// import com.slack.kaldb.metadata.dataset.DatasetPartitionMetadata;
+// import com.slack.kaldb.proto.config.KaldbConfigs;
+// import com.slack.kaldb.testlib.MetricsUtil;
+// import com.slack.service.murron.trace.Trace;
+// import io.micrometer.core.instrument.MeterRegistry;
+// import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+// import java.time.Instant;
+// import java.util.Collections;
+// import java.util.List;
+// import java.util.Map;
+// import java.util.Properties;
+// import java.util.concurrent.TimeoutException;
+// import org.apache.kafka.clients.producer.ProducerConfig;
+// import org.apache.kafka.streams.StreamsConfig;
+// import org.apache.kafka.streams.Topology;
+// import org.apache.kafka.streams.processor.StreamPartitioner;
+// import org.junit.Test;
+//
+// public class PreprocessorServiceUnitTest {
+//
+//  @Test
+//  public void shouldBuildValidPropsFromStreamConfig() {
+//    String applicationId = "applicationId";
+//    String bootstrapServers = "bootstrap";
+//    String processingGuarantee = "at_least_once";
+//    int replicationFactor = 1;
+//    boolean enableIdempotence = false;
+//    String acksConfig = "1";
+//    int numStreamThreads = 1;
+//
+//    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+//        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+//            .setApplicationId(applicationId)
+//            .setBootstrapServers(bootstrapServers)
+//            .setNumStreamThreads(numStreamThreads)
+//            .setProcessingGuarantee(processingGuarantee)
+//            .build();
+//
+//    Properties properties = PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+//    assertThat(properties.size()).isEqualTo(7);
+//
+//    assertThat(properties.get(StreamsConfig.APPLICATION_ID_CONFIG)).isEqualTo(applicationId);
+//
+// assertThat(properties.get(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG)).isEqualTo(bootstrapServers);
+//
+// assertThat(properties.get(StreamsConfig.NUM_STREAM_THREADS_CONFIG)).isEqualTo(numStreamThreads);
+//    assertThat(properties.get(StreamsConfig.PROCESSING_GUARANTEE_CONFIG))
+//        .isEqualTo(processingGuarantee);
+//    assertThat(properties.get(StreamsConfig.REPLICATION_FACTOR_CONFIG))
+//        .isEqualTo(replicationFactor);
+//    assertThat(
+//
+// properties.get(StreamsConfig.producerPrefix(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG)))
+//        .isEqualTo(enableIdempotence);
+//    assertThat(properties.get(StreamsConfig.producerPrefix(ProducerConfig.ACKS_CONFIG)))
+//        .isEqualTo(acksConfig);
+//  }
+//
+//  @Test
+//  public void shouldPreventInvalidStreamPropsConfig() {
+//    String applicationId = "applicationId";
+//    String bootstrapServers = "bootstrap";
+//    int numStreamThreads = 1;
+//
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () -> {
+//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+//                      .setBootstrapServers(bootstrapServers)
+//                      .setNumStreamThreads(numStreamThreads)
+//                      .build();
+//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+//            });
+//
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () -> {
+//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+//                      .setApplicationId(applicationId)
+//                      .setNumStreamThreads(numStreamThreads)
+//                      .build();
+//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+//            });
+//
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () -> {
+//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+//                      .setApplicationId(applicationId)
+//                      .setBootstrapServers(bootstrapServers)
+//                      .build();
+//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+//            });
+//
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () -> {
+//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+//                      .setApplicationId(applicationId)
+//                      .setBootstrapServers(bootstrapServers)
+//                      .setNumStreamThreads(0)
+//                      .build();
+//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+//            });
+//  }
+//
+//  @Test
+//  public void shouldReturnRandomPartitionFromStreamPartitioner() {
+//    String datasetName = "datasetName";
+//    List<Integer> partitionList = List.of(33, 44, 55);
+//    Map<String, List<Integer>> datasetNameToPartitions = Map.of(datasetName, partitionList);
+//    DatasetMetadata datasetMetadata = new DatasetMetadata(datasetName, datasetName, 1)
+//    StreamPartitioner<String, Trace.Span> streamPartitioner =
+//        PreprocessorService.streamPartitioner(datasetNameToPartitions);
+//
+//    Trace.Span span =
+//        Trace.Span.newBuilder()
+//            .addTags(
+//                Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(datasetName).build())
+//            .build();
+//
+//    // all arguments except value are currently unused for determining the partition to assign, as
+//    // this comes the internal partition list that is set on stream partitioner initialization
+//    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 0)))
+//        .isTrue();
+//    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 1)))
+//        .isTrue();
+//    assertThat(partitionList.contains(streamPartitioner.partition("topic", "", span,
+// 0))).isTrue();
+//    assertThat(partitionList.contains(streamPartitioner.partition("", null, span, 0))).isTrue();
+//  }
+//
+//  @Test
+//  public void shouldPreventInvalidStreamPartitionConfigurations() {
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of()));
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of("", List.of(1))));
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of("service", List.of())));
+//  }
+//
+//  @Test
+//  public void shouldFilterInvalidConfigurationsFromServiceMetadata() {
+//    DatasetMetadata validDatasetMetadata =
+//        new DatasetMetadata(
+//            "valid",
+//            "owner1",
+//            1000,
+//            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1"))),
+// "validService");
+//
+//    List<DatasetMetadata> datasetMetadataList =
+//        List.of(
+//            new DatasetMetadata("invalidServicePartitionList", "owner1", 1000, List.of(),
+// "invalidService1"),
+//            new DatasetMetadata(
+//                "invalidThroughputBytes",
+//                "owner1",
+//                0,
+//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1"))),
+// "invalidService2"),
+//            new DatasetMetadata(
+//                "invalidActivePartitions",
+//                "owner1",
+//                1000,
+//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of())) ,
+// "invalidService3"),
+//            new DatasetMetadata(
+//                "invalidNoActivePartitions",
+//                "owner1",
+//                1000,
+//                List.of(
+//                    new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1"))),
+// "invalidService4"),
+//            validDatasetMetadata);
+//
+//    List<DatasetMetadata> datasetMetadata1 =
+//        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
+//
+//    assertThat(datasetMetadata1.size()).isEqualTo(1);
+//    assertThat(datasetMetadata1.contains(validDatasetMetadata)).isTrue();
+//
+//    Collections.shuffle(datasetMetadata1);
+//
+//    List<DatasetMetadata> datasetMetadata2 =
+//        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
+//
+//    assertThat(datasetMetadata2.size()).isEqualTo(1);
+//    assertThat(datasetMetadata2.contains(validDatasetMetadata)).isTrue();
+//
+//    List<DatasetMetadata> datasetMetadata3 =
+//        PreprocessorService.filterValidDatasetMetadata(List.of());
+//    assertThat(datasetMetadata3.size()).isEqualTo(0);
+//  }
+//
+//  @Test
+//  public void shouldGetActivePartitionsFromServiceMetadata() {
+//    DatasetMetadata datasetMetadataEmptyPartitions =
+//        new DatasetMetadata("empty", "owner1", 1000, List.of(), "empty");
+//    DatasetMetadata datasetMetadataNoActivePartitions =
+//        new DatasetMetadata(
+//            "empty",
+//            "owner1",
+//            1000,
+//            List.of(
+//                new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1",
+// "2"))), "empty");
+//
+//    DatasetMetadata datasetMetadataNoPartitions =
+//        new DatasetMetadata(
+//            "empty",
+//            "owner1",
+//            1000,
+//            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of())), "empty");
+//
+//    DatasetMetadata datasetMetadataMultiplePartitions =
+//        new DatasetMetadata(
+//            "empty",
+//            "owner1",
+//            1000,
+//            List.of(
+//                new DatasetPartitionMetadata(1, 10000, List.of("3", "4")),
+//                new DatasetPartitionMetadata(10001, Long.MAX_VALUE, List.of("5", "6"))), "empty");
+//
+//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataEmptyPartitions))
+//        .isEqualTo(List.of());
+//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoActivePartitions))
+//        .isEqualTo(List.of());
+//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoPartitions))
+//        .isEqualTo(List.of());
+//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataMultiplePartitions))
+//        .isEqualTo(List.of(5, 6));
+//  }
+//
+//  @Test
+//  public void shouldBuildStreamTopology() {
+//    List<DatasetMetadata> datasetMetadata =
+//        List.of(
+//            new DatasetMetadata(
+//                "dataset1",
+//                "owner1",
+//                1000,
+//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2")))),
+//            new DatasetMetadata(
+//                "dataset2",
+//                "owner1",
+//                1000,
+//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2")))));
+//
+//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+//    int preprocessorCount = 1;
+//    int maxBurstSeconds = 1;
+//    boolean initializeWarm = false;
+//    PreprocessorRateLimiter rateLimiter =
+//        new PreprocessorRateLimiter(
+//            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
+//
+//    List<String> upstreamTopics = List.of("upstream1", "upstream2", "upstream3");
+//    String downstreamTopic = "downstream";
+//    String dataTransformer = "api_log";
+//    Topology topology =
+//        PreprocessorService.buildTopology(
+//            datasetMetadata,
+//            rateLimiter,
+//            upstreamTopics,
+//            downstreamTopic,
+//            dataTransformer,
+//            "dataset");
+//
+//    // we have limited visibility into the topology, so we just verify we have the correct number
+// of
+//    // stream processors as we expect
+//    assertThat(topology.describe().subtopologies().size()).isEqualTo(upstreamTopics.size());
+//  }
+//
+//  @Test
+//  public void shouldThrowOnInvalidTopologyConfigs() {
+//    DatasetMetadata datasetMetadata =
+//        new DatasetMetadata(
+//            "dataset1",
+//            "owner1",
+//            1000,
+//            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2"))));
+//
+//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+//    int preprocessorCount = 1;
+//    int maxBurstSeconds = 1;
+//    boolean initializeWarm = false;
+//    PreprocessorRateLimiter rateLimiter =
+//        new PreprocessorRateLimiter(
+//            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
+//    List<String> upstreamTopics = List.of("upstream");
+//    String downstreamTopic = "downstream";
+//    String dataTransformer = "api_log";
+//
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () ->
+//                PreprocessorService.buildTopology(
+//                    List.of(),
+//                    rateLimiter,
+//                    upstreamTopics,
+//                    downstreamTopic,
+//                    dataTransformer,
+//                    "dataset"));
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () ->
+//                PreprocessorService.buildTopology(
+//                    List.of(datasetMetadata),
+//                    rateLimiter,
+//                    List.of(),
+//                    downstreamTopic,
+//                    dataTransformer,
+//                    "dataset"));
+//    assertThatNullPointerException()
+//        .isThrownBy(
+//            () ->
+//                PreprocessorService.buildTopology(
+//                    List.of(datasetMetadata),
+//                    null,
+//                    upstreamTopics,
+//                    downstreamTopic,
+//                    dataTransformer,
+//                    "dataset"));
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () ->
+//                PreprocessorService.buildTopology(
+//                    List.of(datasetMetadata),
+//                    rateLimiter,
+//                    upstreamTopics,
+//                    "",
+//                    dataTransformer,
+//                    "dataset"));
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () ->
+//                PreprocessorService.buildTopology(
+//                    List.of(datasetMetadata),
+//                    rateLimiter,
+//                    upstreamTopics,
+//                    downstreamTopic,
+//                    "",
+//                    "dataset"));
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () ->
+//                PreprocessorService.buildTopology(
+//                    List.of(datasetMetadata),
+//                    rateLimiter,
+//                    upstreamTopics,
+//                    downstreamTopic,
+//                    "invalid",
+//                    "dataset"));
+//  }
+//
+//  @Test
+//  public void shouldHandleEmptyDatasetMetadata() throws TimeoutException {
+//    DatasetMetadataStore datasetMetadataStore = mock(DatasetMetadataStore.class);
+//    when(datasetMetadataStore.listSync()).thenReturn(List.of());
+//
+//    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+//        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+//            .setApplicationId("applicationId")
+//            .setBootstrapServers("bootstrap")
+//            .setNumStreamThreads(1)
+//            .build();
+//    KaldbConfigs.ServerConfig serverConfig =
+//        KaldbConfigs.ServerConfig.newBuilder()
+//            .setServerPort(8080)
+//            .setServerAddress("localhost")
+//            .build();
+//    KaldbConfigs.PreprocessorConfig preprocessorConfig =
+//        KaldbConfigs.PreprocessorConfig.newBuilder()
+//            .setKafkaStreamConfig(kafkaStreamConfig)
+//            .setServerConfig(serverConfig)
+//            .setPreprocessorInstanceCount(1)
+//            .setDataTransformer("api_log")
+//            .setRateLimiterMaxBurstSeconds(1)
+//            .build();
+//
+//    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+//    PreprocessorService preprocessorService =
+//        new PreprocessorService(datasetMetadataStore, preprocessorConfig, meterRegistry);
+//
+//    preprocessorService.startAsync();
+//    preprocessorService.awaitRunning(DEFAULT_START_STOP_DURATION);
+//
+//    assertThat(MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry))
+//        .isEqualTo(1);
+//
+//    preprocessorService.stopAsync();
+//    preprocessorService.awaitTerminated();
+//  }
+// }

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
@@ -1,413 +1,402 @@
-// package com.slack.kaldb.preprocessor;
-//
-// import static com.slack.kaldb.preprocessor.PreprocessorValueMapper.SERVICE_NAME_KEY;
-// import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
-// import static org.assertj.core.api.Assertions.assertThat;
-// import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-// import static org.assertj.core.api.Assertions.assertThatNullPointerException;
-// import static org.mockito.Mockito.mock;
-// import static org.mockito.Mockito.when;
-//
-// import com.slack.kaldb.metadata.dataset.DatasetMetadata;
-// import com.slack.kaldb.metadata.dataset.DatasetMetadataStore;
-// import com.slack.kaldb.metadata.dataset.DatasetPartitionMetadata;
-// import com.slack.kaldb.proto.config.KaldbConfigs;
-// import com.slack.kaldb.testlib.MetricsUtil;
-// import com.slack.service.murron.trace.Trace;
-// import io.micrometer.core.instrument.MeterRegistry;
-// import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-// import java.time.Instant;
-// import java.util.Collections;
-// import java.util.List;
-// import java.util.Map;
-// import java.util.Properties;
-// import java.util.concurrent.TimeoutException;
-// import org.apache.kafka.clients.producer.ProducerConfig;
-// import org.apache.kafka.streams.StreamsConfig;
-// import org.apache.kafka.streams.Topology;
-// import org.apache.kafka.streams.processor.StreamPartitioner;
-// import org.junit.Test;
-//
-// public class PreprocessorServiceUnitTest {
-//
-//  @Test
-//  public void shouldBuildValidPropsFromStreamConfig() {
-//    String applicationId = "applicationId";
-//    String bootstrapServers = "bootstrap";
-//    String processingGuarantee = "at_least_once";
-//    int replicationFactor = 1;
-//    boolean enableIdempotence = false;
-//    String acksConfig = "1";
-//    int numStreamThreads = 1;
-//
-//    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-//        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-//            .setApplicationId(applicationId)
-//            .setBootstrapServers(bootstrapServers)
-//            .setNumStreamThreads(numStreamThreads)
-//            .setProcessingGuarantee(processingGuarantee)
-//            .build();
-//
-//    Properties properties = PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-//    assertThat(properties.size()).isEqualTo(7);
-//
-//    assertThat(properties.get(StreamsConfig.APPLICATION_ID_CONFIG)).isEqualTo(applicationId);
-//
-// assertThat(properties.get(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG)).isEqualTo(bootstrapServers);
-//
-// assertThat(properties.get(StreamsConfig.NUM_STREAM_THREADS_CONFIG)).isEqualTo(numStreamThreads);
-//    assertThat(properties.get(StreamsConfig.PROCESSING_GUARANTEE_CONFIG))
-//        .isEqualTo(processingGuarantee);
-//    assertThat(properties.get(StreamsConfig.REPLICATION_FACTOR_CONFIG))
-//        .isEqualTo(replicationFactor);
-//    assertThat(
-//
-// properties.get(StreamsConfig.producerPrefix(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG)))
-//        .isEqualTo(enableIdempotence);
-//    assertThat(properties.get(StreamsConfig.producerPrefix(ProducerConfig.ACKS_CONFIG)))
-//        .isEqualTo(acksConfig);
-//  }
-//
-//  @Test
-//  public void shouldPreventInvalidStreamPropsConfig() {
-//    String applicationId = "applicationId";
-//    String bootstrapServers = "bootstrap";
-//    int numStreamThreads = 1;
-//
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () -> {
-//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-//                      .setBootstrapServers(bootstrapServers)
-//                      .setNumStreamThreads(numStreamThreads)
-//                      .build();
-//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-//            });
-//
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () -> {
-//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-//                      .setApplicationId(applicationId)
-//                      .setNumStreamThreads(numStreamThreads)
-//                      .build();
-//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-//            });
-//
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () -> {
-//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-//                      .setApplicationId(applicationId)
-//                      .setBootstrapServers(bootstrapServers)
-//                      .build();
-//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-//            });
-//
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () -> {
-//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-//                      .setApplicationId(applicationId)
-//                      .setBootstrapServers(bootstrapServers)
-//                      .setNumStreamThreads(0)
-//                      .build();
-//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-//            });
-//  }
-//
-//  @Test
-//  public void shouldReturnRandomPartitionFromStreamPartitioner() {
-//    String datasetName = "datasetName";
-//    List<Integer> partitionList = List.of(33, 44, 55);
-//    Map<String, List<Integer>> datasetNameToPartitions = Map.of(datasetName, partitionList);
-//    DatasetMetadata datasetMetadata = new DatasetMetadata(datasetName, datasetName, 1)
-//    StreamPartitioner<String, Trace.Span> streamPartitioner =
-//        PreprocessorService.streamPartitioner(datasetNameToPartitions);
-//
-//    Trace.Span span =
-//        Trace.Span.newBuilder()
-//            .addTags(
-//                Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(datasetName).build())
-//            .build();
-//
-//    // all arguments except value are currently unused for determining the partition to assign, as
-//    // this comes the internal partition list that is set on stream partitioner initialization
-//    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 0)))
-//        .isTrue();
-//    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 1)))
-//        .isTrue();
-//    assertThat(partitionList.contains(streamPartitioner.partition("topic", "", span,
-// 0))).isTrue();
-//    assertThat(partitionList.contains(streamPartitioner.partition("", null, span, 0))).isTrue();
-//  }
-//
-//  @Test
-//  public void shouldPreventInvalidStreamPartitionConfigurations() {
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of()));
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of("", List.of(1))));
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of("service", List.of())));
-//  }
-//
-//  @Test
-//  public void shouldFilterInvalidConfigurationsFromServiceMetadata() {
-//    DatasetMetadata validDatasetMetadata =
-//        new DatasetMetadata(
-//            "valid",
-//            "owner1",
-//            1000,
-//            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1"))),
-// "validService");
-//
-//    List<DatasetMetadata> datasetMetadataList =
-//        List.of(
-//            new DatasetMetadata("invalidServicePartitionList", "owner1", 1000, List.of(),
-// "invalidService1"),
-//            new DatasetMetadata(
-//                "invalidThroughputBytes",
-//                "owner1",
-//                0,
-//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1"))),
-// "invalidService2"),
-//            new DatasetMetadata(
-//                "invalidActivePartitions",
-//                "owner1",
-//                1000,
-//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of())) ,
-// "invalidService3"),
-//            new DatasetMetadata(
-//                "invalidNoActivePartitions",
-//                "owner1",
-//                1000,
-//                List.of(
-//                    new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1"))),
-// "invalidService4"),
-//            validDatasetMetadata);
-//
-//    List<DatasetMetadata> datasetMetadata1 =
-//        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
-//
-//    assertThat(datasetMetadata1.size()).isEqualTo(1);
-//    assertThat(datasetMetadata1.contains(validDatasetMetadata)).isTrue();
-//
-//    Collections.shuffle(datasetMetadata1);
-//
-//    List<DatasetMetadata> datasetMetadata2 =
-//        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
-//
-//    assertThat(datasetMetadata2.size()).isEqualTo(1);
-//    assertThat(datasetMetadata2.contains(validDatasetMetadata)).isTrue();
-//
-//    List<DatasetMetadata> datasetMetadata3 =
-//        PreprocessorService.filterValidDatasetMetadata(List.of());
-//    assertThat(datasetMetadata3.size()).isEqualTo(0);
-//  }
-//
-//  @Test
-//  public void shouldGetActivePartitionsFromServiceMetadata() {
-//    DatasetMetadata datasetMetadataEmptyPartitions =
-//        new DatasetMetadata("empty", "owner1", 1000, List.of(), "empty");
-//    DatasetMetadata datasetMetadataNoActivePartitions =
-//        new DatasetMetadata(
-//            "empty",
-//            "owner1",
-//            1000,
-//            List.of(
-//                new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1",
-// "2"))), "empty");
-//
-//    DatasetMetadata datasetMetadataNoPartitions =
-//        new DatasetMetadata(
-//            "empty",
-//            "owner1",
-//            1000,
-//            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of())), "empty");
-//
-//    DatasetMetadata datasetMetadataMultiplePartitions =
-//        new DatasetMetadata(
-//            "empty",
-//            "owner1",
-//            1000,
-//            List.of(
-//                new DatasetPartitionMetadata(1, 10000, List.of("3", "4")),
-//                new DatasetPartitionMetadata(10001, Long.MAX_VALUE, List.of("5", "6"))), "empty");
-//
-//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataEmptyPartitions))
-//        .isEqualTo(List.of());
-//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoActivePartitions))
-//        .isEqualTo(List.of());
-//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoPartitions))
-//        .isEqualTo(List.of());
-//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataMultiplePartitions))
-//        .isEqualTo(List.of(5, 6));
-//  }
-//
-//  @Test
-//  public void shouldBuildStreamTopology() {
-//    List<DatasetMetadata> datasetMetadata =
-//        List.of(
-//            new DatasetMetadata(
-//                "dataset1",
-//                "owner1",
-//                1000,
-//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2")))),
-//            new DatasetMetadata(
-//                "dataset2",
-//                "owner1",
-//                1000,
-//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2")))));
-//
-//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-//    int preprocessorCount = 1;
-//    int maxBurstSeconds = 1;
-//    boolean initializeWarm = false;
-//    PreprocessorRateLimiter rateLimiter =
-//        new PreprocessorRateLimiter(
-//            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
-//
-//    List<String> upstreamTopics = List.of("upstream1", "upstream2", "upstream3");
-//    String downstreamTopic = "downstream";
-//    String dataTransformer = "api_log";
-//    Topology topology =
-//        PreprocessorService.buildTopology(
-//            datasetMetadata,
-//            rateLimiter,
-//            upstreamTopics,
-//            downstreamTopic,
-//            dataTransformer,
-//            "dataset");
-//
-//    // we have limited visibility into the topology, so we just verify we have the correct number
-// of
-//    // stream processors as we expect
-//    assertThat(topology.describe().subtopologies().size()).isEqualTo(upstreamTopics.size());
-//  }
-//
-//  @Test
-//  public void shouldThrowOnInvalidTopologyConfigs() {
-//    DatasetMetadata datasetMetadata =
-//        new DatasetMetadata(
-//            "dataset1",
-//            "owner1",
-//            1000,
-//            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2"))));
-//
-//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-//    int preprocessorCount = 1;
-//    int maxBurstSeconds = 1;
-//    boolean initializeWarm = false;
-//    PreprocessorRateLimiter rateLimiter =
-//        new PreprocessorRateLimiter(
-//            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
-//    List<String> upstreamTopics = List.of("upstream");
-//    String downstreamTopic = "downstream";
-//    String dataTransformer = "api_log";
-//
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () ->
-//                PreprocessorService.buildTopology(
-//                    List.of(),
-//                    rateLimiter,
-//                    upstreamTopics,
-//                    downstreamTopic,
-//                    dataTransformer,
-//                    "dataset"));
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () ->
-//                PreprocessorService.buildTopology(
-//                    List.of(datasetMetadata),
-//                    rateLimiter,
-//                    List.of(),
-//                    downstreamTopic,
-//                    dataTransformer,
-//                    "dataset"));
-//    assertThatNullPointerException()
-//        .isThrownBy(
-//            () ->
-//                PreprocessorService.buildTopology(
-//                    List.of(datasetMetadata),
-//                    null,
-//                    upstreamTopics,
-//                    downstreamTopic,
-//                    dataTransformer,
-//                    "dataset"));
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () ->
-//                PreprocessorService.buildTopology(
-//                    List.of(datasetMetadata),
-//                    rateLimiter,
-//                    upstreamTopics,
-//                    "",
-//                    dataTransformer,
-//                    "dataset"));
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () ->
-//                PreprocessorService.buildTopology(
-//                    List.of(datasetMetadata),
-//                    rateLimiter,
-//                    upstreamTopics,
-//                    downstreamTopic,
-//                    "",
-//                    "dataset"));
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () ->
-//                PreprocessorService.buildTopology(
-//                    List.of(datasetMetadata),
-//                    rateLimiter,
-//                    upstreamTopics,
-//                    downstreamTopic,
-//                    "invalid",
-//                    "dataset"));
-//  }
-//
-//  @Test
-//  public void shouldHandleEmptyDatasetMetadata() throws TimeoutException {
-//    DatasetMetadataStore datasetMetadataStore = mock(DatasetMetadataStore.class);
-//    when(datasetMetadataStore.listSync()).thenReturn(List.of());
-//
-//    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-//        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-//            .setApplicationId("applicationId")
-//            .setBootstrapServers("bootstrap")
-//            .setNumStreamThreads(1)
-//            .build();
-//    KaldbConfigs.ServerConfig serverConfig =
-//        KaldbConfigs.ServerConfig.newBuilder()
-//            .setServerPort(8080)
-//            .setServerAddress("localhost")
-//            .build();
-//    KaldbConfigs.PreprocessorConfig preprocessorConfig =
-//        KaldbConfigs.PreprocessorConfig.newBuilder()
-//            .setKafkaStreamConfig(kafkaStreamConfig)
-//            .setServerConfig(serverConfig)
-//            .setPreprocessorInstanceCount(1)
-//            .setDataTransformer("api_log")
-//            .setRateLimiterMaxBurstSeconds(1)
-//            .build();
-//
-//    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-//    PreprocessorService preprocessorService =
-//        new PreprocessorService(datasetMetadataStore, preprocessorConfig, meterRegistry);
-//
-//    preprocessorService.startAsync();
-//    preprocessorService.awaitRunning(DEFAULT_START_STOP_DURATION);
-//
-//    assertThat(MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry))
-//        .isEqualTo(1);
-//
-//    preprocessorService.stopAsync();
-//    preprocessorService.awaitTerminated();
-//  }
-// }
+package com.slack.kaldb.preprocessor;
+
+import static com.slack.kaldb.preprocessor.PreprocessorValueMapper.SERVICE_NAME_KEY;
+import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.slack.kaldb.metadata.dataset.DatasetMetadata;
+import com.slack.kaldb.metadata.dataset.DatasetMetadataStore;
+import com.slack.kaldb.metadata.dataset.DatasetPartitionMetadata;
+import com.slack.kaldb.proto.config.KaldbConfigs;
+import com.slack.kaldb.testlib.MetricsUtil;
+import com.slack.service.murron.trace.Trace;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeoutException;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.processor.StreamPartitioner;
+import org.junit.Test;
+
+public class PreprocessorServiceUnitTest {
+
+  @Test
+  public void shouldBuildValidPropsFromStreamConfig() {
+    String applicationId = "applicationId";
+    String bootstrapServers = "bootstrap";
+    String processingGuarantee = "at_least_once";
+    int replicationFactor = 1;
+    boolean enableIdempotence = false;
+    String acksConfig = "1";
+    int numStreamThreads = 1;
+
+    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+            .setApplicationId(applicationId)
+            .setBootstrapServers(bootstrapServers)
+            .setNumStreamThreads(numStreamThreads)
+            .setProcessingGuarantee(processingGuarantee)
+            .build();
+
+    Properties properties = PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+    assertThat(properties.size()).isEqualTo(7);
+
+    assertThat(properties.get(StreamsConfig.APPLICATION_ID_CONFIG)).isEqualTo(applicationId);
+
+    assertThat(properties.get(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG)).isEqualTo(bootstrapServers);
+
+    assertThat(properties.get(StreamsConfig.NUM_STREAM_THREADS_CONFIG)).isEqualTo(numStreamThreads);
+    assertThat(properties.get(StreamsConfig.PROCESSING_GUARANTEE_CONFIG))
+        .isEqualTo(processingGuarantee);
+    assertThat(properties.get(StreamsConfig.REPLICATION_FACTOR_CONFIG))
+        .isEqualTo(replicationFactor);
+    assertThat(
+            properties.get(StreamsConfig.producerPrefix(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG)))
+        .isEqualTo(enableIdempotence);
+    assertThat(properties.get(StreamsConfig.producerPrefix(ProducerConfig.ACKS_CONFIG)))
+        .isEqualTo(acksConfig);
+  }
+
+  @Test
+  public void shouldPreventInvalidStreamPropsConfig() {
+    String applicationId = "applicationId";
+    String bootstrapServers = "bootstrap";
+    int numStreamThreads = 1;
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () -> {
+              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+                      .setBootstrapServers(bootstrapServers)
+                      .setNumStreamThreads(numStreamThreads)
+                      .build();
+              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+            });
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () -> {
+              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+                      .setApplicationId(applicationId)
+                      .setNumStreamThreads(numStreamThreads)
+                      .build();
+              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+            });
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () -> {
+              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+                      .setApplicationId(applicationId)
+                      .setBootstrapServers(bootstrapServers)
+                      .build();
+              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+            });
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () -> {
+              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+                      .setApplicationId(applicationId)
+                      .setBootstrapServers(bootstrapServers)
+                      .setNumStreamThreads(0)
+                      .build();
+              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+            });
+  }
+
+  @Test
+  public void shouldReturnRandomPartitionFromStreamPartitioner() {
+    String datasetName = "datasetName";
+    List<Integer> partitionList = List.of(33, 44, 55);
+    DatasetMetadata datasetMetadata =
+        new DatasetMetadata(
+            datasetName,
+            datasetName,
+            1,
+            List.of(new DatasetPartitionMetadata(100, Long.MAX_VALUE, List.of("33", "44", "55"))),
+            datasetName);
+    StreamPartitioner<String, Trace.Span> streamPartitioner =
+        PreprocessorService.streamPartitioner(datasetMetadata);
+
+    Trace.Span span =
+        Trace.Span.newBuilder()
+            .addTags(
+                Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(datasetName).build())
+            .build();
+
+    // all arguments except value are currently unused for determining the partition to assign, as
+    // this comes the internal partition list that is set on stream partitioner initialization
+    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 0)))
+        .isTrue();
+    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 1)))
+        .isTrue();
+    assertThat(partitionList.contains(streamPartitioner.partition("topic", "", span, 0))).isTrue();
+    assertThat(partitionList.contains(streamPartitioner.partition("", null, span, 0))).isTrue();
+  }
+
+  @Test
+  public void shouldPreventInvalidStreamPartitionConfigurations() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> PreprocessorService.streamPartitioner(null));
+    String datasetName = "datasetName";
+    DatasetMetadata datasetMetadata =
+        new DatasetMetadata(
+            datasetName,
+            datasetName,
+            1,
+            List.of(new DatasetPartitionMetadata(100, 200, List.of())),
+            datasetName);
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> PreprocessorService.streamPartitioner(datasetMetadata));
+  }
+
+  @Test
+  public void shouldFilterInvalidConfigurationsFromServiceMetadata() {
+    DatasetMetadata validDatasetMetadata =
+        new DatasetMetadata(
+            "valid",
+            "owner1",
+            1000,
+            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1"))),
+            "validService");
+
+    List<DatasetMetadata> datasetMetadataList =
+        List.of(
+            new DatasetMetadata(
+                "invalidServicePartitionList", "owner1", 1000, List.of(), "invalidService1"),
+            new DatasetMetadata(
+                "invalidThroughputBytes",
+                "owner1",
+                0,
+                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1"))),
+                "invalidService2"),
+            new DatasetMetadata(
+                "invalidActivePartitions",
+                "owner1",
+                1000,
+                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of())),
+                "invalidService3"),
+            new DatasetMetadata(
+                "invalidNoActivePartitions",
+                "owner1",
+                1000,
+                List.of(
+                    new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1"))),
+                "invalidService4"),
+            validDatasetMetadata);
+
+    List<DatasetMetadata> datasetMetadata1 =
+        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
+
+    assertThat(datasetMetadata1.size()).isEqualTo(1);
+    assertThat(datasetMetadata1.contains(validDatasetMetadata)).isTrue();
+
+    Collections.shuffle(datasetMetadata1);
+
+    List<DatasetMetadata> datasetMetadata2 =
+        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
+
+    assertThat(datasetMetadata2.size()).isEqualTo(1);
+    assertThat(datasetMetadata2.contains(validDatasetMetadata)).isTrue();
+
+    List<DatasetMetadata> datasetMetadata3 =
+        PreprocessorService.filterValidDatasetMetadata(List.of());
+    assertThat(datasetMetadata3.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldGetActivePartitionsFromServiceMetadata() {
+    DatasetMetadata datasetMetadataEmptyPartitions =
+        new DatasetMetadata("empty", "owner1", 1000, List.of(), "empty");
+    DatasetMetadata datasetMetadataNoActivePartitions =
+        new DatasetMetadata(
+            "empty",
+            "owner1",
+            1000,
+            List.of(
+                new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1", "2"))),
+            "empty");
+
+    DatasetMetadata datasetMetadataNoPartitions =
+        new DatasetMetadata(
+            "empty",
+            "owner1",
+            1000,
+            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of())),
+            "empty");
+
+    DatasetMetadata datasetMetadataMultiplePartitions =
+        new DatasetMetadata(
+            "empty",
+            "owner1",
+            1000,
+            List.of(
+                new DatasetPartitionMetadata(1, 10000, List.of("3", "4")),
+                new DatasetPartitionMetadata(10001, Long.MAX_VALUE, List.of("5", "6"))),
+            "empty");
+
+    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataEmptyPartitions))
+        .isEqualTo(List.of());
+    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoActivePartitions))
+        .isEqualTo(List.of());
+    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoPartitions))
+        .isEqualTo(List.of());
+    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataMultiplePartitions))
+        .isEqualTo(List.of(5, 6));
+  }
+
+  @Test
+  public void shouldBuildStreamTopology() {
+    List<DatasetMetadata> datasetMetadata =
+        List.of(
+            new DatasetMetadata(
+                "dataset1",
+                "owner1",
+                1000,
+                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2"))),
+                "dataset1"),
+            new DatasetMetadata(
+                "dataset2",
+                "owner1",
+                1000,
+                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2"))),
+                "dataset2"));
+
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    int preprocessorCount = 1;
+    int maxBurstSeconds = 1;
+    boolean initializeWarm = false;
+    PreprocessorRateLimiter rateLimiter =
+        new PreprocessorRateLimiter(
+            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
+
+    List<String> upstreamTopics = List.of("upstream1", "upstream2", "upstream3");
+    String downstreamTopic = "downstream";
+    String dataTransformer = "api_log";
+    Topology topology =
+        PreprocessorService.buildTopology(
+            datasetMetadata, rateLimiter, upstreamTopics, downstreamTopic, dataTransformer);
+
+    // we have limited visibility into the topology, so we just verify we have the correct number
+    // of stream processors as we expect
+    assertThat(topology.describe().subtopologies().size()).isEqualTo(upstreamTopics.size());
+  }
+
+  @Test
+  public void shouldThrowOnInvalidTopologyConfigs() {
+    DatasetMetadata datasetMetadata =
+        new DatasetMetadata(
+            "dataset1",
+            "owner1",
+            1000,
+            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2"))),
+            "dataset1");
+
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    int preprocessorCount = 1;
+    int maxBurstSeconds = 1;
+    boolean initializeWarm = false;
+    PreprocessorRateLimiter rateLimiter =
+        new PreprocessorRateLimiter(
+            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
+    List<String> upstreamTopics = List.of("upstream");
+    String downstreamTopic = "downstream";
+    String dataTransformer = "api_log";
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                PreprocessorService.buildTopology(
+                    List.of(), rateLimiter, upstreamTopics, downstreamTopic, dataTransformer));
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                PreprocessorService.buildTopology(
+                    List.of(datasetMetadata),
+                    rateLimiter,
+                    List.of(),
+                    downstreamTopic,
+                    dataTransformer));
+    assertThatNullPointerException()
+        .isThrownBy(
+            () ->
+                PreprocessorService.buildTopology(
+                    List.of(datasetMetadata),
+                    null,
+                    upstreamTopics,
+                    downstreamTopic,
+                    dataTransformer));
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                PreprocessorService.buildTopology(
+                    List.of(datasetMetadata), rateLimiter, upstreamTopics, "", dataTransformer));
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                PreprocessorService.buildTopology(
+                    List.of(datasetMetadata), rateLimiter, upstreamTopics, downstreamTopic, ""));
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                PreprocessorService.buildTopology(
+                    List.of(datasetMetadata),
+                    rateLimiter,
+                    upstreamTopics,
+                    downstreamTopic,
+                    "invalid"));
+  }
+
+  @Test
+  public void shouldHandleEmptyDatasetMetadata() throws TimeoutException {
+    DatasetMetadataStore datasetMetadataStore = mock(DatasetMetadataStore.class);
+    when(datasetMetadataStore.listSync()).thenReturn(List.of());
+
+    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+            .setApplicationId("applicationId")
+            .setBootstrapServers("bootstrap")
+            .setNumStreamThreads(1)
+            .build();
+    KaldbConfigs.ServerConfig serverConfig =
+        KaldbConfigs.ServerConfig.newBuilder()
+            .setServerPort(8080)
+            .setServerAddress("localhost")
+            .build();
+    KaldbConfigs.PreprocessorConfig preprocessorConfig =
+        KaldbConfigs.PreprocessorConfig.newBuilder()
+            .setKafkaStreamConfig(kafkaStreamConfig)
+            .setServerConfig(serverConfig)
+            .setPreprocessorInstanceCount(1)
+            .setDataTransformer("api_log")
+            .setRateLimiterMaxBurstSeconds(1)
+            .build();
+
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    PreprocessorService preprocessorService =
+        new PreprocessorService(datasetMetadataStore, preprocessorConfig, meterRegistry);
+
+    preprocessorService.startAsync();
+    preprocessorService.awaitRunning(DEFAULT_START_STOP_DURATION);
+
+    assertThat(MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry))
+        .isEqualTo(1);
+
+    preprocessorService.stopAsync();
+    preprocessorService.awaitTerminated();
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
@@ -1,407 +1,407 @@
-// package com.slack.kaldb.preprocessor;
-//
-// import static com.slack.kaldb.preprocessor.PreprocessorValueMapper.SERVICE_NAME_KEY;
-// import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
-// import static org.assertj.core.api.Assertions.assertThat;
-// import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-// import static org.assertj.core.api.Assertions.assertThatNullPointerException;
-// import static org.mockito.Mockito.mock;
-// import static org.mockito.Mockito.when;
-//
-// import com.slack.kaldb.metadata.dataset.DatasetMetadata;
-// import com.slack.kaldb.metadata.dataset.DatasetMetadataStore;
-// import com.slack.kaldb.metadata.dataset.DatasetPartitionMetadata;
-// import com.slack.kaldb.proto.config.KaldbConfigs;
-// import com.slack.kaldb.testlib.MetricsUtil;
-// import com.slack.service.murron.trace.Trace;
-// import io.micrometer.core.instrument.MeterRegistry;
-// import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-// import java.time.Instant;
-// import java.util.Collections;
-// import java.util.List;
-// import java.util.Map;
-// import java.util.Properties;
-// import java.util.concurrent.TimeoutException;
-// import org.apache.kafka.clients.producer.ProducerConfig;
-// import org.apache.kafka.streams.StreamsConfig;
-// import org.apache.kafka.streams.Topology;
-// import org.apache.kafka.streams.processor.StreamPartitioner;
-// import org.junit.Test;
-//
-// public class PreprocessorServiceUnitTest {
-//
-//  @Test
-//  public void shouldBuildValidPropsFromStreamConfig() {
-//    String applicationId = "applicationId";
-//    String bootstrapServers = "bootstrap";
-//    String processingGuarantee = "at_least_once";
-//    int replicationFactor = 1;
-//    boolean enableIdempotence = false;
-//    String acksConfig = "1";
-//    int numStreamThreads = 1;
-//
-//    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-//        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-//            .setApplicationId(applicationId)
-//            .setBootstrapServers(bootstrapServers)
-//            .setNumStreamThreads(numStreamThreads)
-//            .setProcessingGuarantee(processingGuarantee)
-//            .build();
-//
-//    Properties properties = PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-//    assertThat(properties.size()).isEqualTo(7);
-//
-//    assertThat(properties.get(StreamsConfig.APPLICATION_ID_CONFIG)).isEqualTo(applicationId);
-//
-// assertThat(properties.get(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG)).isEqualTo(bootstrapServers);
-//
-// assertThat(properties.get(StreamsConfig.NUM_STREAM_THREADS_CONFIG)).isEqualTo(numStreamThreads);
-//    assertThat(properties.get(StreamsConfig.PROCESSING_GUARANTEE_CONFIG))
-//        .isEqualTo(processingGuarantee);
-//    assertThat(properties.get(StreamsConfig.REPLICATION_FACTOR_CONFIG))
-//        .isEqualTo(replicationFactor);
-//    assertThat(
-//
-// properties.get(StreamsConfig.producerPrefix(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG)))
-//        .isEqualTo(enableIdempotence);
-//    assertThat(properties.get(StreamsConfig.producerPrefix(ProducerConfig.ACKS_CONFIG)))
-//        .isEqualTo(acksConfig);
-//  }
-//
-//  @Test
-//  public void shouldPreventInvalidStreamPropsConfig() {
-//    String applicationId = "applicationId";
-//    String bootstrapServers = "bootstrap";
-//    int numStreamThreads = 1;
-//
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () -> {
-//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-//                      .setBootstrapServers(bootstrapServers)
-//                      .setNumStreamThreads(numStreamThreads)
-//                      .build();
-//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-//            });
-//
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () -> {
-//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-//                      .setApplicationId(applicationId)
-//                      .setNumStreamThreads(numStreamThreads)
-//                      .build();
-//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-//            });
-//
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () -> {
-//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-//                      .setApplicationId(applicationId)
-//                      .setBootstrapServers(bootstrapServers)
-//                      .build();
-//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-//            });
-//
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () -> {
-//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-//                      .setApplicationId(applicationId)
-//                      .setBootstrapServers(bootstrapServers)
-//                      .setNumStreamThreads(0)
-//                      .build();
-//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-//            });
-//  }
-//
-//  @Test
-//  public void shouldReturnRandomPartitionFromStreamPartitioner() {
-//    String datasetName = "datasetName";
-//    List<Integer> partitionList = List.of(33, 44, 55);
-//    Map<String, List<Integer>> datasetNameToPartitions = Map.of(datasetName, partitionList);
-//    StreamPartitioner<String, Trace.Span> streamPartitioner =
-//        PreprocessorService.streamPartitioner(datasetNameToPartitions);
-//
-//    Trace.Span span =
-//        Trace.Span.newBuilder()
-//            .addTags(
-//                Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(datasetName).build())
-//            .build();
-//
-//    // all arguments except value are currently unused for determining the partition to assign, as
-//    // this comes the internal partition list that is set on stream partitioner initialization
-//    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 0)))
-//        .isTrue();
-//    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 1)))
-//        .isTrue();
-//    assertThat(partitionList.contains(streamPartitioner.partition("topic", "", span,
-// 0))).isTrue();
-//    assertThat(partitionList.contains(streamPartitioner.partition("", null, span, 0))).isTrue();
-//  }
-//
-//  @Test
-//  public void shouldPreventInvalidStreamPartitionConfigurations() {
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of()));
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of("", List.of(1))));
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of("service", List.of())));
-//  }
-//
-//  @Test
-//  public void shouldFilterInvalidConfigurationsFromServiceMetadata() {
-//    DatasetMetadata validDatasetMetadata =
-//        new DatasetMetadata(
-//            "valid",
-//            "owner1",
-//            1000,
-//            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1"))));
-//
-//    List<DatasetMetadata> datasetMetadataList =
-//        List.of(
-//            new DatasetMetadata("invalidServicePartitionList", "owner1", 1000, List.of()),
-//            new DatasetMetadata(
-//                "invalidThroughputBytes",
-//                "owner1",
-//                0,
-//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1")))),
-//            new DatasetMetadata(
-//                "invalidActivePartitions",
-//                "owner1",
-//                1000,
-//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of()))),
-//            new DatasetMetadata(
-//                "invalidNoActivePartitions",
-//                "owner1",
-//                1000,
-//                List.of(
-//                    new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1")))),
-//            validDatasetMetadata);
-//
-//    List<DatasetMetadata> datasetMetadata1 =
-//        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
-//
-//    assertThat(datasetMetadata1.size()).isEqualTo(1);
-//    assertThat(datasetMetadata1.contains(validDatasetMetadata)).isTrue();
-//
-//    Collections.shuffle(datasetMetadata1);
-//
-//    List<DatasetMetadata> datasetMetadata2 =
-//        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
-//
-//    assertThat(datasetMetadata2.size()).isEqualTo(1);
-//    assertThat(datasetMetadata2.contains(validDatasetMetadata)).isTrue();
-//
-//    List<DatasetMetadata> datasetMetadata3 =
-//        PreprocessorService.filterValidDatasetMetadata(List.of());
-//    assertThat(datasetMetadata3.size()).isEqualTo(0);
-//  }
-//
-//  @Test
-//  public void shouldGetActivePartitionsFromServiceMetadata() {
-//    DatasetMetadata datasetMetadataEmptyPartitions =
-//        new DatasetMetadata("empty", "owner1", 1000, List.of());
-//    DatasetMetadata datasetMetadataNoActivePartitions =
-//        new DatasetMetadata(
-//            "empty",
-//            "owner1",
-//            1000,
-//            List.of(
-//                new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1",
-// "2"))));
-//
-//    DatasetMetadata datasetMetadataNoPartitions =
-//        new DatasetMetadata(
-//            "empty",
-//            "owner1",
-//            1000,
-//            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of())));
-//
-//    DatasetMetadata datasetMetadataMultiplePartitions =
-//        new DatasetMetadata(
-//            "empty",
-//            "owner1",
-//            1000,
-//            List.of(
-//                new DatasetPartitionMetadata(1, 10000, List.of("3", "4")),
-//                new DatasetPartitionMetadata(10001, Long.MAX_VALUE, List.of("5", "6"))));
-//
-//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataEmptyPartitions))
-//        .isEqualTo(List.of());
-//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoActivePartitions))
-//        .isEqualTo(List.of());
-//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoPartitions))
-//        .isEqualTo(List.of());
-//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataMultiplePartitions))
-//        .isEqualTo(List.of(5, 6));
-//  }
-//
-//  @Test
-//  public void shouldBuildStreamTopology() {
-//    List<DatasetMetadata> datasetMetadata =
-//        List.of(
-//            new DatasetMetadata(
-//                "dataset1",
-//                "owner1",
-//                1000,
-//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2")))),
-//            new DatasetMetadata(
-//                "dataset2",
-//                "owner1",
-//                1000,
-//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2")))));
-//
-//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-//    int preprocessorCount = 1;
-//    int maxBurstSeconds = 1;
-//    boolean initializeWarm = false;
-//    PreprocessorRateLimiter rateLimiter =
-//        new PreprocessorRateLimiter(
-//            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
-//
-//    List<String> upstreamTopics = List.of("upstream1", "upstream2", "upstream3");
-//    String downstreamTopic = "downstream";
-//    String dataTransformer = "api_log";
-//    Topology topology =
-//        PreprocessorService.buildTopology(
-//            datasetMetadata,
-//            rateLimiter,
-//            upstreamTopics,
-//            downstreamTopic,
-//            dataTransformer,
-//            "dataset");
-//
-//    // we have limited visibility into the topology, so we just verify we have the correct number
-// of
-//    // stream processors as we expect
-//    assertThat(topology.describe().subtopologies().size()).isEqualTo(upstreamTopics.size());
-//  }
-//
-//  @Test
-//  public void shouldThrowOnInvalidTopologyConfigs() {
-//    DatasetMetadata datasetMetadata =
-//        new DatasetMetadata(
-//            "dataset1",
-//            "owner1",
-//            1000,
-//            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2"))));
-//
-//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-//    int preprocessorCount = 1;
-//    int maxBurstSeconds = 1;
-//    boolean initializeWarm = false;
-//    PreprocessorRateLimiter rateLimiter =
-//        new PreprocessorRateLimiter(
-//            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
-//    List<String> upstreamTopics = List.of("upstream");
-//    String downstreamTopic = "downstream";
-//    String dataTransformer = "api_log";
-//
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () ->
-//                PreprocessorService.buildTopology(
-//                    List.of(),
-//                    rateLimiter,
-//                    upstreamTopics,
-//                    downstreamTopic,
-//                    dataTransformer,
-//                    "dataset"));
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () ->
-//                PreprocessorService.buildTopology(
-//                    List.of(datasetMetadata),
-//                    rateLimiter,
-//                    List.of(),
-//                    downstreamTopic,
-//                    dataTransformer,
-//                    "dataset"));
-//    assertThatNullPointerException()
-//        .isThrownBy(
-//            () ->
-//                PreprocessorService.buildTopology(
-//                    List.of(datasetMetadata),
-//                    null,
-//                    upstreamTopics,
-//                    downstreamTopic,
-//                    dataTransformer,
-//                    "dataset"));
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () ->
-//                PreprocessorService.buildTopology(
-//                    List.of(datasetMetadata),
-//                    rateLimiter,
-//                    upstreamTopics,
-//                    "",
-//                    dataTransformer,
-//                    "dataset"));
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () ->
-//                PreprocessorService.buildTopology(
-//                    List.of(datasetMetadata),
-//                    rateLimiter,
-//                    upstreamTopics,
-//                    downstreamTopic,
-//                    "",
-//                    "dataset"));
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () ->
-//                PreprocessorService.buildTopology(
-//                    List.of(datasetMetadata),
-//                    rateLimiter,
-//                    upstreamTopics,
-//                    downstreamTopic,
-//                    "invalid",
-//                    "dataset"));
-//  }
-//
-//  @Test
-//  public void shouldHandleEmptyDatasetMetadata() throws TimeoutException {
-//    DatasetMetadataStore datasetMetadataStore = mock(DatasetMetadataStore.class);
-//    when(datasetMetadataStore.listSync()).thenReturn(List.of());
-//
-//    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-//        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-//            .setApplicationId("applicationId")
-//            .setBootstrapServers("bootstrap")
-//            .setNumStreamThreads(1)
-//            .build();
-//    KaldbConfigs.ServerConfig serverConfig =
-//        KaldbConfigs.ServerConfig.newBuilder()
-//            .setServerPort(8080)
-//            .setServerAddress("localhost")
-//            .build();
-//    KaldbConfigs.PreprocessorConfig preprocessorConfig =
-//        KaldbConfigs.PreprocessorConfig.newBuilder()
-//            .setKafkaStreamConfig(kafkaStreamConfig)
-//            .setServerConfig(serverConfig)
-//            .setPreprocessorInstanceCount(1)
-//            .setDataTransformer("api_log")
-//            .setRateLimiterMaxBurstSeconds(1)
-//            .build();
-//
-//    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-//    PreprocessorService preprocessorService =
-//        new PreprocessorService(datasetMetadataStore, preprocessorConfig, meterRegistry);
-//
-//    preprocessorService.startAsync();
-//    preprocessorService.awaitRunning(DEFAULT_START_STOP_DURATION);
-//
-//    assertThat(MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry))
-//        .isEqualTo(1);
-//
-//    preprocessorService.stopAsync();
-//    preprocessorService.awaitTerminated();
-//  }
-// }
+ package com.slack.kaldb.preprocessor;
+
+ import static com.slack.kaldb.preprocessor.PreprocessorValueMapper.SERVICE_NAME_KEY;
+ import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
+ import static org.assertj.core.api.Assertions.assertThat;
+ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+ import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+ import static org.mockito.Mockito.mock;
+ import static org.mockito.Mockito.when;
+
+ import com.slack.kaldb.metadata.dataset.DatasetMetadata;
+ import com.slack.kaldb.metadata.dataset.DatasetMetadataStore;
+ import com.slack.kaldb.metadata.dataset.DatasetPartitionMetadata;
+ import com.slack.kaldb.proto.config.KaldbConfigs;
+ import com.slack.kaldb.testlib.MetricsUtil;
+ import com.slack.service.murron.trace.Trace;
+ import io.micrometer.core.instrument.MeterRegistry;
+ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+ import java.time.Instant;
+ import java.util.Collections;
+ import java.util.List;
+ import java.util.Map;
+ import java.util.Properties;
+ import java.util.concurrent.TimeoutException;
+ import org.apache.kafka.clients.producer.ProducerConfig;
+ import org.apache.kafka.streams.StreamsConfig;
+ import org.apache.kafka.streams.Topology;
+ import org.apache.kafka.streams.processor.StreamPartitioner;
+ import org.junit.Test;
+
+ public class PreprocessorServiceUnitTest {
+
+  @Test
+  public void shouldBuildValidPropsFromStreamConfig() {
+    String applicationId = "applicationId";
+    String bootstrapServers = "bootstrap";
+    String processingGuarantee = "at_least_once";
+    int replicationFactor = 1;
+    boolean enableIdempotence = false;
+    String acksConfig = "1";
+    int numStreamThreads = 1;
+
+    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+            .setApplicationId(applicationId)
+            .setBootstrapServers(bootstrapServers)
+            .setNumStreamThreads(numStreamThreads)
+            .setProcessingGuarantee(processingGuarantee)
+            .build();
+
+    Properties properties = PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+    assertThat(properties.size()).isEqualTo(7);
+
+    assertThat(properties.get(StreamsConfig.APPLICATION_ID_CONFIG)).isEqualTo(applicationId);
+
+ assertThat(properties.get(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG)).isEqualTo(bootstrapServers);
+
+ assertThat(properties.get(StreamsConfig.NUM_STREAM_THREADS_CONFIG)).isEqualTo(numStreamThreads);
+    assertThat(properties.get(StreamsConfig.PROCESSING_GUARANTEE_CONFIG))
+        .isEqualTo(processingGuarantee);
+    assertThat(properties.get(StreamsConfig.REPLICATION_FACTOR_CONFIG))
+        .isEqualTo(replicationFactor);
+    assertThat(
+
+ properties.get(StreamsConfig.producerPrefix(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG)))
+        .isEqualTo(enableIdempotence);
+    assertThat(properties.get(StreamsConfig.producerPrefix(ProducerConfig.ACKS_CONFIG)))
+        .isEqualTo(acksConfig);
+  }
+
+  @Test
+  public void shouldPreventInvalidStreamPropsConfig() {
+    String applicationId = "applicationId";
+    String bootstrapServers = "bootstrap";
+    int numStreamThreads = 1;
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () -> {
+              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+                      .setBootstrapServers(bootstrapServers)
+                      .setNumStreamThreads(numStreamThreads)
+                      .build();
+              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+            });
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () -> {
+              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+                      .setApplicationId(applicationId)
+                      .setNumStreamThreads(numStreamThreads)
+                      .build();
+              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+            });
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () -> {
+              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+                      .setApplicationId(applicationId)
+                      .setBootstrapServers(bootstrapServers)
+                      .build();
+              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+            });
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () -> {
+              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+                      .setApplicationId(applicationId)
+                      .setBootstrapServers(bootstrapServers)
+                      .setNumStreamThreads(0)
+                      .build();
+              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+            });
+  }
+
+  @Test
+  public void shouldReturnRandomPartitionFromStreamPartitioner() {
+    String datasetName = "datasetName";
+    List<Integer> partitionList = List.of(33, 44, 55);
+    Map<String, List<Integer>> datasetNameToPartitions = Map.of(datasetName, partitionList);
+    StreamPartitioner<String, Trace.Span> streamPartitioner =
+        PreprocessorService.streamPartitioner(datasetNameToPartitions);
+
+    Trace.Span span =
+        Trace.Span.newBuilder()
+            .addTags(
+                Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(datasetName).build())
+            .build();
+
+    // all arguments except value are currently unused for determining the partition to assign, as
+    // this comes the internal partition list that is set on stream partitioner initialization
+    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 0)))
+        .isTrue();
+    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 1)))
+        .isTrue();
+    assertThat(partitionList.contains(streamPartitioner.partition("topic", "", span,
+ 0))).isTrue();
+    assertThat(partitionList.contains(streamPartitioner.partition("", null, span, 0))).isTrue();
+  }
+
+  @Test
+  public void shouldPreventInvalidStreamPartitionConfigurations() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of()));
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of("", List.of(1))));
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of("service", List.of())));
+  }
+
+  @Test
+  public void shouldFilterInvalidConfigurationsFromServiceMetadata() {
+    DatasetMetadata validDatasetMetadata =
+        new DatasetMetadata(
+            "valid",
+            "owner1",
+            1000,
+            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1"))), "validService");
+
+    List<DatasetMetadata> datasetMetadataList =
+        List.of(
+            new DatasetMetadata("invalidServicePartitionList", "owner1", 1000, List.of(), "invalidService1"),
+            new DatasetMetadata(
+                "invalidThroughputBytes",
+                "owner1",
+                0,
+                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1"))), "invalidService2"),
+            new DatasetMetadata(
+                "invalidActivePartitions",
+                "owner1",
+                1000,
+                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of())) , "invalidService3"),
+            new DatasetMetadata(
+                "invalidNoActivePartitions",
+                "owner1",
+                1000,
+                List.of(
+                    new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1"))), "invalidService4"),
+            validDatasetMetadata);
+
+    List<DatasetMetadata> datasetMetadata1 =
+        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
+
+    assertThat(datasetMetadata1.size()).isEqualTo(1);
+    assertThat(datasetMetadata1.contains(validDatasetMetadata)).isTrue();
+
+    Collections.shuffle(datasetMetadata1);
+
+    List<DatasetMetadata> datasetMetadata2 =
+        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
+
+    assertThat(datasetMetadata2.size()).isEqualTo(1);
+    assertThat(datasetMetadata2.contains(validDatasetMetadata)).isTrue();
+
+    List<DatasetMetadata> datasetMetadata3 =
+        PreprocessorService.filterValidDatasetMetadata(List.of());
+    assertThat(datasetMetadata3.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldGetActivePartitionsFromServiceMetadata() {
+    DatasetMetadata datasetMetadataEmptyPartitions =
+        new DatasetMetadata("empty", "owner1", 1000, List.of(), "empty");
+    DatasetMetadata datasetMetadataNoActivePartitions =
+        new DatasetMetadata(
+            "empty",
+            "owner1",
+            1000,
+            List.of(
+                new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1",
+ "2"))), "empty");
+
+    DatasetMetadata datasetMetadataNoPartitions =
+        new DatasetMetadata(
+            "empty",
+            "owner1",
+            1000,
+            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of())), "empty");
+
+    DatasetMetadata datasetMetadataMultiplePartitions =
+        new DatasetMetadata(
+            "empty",
+            "owner1",
+            1000,
+            List.of(
+                new DatasetPartitionMetadata(1, 10000, List.of("3", "4")),
+                new DatasetPartitionMetadata(10001, Long.MAX_VALUE, List.of("5", "6"))), "empty");
+
+    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataEmptyPartitions))
+        .isEqualTo(List.of());
+    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoActivePartitions))
+        .isEqualTo(List.of());
+    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoPartitions))
+        .isEqualTo(List.of());
+    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataMultiplePartitions))
+        .isEqualTo(List.of(5, 6));
+  }
+
+  @Test
+  public void shouldBuildStreamTopology() {
+    List<DatasetMetadata> datasetMetadata =
+        List.of(
+            new DatasetMetadata(
+                "dataset1",
+                "owner1",
+                1000,
+                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2")))),
+            new DatasetMetadata(
+                "dataset2",
+                "owner1",
+                1000,
+                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2")))));
+
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    int preprocessorCount = 1;
+    int maxBurstSeconds = 1;
+    boolean initializeWarm = false;
+    PreprocessorRateLimiter rateLimiter =
+        new PreprocessorRateLimiter(
+            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
+
+    List<String> upstreamTopics = List.of("upstream1", "upstream2", "upstream3");
+    String downstreamTopic = "downstream";
+    String dataTransformer = "api_log";
+    Topology topology =
+        PreprocessorService.buildTopology(
+            datasetMetadata,
+            rateLimiter,
+            upstreamTopics,
+            downstreamTopic,
+            dataTransformer,
+            "dataset");
+
+    // we have limited visibility into the topology, so we just verify we have the correct number
+ of
+    // stream processors as we expect
+    assertThat(topology.describe().subtopologies().size()).isEqualTo(upstreamTopics.size());
+  }
+
+  @Test
+  public void shouldThrowOnInvalidTopologyConfigs() {
+    DatasetMetadata datasetMetadata =
+        new DatasetMetadata(
+            "dataset1",
+            "owner1",
+            1000,
+            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2"))));
+
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    int preprocessorCount = 1;
+    int maxBurstSeconds = 1;
+    boolean initializeWarm = false;
+    PreprocessorRateLimiter rateLimiter =
+        new PreprocessorRateLimiter(
+            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
+    List<String> upstreamTopics = List.of("upstream");
+    String downstreamTopic = "downstream";
+    String dataTransformer = "api_log";
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                PreprocessorService.buildTopology(
+                    List.of(),
+                    rateLimiter,
+                    upstreamTopics,
+                    downstreamTopic,
+                    dataTransformer,
+                    "dataset"));
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                PreprocessorService.buildTopology(
+                    List.of(datasetMetadata),
+                    rateLimiter,
+                    List.of(),
+                    downstreamTopic,
+                    dataTransformer,
+                    "dataset"));
+    assertThatNullPointerException()
+        .isThrownBy(
+            () ->
+                PreprocessorService.buildTopology(
+                    List.of(datasetMetadata),
+                    null,
+                    upstreamTopics,
+                    downstreamTopic,
+                    dataTransformer,
+                    "dataset"));
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                PreprocessorService.buildTopology(
+                    List.of(datasetMetadata),
+                    rateLimiter,
+                    upstreamTopics,
+                    "",
+                    dataTransformer,
+                    "dataset"));
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                PreprocessorService.buildTopology(
+                    List.of(datasetMetadata),
+                    rateLimiter,
+                    upstreamTopics,
+                    downstreamTopic,
+                    "",
+                    "dataset"));
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                PreprocessorService.buildTopology(
+                    List.of(datasetMetadata),
+                    rateLimiter,
+                    upstreamTopics,
+                    downstreamTopic,
+                    "invalid",
+                    "dataset"));
+  }
+
+  @Test
+  public void shouldHandleEmptyDatasetMetadata() throws TimeoutException {
+    DatasetMetadataStore datasetMetadataStore = mock(DatasetMetadataStore.class);
+    when(datasetMetadataStore.listSync()).thenReturn(List.of());
+
+    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+            .setApplicationId("applicationId")
+            .setBootstrapServers("bootstrap")
+            .setNumStreamThreads(1)
+            .build();
+    KaldbConfigs.ServerConfig serverConfig =
+        KaldbConfigs.ServerConfig.newBuilder()
+            .setServerPort(8080)
+            .setServerAddress("localhost")
+            .build();
+    KaldbConfigs.PreprocessorConfig preprocessorConfig =
+        KaldbConfigs.PreprocessorConfig.newBuilder()
+            .setKafkaStreamConfig(kafkaStreamConfig)
+            .setServerConfig(serverConfig)
+            .setPreprocessorInstanceCount(1)
+            .setDataTransformer("api_log")
+            .setRateLimiterMaxBurstSeconds(1)
+            .build();
+
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    PreprocessorService preprocessorService =
+        new PreprocessorService(datasetMetadataStore, preprocessorConfig, meterRegistry);
+
+    preprocessorService.startAsync();
+    preprocessorService.awaitRunning(DEFAULT_START_STOP_DURATION);
+
+    assertThat(MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry))
+        .isEqualTo(1);
+
+    preprocessorService.stopAsync();
+    preprocessorService.awaitTerminated();
+  }
+ }

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorValueMapperTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorValueMapperTest.java
@@ -159,9 +159,9 @@ public class PreprocessorValueMapperTest {
                     .build())
             .build();
 
-    assertThat(PreprocessorValueMapper.getDatasetName(span1)).isEqualTo(service1);
+    assertThat(PreprocessorValueMapper.getServiceName(span1)).isEqualTo(service1);
 
     Trace.Span span2 = Trace.Span.newBuilder().build();
-    assertThat(PreprocessorValueMapper.getDatasetName(span2)).isNull();
+    assertThat(PreprocessorValueMapper.getServiceName(span2)).isNull();
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
@@ -123,7 +123,12 @@ public class KaldbTest {
         new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("0", "1"));
     final List<DatasetPartitionMetadata> partitionConfigs = Collections.singletonList(partition);
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(MessageUtil.TEST_DATASET_NAME, "serviceOwner", 1000, partitionConfigs);
+        new DatasetMetadata(
+            MessageUtil.TEST_DATASET_NAME,
+            "serviceOwner",
+            1000,
+            partitionConfigs,
+            MessageUtil.TEST_DATASET_NAME);
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.listSync().size() == 1);
   }

--- a/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
@@ -472,6 +472,7 @@ public class ManagerApiGrpcTest {
                         ManagerApi.CreateDatasetMetadataRequest.newBuilder()
                             .setName(datasetName)
                             .setOwner(datasetOwner)
+                            .setServiceName(datasetName)
                             .build()));
 
     assertThat(throwableCreate.getStatus().getCode()).isEqualTo(Status.UNKNOWN.getCode());

--- a/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
@@ -445,8 +445,10 @@ public class ManagerApiGrpcTest {
             .listSync()
             .containsAll(
                 List.of(
-                    new DatasetMetadata(datasetName1, datasetOwner1, 0, Collections.emptyList()),
-                    new DatasetMetadata(datasetName2, datasetOwner2, 0, Collections.emptyList()))));
+                    new DatasetMetadata(
+                        datasetName1, datasetOwner1, 0, Collections.emptyList(), datasetName1),
+                    new DatasetMetadata(
+                        datasetName2, datasetOwner2, 0, Collections.emptyList(), datasetName2))));
   }
 
   @Test
@@ -458,7 +460,9 @@ public class ManagerApiGrpcTest {
     doThrow(new InternalMetadataStoreException(errorString))
         .when(datasetMetadataStore)
         .createSync(
-            eq(new DatasetMetadata(datasetName, datasetOwner, 0L, Collections.emptyList())));
+            eq(
+                new DatasetMetadata(
+                    datasetName, datasetOwner, 0L, Collections.emptyList(), datasetName)));
 
     StatusRuntimeException throwableCreate =
         (StatusRuntimeException)
@@ -476,7 +480,9 @@ public class ManagerApiGrpcTest {
     doThrow(new InternalMetadataStoreException(errorString))
         .when(datasetMetadataStore)
         .updateSync(
-            eq(new DatasetMetadata(datasetName, datasetOwner, 0L, Collections.emptyList())));
+            eq(
+                new DatasetMetadata(
+                    datasetName, datasetOwner, 0L, Collections.emptyList(), datasetName)));
 
     StatusRuntimeException throwableUpdate =
         (StatusRuntimeException)
@@ -540,7 +546,8 @@ public class ManagerApiGrpcTest {
             "foo",
             "a",
             1,
-            List.of(new DatasetPartitionMetadata(startTime + 5, startTime + 6, List.of("a"))));
+            List.of(new DatasetPartitionMetadata(startTime + 5, startTime + 6, List.of("a"))),
+            "foo");
 
     datasetMetadataStore.createSync(datasetWithDataInPartitionA);
 
@@ -596,7 +603,8 @@ public class ManagerApiGrpcTest {
             "foo",
             "a",
             1,
-            List.of(new DatasetPartitionMetadata(startTime + 5, startTime + 6, List.of("a"))));
+            List.of(new DatasetPartitionMetadata(startTime + 5, startTime + 6, List.of("a"))),
+            "foo");
 
     datasetMetadataStore.createSync(serviceWithDataInPartitionA);
 
@@ -643,7 +651,8 @@ public class ManagerApiGrpcTest {
             "foo",
             "a",
             1,
-            List.of(new DatasetPartitionMetadata(startTime + 5, startTime + 6, List.of("a", "b"))));
+            List.of(new DatasetPartitionMetadata(startTime + 5, startTime + 6, List.of("a", "b"))),
+            "foo");
 
     datasetMetadataStore.createSync(serviceWithDataInPartitionA);
 

--- a/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceTest.java
@@ -88,7 +88,8 @@ public class ZipkinServiceTest {
         new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("0", "1"));
     final List<DatasetPartitionMetadata> partitionConfigs = Collections.singletonList(partition);
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(TEST_DATASET_NAME, "serviceOwner", 1000, partitionConfigs);
+        new DatasetMetadata(
+            TEST_DATASET_NAME, "serviceOwner", 1000, partitionConfigs, TEST_DATASET_NAME);
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.listSync().size() == 1);
   }


### PR DESCRIPTION
1. Rate limits apply to datasets
2. Datasets match with upstream topic names
3. If datasets specify service names then match those from the record 