### PR TITLE
Add cached threadpool for parallel multisearch queries

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
@@ -2,7 +2,11 @@ package com.slack.kaldb.elasticsearchApi;
 
 import brave.ScopedSpan;
 import brave.Tracing;
+import brave.propagation.TraceContext;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.ByteString;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
@@ -31,6 +35,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,6 +53,9 @@ import org.slf4j.LoggerFactory;
 public class ElasticsearchApiService {
   private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchApiService.class);
   private final KaldbQueryServiceBase searcher;
+  private final ExecutorService executorService =
+      Executors.newCachedThreadPool(
+          new ThreadFactoryBuilder().setNameFormat("elasticsearch-api-%d").build());
 
   public ElasticsearchApiService(KaldbQueryServiceBase searcher) {
     this.searcher = searcher;
@@ -62,14 +71,24 @@ public class ElasticsearchApiService {
   @Post
   @Blocking
   @Path("/_msearch")
-  public HttpResponse multiSearch(String postBody) throws IOException {
+  public HttpResponse multiSearch(String postBody) throws Exception {
     LOG.debug("Search request: {}", postBody);
 
     List<EsSearchRequest> requests = EsSearchRequest.parse(postBody);
-    List<EsSearchResponse> responses =
-        requests.parallelStream().map(this::doSearch).collect(Collectors.toList());
 
-    SearchResponseMetadata responseMetadata = new SearchResponseMetadata(0, responses);
+    List<ListenableFuture<EsSearchResponse>> responseFutures =
+        requests
+            .stream()
+            .map(
+                (request) ->
+                    Futures.submit(
+                        () -> this.doSearch(request),
+                        Tracing.current().currentTraceContext().executor(executorService)))
+            .collect(Collectors.toList());
+
+    SearchResponseMetadata responseMetadata =
+        new SearchResponseMetadata(
+            0, Futures.allAsList(responseFutures).get(), Map.of("traceId", getTraceId()));
     return HttpResponse.of(
         HttpStatus.OK, MediaType.JSON_UTF_8, JsonUtil.writeAsString(responseMetadata));
   }
@@ -102,8 +121,6 @@ public class ElasticsearchApiService {
       return new EsSearchResponse.Builder()
           .hits(hits)
           .aggregations(aggregations)
-          .debugMetadata(
-              Map.of("traceId", Tracing.current().currentTraceContext().get().traceIdString()))
           .took(Duration.of(searchResult.getTookMicros(), ChronoUnit.MICROS).toMillis())
           .shardsMetadata(searchResult.getTotalNodes(), searchResult.getFailedNodes())
           .status(200)
@@ -112,8 +129,6 @@ public class ElasticsearchApiService {
       LOG.error("Error fulfilling request for multisearch query", e);
       span.error(e);
       return new EsSearchResponse.Builder()
-          .debugMetadata(
-              Map.of("traceId", Tracing.current().currentTraceContext().get().traceIdString()))
           .took(Duration.of(searchResult.getTookMicros(), ChronoUnit.MICROS).toMillis())
           .shardsMetadata(searchResult.getTotalNodes(), searchResult.getFailedNodes())
           .status(500)
@@ -121,6 +136,14 @@ public class ElasticsearchApiService {
     } finally {
       span.finish();
     }
+  }
+
+  private String getTraceId() {
+    TraceContext traceContext = Tracing.current().currentTraceContext().get();
+    if (traceContext != null) {
+      return traceContext.traceIdString();
+    }
+    return "";
   }
 
   private HitsMetadata getHits(KaldbSearch.SearchResult searchResult) throws IOException {

--- a/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/searchResponse/SearchResponseMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/searchResponse/SearchResponseMetadata.java
@@ -2,6 +2,7 @@ package com.slack.kaldb.elasticsearchApi.searchResponse;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import java.util.Map;
 
 public class SearchResponseMetadata {
 
@@ -11,9 +12,14 @@ public class SearchResponseMetadata {
   @JsonProperty("responses")
   private final List<EsSearchResponse> responses;
 
-  public SearchResponseMetadata(long took, List<EsSearchResponse> responses) {
+  @JsonProperty("_debug")
+  private final Map<String, String> debugMetadata;
+
+  public SearchResponseMetadata(
+      long took, List<EsSearchResponse> responses, Map<String, String> debugMetadata) {
     this.took = took;
     this.responses = responses;
+    this.debugMetadata = debugMetadata;
   }
 
   public long getTook() {
@@ -22,5 +28,9 @@ public class SearchResponseMetadata {
 
   public List<EsSearchResponse> getResponses() {
     return responses;
+  }
+
+  public Map<String, String> getDebugMetadata() {
+    return debugMetadata;
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiServiceTest.java
@@ -73,7 +73,7 @@ public class ElasticsearchApiServiceTest {
 
   // todo - test mapping
   @Test
-  public void testResultsAreReturnedForValidQuery() throws IOException {
+  public void testResultsAreReturnedForValidQuery() throws Exception {
     List<LogMessage> messages = MessageUtil.makeMessagesWithTimeDifference(1, 100);
     addMessagesToChunkManager(messages);
 
@@ -111,7 +111,7 @@ public class ElasticsearchApiServiceTest {
   }
 
   @Test
-  public void testSearchStringWithOneResult() throws IOException {
+  public void testSearchStringWithOneResult() throws Exception {
     List<LogMessage> messages = MessageUtil.makeMessagesWithTimeDifference(1, 100);
     addMessagesToChunkManager(messages);
 
@@ -140,7 +140,7 @@ public class ElasticsearchApiServiceTest {
   }
 
   @Test
-  public void testSearchStringWithNoResult() throws IOException {
+  public void testSearchStringWithNoResult() throws Exception {
     // add 100 results around now
     List<LogMessage> messages = MessageUtil.makeMessagesWithTimeDifference(1, 100);
     addMessagesToChunkManager(messages);
@@ -162,7 +162,7 @@ public class ElasticsearchApiServiceTest {
   }
 
   @Test
-  public void testResultSizeIsRespected() throws IOException {
+  public void testResultSizeIsRespected() throws Exception {
     List<LogMessage> messages = MessageUtil.makeMessagesWithTimeDifference(1, 100);
     addMessagesToChunkManager(messages);
 
@@ -236,7 +236,7 @@ public class ElasticsearchApiServiceTest {
   }
 
   @Test
-  public void testEmptySearchGrafana7() throws IOException {
+  public void testEmptySearchGrafana7() throws Exception {
     String postBody =
         Resources.toString(
             Resources.getResource("elasticsearchApi/empty_search_grafana7.ndjson"),
@@ -253,7 +253,7 @@ public class ElasticsearchApiServiceTest {
   }
 
   @Test
-  public void testEmptySearchGrafana8() throws IOException {
+  public void testEmptySearchGrafana8() throws Exception {
     String postBody =
         Resources.toString(
             Resources.getResource("elasticsearchApi/empty_search_grafana8.ndjson"),


### PR DESCRIPTION
This adds parallel query handling for multisearch, and also supports the appropriate trace instrumentation. I also included some additional helpful troubleshooting info around a potential timeout exception that I observed while working on this, and why it would be expected to happen.

This no longer attempts to use forkjoin, but uses a cached executor and futures like we do in the distributed query code as it's easier to instrument with our tracing and is consistent with our other code.

![Screenshot 2022-11-08 at 11 13 30 AM](https://user-images.githubusercontent.com/771133/200643108-5d05db63-d069-477d-86b1-cf30f004ded7.png)
