### PR TITLE
Add service name to datasets and use that to apply rate filtering of documents

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadata.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 public class DatasetMetadata extends KaldbMetadata {
 
   public final String owner;
+  public final String serviceNamePattern;
   public final long throughputBytes;
   public final ImmutableList<DatasetPartitionMetadata> partitionConfigs;
 
@@ -23,7 +24,8 @@ public class DatasetMetadata extends KaldbMetadata {
       String name,
       String owner,
       long throughputBytes,
-      List<DatasetPartitionMetadata> partitionConfigs) {
+      List<DatasetPartitionMetadata> partitionConfigs,
+      String serviceNamePattern) {
     super(name);
     checkArgument(name.length() <= 256, "name must be no longer than 256 chars");
     checkArgument(name.matches("^[a-zA-Z0-9_-]*$"), "name must contain only [a-zA-Z0-9_-]");
@@ -32,9 +34,20 @@ public class DatasetMetadata extends KaldbMetadata {
     checkArgument(throughputBytes >= 0, "throughputBytes must be greater than or equal to 0");
     checkPartitions(partitionConfigs, "partitionConfigs must not overlap start and end times");
 
+    checkArgument(
+        serviceNamePattern.length() <= 256, "serviceNamePattern must be no longer than 256 chars");
+    checkArgument(
+        serviceNamePattern.matches("^[a-zA-Z0-9_-]*$"),
+        "serviceName must contain only [a-zA-Z0-9_-]");
+
     this.owner = owner;
+    this.serviceNamePattern = serviceNamePattern;
     this.throughputBytes = throughputBytes;
     this.partitionConfigs = ImmutableList.copyOf(partitionConfigs);
+  }
+
+  public DatasetMetadata getDataset() {
+    return this;
   }
 
   public String getOwner() {
@@ -49,20 +62,27 @@ public class DatasetMetadata extends KaldbMetadata {
     return partitionConfigs;
   }
 
+  public String getServiceNamePattern() {
+    return serviceNamePattern;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof DatasetMetadata)) return false;
     if (!super.equals(o)) return false;
     DatasetMetadata that = (DatasetMetadata) o;
     return throughputBytes == that.throughputBytes
+        && name.equals(that.name)
         && owner.equals(that.owner)
+        && serviceNamePattern.equals(that.serviceNamePattern)
         && partitionConfigs.equals(that.partitionConfigs);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), owner, throughputBytes, partitionConfigs);
+    return Objects.hash(
+        super.hashCode(), name, owner, serviceNamePattern, throughputBytes, partitionConfigs);
   }
 
   @Override
@@ -73,6 +93,9 @@ public class DatasetMetadata extends KaldbMetadata {
         + '\''
         + ", owner='"
         + owner
+        + '\''
+        + ", serviceNamePattern='"
+        + serviceNamePattern
         + '\''
         + ", throughputBytes="
         + throughputBytes

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadata.java
@@ -15,6 +15,9 @@ import java.util.stream.Collectors;
  */
 public class DatasetMetadata extends KaldbMetadata {
 
+  public static final String MATCH_ALL_SERVICE = "_all";
+  public static final String MATCH_STAR_SERVICE = "*";
+
   public final String owner;
   public final String serviceNamePattern;
   public final long throughputBytes;

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadata.java
@@ -36,9 +36,6 @@ public class DatasetMetadata extends KaldbMetadata {
 
     checkArgument(
         serviceNamePattern.length() <= 256, "serviceNamePattern must be no longer than 256 chars");
-    checkArgument(
-        serviceNamePattern.matches("^[a-zA-Z0-9_-]*$"),
-        "serviceName must contain only [a-zA-Z0-9_-]");
 
     this.owner = owner;
     this.serviceNamePattern = serviceNamePattern;

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadata.java
@@ -37,8 +37,12 @@ public class DatasetMetadata extends KaldbMetadata {
     checkArgument(throughputBytes >= 0, "throughputBytes must be greater than or equal to 0");
     checkPartitions(partitionConfigs, "partitionConfigs must not overlap start and end times");
 
-    checkArgument(
-        serviceNamePattern.length() <= 256, "serviceNamePattern must be no longer than 256 chars");
+    // back compat - make this into a null check in the future?
+    if (serviceNamePattern != null && !serviceNamePattern.isBlank()) {
+      checkArgument(
+          serviceNamePattern.length() <= 256,
+          "serviceNamePattern must be no longer than 256 chars");
+    }
 
     this.owner = owner;
     this.serviceNamePattern = serviceNamePattern;

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadataSerializer.java
@@ -21,7 +21,8 @@ public class DatasetMetadataSerializer implements MetadataSerializer<DatasetMeta
         datasetMetadataProto.getName(),
         datasetMetadataProto.getOwner(),
         datasetMetadataProto.getThroughputBytes(),
-        datasetPartitionMetadata);
+        datasetPartitionMetadata,
+        datasetMetadataProto.getServiceNamePattern());
   }
 
   public static Metadata.DatasetMetadata toDatasetMetadataProto(DatasetMetadata metadata) {

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadataSerializer.java
@@ -38,6 +38,7 @@ public class DatasetMetadataSerializer implements MetadataSerializer<DatasetMeta
         .setOwner(metadata.owner)
         .setThroughputBytes(metadata.throughputBytes)
         .addAllPartitionConfigs(datasetPartitionMetadata)
+        .setServiceNamePattern(metadata.serviceNamePattern)
         .build();
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiter.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiter.java
@@ -157,8 +157,12 @@ public class PreprocessorRateLimiter {
 
       for (DatasetMetadata datasetMetadata : throughputSortedDatasets) {
         String serviceNamePattern = datasetMetadata.getServiceNamePattern();
-        if (serviceName.equals(MATCH_ALL_SERVICE)
-            || serviceName.equals(MATCH_STAR_SERVICE)
+        // back-compat since this is a new field
+        if (serviceNamePattern == null) {
+          serviceNamePattern = datasetMetadata.getName();
+        }
+        if (serviceNamePattern.equals(MATCH_ALL_SERVICE)
+            || serviceNamePattern.equals(MATCH_STAR_SERVICE)
             || serviceName.equals(serviceNamePattern)) {
           RateLimiter rateLimiter = rateLimiterMap.get(datasetMetadata.getName());
           if (rateLimiter.tryAcquire(bytes)) {

--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiter.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiter.java
@@ -2,6 +2,7 @@ package com.slack.kaldb.preprocessor;
 
 import static com.slack.kaldb.metadata.dataset.DatasetMetadata.MATCH_ALL_SERVICE;
 import static com.slack.kaldb.metadata.dataset.DatasetMetadata.MATCH_STAR_SERVICE;
+import static com.slack.kaldb.preprocessor.PreprocessorService.sortDatasetsOnThroughput;
 
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.RateLimiter;
@@ -12,11 +13,9 @@ import io.micrometer.core.instrument.Tag;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.kafka.streams.kstream.Predicate;
 import org.slf4j.Logger;
@@ -111,11 +110,7 @@ public class PreprocessorRateLimiter {
   public Predicate<String, Trace.Span> createRateLimiter(
       List<DatasetMetadata> datasetMetadataList) {
 
-    List<DatasetMetadata> throughputSortedDatasets =
-        datasetMetadataList
-            .stream()
-            .sorted(Comparator.comparingLong(DatasetMetadata::getThroughputBytes))
-            .collect(Collectors.toList());
+    List<DatasetMetadata> throughputSortedDatasets = sortDatasetsOnThroughput(datasetMetadataList);
 
     Map<String, RateLimiter> rateLimiterMap = new HashMap<>(datasetMetadataList.size());
 

--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorService.java
@@ -272,7 +272,7 @@ public class PreprocessorService extends AbstractService {
         "datasetToPartitionList cannot have any empty partition lists");
 
     return (topic, key, value, partitionCount) -> {
-      String datasetName = PreprocessorValueMapper.getDatasetName(value);
+      String datasetName = PreprocessorValueMapper.getServiceName(value);
       if (!datasetToPartitionList.containsKey(datasetName)) {
         // this shouldn't happen, as we should have filtered all the missing datasets in the value
         // mapper stage

--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorService.java
@@ -252,6 +252,14 @@ public class PreprocessorService extends AbstractService {
         .collect(Collectors.toUnmodifiableList());
   }
 
+  public static List<DatasetMetadata> sortDatasetsOnThroughput(
+      List<DatasetMetadata> datasetMetadataList) {
+    return datasetMetadataList
+        .stream()
+        .sorted(Comparator.comparingLong(DatasetMetadata::getThroughputBytes).reversed())
+        .collect(Collectors.toList());
+  }
+
   /**
    * Returns a StreamPartitioner that selects from the provided list of dataset metadata. If no
    * valid dataset metadata are provided throws an exception.
@@ -259,11 +267,7 @@ public class PreprocessorService extends AbstractService {
   protected static StreamPartitioner<String, Trace.Span> streamPartitioner(
       List<DatasetMetadata> datasetMetadataList) {
 
-    List<DatasetMetadata> throughputSortedDatasets =
-        datasetMetadataList
-            .stream()
-            .sorted(Comparator.comparingLong(DatasetMetadata::getThroughputBytes))
-            .collect(Collectors.toList());
+    List<DatasetMetadata> throughputSortedDatasets = sortDatasetsOnThroughput(datasetMetadataList);
 
     return (topic, key, value, partitionCount) -> {
       String serviceName = PreprocessorValueMapper.getServiceName(value);

--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorService.java
@@ -201,12 +201,7 @@ public class PreprocessorService extends AbstractService {
                         KaldbMetadata::getName, PreprocessorService::getActivePartitionList)));
 
     Predicate<String, Trace.Span> rateLimitPredicate =
-        rateLimiter.createRateLimiter(
-            datasetMetadataList
-                .stream()
-                .collect(
-                    Collectors.toUnmodifiableMap(
-                        KaldbMetadata::getName, DatasetMetadata::getThroughputBytes)));
+        rateLimiter.createRateLimiter(datasetMetadataList);
 
     upstreamTopics.forEach(
         (upstreamTopic ->

--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorService.java
@@ -252,6 +252,8 @@ public class PreprocessorService extends AbstractService {
         .collect(Collectors.toUnmodifiableList());
   }
 
+  // we sort the datasets to rank from which dataset do we start matching candidate service names
+  // in the future we can change the ordering from sort to something else
   public static List<DatasetMetadata> sortDatasetsOnThroughput(
       List<DatasetMetadata> datasetMetadataList) {
     return datasetMetadataList

--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorValueMapper.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorValueMapper.java
@@ -63,7 +63,7 @@ public class PreprocessorValueMapper {
    *
    * <p>todo - consider putting the service name into a top-level Trace.Span property
    */
-  public static String getDatasetName(Trace.Span span) {
+  public static String getServiceName(Trace.Span span) {
     return span.getTagsList()
         .stream()
         .filter(tag -> tag.getKey().equals(SERVICE_NAME_KEY))

--- a/kaldb/src/main/java/com/slack/kaldb/server/ManagerApiGrpc.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ManagerApiGrpc.java
@@ -59,7 +59,12 @@ public class ManagerApiGrpc extends ManagerApiServiceGrpc.ManagerApiServiceImplB
 
     try {
       datasetMetadataStore.createSync(
-          new DatasetMetadata(request.getName(), request.getOwner(), 0L, Collections.emptyList()));
+          new DatasetMetadata(
+              request.getName(),
+              request.getOwner(),
+              0L,
+              Collections.emptyList(),
+              request.getServiceNamePattern()));
       responseObserver.onNext(
           toDatasetMetadataProto(datasetMetadataStore.getNodeSync(request.getName())));
       responseObserver.onCompleted();
@@ -83,7 +88,8 @@ public class ManagerApiGrpc extends ManagerApiServiceGrpc.ManagerApiServiceImplB
               existingDatasetMetadata.getName(),
               request.getOwner(),
               existingDatasetMetadata.getThroughputBytes(),
-              existingDatasetMetadata.getPartitionConfigs());
+              existingDatasetMetadata.getPartitionConfigs(),
+              request.getServiceNamePattern());
       datasetMetadataStore.updateSync(updatedDatasetMetadata);
       responseObserver.onNext(toDatasetMetadataProto(updatedDatasetMetadata));
       responseObserver.onCompleted();
@@ -167,7 +173,8 @@ public class ManagerApiGrpc extends ManagerApiServiceGrpc.ManagerApiServiceImplB
               datasetMetadata.getName(),
               datasetMetadata.getOwner(),
               updatedThroughputBytes,
-              updatedDatasetPartitionMetadata);
+              updatedDatasetPartitionMetadata,
+              datasetMetadata.getServiceNamePattern());
       datasetMetadataStore.updateSync(updatedDatasetMetadata);
 
       responseObserver.onNext(

--- a/kaldb/src/main/proto/manager_api.proto
+++ b/kaldb/src/main/proto/manager_api.proto
@@ -31,6 +31,8 @@ message CreateDatasetMetadataRequest {
   string name = 1;
   // Owner information, maybe be any string
   string owner = 2;
+  // The service name pattern that the dataset is indexing
+  string service_name_pattern = 3;
 }
 
 // UpdateDatasetMetadataRequest represents a request to update an existing dataset
@@ -39,6 +41,8 @@ message UpdateDatasetMetadataRequest {
   string name = 1;
   // Owner information, maybe be any string
   string owner = 2;
+  // The service name pattern that the dataset is indexing
+  string service_name_pattern = 3;
 }
 
 // GetDatasetMetadataRequest represents a request to fetch an existing dataset

--- a/kaldb/src/main/proto/metadata.proto
+++ b/kaldb/src/main/proto/metadata.proto
@@ -134,6 +134,9 @@ message DatasetMetadata {
 
   // List of partitions assigned to this service, and their effective times
   repeated DatasetPartitionMetadata partition_configs = 4;
+
+  // either same as name or a special value _all
+  string service_name_pattern = 5;
 }
 
 // Describes a set of partitions along with their effective start and end times

--- a/kaldb/src/main/proto/metadata.proto
+++ b/kaldb/src/main/proto/metadata.proto
@@ -135,7 +135,7 @@ message DatasetMetadata {
   // List of partitions assigned to this service, and their effective times
   repeated DatasetPartitionMetadata partition_configs = 4;
 
-  // either same as name or a special value _all
+  // either same as name or a special value _all or * which matches all services
   string service_name_pattern = 5;
 }
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
@@ -120,7 +120,7 @@ public class KaldbDistributedQueryServiceTest {
 
     DatasetPartitionMetadata partition = new DatasetPartitionMetadata(1, 300, List.of("1"));
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(indexName, "testOwner", 1, List.of(partition));
+        new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
@@ -192,7 +192,7 @@ public class KaldbDistributedQueryServiceTest {
     datasetMetadataStore.delete(datasetMetadata.name);
     await().until(() -> datasetMetadataStore.listSync().size() == 0);
     partition = new DatasetPartitionMetadata(1, 99, List.of("1"));
-    datasetMetadata = new DatasetMetadata(indexName, "testOwner", 1, List.of(partition));
+    datasetMetadata = new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
@@ -217,7 +217,7 @@ public class KaldbDistributedQueryServiceTest {
     String indexName = "testIndex";
     DatasetPartitionMetadata partition = new DatasetPartitionMetadata(1, 500, List.of("1"));
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(indexName, "testOwner", 1, List.of(partition));
+        new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
@@ -373,7 +373,7 @@ public class KaldbDistributedQueryServiceTest {
     String indexName = "testIndex";
     DatasetPartitionMetadata partition = new DatasetPartitionMetadata(199, 500, List.of("1"));
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(indexName, "testOwner", 1, List.of(partition));
+        new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
@@ -471,7 +471,7 @@ public class KaldbDistributedQueryServiceTest {
     datasetMetadataStore.delete(datasetMetadata.name);
     await().until(() -> datasetMetadataStore.listSync().size() == 0);
     partition = new DatasetPartitionMetadata(1, 99, List.of("1"));
-    datasetMetadata = new DatasetMetadata(indexName, "testOwner", 1, List.of(partition));
+    datasetMetadata = new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
@@ -507,7 +507,7 @@ public class KaldbDistributedQueryServiceTest {
 
     DatasetPartitionMetadata partition = new DatasetPartitionMetadata(1, 500, List.of("1"));
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(indexName, "testOwner", 1, List.of(partition));
+        new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
@@ -658,7 +658,7 @@ public class KaldbDistributedQueryServiceTest {
         new DatasetPartitionMetadata(201, 300, List.of("2"));
 
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(name, owner, throughputBytes, List.of(partition11, partition12));
+        new DatasetMetadata(name, owner, throughputBytes, List.of(partition11, partition12), name);
 
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.listSync().size() == 1);
@@ -687,7 +687,8 @@ public class KaldbDistributedQueryServiceTest {
         new DatasetPartitionMetadata(201, 300, List.of("1"));
 
     DatasetMetadata datasetMetadata1 =
-        new DatasetMetadata(name1, owner1, throughputBytes1, List.of(partition21, partition22));
+        new DatasetMetadata(
+            name1, owner1, throughputBytes1, List.of(partition21, partition22), name1);
     datasetMetadataStore.createSync(datasetMetadata1);
     await().until(() -> datasetMetadataStore.listSync().size() == 2);
 
@@ -744,7 +745,7 @@ public class KaldbDistributedQueryServiceTest {
 
     DatasetPartitionMetadata partition = new DatasetPartitionMetadata(1, 200, List.of("1"));
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(indexName1, "testOwner1", 1, List.of(partition));
+        new DatasetMetadata(indexName1, "testOwner1", 1, List.of(partition), indexName1);
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
@@ -765,7 +766,8 @@ public class KaldbDistributedQueryServiceTest {
     await().until(() -> searchMetadataStore.listSync().size() == 2);
 
     partition = new DatasetPartitionMetadata(1, 101, List.of("2"));
-    datasetMetadata = new DatasetMetadata(indexName2, "testOwner2", 1, List.of(partition));
+    datasetMetadata =
+        new DatasetMetadata(indexName2, "testOwner2", 1, List.of(partition), indexName2);
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.listSync().size() == 2);
 

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetMetadataSerializerTest.java
@@ -23,12 +23,14 @@ public class DatasetMetadataSerializerTest {
 
     final String name = "testDataset";
     final String owner = "testOwner";
+    final String serviceNamePattern = "service1";
     final long throughput = 2000;
     final List<DatasetPartitionMetadata> list =
         Collections.singletonList(
             new DatasetPartitionMetadata(
                 partitionStart.toEpochMilli(), partitionEnd.toEpochMilli(), partitionList));
-    final DatasetMetadata datasetMetadata = new DatasetMetadata(name, owner, throughput, list);
+    final DatasetMetadata datasetMetadata =
+        new DatasetMetadata(name, owner, throughput, list, serviceNamePattern);
 
     String serializedDatasetMetadata = serDe.toJsonStr(datasetMetadata);
     assertThat(serializedDatasetMetadata).isNotEmpty();
@@ -37,6 +39,37 @@ public class DatasetMetadataSerializerTest {
     assertThat(deserializedDatasetMetadata).isEqualTo(datasetMetadata);
 
     assertThat(deserializedDatasetMetadata.name).isEqualTo(name);
+    assertThat(deserializedDatasetMetadata.serviceNamePattern).isEqualTo(serviceNamePattern);
+    assertThat(deserializedDatasetMetadata.partitionConfigs).isEqualTo(list);
+  }
+
+  @Test
+  public void testDatasetMetadataSerializerForRegexServiceNames()
+      throws InvalidProtocolBufferException {
+    final Instant partitionStart = Instant.now();
+    final Instant partitionEnd = Instant.now().plus(1, ChronoUnit.DAYS);
+    final String partitionName = "partitionName";
+    final List<String> partitionList = List.of(partitionName);
+
+    final String name = "testDataset";
+    final String owner = "testOwner";
+    final String serviceNamePattern1 = "abc";
+    final long throughput = 2000;
+    final List<DatasetPartitionMetadata> list =
+        Collections.singletonList(
+            new DatasetPartitionMetadata(
+                partitionStart.toEpochMilli(), partitionEnd.toEpochMilli(), partitionList));
+    final DatasetMetadata datasetMetadata =
+        new DatasetMetadata(name, owner, throughput, list, serviceNamePattern1);
+
+    String serializedDatasetMetadata = serDe.toJsonStr(datasetMetadata);
+    assertThat(serializedDatasetMetadata).isNotEmpty();
+
+    DatasetMetadata deserializedDatasetMetadata = serDe.fromJsonStr(serializedDatasetMetadata);
+    assertThat(deserializedDatasetMetadata).isEqualTo(datasetMetadata);
+
+    assertThat(deserializedDatasetMetadata.name).isEqualTo(name);
+    assertThat(deserializedDatasetMetadata.serviceNamePattern).isEqualTo(serviceNamePattern1);
     assertThat(deserializedDatasetMetadata.partitionConfigs).isEqualTo(list);
   }
 
@@ -52,6 +85,7 @@ public class DatasetMetadataSerializerTest {
 
     final String name = "testDataset";
     final String owner = "testOwner";
+    final String serviceNamePattern = "serviceName";
     final long throughput = 2000;
     final List<DatasetPartitionMetadata> list =
         List.of(
@@ -59,7 +93,8 @@ public class DatasetMetadataSerializerTest {
                 partitionStart1.toEpochMilli(), partitionEnd1.toEpochMilli(), partitionList),
             new DatasetPartitionMetadata(
                 partitionStart2.toEpochMilli(), partitionEnd2.toEpochMilli(), partitionList));
-    final DatasetMetadata datasetMetadata = new DatasetMetadata(name, owner, throughput, list);
+    final DatasetMetadata datasetMetadata =
+        new DatasetMetadata(name, owner, throughput, list, serviceNamePattern);
 
     String serializedDatasetMetadata = serDe.toJsonStr(datasetMetadata);
     assertThat(serializedDatasetMetadata).isNotEmpty();
@@ -68,6 +103,7 @@ public class DatasetMetadataSerializerTest {
     assertThat(deserializedDatasetMetadata).isEqualTo(datasetMetadata);
 
     assertThat(deserializedDatasetMetadata.name).isEqualTo(name);
+    assertThat(deserializedDatasetMetadata.serviceNamePattern).isEqualTo(serviceNamePattern);
     assertThat(deserializedDatasetMetadata.partitionConfigs).isEqualTo(list);
   }
 
@@ -75,9 +111,11 @@ public class DatasetMetadataSerializerTest {
   public void testDatasetMetadataSerializerEmptyList() throws InvalidProtocolBufferException {
     final String name = "testDataset";
     final String owner = "testOwner";
+    final String serviceNamePattern = "serviceName";
     final long throughput = 2000;
     final List<DatasetPartitionMetadata> list = Collections.emptyList();
-    final DatasetMetadata datasetMetadata = new DatasetMetadata(name, owner, throughput, list);
+    final DatasetMetadata datasetMetadata =
+        new DatasetMetadata(name, owner, throughput, list, serviceNamePattern);
 
     String serializedDatasetMetadata = serDe.toJsonStr(datasetMetadata);
     assertThat(serializedDatasetMetadata).isNotEmpty();
@@ -86,6 +124,7 @@ public class DatasetMetadataSerializerTest {
     assertThat(deserializedDatasetMetadata).isEqualTo(datasetMetadata);
 
     assertThat(deserializedDatasetMetadata.name).isEqualTo(name);
+    assertThat(deserializedDatasetMetadata.serviceNamePattern).isEqualTo(serviceNamePattern);
     assertThat(deserializedDatasetMetadata.partitionConfigs).isEqualTo(list);
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetMetadataSerializerTest.java
@@ -44,7 +44,7 @@ public class DatasetMetadataSerializerTest {
   }
 
   @Test
-  public void testDatasetMetadataSerializerForRegexServiceNames()
+  public void testDatasetMetadataSerializerWithServiceNames()
       throws InvalidProtocolBufferException {
     final Instant partitionStart = Instant.now();
     final Instant partitionEnd = Instant.now().plus(1, ChronoUnit.DAYS);

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetMetadataTest.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Test;
 
 public class DatasetMetadataTest {
@@ -37,6 +38,7 @@ public class DatasetMetadataTest {
   public void testInvalidServiceMetadataNames() {
     assertThatIllegalArgumentException()
         .isThrownBy(() -> new DatasetMetadata("&", "owner", 0, null, "&"));
+
     assertThatIllegalArgumentException()
         .isThrownBy(() -> new DatasetMetadata("test%", "owner", 0, null, "test%"));
     assertThatIllegalArgumentException()
@@ -51,6 +53,18 @@ public class DatasetMetadataTest {
                     0,
                     null,
                     "jZOGhT2v86abA0h6yX6DUeKOkKE06nR0TlExO0bp7HBv"));
+
+    final DatasetPartitionMetadata partition =
+        new DatasetPartitionMetadata(
+            Instant.now().toEpochMilli(),
+            Instant.now().plusSeconds(90).toEpochMilli(),
+            List.of("partition"));
+    final List<DatasetPartitionMetadata> partitionConfigs1 = Collections.singletonList(partition);
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                new DatasetMetadata(
+                    "name", "owner", 1, partitionConfigs1, RandomStringUtils.random(257)));
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetMetadataTest.java
@@ -25,7 +25,7 @@ public class DatasetMetadataTest {
             List.of("partition"));
     final List<DatasetPartitionMetadata> partitionConfigs = Collections.singletonList(partition);
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(name, owner, throughputBytes, partitionConfigs);
+        new DatasetMetadata(name, owner, throughputBytes, partitionConfigs, name);
 
     assertThat(datasetMetadata.name).isEqualTo(name);
     assertThat(datasetMetadata.owner).isEqualTo(owner);
@@ -36,9 +36,9 @@ public class DatasetMetadataTest {
   @Test
   public void testInvalidServiceMetadataNames() {
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new DatasetMetadata("&", "owner", 0, null));
+        .isThrownBy(() -> new DatasetMetadata("&", "owner", 0, null, "&"));
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new DatasetMetadata("test%", "owner", 0, null));
+        .isThrownBy(() -> new DatasetMetadata("test%", "owner", 0, null, "test%"));
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
@@ -49,7 +49,8 @@ public class DatasetMetadataTest {
                         + "FY9LMMsA2aPtQ7Q8g4eZzm6Kv51r0x26pFQhxfHCwUZqa",
                     "owner",
                     0,
-                    null));
+                    null,
+                    "jZOGhT2v86abA0h6yX6DUeKOkKE06nR0TlExO0bp7HBv"));
   }
 
   @Test
@@ -65,7 +66,7 @@ public class DatasetMetadataTest {
             List.of("partition"));
     final List<DatasetPartitionMetadata> partitionConfigs1 = Collections.singletonList(partition);
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(name, owner, throughputBytes, partitionConfigs1);
+        new DatasetMetadata(name, owner, throughputBytes, partitionConfigs1, name);
 
     assertThat(datasetMetadata.name).isEqualTo(name);
     assertThat(datasetMetadata.owner).isEqualTo(owner);
@@ -95,15 +96,15 @@ public class DatasetMetadataTest {
     final List<DatasetPartitionMetadata> partitionConfig = Collections.singletonList(partition);
 
     DatasetMetadata datasetMetadata1 =
-        new DatasetMetadata(name, owner, throughputBytes, partitionConfig);
+        new DatasetMetadata(name, owner, throughputBytes, partitionConfig, name);
     DatasetMetadata datasetMetadata2 =
-        new DatasetMetadata(name + "2", owner, throughputBytes, partitionConfig);
+        new DatasetMetadata(name + "2", owner, throughputBytes, partitionConfig, name + "2");
     DatasetMetadata datasetMetadata3 =
-        new DatasetMetadata(name, owner + "3", throughputBytes, partitionConfig);
+        new DatasetMetadata(name, owner + "3", throughputBytes, partitionConfig, name);
     DatasetMetadata datasetMetadata4 =
-        new DatasetMetadata(name, owner, throughputBytes + 4, partitionConfig);
+        new DatasetMetadata(name, owner, throughputBytes + 4, partitionConfig, name);
     DatasetMetadata datasetMetadata5 =
-        new DatasetMetadata(name, owner, throughputBytes, Collections.emptyList());
+        new DatasetMetadata(name, owner, throughputBytes, Collections.emptyList(), name);
 
     assertThat(datasetMetadata1).isEqualTo(datasetMetadata1);
     assertThat(datasetMetadata1).isNotEqualTo(datasetMetadata2);
@@ -140,17 +141,17 @@ public class DatasetMetadataTest {
     final List<DatasetPartitionMetadata> partitionConfig = Collections.singletonList(partition);
 
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new DatasetMetadata("", owner, throughputBytes, partitionConfig));
+        .isThrownBy(() -> new DatasetMetadata("", owner, throughputBytes, partitionConfig, ""));
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new DatasetMetadata(null, owner, throughputBytes, partitionConfig));
+        .isThrownBy(() -> new DatasetMetadata(null, owner, throughputBytes, partitionConfig, null));
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new DatasetMetadata(name, "", throughputBytes, partitionConfig));
+        .isThrownBy(() -> new DatasetMetadata(name, "", throughputBytes, partitionConfig, name));
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new DatasetMetadata(name, null, throughputBytes, partitionConfig));
+        .isThrownBy(() -> new DatasetMetadata(name, null, throughputBytes, partitionConfig, name));
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new DatasetMetadata(name, owner, -1, partitionConfig));
+        .isThrownBy(() -> new DatasetMetadata(name, owner, -1, partitionConfig, name));
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new DatasetMetadata(name, owner, throughputBytes, null));
+        .isThrownBy(() -> new DatasetMetadata(name, owner, throughputBytes, null, name));
   }
 
   @Test
@@ -170,7 +171,8 @@ public class DatasetMetadataTest {
                     throughputBytes,
                     List.of(
                         new DatasetPartitionMetadata(0, 2000, partitionlist),
-                        new DatasetPartitionMetadata(0, 3000, partitionlist))));
+                        new DatasetPartitionMetadata(0, 3000, partitionlist)),
+                    name));
 
     assertThatIllegalArgumentException()
         .isThrownBy(
@@ -181,7 +183,8 @@ public class DatasetMetadataTest {
                     throughputBytes,
                     List.of(
                         new DatasetPartitionMetadata(0, 2000, partitionlist),
-                        new DatasetPartitionMetadata(2000, 3000, partitionlist))));
+                        new DatasetPartitionMetadata(2000, 3000, partitionlist)),
+                    name));
 
     assertThatIllegalArgumentException()
         .isThrownBy(
@@ -192,7 +195,8 @@ public class DatasetMetadataTest {
                     throughputBytes,
                     List.of(
                         new DatasetPartitionMetadata(0, 3000, partitionlist),
-                        new DatasetPartitionMetadata(0, 2000, partitionlist))));
+                        new DatasetPartitionMetadata(0, 2000, partitionlist)),
+                    name));
 
     assertThatIllegalArgumentException()
         .isThrownBy(
@@ -203,6 +207,7 @@ public class DatasetMetadataTest {
                     throughputBytes,
                     List.of(
                         new DatasetPartitionMetadata(0, 2000, partitionlist),
-                        new DatasetPartitionMetadata(1800, 3000, partitionlist))));
+                        new DatasetPartitionMetadata(1800, 3000, partitionlist)),
+                    name));
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetPartitionMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetPartitionMetadataTest.java
@@ -131,7 +131,8 @@ public class DatasetPartitionMetadataTest {
       DatasetPartitionMetadata partition = new DatasetPartitionMetadata(100, 200, List.of("1"));
 
       DatasetMetadata datasetMetadata =
-          new DatasetMetadata("testDataset1", "datasetOwner1", throughputBytes, List.of(partition));
+          new DatasetMetadata(
+              "testDataset1", "datasetOwner1", throughputBytes, List.of(partition), "testDataset1");
 
       datasetMetadataStore.createSync(datasetMetadata);
       await().until(() -> datasetMetadataStore.getCached().size() == 1);
@@ -140,7 +141,8 @@ public class DatasetPartitionMetadataTest {
     {
       DatasetPartitionMetadata partition = new DatasetPartitionMetadata(201, 300, List.of("2"));
       DatasetMetadata datasetMetadata =
-          new DatasetMetadata("testDataset2", "datasetOwner2", throughputBytes, List.of(partition));
+          new DatasetMetadata(
+              "testDataset2", "datasetOwner2", throughputBytes, List.of(partition), "testDataset2");
       datasetMetadataStore.createSync(datasetMetadata);
       await().until(() -> datasetMetadataStore.getCached().size() == 2);
     }
@@ -182,7 +184,7 @@ public class DatasetPartitionMetadataTest {
     final DatasetPartitionMetadata partition = new DatasetPartitionMetadata(100, 200, List.of("1"));
 
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(name, owner, throughputBytes, List.of(partition));
+        new DatasetMetadata(name, owner, throughputBytes, List.of(partition), name);
 
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.getCached().size() == 1);
@@ -225,7 +227,7 @@ public class DatasetPartitionMetadataTest {
         new DatasetPartitionMetadata(201, 300, List.of("2", "3"));
 
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(name, owner, throughputBytes, List.of(partition1, partition2));
+        new DatasetMetadata(name, owner, throughputBytes, List.of(partition1, partition2), name);
 
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.getCached().size() == 1);
@@ -266,7 +268,7 @@ public class DatasetPartitionMetadataTest {
     final DatasetPartitionMetadata partition = new DatasetPartitionMetadata(100, 200, List.of("1"));
 
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(name, owner, throughputBytes, List.of(partition));
+        new DatasetMetadata(name, owner, throughputBytes, List.of(partition), name);
 
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.getCached().size() == 1);
@@ -278,7 +280,7 @@ public class DatasetPartitionMetadataTest {
         new DatasetPartitionMetadata(100, 200, List.of("2"));
 
     DatasetMetadata datasetMetadata1 =
-        new DatasetMetadata(name1, owner1, throughputBytes1, List.of(partition1));
+        new DatasetMetadata(name1, owner1, throughputBytes1, List.of(partition1), name1);
 
     datasetMetadataStore.createSync(datasetMetadata1);
     await().until(() -> datasetMetadataStore.getCached().size() == 2);

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiterTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiterTest.java
@@ -1,187 +1,223 @@
-// package com.slack.kaldb.preprocessor;
-//
-// import static com.slack.kaldb.preprocessor.PreprocessorRateLimiter.BYTES_DROPPED;
-// import static com.slack.kaldb.preprocessor.PreprocessorRateLimiter.MESSAGES_DROPPED;
-// import static com.slack.kaldb.preprocessor.PreprocessorValueMapper.SERVICE_NAME_KEY;
-// import static org.assertj.core.api.Assertions.assertThat;
-// import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-//
-// import com.slack.service.murron.trace.Trace;
-// import io.micrometer.core.instrument.MeterRegistry;
-// import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-// import java.util.Map;
-// import org.apache.kafka.streams.kstream.Predicate;
-// import org.junit.Test;
-//
-// public class PreprocessorRateLimiterTest {
-//
-//  @Test
-//  public void shouldApplyScaledRateLimit() throws InterruptedException {
-//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-//    int preprocessorCount = 2;
-//    int maxBurstSeconds = 1;
-//    boolean initializeWarm = false;
-//    PreprocessorRateLimiter rateLimiter =
-//        new PreprocessorRateLimiter(
-//            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
-//
-//    String name = "rateLimiter";
-//    Trace.Span span =
-//        Trace.Span.newBuilder()
-//            .addTags(Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(name).build())
-//            .build();
-//
-//    // set the target so that we pass the first add, then fail the second
-//    long targetThroughput = ((long) span.toByteArray().length * preprocessorCount) + 1;
-//    Predicate<String, Trace.Span> predicate =
-//        rateLimiter.createRateLimiter(Map.of(name, targetThroughput));
-//
-//    // try to get just below the scaled limit, then try to go over
-//    assertThat(predicate.test("key", span)).isTrue();
-//    assertThat(predicate.test("key", span)).isFalse();
-//
-//    // rate limit is targetThroughput per second, so 1 second should refill our limit
-//    Thread.sleep(1000);
-//
-//    // try to get just below the scaled limit, then try to go over
-//    assertThat(predicate.test("key", span)).isTrue();
-//    assertThat(predicate.test("key", span)).isFalse();
-//
-//    assertThat(
-//            meterRegistry
-//                .get(MESSAGES_DROPPED)
-//                .tag("reason",
-// String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
-//                .counter()
-//                .count())
-//        .isEqualTo(2);
-//    assertThat(
-//            meterRegistry
-//                .get(BYTES_DROPPED)
-//                .tag("reason",
-// String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
-//                .counter()
-//                .count())
-//        .isEqualTo(span.toByteArray().length * 2);
-//  }
-//
-//  @Test
-//  public void shouldDropMessagesWithNoConfiguration() {
-//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-//    PreprocessorRateLimiter rateLimiter = new PreprocessorRateLimiter(meterRegistry, 1, 1, false);
-//
-//    Trace.Span span =
-//        Trace.Span.newBuilder()
-//            .addTags(
-//                Trace.KeyValue.newBuilder()
-//                    .setKey(SERVICE_NAME_KEY)
-//                    .setVStr("unprovisioned_service")
-//                    .build())
-//            .build();
-//    Predicate<String, Trace.Span> predicate =
-//        rateLimiter.createRateLimiter(Map.of("provisioned_service", Long.MAX_VALUE));
-//
-//    // this should be immediately dropped
-//    assertThat(predicate.test("key", span)).isFalse();
-//
-//    assertThat(
-//            meterRegistry
-//                .get(MESSAGES_DROPPED)
-//                .tag(
-//                    "reason",
-//                    String.valueOf(PreprocessorRateLimiter.MessageDropReason.NOT_PROVISIONED))
-//                .counter()
-//                .count())
-//        .isEqualTo(1);
-//    assertThat(
-//            meterRegistry
-//                .get(BYTES_DROPPED)
-//                .tag(
-//                    "reason",
-//                    String.valueOf(PreprocessorRateLimiter.MessageDropReason.NOT_PROVISIONED))
-//                .counter()
-//                .count())
-//        .isEqualTo(span.toByteArray().length);
-//  }
-//
-//  @Test
-//  public void shouldHandleEmptyMessages() {
-//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-//    int preprocessorCount = 1;
-//    int maxBurstSeconds = 1;
-//    boolean initializeWarm = false;
-//    PreprocessorRateLimiter rateLimiter =
-//        new PreprocessorRateLimiter(
-//            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
-//
-//    String name = "rateLimiter";
-//    long targetThroughput = 1000;
-//    Predicate<String, Trace.Span> predicate =
-//        rateLimiter.createRateLimiter(Map.of(name, targetThroughput));
-//
-//    assertThat(predicate.test("key", Trace.Span.newBuilder().build())).isFalse();
-//    assertThat(predicate.test("key", null)).isFalse();
-//  }
-//
-//  @Test
-//  public void shouldThrowOnInvalidConfigurations() {
-//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(() -> new PreprocessorRateLimiter(meterRegistry, 0, 1, true));
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(() -> new PreprocessorRateLimiter(meterRegistry, 1, 0, true));
-//  }
-//
-//  @Test
-//  public void shouldAllowBurstingOverLimitWarm() throws InterruptedException {
-//    String name = "rateLimiter";
-//    Trace.Span span =
-//        Trace.Span.newBuilder()
-//            .addTags(Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(name).build())
-//            .build();
-//
-//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-//    PreprocessorRateLimiter rateLimiter = new PreprocessorRateLimiter(meterRegistry, 1, 3, true);
-//
-//    long targetThroughput = span.getSerializedSize() - 1;
-//    Predicate<String, Trace.Span> predicate =
-//        rateLimiter.createRateLimiter(Map.of(name, targetThroughput));
-//
-//    assertThat(predicate.test("key", span)).isTrue();
-//    assertThat(predicate.test("key", span)).isTrue();
-//    assertThat(predicate.test("key", span)).isTrue();
-//    assertThat(predicate.test("key", span)).isFalse();
-//
-//    Thread.sleep(2000);
-//
-//    assertThat(predicate.test("key", span)).isTrue();
-//    assertThat(predicate.test("key", span)).isTrue();
-//    assertThat(predicate.test("key", span)).isFalse();
-//  }
-//
-//  @Test
-//  public void shouldAllowBurstingOverLimitCold() throws InterruptedException {
-//    String name = "rateLimiter";
-//    Trace.Span span =
-//        Trace.Span.newBuilder()
-//            .addTags(Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(name).build())
-//            .build();
-//
-//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-//    PreprocessorRateLimiter rateLimiter = new PreprocessorRateLimiter(meterRegistry, 1, 3, false);
-//
-//    long targetThroughput = span.getSerializedSize() - 1;
-//    Predicate<String, Trace.Span> predicate =
-//        rateLimiter.createRateLimiter(Map.of(name, targetThroughput));
-//
-//    assertThat(predicate.test("key", span)).isTrue();
-//    assertThat(predicate.test("key", span)).isFalse();
-//
-//    Thread.sleep(4000);
-//
-//    assertThat(predicate.test("key", span)).isTrue();
-//    assertThat(predicate.test("key", span)).isTrue();
-//    assertThat(predicate.test("key", span)).isTrue();
-//    assertThat(predicate.test("key", span)).isFalse();
-//  }
-// }
+package com.slack.kaldb.preprocessor;
+
+import static com.slack.kaldb.preprocessor.PreprocessorRateLimiter.BYTES_DROPPED;
+import static com.slack.kaldb.preprocessor.PreprocessorRateLimiter.MESSAGES_DROPPED;
+import static com.slack.kaldb.preprocessor.PreprocessorValueMapper.SERVICE_NAME_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import com.slack.kaldb.metadata.dataset.DatasetMetadata;
+import com.slack.kaldb.metadata.dataset.DatasetPartitionMetadata;
+import com.slack.service.murron.trace.Trace;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import org.apache.kafka.streams.kstream.Predicate;
+import org.junit.Test;
+
+public class PreprocessorRateLimiterTest {
+
+  @Test
+  public void shouldApplyScaledRateLimit() throws InterruptedException {
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    int preprocessorCount = 2;
+    int maxBurstSeconds = 1;
+    boolean initializeWarm = false;
+    PreprocessorRateLimiter rateLimiter =
+        new PreprocessorRateLimiter(
+            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
+
+    String name = "rateLimiter";
+    Trace.Span span =
+        Trace.Span.newBuilder()
+            .addTags(Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(name).build())
+            .build();
+
+    // set the target so that we pass the first add, then fail the second
+    long targetThroughput = ((long) span.toByteArray().length * preprocessorCount) + 1;
+    DatasetMetadata datasetMetadata =
+        new DatasetMetadata(
+            name,
+            name,
+            targetThroughput,
+            List.of(new DatasetPartitionMetadata(100, 200, List.of("0"))),
+            name);
+    Predicate<String, Trace.Span> predicate =
+        rateLimiter.createRateLimiter(List.of(datasetMetadata));
+
+    // try to get just below the scaled limit, then try to go over
+    assertThat(predicate.test("key", span)).isTrue();
+    assertThat(predicate.test("key", span)).isFalse();
+
+    // rate limit is targetThroughput per second, so 1 second should refill our limit
+    Thread.sleep(1000);
+
+    // try to get just below the scaled limit, then try to go over
+    assertThat(predicate.test("key", span)).isTrue();
+    assertThat(predicate.test("key", span)).isFalse();
+
+    assertThat(
+            meterRegistry
+                .get(MESSAGES_DROPPED)
+                .tag("reason", String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
+                .counter()
+                .count())
+        .isEqualTo(2);
+    assertThat(
+            meterRegistry
+                .get(BYTES_DROPPED)
+                .tag("reason", String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
+                .counter()
+                .count())
+        .isEqualTo(span.toByteArray().length * 2);
+  }
+
+  @Test
+  public void shouldDropMessagesWithNoConfiguration() {
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    PreprocessorRateLimiter rateLimiter = new PreprocessorRateLimiter(meterRegistry, 1, 1, false);
+
+    Trace.Span span =
+        Trace.Span.newBuilder()
+            .addTags(
+                Trace.KeyValue.newBuilder()
+                    .setKey(SERVICE_NAME_KEY)
+                    .setVStr("unprovisioned_service")
+                    .build())
+            .build();
+
+    DatasetMetadata datasetMetadata =
+        new DatasetMetadata(
+            "wrong_service",
+            "wrong_service",
+            Long.MAX_VALUE,
+            List.of(new DatasetPartitionMetadata(100, 200, List.of("0"))),
+            "wrong_service");
+    Predicate<String, Trace.Span> predicate =
+        rateLimiter.createRateLimiter(List.of(datasetMetadata));
+
+    // this should be immediately dropped
+    assertThat(predicate.test("key", span)).isFalse();
+
+    assertThat(
+            meterRegistry
+                .get(MESSAGES_DROPPED)
+                .tag(
+                    "reason",
+                    String.valueOf(PreprocessorRateLimiter.MessageDropReason.NOT_PROVISIONED))
+                .counter()
+                .count())
+        .isEqualTo(1);
+    assertThat(
+            meterRegistry
+                .get(BYTES_DROPPED)
+                .tag(
+                    "reason",
+                    String.valueOf(PreprocessorRateLimiter.MessageDropReason.NOT_PROVISIONED))
+                .counter()
+                .count())
+        .isEqualTo(span.toByteArray().length);
+  }
+
+  @Test
+  public void shouldHandleEmptyMessages() {
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    int preprocessorCount = 1;
+    int maxBurstSeconds = 1;
+    boolean initializeWarm = false;
+    PreprocessorRateLimiter rateLimiter =
+        new PreprocessorRateLimiter(
+            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
+
+    String name = "rateLimiter";
+    long targetThroughput = 1000;
+    DatasetMetadata datasetMetadata =
+        new DatasetMetadata(
+            name,
+            name,
+            targetThroughput,
+            List.of(new DatasetPartitionMetadata(100, 200, List.of("0"))),
+            name);
+    Predicate<String, Trace.Span> predicate =
+        rateLimiter.createRateLimiter(List.of(datasetMetadata));
+
+    assertThat(predicate.test("key", Trace.Span.newBuilder().build())).isFalse();
+    assertThat(predicate.test("key", null)).isFalse();
+  }
+
+  @Test
+  public void shouldThrowOnInvalidConfigurations() {
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> new PreprocessorRateLimiter(meterRegistry, 0, 1, true));
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> new PreprocessorRateLimiter(meterRegistry, 1, 0, true));
+  }
+
+  @Test
+  public void shouldAllowBurstingOverLimitWarm() throws InterruptedException {
+    String name = "rateLimiter";
+    Trace.Span span =
+        Trace.Span.newBuilder()
+            .addTags(Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(name).build())
+            .build();
+
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    PreprocessorRateLimiter rateLimiter = new PreprocessorRateLimiter(meterRegistry, 1, 3, true);
+
+    long targetThroughput = span.getSerializedSize() - 1;
+    DatasetMetadata datasetMetadata =
+        new DatasetMetadata(
+            name,
+            name,
+            targetThroughput,
+            List.of(new DatasetPartitionMetadata(100, 200, List.of("0"))),
+            name);
+    Predicate<String, Trace.Span> predicate =
+        rateLimiter.createRateLimiter(List.of(datasetMetadata));
+
+    assertThat(predicate.test("key", span)).isTrue();
+    assertThat(predicate.test("key", span)).isTrue();
+    assertThat(predicate.test("key", span)).isTrue();
+    assertThat(predicate.test("key", span)).isFalse();
+
+    Thread.sleep(2000);
+
+    assertThat(predicate.test("key", span)).isTrue();
+    assertThat(predicate.test("key", span)).isTrue();
+    assertThat(predicate.test("key", span)).isFalse();
+  }
+
+  @Test
+  public void shouldAllowBurstingOverLimitCold() throws InterruptedException {
+    String name = "rateLimiter";
+    Trace.Span span =
+        Trace.Span.newBuilder()
+            .addTags(Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(name).build())
+            .build();
+
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    PreprocessorRateLimiter rateLimiter = new PreprocessorRateLimiter(meterRegistry, 1, 3, false);
+
+    long targetThroughput = span.getSerializedSize() - 1;
+    DatasetMetadata datasetMetadata =
+        new DatasetMetadata(
+            name,
+            name,
+            targetThroughput,
+            List.of(new DatasetPartitionMetadata(100, 200, List.of("0"))),
+            name);
+    Predicate<String, Trace.Span> predicate =
+        rateLimiter.createRateLimiter(List.of(datasetMetadata));
+
+    assertThat(predicate.test("key", span)).isTrue();
+    assertThat(predicate.test("key", span)).isFalse();
+
+    Thread.sleep(4000);
+
+    assertThat(predicate.test("key", span)).isTrue();
+    assertThat(predicate.test("key", span)).isTrue();
+    assertThat(predicate.test("key", span)).isTrue();
+    assertThat(predicate.test("key", span)).isFalse();
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiterTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiterTest.java
@@ -73,6 +73,215 @@ public class PreprocessorRateLimiterTest {
   }
 
   @Test
+  public void shouldApplyScaledRateLimitWithAllServices() throws InterruptedException {
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    int preprocessorCount = 2;
+    int maxBurstSeconds = 1;
+    boolean initializeWarm = false;
+    PreprocessorRateLimiter rateLimiter =
+        new PreprocessorRateLimiter(
+            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
+
+    String name = "rateLimiter";
+    Trace.Span span =
+        Trace.Span.newBuilder()
+            .addTags(Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(name).build())
+            .build();
+
+    // set the target so that we pass the first add, then fail the second
+    long targetThroughput = ((long) span.toByteArray().length * preprocessorCount) + 1;
+
+    // Check if _all works
+    DatasetMetadata datasetMetadata =
+        new DatasetMetadata(
+            name,
+            name,
+            targetThroughput,
+            List.of(new DatasetPartitionMetadata(100, 200, List.of("0"))),
+            DatasetMetadata.MATCH_ALL_SERVICE);
+    Predicate<String, Trace.Span> predicate =
+        rateLimiter.createRateLimiter(List.of(datasetMetadata));
+
+    // try to get just below the scaled limit, then try to go over
+    assertThat(predicate.test("key", span)).isTrue();
+    assertThat(predicate.test("key", span)).isFalse();
+
+    // rate limit is targetThroughput per second, so 1 second should refill our limit
+    Thread.sleep(1000);
+
+    // try to get just below the scaled limit, then try to go over
+    assertThat(predicate.test("key", span)).isTrue();
+    assertThat(predicate.test("key", span)).isFalse();
+
+    assertThat(
+            meterRegistry
+                .get(MESSAGES_DROPPED)
+                .tag("reason", String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
+                .counter()
+                .count())
+        .isEqualTo(2);
+    assertThat(
+            meterRegistry
+                .get(BYTES_DROPPED)
+                .tag("reason", String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
+                .counter()
+                .count())
+        .isEqualTo(span.toByteArray().length * 2);
+
+    // Check if * works
+    MeterRegistry meterRegistry1 = new SimpleMeterRegistry();
+    PreprocessorRateLimiter rateLimiter1 =
+        new PreprocessorRateLimiter(
+            meterRegistry1, preprocessorCount, maxBurstSeconds, initializeWarm);
+    DatasetMetadata datasetMetadata1 =
+        new DatasetMetadata(
+            name,
+            name,
+            targetThroughput,
+            List.of(new DatasetPartitionMetadata(100, 200, List.of("0"))),
+            DatasetMetadata.MATCH_STAR_SERVICE);
+    Predicate<String, Trace.Span> predicate1 =
+        rateLimiter1.createRateLimiter(List.of(datasetMetadata1));
+
+    // try to get just below the scaled limit, then try to go over
+    assertThat(predicate1.test("key", span)).isTrue();
+    assertThat(predicate1.test("key", span)).isFalse();
+
+    // rate limit is targetThroughput per second, so 1 second should refill our limit
+    Thread.sleep(1000);
+
+    // try to get just below the scaled limit, then try to go over
+    assertThat(predicate1.test("key", span)).isTrue();
+    assertThat(predicate1.test("key", span)).isFalse();
+
+    assertThat(
+            meterRegistry1
+                .get(MESSAGES_DROPPED)
+                .tag("reason", String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
+                .counter()
+                .count())
+        .isEqualTo(2);
+    assertThat(
+            meterRegistry1
+                .get(BYTES_DROPPED)
+                .tag("reason", String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
+                .counter()
+                .count())
+        .isEqualTo(span.toByteArray().length * 2);
+
+    // check back compat where service name will be null
+    MeterRegistry meterRegistry2 = new SimpleMeterRegistry();
+    PreprocessorRateLimiter rateLimiter2 =
+        new PreprocessorRateLimiter(
+            meterRegistry2, preprocessorCount, maxBurstSeconds, initializeWarm);
+    DatasetMetadata datasetMetadata2 =
+        new DatasetMetadata(
+            name,
+            name,
+            targetThroughput,
+            List.of(new DatasetPartitionMetadata(100, 200, List.of("0"))),
+            null);
+    Predicate<String, Trace.Span> predicate2 =
+        rateLimiter2.createRateLimiter(List.of(datasetMetadata2));
+
+    // try to get just below the scaled limit, then try to go over
+    assertThat(predicate2.test("key", span)).isTrue();
+    assertThat(predicate2.test("key", span)).isFalse();
+
+    // rate limit is targetThroughput per second, so 1 second should refill our limit
+    Thread.sleep(1000);
+
+    // try to get just below the scaled limit, then try to go over
+    assertThat(predicate2.test("key", span)).isTrue();
+    assertThat(predicate2.test("key", span)).isFalse();
+
+    assertThat(
+            meterRegistry2
+                .get(MESSAGES_DROPPED)
+                .tag("reason", String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
+                .counter()
+                .count())
+        .isEqualTo(2);
+    assertThat(
+            meterRegistry2
+                .get(BYTES_DROPPED)
+                .tag("reason", String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
+                .counter()
+                .count())
+        .isEqualTo(span.toByteArray().length * 2);
+  }
+
+  @Test
+  public void shouldApplyRateLimitsAgainstMultipleDatasets() throws InterruptedException {
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    int preprocessorCount = 2;
+    int maxBurstSeconds = 1;
+    boolean initializeWarm = false;
+    PreprocessorRateLimiter rateLimiter =
+        new PreprocessorRateLimiter(
+            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
+
+    String name = "rateLimiter";
+    Trace.Span span =
+        Trace.Span.newBuilder()
+            .addTags(Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(name).build())
+            .build();
+
+    // set the target so that we pass the first add, then fail the second
+    long targetThroughput = ((long) span.toByteArray().length * preprocessorCount) + 1;
+
+    // Dataset 1 has service name will never match the record while dataset 2 will match
+    DatasetMetadata datasetMetadata1 =
+        new DatasetMetadata(
+            name,
+            name,
+            targetThroughput,
+            List.of(new DatasetPartitionMetadata(100, 200, List.of("0"))),
+            "no_service_matching_docs");
+    DatasetMetadata datasetMetadata2 =
+        new DatasetMetadata(
+            name,
+            name,
+            targetThroughput,
+            List.of(new DatasetPartitionMetadata(100, 200, List.of("0"))),
+            DatasetMetadata.MATCH_ALL_SERVICE);
+
+    // ensure we always drop for dataset1
+    Predicate<String, Trace.Span> predicate1 =
+        rateLimiter.createRateLimiter(List.of(datasetMetadata1));
+    assertThat(predicate1.test("key", span)).isFalse();
+
+    Predicate<String, Trace.Span> predicate2 =
+        rateLimiter.createRateLimiter(List.of(datasetMetadata1, datasetMetadata2));
+
+    // try to get just below the scaled limit, then try to go over
+    assertThat(predicate2.test("key", span)).isTrue();
+    assertThat(predicate2.test("key", span)).isFalse();
+
+    // rate limit is targetThroughput per second, so 1 second should refill our limit
+    Thread.sleep(1000);
+
+    // try to get just below the scaled limit, then try to go over
+    assertThat(predicate2.test("key", span)).isTrue();
+    assertThat(predicate2.test("key", span)).isFalse();
+
+    assertThat(
+            meterRegistry
+                .get(MESSAGES_DROPPED)
+                .tag("reason", String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
+                .counter()
+                .count())
+        .isEqualTo(2);
+    assertThat(
+            meterRegistry
+                .get(BYTES_DROPPED)
+                .tag("reason", String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
+                .counter()
+                .count())
+        .isEqualTo(span.toByteArray().length * 2);
+  }
+
+  @Test
   public void shouldDropMessagesWithNoConfiguration() {
     MeterRegistry meterRegistry = new SimpleMeterRegistry();
     PreprocessorRateLimiter rateLimiter = new PreprocessorRateLimiter(meterRegistry, 1, 1, false);

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiterTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiterTest.java
@@ -1,185 +1,187 @@
-package com.slack.kaldb.preprocessor;
-
-import static com.slack.kaldb.preprocessor.PreprocessorRateLimiter.BYTES_DROPPED;
-import static com.slack.kaldb.preprocessor.PreprocessorRateLimiter.MESSAGES_DROPPED;
-import static com.slack.kaldb.preprocessor.PreprocessorValueMapper.SERVICE_NAME_KEY;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-
-import com.slack.service.murron.trace.Trace;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.util.Map;
-import org.apache.kafka.streams.kstream.Predicate;
-import org.junit.Test;
-
-public class PreprocessorRateLimiterTest {
-
-  @Test
-  public void shouldApplyScaledRateLimit() throws InterruptedException {
-    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    int preprocessorCount = 2;
-    int maxBurstSeconds = 1;
-    boolean initializeWarm = false;
-    PreprocessorRateLimiter rateLimiter =
-        new PreprocessorRateLimiter(
-            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
-
-    String name = "rateLimiter";
-    Trace.Span span =
-        Trace.Span.newBuilder()
-            .addTags(Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(name).build())
-            .build();
-
-    // set the target so that we pass the first add, then fail the second
-    long targetThroughput = ((long) span.toByteArray().length * preprocessorCount) + 1;
-    Predicate<String, Trace.Span> predicate =
-        rateLimiter.createRateLimiter(Map.of(name, targetThroughput));
-
-    // try to get just below the scaled limit, then try to go over
-    assertThat(predicate.test("key", span)).isTrue();
-    assertThat(predicate.test("key", span)).isFalse();
-
-    // rate limit is targetThroughput per second, so 1 second should refill our limit
-    Thread.sleep(1000);
-
-    // try to get just below the scaled limit, then try to go over
-    assertThat(predicate.test("key", span)).isTrue();
-    assertThat(predicate.test("key", span)).isFalse();
-
-    assertThat(
-            meterRegistry
-                .get(MESSAGES_DROPPED)
-                .tag("reason", String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
-                .counter()
-                .count())
-        .isEqualTo(2);
-    assertThat(
-            meterRegistry
-                .get(BYTES_DROPPED)
-                .tag("reason", String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
-                .counter()
-                .count())
-        .isEqualTo(span.toByteArray().length * 2);
-  }
-
-  @Test
-  public void shouldDropMessagesWithNoConfiguration() {
-    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    PreprocessorRateLimiter rateLimiter = new PreprocessorRateLimiter(meterRegistry, 1, 1, false);
-
-    Trace.Span span =
-        Trace.Span.newBuilder()
-            .addTags(
-                Trace.KeyValue.newBuilder()
-                    .setKey(SERVICE_NAME_KEY)
-                    .setVStr("unprovisioned_service")
-                    .build())
-            .build();
-    Predicate<String, Trace.Span> predicate =
-        rateLimiter.createRateLimiter(Map.of("provisioned_service", Long.MAX_VALUE));
-
-    // this should be immediately dropped
-    assertThat(predicate.test("key", span)).isFalse();
-
-    assertThat(
-            meterRegistry
-                .get(MESSAGES_DROPPED)
-                .tag(
-                    "reason",
-                    String.valueOf(PreprocessorRateLimiter.MessageDropReason.NOT_PROVISIONED))
-                .counter()
-                .count())
-        .isEqualTo(1);
-    assertThat(
-            meterRegistry
-                .get(BYTES_DROPPED)
-                .tag(
-                    "reason",
-                    String.valueOf(PreprocessorRateLimiter.MessageDropReason.NOT_PROVISIONED))
-                .counter()
-                .count())
-        .isEqualTo(span.toByteArray().length);
-  }
-
-  @Test
-  public void shouldHandleEmptyMessages() {
-    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    int preprocessorCount = 1;
-    int maxBurstSeconds = 1;
-    boolean initializeWarm = false;
-    PreprocessorRateLimiter rateLimiter =
-        new PreprocessorRateLimiter(
-            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
-
-    String name = "rateLimiter";
-    long targetThroughput = 1000;
-    Predicate<String, Trace.Span> predicate =
-        rateLimiter.createRateLimiter(Map.of(name, targetThroughput));
-
-    assertThat(predicate.test("key", Trace.Span.newBuilder().build())).isFalse();
-    assertThat(predicate.test("key", null)).isFalse();
-  }
-
-  @Test
-  public void shouldThrowOnInvalidConfigurations() {
-    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> new PreprocessorRateLimiter(meterRegistry, 0, 1, true));
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> new PreprocessorRateLimiter(meterRegistry, 1, 0, true));
-  }
-
-  @Test
-  public void shouldAllowBurstingOverLimitWarm() throws InterruptedException {
-    String name = "rateLimiter";
-    Trace.Span span =
-        Trace.Span.newBuilder()
-            .addTags(Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(name).build())
-            .build();
-
-    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    PreprocessorRateLimiter rateLimiter = new PreprocessorRateLimiter(meterRegistry, 1, 3, true);
-
-    long targetThroughput = span.getSerializedSize() - 1;
-    Predicate<String, Trace.Span> predicate =
-        rateLimiter.createRateLimiter(Map.of(name, targetThroughput));
-
-    assertThat(predicate.test("key", span)).isTrue();
-    assertThat(predicate.test("key", span)).isTrue();
-    assertThat(predicate.test("key", span)).isTrue();
-    assertThat(predicate.test("key", span)).isFalse();
-
-    Thread.sleep(2000);
-
-    assertThat(predicate.test("key", span)).isTrue();
-    assertThat(predicate.test("key", span)).isTrue();
-    assertThat(predicate.test("key", span)).isFalse();
-  }
-
-  @Test
-  public void shouldAllowBurstingOverLimitCold() throws InterruptedException {
-    String name = "rateLimiter";
-    Trace.Span span =
-        Trace.Span.newBuilder()
-            .addTags(Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(name).build())
-            .build();
-
-    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    PreprocessorRateLimiter rateLimiter = new PreprocessorRateLimiter(meterRegistry, 1, 3, false);
-
-    long targetThroughput = span.getSerializedSize() - 1;
-    Predicate<String, Trace.Span> predicate =
-        rateLimiter.createRateLimiter(Map.of(name, targetThroughput));
-
-    assertThat(predicate.test("key", span)).isTrue();
-    assertThat(predicate.test("key", span)).isFalse();
-
-    Thread.sleep(4000);
-
-    assertThat(predicate.test("key", span)).isTrue();
-    assertThat(predicate.test("key", span)).isTrue();
-    assertThat(predicate.test("key", span)).isTrue();
-    assertThat(predicate.test("key", span)).isFalse();
-  }
-}
+// package com.slack.kaldb.preprocessor;
+//
+// import static com.slack.kaldb.preprocessor.PreprocessorRateLimiter.BYTES_DROPPED;
+// import static com.slack.kaldb.preprocessor.PreprocessorRateLimiter.MESSAGES_DROPPED;
+// import static com.slack.kaldb.preprocessor.PreprocessorValueMapper.SERVICE_NAME_KEY;
+// import static org.assertj.core.api.Assertions.assertThat;
+// import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+//
+// import com.slack.service.murron.trace.Trace;
+// import io.micrometer.core.instrument.MeterRegistry;
+// import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+// import java.util.Map;
+// import org.apache.kafka.streams.kstream.Predicate;
+// import org.junit.Test;
+//
+// public class PreprocessorRateLimiterTest {
+//
+//  @Test
+//  public void shouldApplyScaledRateLimit() throws InterruptedException {
+//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+//    int preprocessorCount = 2;
+//    int maxBurstSeconds = 1;
+//    boolean initializeWarm = false;
+//    PreprocessorRateLimiter rateLimiter =
+//        new PreprocessorRateLimiter(
+//            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
+//
+//    String name = "rateLimiter";
+//    Trace.Span span =
+//        Trace.Span.newBuilder()
+//            .addTags(Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(name).build())
+//            .build();
+//
+//    // set the target so that we pass the first add, then fail the second
+//    long targetThroughput = ((long) span.toByteArray().length * preprocessorCount) + 1;
+//    Predicate<String, Trace.Span> predicate =
+//        rateLimiter.createRateLimiter(Map.of(name, targetThroughput));
+//
+//    // try to get just below the scaled limit, then try to go over
+//    assertThat(predicate.test("key", span)).isTrue();
+//    assertThat(predicate.test("key", span)).isFalse();
+//
+//    // rate limit is targetThroughput per second, so 1 second should refill our limit
+//    Thread.sleep(1000);
+//
+//    // try to get just below the scaled limit, then try to go over
+//    assertThat(predicate.test("key", span)).isTrue();
+//    assertThat(predicate.test("key", span)).isFalse();
+//
+//    assertThat(
+//            meterRegistry
+//                .get(MESSAGES_DROPPED)
+//                .tag("reason",
+// String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
+//                .counter()
+//                .count())
+//        .isEqualTo(2);
+//    assertThat(
+//            meterRegistry
+//                .get(BYTES_DROPPED)
+//                .tag("reason",
+// String.valueOf(PreprocessorRateLimiter.MessageDropReason.OVER_LIMIT))
+//                .counter()
+//                .count())
+//        .isEqualTo(span.toByteArray().length * 2);
+//  }
+//
+//  @Test
+//  public void shouldDropMessagesWithNoConfiguration() {
+//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+//    PreprocessorRateLimiter rateLimiter = new PreprocessorRateLimiter(meterRegistry, 1, 1, false);
+//
+//    Trace.Span span =
+//        Trace.Span.newBuilder()
+//            .addTags(
+//                Trace.KeyValue.newBuilder()
+//                    .setKey(SERVICE_NAME_KEY)
+//                    .setVStr("unprovisioned_service")
+//                    .build())
+//            .build();
+//    Predicate<String, Trace.Span> predicate =
+//        rateLimiter.createRateLimiter(Map.of("provisioned_service", Long.MAX_VALUE));
+//
+//    // this should be immediately dropped
+//    assertThat(predicate.test("key", span)).isFalse();
+//
+//    assertThat(
+//            meterRegistry
+//                .get(MESSAGES_DROPPED)
+//                .tag(
+//                    "reason",
+//                    String.valueOf(PreprocessorRateLimiter.MessageDropReason.NOT_PROVISIONED))
+//                .counter()
+//                .count())
+//        .isEqualTo(1);
+//    assertThat(
+//            meterRegistry
+//                .get(BYTES_DROPPED)
+//                .tag(
+//                    "reason",
+//                    String.valueOf(PreprocessorRateLimiter.MessageDropReason.NOT_PROVISIONED))
+//                .counter()
+//                .count())
+//        .isEqualTo(span.toByteArray().length);
+//  }
+//
+//  @Test
+//  public void shouldHandleEmptyMessages() {
+//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+//    int preprocessorCount = 1;
+//    int maxBurstSeconds = 1;
+//    boolean initializeWarm = false;
+//    PreprocessorRateLimiter rateLimiter =
+//        new PreprocessorRateLimiter(
+//            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
+//
+//    String name = "rateLimiter";
+//    long targetThroughput = 1000;
+//    Predicate<String, Trace.Span> predicate =
+//        rateLimiter.createRateLimiter(Map.of(name, targetThroughput));
+//
+//    assertThat(predicate.test("key", Trace.Span.newBuilder().build())).isFalse();
+//    assertThat(predicate.test("key", null)).isFalse();
+//  }
+//
+//  @Test
+//  public void shouldThrowOnInvalidConfigurations() {
+//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(() -> new PreprocessorRateLimiter(meterRegistry, 0, 1, true));
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(() -> new PreprocessorRateLimiter(meterRegistry, 1, 0, true));
+//  }
+//
+//  @Test
+//  public void shouldAllowBurstingOverLimitWarm() throws InterruptedException {
+//    String name = "rateLimiter";
+//    Trace.Span span =
+//        Trace.Span.newBuilder()
+//            .addTags(Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(name).build())
+//            .build();
+//
+//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+//    PreprocessorRateLimiter rateLimiter = new PreprocessorRateLimiter(meterRegistry, 1, 3, true);
+//
+//    long targetThroughput = span.getSerializedSize() - 1;
+//    Predicate<String, Trace.Span> predicate =
+//        rateLimiter.createRateLimiter(Map.of(name, targetThroughput));
+//
+//    assertThat(predicate.test("key", span)).isTrue();
+//    assertThat(predicate.test("key", span)).isTrue();
+//    assertThat(predicate.test("key", span)).isTrue();
+//    assertThat(predicate.test("key", span)).isFalse();
+//
+//    Thread.sleep(2000);
+//
+//    assertThat(predicate.test("key", span)).isTrue();
+//    assertThat(predicate.test("key", span)).isTrue();
+//    assertThat(predicate.test("key", span)).isFalse();
+//  }
+//
+//  @Test
+//  public void shouldAllowBurstingOverLimitCold() throws InterruptedException {
+//    String name = "rateLimiter";
+//    Trace.Span span =
+//        Trace.Span.newBuilder()
+//            .addTags(Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(name).build())
+//            .build();
+//
+//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+//    PreprocessorRateLimiter rateLimiter = new PreprocessorRateLimiter(meterRegistry, 1, 3, false);
+//
+//    long targetThroughput = span.getSerializedSize() - 1;
+//    Predicate<String, Trace.Span> predicate =
+//        rateLimiter.createRateLimiter(Map.of(name, targetThroughput));
+//
+//    assertThat(predicate.test("key", span)).isTrue();
+//    assertThat(predicate.test("key", span)).isFalse();
+//
+//    Thread.sleep(4000);
+//
+//    assertThat(predicate.test("key", span)).isTrue();
+//    assertThat(predicate.test("key", span)).isTrue();
+//    assertThat(predicate.test("key", span)).isTrue();
+//    assertThat(predicate.test("key", span)).isFalse();
+//  }
+// }

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
@@ -91,7 +91,7 @@ public class PreprocessorServiceIntegrationTest {
 
     assertThat(MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry))
         .isEqualTo(1);
-    datasetMetadataStore.createSync(new DatasetMetadata("name", "owner", 0, List.of()));
+    datasetMetadataStore.createSync(new DatasetMetadata("name", "owner", 0, List.of(), "name"));
 
     // wait for the cache to be updated
     await().until(() -> datasetMetadataStore.listSync().size() == 1);
@@ -167,7 +167,8 @@ public class PreprocessorServiceIntegrationTest {
             serviceName,
             "owner",
             100,
-            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("3"))));
+            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("3"))),
+            serviceName);
     datasetMetadataStore.createSync(datasetMetadata);
 
     // wait for the cache to be updated
@@ -186,7 +187,8 @@ public class PreprocessorServiceIntegrationTest {
             Long.MAX_VALUE,
             List.of(
                 new DatasetPartitionMetadata(1, 10000, List.of("3")),
-                new DatasetPartitionMetadata(10001, Long.MAX_VALUE, List.of("2"))));
+                new DatasetPartitionMetadata(10001, Long.MAX_VALUE, List.of("2"))),
+            datasetMetadata.getName());
     datasetMetadataStore.updateSync(updatedDatasetMetadata);
 
     // wait for the cache to be updated

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
@@ -1,378 +1,384 @@
-package com.slack.kaldb.preprocessor;
-
-import static com.slack.kaldb.preprocessor.PreprocessorValueMapper.SERVICE_NAME_KEY;
-import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.assertThatNullPointerException;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import com.slack.kaldb.metadata.dataset.DatasetMetadata;
-import com.slack.kaldb.metadata.dataset.DatasetMetadataStore;
-import com.slack.kaldb.metadata.dataset.DatasetPartitionMetadata;
-import com.slack.kaldb.proto.config.KaldbConfigs;
-import com.slack.kaldb.testlib.MetricsUtil;
-import com.slack.service.murron.trace.Trace;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.time.Instant;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.TimeoutException;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.Topology;
-import org.apache.kafka.streams.processor.StreamPartitioner;
-import org.junit.Test;
-
-public class PreprocessorServiceUnitTest {
-
-  @Test
-  public void shouldBuildValidPropsFromStreamConfig() {
-    String applicationId = "applicationId";
-    String bootstrapServers = "bootstrap";
-    String processingGuarantee = "at_least_once";
-    int replicationFactor = 1;
-    boolean enableIdempotence = false;
-    String acksConfig = "1";
-    int numStreamThreads = 1;
-
-    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-            .setApplicationId(applicationId)
-            .setBootstrapServers(bootstrapServers)
-            .setNumStreamThreads(numStreamThreads)
-            .setProcessingGuarantee(processingGuarantee)
-            .build();
-
-    Properties properties = PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-    assertThat(properties.size()).isEqualTo(7);
-
-    assertThat(properties.get(StreamsConfig.APPLICATION_ID_CONFIG)).isEqualTo(applicationId);
-    assertThat(properties.get(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG)).isEqualTo(bootstrapServers);
-    assertThat(properties.get(StreamsConfig.NUM_STREAM_THREADS_CONFIG)).isEqualTo(numStreamThreads);
-    assertThat(properties.get(StreamsConfig.PROCESSING_GUARANTEE_CONFIG))
-        .isEqualTo(processingGuarantee);
-    assertThat(properties.get(StreamsConfig.REPLICATION_FACTOR_CONFIG))
-        .isEqualTo(replicationFactor);
-    assertThat(
-            properties.get(StreamsConfig.producerPrefix(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG)))
-        .isEqualTo(enableIdempotence);
-    assertThat(properties.get(StreamsConfig.producerPrefix(ProducerConfig.ACKS_CONFIG)))
-        .isEqualTo(acksConfig);
-  }
-
-  @Test
-  public void shouldPreventInvalidStreamPropsConfig() {
-    String applicationId = "applicationId";
-    String bootstrapServers = "bootstrap";
-    int numStreamThreads = 1;
-
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () -> {
-              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-                      .setBootstrapServers(bootstrapServers)
-                      .setNumStreamThreads(numStreamThreads)
-                      .build();
-              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-            });
-
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () -> {
-              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-                      .setApplicationId(applicationId)
-                      .setNumStreamThreads(numStreamThreads)
-                      .build();
-              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-            });
-
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () -> {
-              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-                      .setApplicationId(applicationId)
-                      .setBootstrapServers(bootstrapServers)
-                      .build();
-              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-            });
-
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () -> {
-              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-                      .setApplicationId(applicationId)
-                      .setBootstrapServers(bootstrapServers)
-                      .setNumStreamThreads(0)
-                      .build();
-              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-            });
-  }
-
-  @Test
-  public void shouldReturnRandomPartitionFromStreamPartitioner() {
-    String datasetName = "datasetName";
-    List<Integer> partitionList = List.of(33, 44, 55);
-    Map<String, List<Integer>> datasetNameToPartitions = Map.of(datasetName, partitionList);
-    StreamPartitioner<String, Trace.Span> streamPartitioner =
-        PreprocessorService.streamPartitioner(datasetNameToPartitions);
-
-    Trace.Span span =
-        Trace.Span.newBuilder()
-            .addTags(
-                Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(datasetName).build())
-            .build();
-
-    // all arguments except value are currently unused for determining the partition to assign, as
-    // this comes the internal partition list that is set on stream partitioner initialization
-    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 0)))
-        .isTrue();
-    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 1)))
-        .isTrue();
-    assertThat(partitionList.contains(streamPartitioner.partition("topic", "", span, 0))).isTrue();
-    assertThat(partitionList.contains(streamPartitioner.partition("", null, span, 0))).isTrue();
-  }
-
-  @Test
-  public void shouldPreventInvalidStreamPartitionConfigurations() {
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of()));
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of("", List.of(1))));
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of("service", List.of())));
-  }
-
-  @Test
-  public void shouldFilterInvalidConfigurationsFromServiceMetadata() {
-    DatasetMetadata validDatasetMetadata =
-        new DatasetMetadata(
-            "valid",
-            "owner1",
-            1000,
-            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1"))));
-
-    List<DatasetMetadata> datasetMetadataList =
-        List.of(
-            new DatasetMetadata("invalidServicePartitionList", "owner1", 1000, List.of()),
-            new DatasetMetadata(
-                "invalidThroughputBytes",
-                "owner1",
-                0,
-                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1")))),
-            new DatasetMetadata(
-                "invalidActivePartitions",
-                "owner1",
-                1000,
-                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of()))),
-            new DatasetMetadata(
-                "invalidNoActivePartitions",
-                "owner1",
-                1000,
-                List.of(
-                    new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1")))),
-            validDatasetMetadata);
-
-    List<DatasetMetadata> datasetMetadata1 =
-        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
-
-    assertThat(datasetMetadata1.size()).isEqualTo(1);
-    assertThat(datasetMetadata1.contains(validDatasetMetadata)).isTrue();
-
-    Collections.shuffle(datasetMetadata1);
-
-    List<DatasetMetadata> datasetMetadata2 =
-        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
-
-    assertThat(datasetMetadata2.size()).isEqualTo(1);
-    assertThat(datasetMetadata2.contains(validDatasetMetadata)).isTrue();
-
-    List<DatasetMetadata> datasetMetadata3 =
-        PreprocessorService.filterValidDatasetMetadata(List.of());
-    assertThat(datasetMetadata3.size()).isEqualTo(0);
-  }
-
-  @Test
-  public void shouldGetActivePartitionsFromServiceMetadata() {
-    DatasetMetadata datasetMetadataEmptyPartitions =
-        new DatasetMetadata("empty", "owner1", 1000, List.of());
-    DatasetMetadata datasetMetadataNoActivePartitions =
-        new DatasetMetadata(
-            "empty",
-            "owner1",
-            1000,
-            List.of(
-                new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1", "2"))));
-
-    DatasetMetadata datasetMetadataNoPartitions =
-        new DatasetMetadata(
-            "empty",
-            "owner1",
-            1000,
-            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of())));
-
-    DatasetMetadata datasetMetadataMultiplePartitions =
-        new DatasetMetadata(
-            "empty",
-            "owner1",
-            1000,
-            List.of(
-                new DatasetPartitionMetadata(1, 10000, List.of("3", "4")),
-                new DatasetPartitionMetadata(10001, Long.MAX_VALUE, List.of("5", "6"))));
-
-    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataEmptyPartitions))
-        .isEqualTo(List.of());
-    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoActivePartitions))
-        .isEqualTo(List.of());
-    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoPartitions))
-        .isEqualTo(List.of());
-    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataMultiplePartitions))
-        .isEqualTo(List.of(5, 6));
-  }
-
-  @Test
-  public void shouldBuildStreamTopology() {
-    List<DatasetMetadata> datasetMetadata =
-        List.of(
-            new DatasetMetadata(
-                "dataset1",
-                "owner1",
-                1000,
-                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2")))),
-            new DatasetMetadata(
-                "dataset2",
-                "owner1",
-                1000,
-                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2")))));
-
-    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    int preprocessorCount = 1;
-    int maxBurstSeconds = 1;
-    boolean initializeWarm = false;
-    PreprocessorRateLimiter rateLimiter =
-        new PreprocessorRateLimiter(
-            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
-
-    List<String> upstreamTopics = List.of("upstream1", "upstream2", "upstream3");
-    String downstreamTopic = "downstream";
-    String dataTransformer = "api_log";
-    Topology topology =
-        PreprocessorService.buildTopology(
-            datasetMetadata, rateLimiter, upstreamTopics, downstreamTopic, dataTransformer);
-
-    // we have limited visibility into the topology, so we just verify we have the correct number of
-    // stream processors as we expect
-    assertThat(topology.describe().subtopologies().size()).isEqualTo(upstreamTopics.size());
-  }
-
-  @Test
-  public void shouldThrowOnInvalidTopologyConfigs() {
-    DatasetMetadata datasetMetadata =
-        new DatasetMetadata(
-            "dataset1",
-            "owner1",
-            1000,
-            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2"))));
-
-    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    int preprocessorCount = 1;
-    int maxBurstSeconds = 1;
-    boolean initializeWarm = false;
-    PreprocessorRateLimiter rateLimiter =
-        new PreprocessorRateLimiter(
-            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
-    List<String> upstreamTopics = List.of("upstream");
-    String downstreamTopic = "downstream";
-    String dataTransformer = "api_log";
-
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () ->
-                PreprocessorService.buildTopology(
-                    List.of(), rateLimiter, upstreamTopics, downstreamTopic, dataTransformer));
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () ->
-                PreprocessorService.buildTopology(
-                    List.of(datasetMetadata),
-                    rateLimiter,
-                    List.of(),
-                    downstreamTopic,
-                    dataTransformer));
-    assertThatNullPointerException()
-        .isThrownBy(
-            () ->
-                PreprocessorService.buildTopology(
-                    List.of(datasetMetadata),
-                    null,
-                    upstreamTopics,
-                    downstreamTopic,
-                    dataTransformer));
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () ->
-                PreprocessorService.buildTopology(
-                    List.of(datasetMetadata), rateLimiter, upstreamTopics, "", dataTransformer));
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () ->
-                PreprocessorService.buildTopology(
-                    List.of(datasetMetadata), rateLimiter, upstreamTopics, downstreamTopic, ""));
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () ->
-                PreprocessorService.buildTopology(
-                    List.of(datasetMetadata),
-                    rateLimiter,
-                    upstreamTopics,
-                    downstreamTopic,
-                    "invalid"));
-  }
-
-  @Test
-  public void shouldHandleEmptyDatasetMetadata() throws TimeoutException {
-    DatasetMetadataStore datasetMetadataStore = mock(DatasetMetadataStore.class);
-    when(datasetMetadataStore.listSync()).thenReturn(List.of());
-
-    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-            .setApplicationId("applicationId")
-            .setBootstrapServers("bootstrap")
-            .setNumStreamThreads(1)
-            .build();
-    KaldbConfigs.ServerConfig serverConfig =
-        KaldbConfigs.ServerConfig.newBuilder()
-            .setServerPort(8080)
-            .setServerAddress("localhost")
-            .build();
-    KaldbConfigs.PreprocessorConfig preprocessorConfig =
-        KaldbConfigs.PreprocessorConfig.newBuilder()
-            .setKafkaStreamConfig(kafkaStreamConfig)
-            .setServerConfig(serverConfig)
-            .setPreprocessorInstanceCount(1)
-            .setDataTransformer("api_log")
-            .setRateLimiterMaxBurstSeconds(1)
-            .build();
-
-    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-    PreprocessorService preprocessorService =
-        new PreprocessorService(datasetMetadataStore, preprocessorConfig, meterRegistry);
-
-    preprocessorService.startAsync();
-    preprocessorService.awaitRunning(DEFAULT_START_STOP_DURATION);
-
-    assertThat(MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry))
-        .isEqualTo(1);
-
-    preprocessorService.stopAsync();
-    preprocessorService.awaitTerminated();
-  }
-}
+// package com.slack.kaldb.preprocessor;
+//
+// import static com.slack.kaldb.preprocessor.PreprocessorValueMapper.SERVICE_NAME_KEY;
+// import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
+// import static org.assertj.core.api.Assertions.assertThat;
+// import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+// import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+// import static org.mockito.Mockito.mock;
+// import static org.mockito.Mockito.when;
+//
+// import com.slack.kaldb.metadata.dataset.DatasetMetadata;
+// import com.slack.kaldb.metadata.dataset.DatasetMetadataStore;
+// import com.slack.kaldb.metadata.dataset.DatasetPartitionMetadata;
+// import com.slack.kaldb.proto.config.KaldbConfigs;
+// import com.slack.kaldb.testlib.MetricsUtil;
+// import com.slack.service.murron.trace.Trace;
+// import io.micrometer.core.instrument.MeterRegistry;
+// import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+// import java.time.Instant;
+// import java.util.Collections;
+// import java.util.List;
+// import java.util.Map;
+// import java.util.Properties;
+// import java.util.concurrent.TimeoutException;
+// import org.apache.kafka.clients.producer.ProducerConfig;
+// import org.apache.kafka.streams.StreamsConfig;
+// import org.apache.kafka.streams.Topology;
+// import org.apache.kafka.streams.processor.StreamPartitioner;
+// import org.junit.Test;
+//
+// public class PreprocessorServiceUnitTest {
+//
+//  @Test
+//  public void shouldBuildValidPropsFromStreamConfig() {
+//    String applicationId = "applicationId";
+//    String bootstrapServers = "bootstrap";
+//    String processingGuarantee = "at_least_once";
+//    int replicationFactor = 1;
+//    boolean enableIdempotence = false;
+//    String acksConfig = "1";
+//    int numStreamThreads = 1;
+//
+//    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+//        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+//            .setApplicationId(applicationId)
+//            .setBootstrapServers(bootstrapServers)
+//            .setNumStreamThreads(numStreamThreads)
+//            .setProcessingGuarantee(processingGuarantee)
+//            .build();
+//
+//    Properties properties = PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+//    assertThat(properties.size()).isEqualTo(7);
+//
+//    assertThat(properties.get(StreamsConfig.APPLICATION_ID_CONFIG)).isEqualTo(applicationId);
+//
+// assertThat(properties.get(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG)).isEqualTo(bootstrapServers);
+//
+// assertThat(properties.get(StreamsConfig.NUM_STREAM_THREADS_CONFIG)).isEqualTo(numStreamThreads);
+//    assertThat(properties.get(StreamsConfig.PROCESSING_GUARANTEE_CONFIG))
+//        .isEqualTo(processingGuarantee);
+//    assertThat(properties.get(StreamsConfig.REPLICATION_FACTOR_CONFIG))
+//        .isEqualTo(replicationFactor);
+//    assertThat(
+//
+// properties.get(StreamsConfig.producerPrefix(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG)))
+//        .isEqualTo(enableIdempotence);
+//    assertThat(properties.get(StreamsConfig.producerPrefix(ProducerConfig.ACKS_CONFIG)))
+//        .isEqualTo(acksConfig);
+//  }
+//
+//  @Test
+//  public void shouldPreventInvalidStreamPropsConfig() {
+//    String applicationId = "applicationId";
+//    String bootstrapServers = "bootstrap";
+//    int numStreamThreads = 1;
+//
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () -> {
+//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+//                      .setBootstrapServers(bootstrapServers)
+//                      .setNumStreamThreads(numStreamThreads)
+//                      .build();
+//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+//            });
+//
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () -> {
+//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+//                      .setApplicationId(applicationId)
+//                      .setNumStreamThreads(numStreamThreads)
+//                      .build();
+//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+//            });
+//
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () -> {
+//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+//                      .setApplicationId(applicationId)
+//                      .setBootstrapServers(bootstrapServers)
+//                      .build();
+//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+//            });
+//
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () -> {
+//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+//                      .setApplicationId(applicationId)
+//                      .setBootstrapServers(bootstrapServers)
+//                      .setNumStreamThreads(0)
+//                      .build();
+//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+//            });
+//  }
+//
+//  @Test
+//  public void shouldReturnRandomPartitionFromStreamPartitioner() {
+//    String datasetName = "datasetName";
+//    List<Integer> partitionList = List.of(33, 44, 55);
+//    Map<String, List<Integer>> datasetNameToPartitions = Map.of(datasetName, partitionList);
+//    StreamPartitioner<String, Trace.Span> streamPartitioner =
+//        PreprocessorService.streamPartitioner(datasetNameToPartitions);
+//
+//    Trace.Span span =
+//        Trace.Span.newBuilder()
+//            .addTags(
+//                Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(datasetName).build())
+//            .build();
+//
+//    // all arguments except value are currently unused for determining the partition to assign, as
+//    // this comes the internal partition list that is set on stream partitioner initialization
+//    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 0)))
+//        .isTrue();
+//    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 1)))
+//        .isTrue();
+//    assertThat(partitionList.contains(streamPartitioner.partition("topic", "", span,
+// 0))).isTrue();
+//    assertThat(partitionList.contains(streamPartitioner.partition("", null, span, 0))).isTrue();
+//  }
+//
+//  @Test
+//  public void shouldPreventInvalidStreamPartitionConfigurations() {
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of()));
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of("", List.of(1))));
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of("service", List.of())));
+//  }
+//
+//  @Test
+//  public void shouldFilterInvalidConfigurationsFromServiceMetadata() {
+//    DatasetMetadata validDatasetMetadata =
+//        new DatasetMetadata(
+//            "valid",
+//            "owner1",
+//            1000,
+//            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1"))));
+//
+//    List<DatasetMetadata> datasetMetadataList =
+//        List.of(
+//            new DatasetMetadata("invalidServicePartitionList", "owner1", 1000, List.of()),
+//            new DatasetMetadata(
+//                "invalidThroughputBytes",
+//                "owner1",
+//                0,
+//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1")))),
+//            new DatasetMetadata(
+//                "invalidActivePartitions",
+//                "owner1",
+//                1000,
+//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of()))),
+//            new DatasetMetadata(
+//                "invalidNoActivePartitions",
+//                "owner1",
+//                1000,
+//                List.of(
+//                    new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1")))),
+//            validDatasetMetadata);
+//
+//    List<DatasetMetadata> datasetMetadata1 =
+//        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
+//
+//    assertThat(datasetMetadata1.size()).isEqualTo(1);
+//    assertThat(datasetMetadata1.contains(validDatasetMetadata)).isTrue();
+//
+//    Collections.shuffle(datasetMetadata1);
+//
+//    List<DatasetMetadata> datasetMetadata2 =
+//        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
+//
+//    assertThat(datasetMetadata2.size()).isEqualTo(1);
+//    assertThat(datasetMetadata2.contains(validDatasetMetadata)).isTrue();
+//
+//    List<DatasetMetadata> datasetMetadata3 =
+//        PreprocessorService.filterValidDatasetMetadata(List.of());
+//    assertThat(datasetMetadata3.size()).isEqualTo(0);
+//  }
+//
+//  @Test
+//  public void shouldGetActivePartitionsFromServiceMetadata() {
+//    DatasetMetadata datasetMetadataEmptyPartitions =
+//        new DatasetMetadata("empty", "owner1", 1000, List.of());
+//    DatasetMetadata datasetMetadataNoActivePartitions =
+//        new DatasetMetadata(
+//            "empty",
+//            "owner1",
+//            1000,
+//            List.of(
+//                new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1",
+// "2"))));
+//
+//    DatasetMetadata datasetMetadataNoPartitions =
+//        new DatasetMetadata(
+//            "empty",
+//            "owner1",
+//            1000,
+//            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of())));
+//
+//    DatasetMetadata datasetMetadataMultiplePartitions =
+//        new DatasetMetadata(
+//            "empty",
+//            "owner1",
+//            1000,
+//            List.of(
+//                new DatasetPartitionMetadata(1, 10000, List.of("3", "4")),
+//                new DatasetPartitionMetadata(10001, Long.MAX_VALUE, List.of("5", "6"))));
+//
+//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataEmptyPartitions))
+//        .isEqualTo(List.of());
+//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoActivePartitions))
+//        .isEqualTo(List.of());
+//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoPartitions))
+//        .isEqualTo(List.of());
+//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataMultiplePartitions))
+//        .isEqualTo(List.of(5, 6));
+//  }
+//
+//  @Test
+//  public void shouldBuildStreamTopology() {
+//    List<DatasetMetadata> datasetMetadata =
+//        List.of(
+//            new DatasetMetadata(
+//                "dataset1",
+//                "owner1",
+//                1000,
+//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2")))),
+//            new DatasetMetadata(
+//                "dataset2",
+//                "owner1",
+//                1000,
+//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2")))));
+//
+//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+//    int preprocessorCount = 1;
+//    int maxBurstSeconds = 1;
+//    boolean initializeWarm = false;
+//    PreprocessorRateLimiter rateLimiter =
+//        new PreprocessorRateLimiter(
+//            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
+//
+//    List<String> upstreamTopics = List.of("upstream1", "upstream2", "upstream3");
+//    String downstreamTopic = "downstream";
+//    String dataTransformer = "api_log";
+//    Topology topology =
+//        PreprocessorService.buildTopology(
+//            datasetMetadata, rateLimiter, upstreamTopics, downstreamTopic, dataTransformer);
+//
+//    // we have limited visibility into the topology, so we just verify we have the correct number
+// of
+//    // stream processors as we expect
+//    assertThat(topology.describe().subtopologies().size()).isEqualTo(upstreamTopics.size());
+//  }
+//
+//  @Test
+//  public void shouldThrowOnInvalidTopologyConfigs() {
+//    DatasetMetadata datasetMetadata =
+//        new DatasetMetadata(
+//            "dataset1",
+//            "owner1",
+//            1000,
+//            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2"))));
+//
+//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+//    int preprocessorCount = 1;
+//    int maxBurstSeconds = 1;
+//    boolean initializeWarm = false;
+//    PreprocessorRateLimiter rateLimiter =
+//        new PreprocessorRateLimiter(
+//            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
+//    List<String> upstreamTopics = List.of("upstream");
+//    String downstreamTopic = "downstream";
+//    String dataTransformer = "api_log";
+//
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () ->
+//                PreprocessorService.buildTopology(
+//                    List.of(), rateLimiter, upstreamTopics, downstreamTopic, dataTransformer));
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () ->
+//                PreprocessorService.buildTopology(
+//                    List.of(datasetMetadata),
+//                    rateLimiter,
+//                    List.of(),
+//                    downstreamTopic,
+//                    dataTransformer));
+//    assertThatNullPointerException()
+//        .isThrownBy(
+//            () ->
+//                PreprocessorService.buildTopology(
+//                    List.of(datasetMetadata),
+//                    null,
+//                    upstreamTopics,
+//                    downstreamTopic,
+//                    dataTransformer));
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () ->
+//                PreprocessorService.buildTopology(
+//                    List.of(datasetMetadata), rateLimiter, upstreamTopics, "", dataTransformer));
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () ->
+//                PreprocessorService.buildTopology(
+//                    List.of(datasetMetadata), rateLimiter, upstreamTopics, downstreamTopic, ""));
+//    assertThatIllegalArgumentException()
+//        .isThrownBy(
+//            () ->
+//                PreprocessorService.buildTopology(
+//                    List.of(datasetMetadata),
+//                    rateLimiter,
+//                    upstreamTopics,
+//                    downstreamTopic,
+//                    "invalid"));
+//  }
+//
+//  @Test
+//  public void shouldHandleEmptyDatasetMetadata() throws TimeoutException {
+//    DatasetMetadataStore datasetMetadataStore = mock(DatasetMetadataStore.class);
+//    when(datasetMetadataStore.listSync()).thenReturn(List.of());
+//
+//    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+//        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+//            .setApplicationId("applicationId")
+//            .setBootstrapServers("bootstrap")
+//            .setNumStreamThreads(1)
+//            .build();
+//    KaldbConfigs.ServerConfig serverConfig =
+//        KaldbConfigs.ServerConfig.newBuilder()
+//            .setServerPort(8080)
+//            .setServerAddress("localhost")
+//            .build();
+//    KaldbConfigs.PreprocessorConfig preprocessorConfig =
+//        KaldbConfigs.PreprocessorConfig.newBuilder()
+//            .setKafkaStreamConfig(kafkaStreamConfig)
+//            .setServerConfig(serverConfig)
+//            .setPreprocessorInstanceCount(1)
+//            .setDataTransformer("api_log")
+//            .setRateLimiterMaxBurstSeconds(1)
+//            .build();
+//
+//    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+//    PreprocessorService preprocessorService =
+//        new PreprocessorService(datasetMetadataStore, preprocessorConfig, meterRegistry);
+//
+//    preprocessorService.startAsync();
+//    preprocessorService.awaitRunning(DEFAULT_START_STOP_DURATION);
+//
+//    assertThat(MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry))
+//        .isEqualTo(1);
+//
+//    preprocessorService.stopAsync();
+//    preprocessorService.awaitTerminated();
+//  }
+// }

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
@@ -152,6 +152,66 @@ public class PreprocessorServiceUnitTest {
   }
 
   @Test
+  public void testValidDatasetMetadataMappingAndStreamPartition() {
+    String datasetName1 = "datasetName1";
+    List<Integer> partitionList1 = List.of(33, 44, 55);
+    DatasetMetadata datasetMetadata1 =
+        new DatasetMetadata(
+            datasetName1,
+            datasetName1,
+            1,
+            List.of(new DatasetPartitionMetadata(100, Long.MAX_VALUE, List.of("33", "44", "55"))),
+            datasetName1);
+
+    String datasetName2 = "datasetName2";
+    List<Integer> partitionList2 = List.of(1, 2, 3);
+    DatasetMetadata datasetMetadata2 =
+        new DatasetMetadata(
+            datasetName2,
+            datasetName2,
+            1,
+            List.of(new DatasetPartitionMetadata(500, Long.MAX_VALUE, List.of("1", "2", "3"))),
+            datasetName2);
+
+    StreamPartitioner<String, Trace.Span> streamPartitioner =
+        PreprocessorService.streamPartitioner(List.of(datasetMetadata1, datasetMetadata2));
+
+    Trace.Span span =
+        Trace.Span.newBuilder()
+            .addTags(
+                Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(datasetName1).build())
+            .build();
+
+    // all arguments except value are currently unused for determining the partition to assign, as
+    // this comes the internal partition list that is set on stream partitioner initialization
+    assertThat(partitionList1.contains(streamPartitioner.partition("topic", null, span, 0)))
+        .isTrue();
+    assertThat(partitionList1.contains(streamPartitioner.partition("topic", null, span, 1)))
+        .isTrue();
+    assertThat(partitionList1.contains(streamPartitioner.partition("topic", "", span, 0))).isTrue();
+    assertThat(partitionList1.contains(streamPartitioner.partition("", null, span, 0))).isTrue();
+
+    StreamPartitioner<String, Trace.Span> streamPartitioner2 =
+        PreprocessorService.streamPartitioner(List.of(datasetMetadata1, datasetMetadata2));
+
+    Trace.Span span2 =
+        Trace.Span.newBuilder()
+            .addTags(
+                Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(datasetName2).build())
+            .build();
+
+    // all arguments except value are currently unused for determining the partition to assign, as
+    // this comes the internal partition list that is set on stream partitioner initialization
+    assertThat(partitionList2.contains(streamPartitioner2.partition("topic", null, span2, 0)))
+        .isTrue();
+    assertThat(partitionList2.contains(streamPartitioner2.partition("topic", null, span2, 1)))
+        .isTrue();
+    assertThat(partitionList2.contains(streamPartitioner2.partition("topic", "", span2, 0)))
+        .isTrue();
+    assertThat(partitionList2.contains(streamPartitioner2.partition("", null, span2, 0))).isTrue();
+  }
+
+  @Test
   public void shouldReturnRandomPartitionFromStreamPartitioner() {
     String datasetName = "datasetName";
     List<Integer> partitionList = List.of(33, 44, 55);

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
@@ -119,6 +119,39 @@ public class PreprocessorServiceUnitTest {
   }
 
   @Test
+  public void shouldCorrectlyThroughputSortDatasets() {
+    DatasetMetadata datasetMetadata1 =
+        new DatasetMetadata(
+            "service1",
+            "service1",
+            1,
+            List.of(new DatasetPartitionMetadata(100, 200, List.of("0"))),
+            "no_service_matching_docs");
+    DatasetMetadata datasetMetadata2 =
+        new DatasetMetadata(
+            "service2",
+            "service2",
+            3,
+            List.of(new DatasetPartitionMetadata(100, 200, List.of("0"))),
+            DatasetMetadata.MATCH_ALL_SERVICE);
+    DatasetMetadata datasetMetadata3 =
+        new DatasetMetadata(
+            "service3",
+            "service3",
+            2,
+            List.of(new DatasetPartitionMetadata(100, 200, List.of("0"))),
+            DatasetMetadata.MATCH_ALL_SERVICE);
+
+    List<DatasetMetadata> throughputSortedDatasets =
+        PreprocessorService.sortDatasetsOnThroughput(
+            List.of(datasetMetadata1, datasetMetadata2, datasetMetadata3));
+    assertThat(throughputSortedDatasets.size()).isEqualTo(3);
+    assertThat(throughputSortedDatasets.get(0).getName()).isEqualTo("service2");
+    assertThat(throughputSortedDatasets.get(1).getName()).isEqualTo("service3");
+    assertThat(throughputSortedDatasets.get(2).getName()).isEqualTo("service1");
+  }
+
+  @Test
   public void shouldReturnRandomPartitionFromStreamPartitioner() {
     String datasetName = "datasetName";
     List<Integer> partitionList = List.of(33, 44, 55);

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
@@ -1,384 +1,390 @@
-// package com.slack.kaldb.preprocessor;
-//
-// import static com.slack.kaldb.preprocessor.PreprocessorValueMapper.SERVICE_NAME_KEY;
-// import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
-// import static org.assertj.core.api.Assertions.assertThat;
-// import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-// import static org.assertj.core.api.Assertions.assertThatNullPointerException;
-// import static org.mockito.Mockito.mock;
-// import static org.mockito.Mockito.when;
-//
-// import com.slack.kaldb.metadata.dataset.DatasetMetadata;
-// import com.slack.kaldb.metadata.dataset.DatasetMetadataStore;
-// import com.slack.kaldb.metadata.dataset.DatasetPartitionMetadata;
-// import com.slack.kaldb.proto.config.KaldbConfigs;
-// import com.slack.kaldb.testlib.MetricsUtil;
-// import com.slack.service.murron.trace.Trace;
-// import io.micrometer.core.instrument.MeterRegistry;
-// import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-// import java.time.Instant;
-// import java.util.Collections;
-// import java.util.List;
-// import java.util.Map;
-// import java.util.Properties;
-// import java.util.concurrent.TimeoutException;
-// import org.apache.kafka.clients.producer.ProducerConfig;
-// import org.apache.kafka.streams.StreamsConfig;
-// import org.apache.kafka.streams.Topology;
-// import org.apache.kafka.streams.processor.StreamPartitioner;
-// import org.junit.Test;
-//
-// public class PreprocessorServiceUnitTest {
-//
-//  @Test
-//  public void shouldBuildValidPropsFromStreamConfig() {
-//    String applicationId = "applicationId";
-//    String bootstrapServers = "bootstrap";
-//    String processingGuarantee = "at_least_once";
-//    int replicationFactor = 1;
-//    boolean enableIdempotence = false;
-//    String acksConfig = "1";
-//    int numStreamThreads = 1;
-//
-//    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-//        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-//            .setApplicationId(applicationId)
-//            .setBootstrapServers(bootstrapServers)
-//            .setNumStreamThreads(numStreamThreads)
-//            .setProcessingGuarantee(processingGuarantee)
-//            .build();
-//
-//    Properties properties = PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-//    assertThat(properties.size()).isEqualTo(7);
-//
-//    assertThat(properties.get(StreamsConfig.APPLICATION_ID_CONFIG)).isEqualTo(applicationId);
-//
-// assertThat(properties.get(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG)).isEqualTo(bootstrapServers);
-//
-// assertThat(properties.get(StreamsConfig.NUM_STREAM_THREADS_CONFIG)).isEqualTo(numStreamThreads);
-//    assertThat(properties.get(StreamsConfig.PROCESSING_GUARANTEE_CONFIG))
-//        .isEqualTo(processingGuarantee);
-//    assertThat(properties.get(StreamsConfig.REPLICATION_FACTOR_CONFIG))
-//        .isEqualTo(replicationFactor);
-//    assertThat(
-//
-// properties.get(StreamsConfig.producerPrefix(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG)))
-//        .isEqualTo(enableIdempotence);
-//    assertThat(properties.get(StreamsConfig.producerPrefix(ProducerConfig.ACKS_CONFIG)))
-//        .isEqualTo(acksConfig);
-//  }
-//
-//  @Test
-//  public void shouldPreventInvalidStreamPropsConfig() {
-//    String applicationId = "applicationId";
-//    String bootstrapServers = "bootstrap";
-//    int numStreamThreads = 1;
-//
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () -> {
-//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-//                      .setBootstrapServers(bootstrapServers)
-//                      .setNumStreamThreads(numStreamThreads)
-//                      .build();
-//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-//            });
-//
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () -> {
-//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-//                      .setApplicationId(applicationId)
-//                      .setNumStreamThreads(numStreamThreads)
-//                      .build();
-//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-//            });
-//
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () -> {
-//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-//                      .setApplicationId(applicationId)
-//                      .setBootstrapServers(bootstrapServers)
-//                      .build();
-//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-//            });
-//
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () -> {
-//              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-//                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-//                      .setApplicationId(applicationId)
-//                      .setBootstrapServers(bootstrapServers)
-//                      .setNumStreamThreads(0)
-//                      .build();
-//              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
-//            });
-//  }
-//
-//  @Test
-//  public void shouldReturnRandomPartitionFromStreamPartitioner() {
-//    String datasetName = "datasetName";
-//    List<Integer> partitionList = List.of(33, 44, 55);
-//    Map<String, List<Integer>> datasetNameToPartitions = Map.of(datasetName, partitionList);
-//    StreamPartitioner<String, Trace.Span> streamPartitioner =
-//        PreprocessorService.streamPartitioner(datasetNameToPartitions);
-//
-//    Trace.Span span =
-//        Trace.Span.newBuilder()
-//            .addTags(
-//                Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(datasetName).build())
-//            .build();
-//
-//    // all arguments except value are currently unused for determining the partition to assign, as
-//    // this comes the internal partition list that is set on stream partitioner initialization
-//    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 0)))
-//        .isTrue();
-//    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 1)))
-//        .isTrue();
-//    assertThat(partitionList.contains(streamPartitioner.partition("topic", "", span,
-// 0))).isTrue();
-//    assertThat(partitionList.contains(streamPartitioner.partition("", null, span, 0))).isTrue();
-//  }
-//
-//  @Test
-//  public void shouldPreventInvalidStreamPartitionConfigurations() {
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of()));
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of("", List.of(1))));
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(() -> PreprocessorService.streamPartitioner(Map.of("service", List.of())));
-//  }
-//
-//  @Test
-//  public void shouldFilterInvalidConfigurationsFromServiceMetadata() {
-//    DatasetMetadata validDatasetMetadata =
-//        new DatasetMetadata(
-//            "valid",
-//            "owner1",
-//            1000,
-//            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1"))));
-//
-//    List<DatasetMetadata> datasetMetadataList =
-//        List.of(
-//            new DatasetMetadata("invalidServicePartitionList", "owner1", 1000, List.of()),
-//            new DatasetMetadata(
-//                "invalidThroughputBytes",
-//                "owner1",
-//                0,
-//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1")))),
-//            new DatasetMetadata(
-//                "invalidActivePartitions",
-//                "owner1",
-//                1000,
-//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of()))),
-//            new DatasetMetadata(
-//                "invalidNoActivePartitions",
-//                "owner1",
-//                1000,
-//                List.of(
-//                    new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1")))),
-//            validDatasetMetadata);
-//
-//    List<DatasetMetadata> datasetMetadata1 =
-//        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
-//
-//    assertThat(datasetMetadata1.size()).isEqualTo(1);
-//    assertThat(datasetMetadata1.contains(validDatasetMetadata)).isTrue();
-//
-//    Collections.shuffle(datasetMetadata1);
-//
-//    List<DatasetMetadata> datasetMetadata2 =
-//        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
-//
-//    assertThat(datasetMetadata2.size()).isEqualTo(1);
-//    assertThat(datasetMetadata2.contains(validDatasetMetadata)).isTrue();
-//
-//    List<DatasetMetadata> datasetMetadata3 =
-//        PreprocessorService.filterValidDatasetMetadata(List.of());
-//    assertThat(datasetMetadata3.size()).isEqualTo(0);
-//  }
-//
-//  @Test
-//  public void shouldGetActivePartitionsFromServiceMetadata() {
-//    DatasetMetadata datasetMetadataEmptyPartitions =
-//        new DatasetMetadata("empty", "owner1", 1000, List.of());
-//    DatasetMetadata datasetMetadataNoActivePartitions =
-//        new DatasetMetadata(
-//            "empty",
-//            "owner1",
-//            1000,
-//            List.of(
-//                new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1",
-// "2"))));
-//
-//    DatasetMetadata datasetMetadataNoPartitions =
-//        new DatasetMetadata(
-//            "empty",
-//            "owner1",
-//            1000,
-//            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of())));
-//
-//    DatasetMetadata datasetMetadataMultiplePartitions =
-//        new DatasetMetadata(
-//            "empty",
-//            "owner1",
-//            1000,
-//            List.of(
-//                new DatasetPartitionMetadata(1, 10000, List.of("3", "4")),
-//                new DatasetPartitionMetadata(10001, Long.MAX_VALUE, List.of("5", "6"))));
-//
-//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataEmptyPartitions))
-//        .isEqualTo(List.of());
-//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoActivePartitions))
-//        .isEqualTo(List.of());
-//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoPartitions))
-//        .isEqualTo(List.of());
-//    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataMultiplePartitions))
-//        .isEqualTo(List.of(5, 6));
-//  }
-//
-//  @Test
-//  public void shouldBuildStreamTopology() {
-//    List<DatasetMetadata> datasetMetadata =
-//        List.of(
-//            new DatasetMetadata(
-//                "dataset1",
-//                "owner1",
-//                1000,
-//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2")))),
-//            new DatasetMetadata(
-//                "dataset2",
-//                "owner1",
-//                1000,
-//                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2")))));
-//
-//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-//    int preprocessorCount = 1;
-//    int maxBurstSeconds = 1;
-//    boolean initializeWarm = false;
-//    PreprocessorRateLimiter rateLimiter =
-//        new PreprocessorRateLimiter(
-//            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
-//
-//    List<String> upstreamTopics = List.of("upstream1", "upstream2", "upstream3");
-//    String downstreamTopic = "downstream";
-//    String dataTransformer = "api_log";
-//    Topology topology =
-//        PreprocessorService.buildTopology(
-//            datasetMetadata, rateLimiter, upstreamTopics, downstreamTopic, dataTransformer);
-//
-//    // we have limited visibility into the topology, so we just verify we have the correct number
-// of
-//    // stream processors as we expect
-//    assertThat(topology.describe().subtopologies().size()).isEqualTo(upstreamTopics.size());
-//  }
-//
-//  @Test
-//  public void shouldThrowOnInvalidTopologyConfigs() {
-//    DatasetMetadata datasetMetadata =
-//        new DatasetMetadata(
-//            "dataset1",
-//            "owner1",
-//            1000,
-//            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2"))));
-//
-//    MeterRegistry meterRegistry = new SimpleMeterRegistry();
-//    int preprocessorCount = 1;
-//    int maxBurstSeconds = 1;
-//    boolean initializeWarm = false;
-//    PreprocessorRateLimiter rateLimiter =
-//        new PreprocessorRateLimiter(
-//            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
-//    List<String> upstreamTopics = List.of("upstream");
-//    String downstreamTopic = "downstream";
-//    String dataTransformer = "api_log";
-//
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () ->
-//                PreprocessorService.buildTopology(
-//                    List.of(), rateLimiter, upstreamTopics, downstreamTopic, dataTransformer));
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () ->
-//                PreprocessorService.buildTopology(
-//                    List.of(datasetMetadata),
-//                    rateLimiter,
-//                    List.of(),
-//                    downstreamTopic,
-//                    dataTransformer));
-//    assertThatNullPointerException()
-//        .isThrownBy(
-//            () ->
-//                PreprocessorService.buildTopology(
-//                    List.of(datasetMetadata),
-//                    null,
-//                    upstreamTopics,
-//                    downstreamTopic,
-//                    dataTransformer));
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () ->
-//                PreprocessorService.buildTopology(
-//                    List.of(datasetMetadata), rateLimiter, upstreamTopics, "", dataTransformer));
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () ->
-//                PreprocessorService.buildTopology(
-//                    List.of(datasetMetadata), rateLimiter, upstreamTopics, downstreamTopic, ""));
-//    assertThatIllegalArgumentException()
-//        .isThrownBy(
-//            () ->
-//                PreprocessorService.buildTopology(
-//                    List.of(datasetMetadata),
-//                    rateLimiter,
-//                    upstreamTopics,
-//                    downstreamTopic,
-//                    "invalid"));
-//  }
-//
-//  @Test
-//  public void shouldHandleEmptyDatasetMetadata() throws TimeoutException {
-//    DatasetMetadataStore datasetMetadataStore = mock(DatasetMetadataStore.class);
-//    when(datasetMetadataStore.listSync()).thenReturn(List.of());
-//
-//    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
-//        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
-//            .setApplicationId("applicationId")
-//            .setBootstrapServers("bootstrap")
-//            .setNumStreamThreads(1)
-//            .build();
-//    KaldbConfigs.ServerConfig serverConfig =
-//        KaldbConfigs.ServerConfig.newBuilder()
-//            .setServerPort(8080)
-//            .setServerAddress("localhost")
-//            .build();
-//    KaldbConfigs.PreprocessorConfig preprocessorConfig =
-//        KaldbConfigs.PreprocessorConfig.newBuilder()
-//            .setKafkaStreamConfig(kafkaStreamConfig)
-//            .setServerConfig(serverConfig)
-//            .setPreprocessorInstanceCount(1)
-//            .setDataTransformer("api_log")
-//            .setRateLimiterMaxBurstSeconds(1)
-//            .build();
-//
-//    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-//    PreprocessorService preprocessorService =
-//        new PreprocessorService(datasetMetadataStore, preprocessorConfig, meterRegistry);
-//
-//    preprocessorService.startAsync();
-//    preprocessorService.awaitRunning(DEFAULT_START_STOP_DURATION);
-//
-//    assertThat(MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry))
-//        .isEqualTo(1);
-//
-//    preprocessorService.stopAsync();
-//    preprocessorService.awaitTerminated();
-//  }
-// }
+package com.slack.kaldb.preprocessor;
+
+import static com.slack.kaldb.preprocessor.PreprocessorValueMapper.SERVICE_NAME_KEY;
+import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.slack.kaldb.metadata.dataset.DatasetMetadata;
+import com.slack.kaldb.metadata.dataset.DatasetMetadataStore;
+import com.slack.kaldb.metadata.dataset.DatasetPartitionMetadata;
+import com.slack.kaldb.proto.config.KaldbConfigs;
+import com.slack.kaldb.testlib.MetricsUtil;
+import com.slack.service.murron.trace.Trace;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeoutException;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.processor.StreamPartitioner;
+import org.junit.Test;
+
+public class PreprocessorServiceUnitTest {
+
+  @Test
+  public void shouldBuildValidPropsFromStreamConfig() {
+    String applicationId = "applicationId";
+    String bootstrapServers = "bootstrap";
+    String processingGuarantee = "at_least_once";
+    int replicationFactor = 1;
+    boolean enableIdempotence = false;
+    String acksConfig = "1";
+    int numStreamThreads = 1;
+
+    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+            .setApplicationId(applicationId)
+            .setBootstrapServers(bootstrapServers)
+            .setNumStreamThreads(numStreamThreads)
+            .setProcessingGuarantee(processingGuarantee)
+            .build();
+
+    Properties properties = PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+    assertThat(properties.size()).isEqualTo(7);
+
+    assertThat(properties.get(StreamsConfig.APPLICATION_ID_CONFIG)).isEqualTo(applicationId);
+
+    assertThat(properties.get(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG)).isEqualTo(bootstrapServers);
+
+    assertThat(properties.get(StreamsConfig.NUM_STREAM_THREADS_CONFIG)).isEqualTo(numStreamThreads);
+    assertThat(properties.get(StreamsConfig.PROCESSING_GUARANTEE_CONFIG))
+        .isEqualTo(processingGuarantee);
+    assertThat(properties.get(StreamsConfig.REPLICATION_FACTOR_CONFIG))
+        .isEqualTo(replicationFactor);
+    assertThat(
+            properties.get(StreamsConfig.producerPrefix(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG)))
+        .isEqualTo(enableIdempotence);
+    assertThat(properties.get(StreamsConfig.producerPrefix(ProducerConfig.ACKS_CONFIG)))
+        .isEqualTo(acksConfig);
+  }
+
+  @Test
+  public void shouldPreventInvalidStreamPropsConfig() {
+    String applicationId = "applicationId";
+    String bootstrapServers = "bootstrap";
+    int numStreamThreads = 1;
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () -> {
+              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+                      .setBootstrapServers(bootstrapServers)
+                      .setNumStreamThreads(numStreamThreads)
+                      .build();
+              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+            });
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () -> {
+              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+                      .setApplicationId(applicationId)
+                      .setNumStreamThreads(numStreamThreads)
+                      .build();
+              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+            });
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () -> {
+              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+                      .setApplicationId(applicationId)
+                      .setBootstrapServers(bootstrapServers)
+                      .build();
+              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+            });
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () -> {
+              KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+                  KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+                      .setApplicationId(applicationId)
+                      .setBootstrapServers(bootstrapServers)
+                      .setNumStreamThreads(0)
+                      .build();
+              PreprocessorService.makeKafkaStreamsProps(kafkaStreamConfig);
+            });
+  }
+
+  @Test
+  public void shouldReturnRandomPartitionFromStreamPartitioner() {
+    String datasetName = "datasetName";
+    List<Integer> partitionList = List.of(33, 44, 55);
+    DatasetMetadata datasetMetadata =
+        new DatasetMetadata(
+            datasetName,
+            datasetName,
+            1,
+            List.of(new DatasetPartitionMetadata(100, Long.MAX_VALUE, List.of("33", "44", "55"))),
+            datasetName);
+    StreamPartitioner<String, Trace.Span> streamPartitioner =
+        PreprocessorService.streamPartitioner(List.of(datasetMetadata));
+
+    Trace.Span span =
+        Trace.Span.newBuilder()
+            .addTags(
+                Trace.KeyValue.newBuilder().setKey(SERVICE_NAME_KEY).setVStr(datasetName).build())
+            .build();
+
+    // all arguments except value are currently unused for determining the partition to assign, as
+    // this comes the internal partition list that is set on stream partitioner initialization
+    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 0)))
+        .isTrue();
+    assertThat(partitionList.contains(streamPartitioner.partition("topic", null, span, 1)))
+        .isTrue();
+    assertThat(partitionList.contains(streamPartitioner.partition("topic", "", span, 0))).isTrue();
+    assertThat(partitionList.contains(streamPartitioner.partition("", null, span, 0))).isTrue();
+  }
+
+  @Test
+  public void shouldFilterInvalidConfigurationsFromServiceMetadata() {
+    DatasetMetadata validDatasetMetadata =
+        new DatasetMetadata(
+            "valid",
+            "owner1",
+            1000,
+            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1"))),
+            "valid");
+
+    List<DatasetMetadata> datasetMetadataList =
+        List.of(
+            new DatasetMetadata(
+                "invalidServicePartitionList",
+                "owner1",
+                1000,
+                List.of(),
+                "invalidServicePartitionList"),
+            new DatasetMetadata(
+                "invalidThroughputBytes",
+                "owner1",
+                0,
+                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1"))),
+                "invalidThroughputBytes"),
+            new DatasetMetadata(
+                "invalidActivePartitions",
+                "owner1",
+                1000,
+                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of())),
+                "invalidActivePartitions"),
+            new DatasetMetadata(
+                "invalidNoActivePartitions",
+                "owner1",
+                1000,
+                List.of(
+                    new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1"))),
+                "invalidNoActivePartitions"),
+            validDatasetMetadata);
+
+    List<DatasetMetadata> datasetMetadata1 =
+        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
+
+    assertThat(datasetMetadata1.size()).isEqualTo(1);
+    assertThat(datasetMetadata1.contains(validDatasetMetadata)).isTrue();
+
+    Collections.shuffle(datasetMetadata1);
+
+    List<DatasetMetadata> datasetMetadata2 =
+        PreprocessorService.filterValidDatasetMetadata(datasetMetadataList);
+
+    assertThat(datasetMetadata2.size()).isEqualTo(1);
+    assertThat(datasetMetadata2.contains(validDatasetMetadata)).isTrue();
+
+    List<DatasetMetadata> datasetMetadata3 =
+        PreprocessorService.filterValidDatasetMetadata(List.of());
+    assertThat(datasetMetadata3.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldGetActivePartitionsFromServiceMetadata() {
+    DatasetMetadata datasetMetadataEmptyPartitions =
+        new DatasetMetadata("empty", "owner1", 1000, List.of(), "empty");
+    DatasetMetadata datasetMetadataNoActivePartitions =
+        new DatasetMetadata(
+            "empty",
+            "owner1",
+            1000,
+            List.of(
+                new DatasetPartitionMetadata(1, Instant.now().toEpochMilli(), List.of("1", "2"))),
+            "empty");
+
+    DatasetMetadata datasetMetadataNoPartitions =
+        new DatasetMetadata(
+            "empty",
+            "owner1",
+            1000,
+            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of())),
+            "empty");
+
+    DatasetMetadata datasetMetadataMultiplePartitions =
+        new DatasetMetadata(
+            "empty",
+            "owner1",
+            1000,
+            List.of(
+                new DatasetPartitionMetadata(1, 10000, List.of("3", "4")),
+                new DatasetPartitionMetadata(10001, Long.MAX_VALUE, List.of("5", "6"))),
+            "empty");
+
+    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataEmptyPartitions))
+        .isEqualTo(List.of());
+    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoActivePartitions))
+        .isEqualTo(List.of());
+    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataNoPartitions))
+        .isEqualTo(List.of());
+    assertThat(PreprocessorService.getActivePartitionList(datasetMetadataMultiplePartitions))
+        .isEqualTo(List.of(5, 6));
+  }
+
+  @Test
+  public void shouldBuildStreamTopology() {
+    List<DatasetMetadata> datasetMetadata =
+        List.of(
+            new DatasetMetadata(
+                "dataset1",
+                "owner1",
+                1000,
+                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2"))),
+                "dataset1"),
+            new DatasetMetadata(
+                "dataset2",
+                "owner1",
+                1000,
+                List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2"))),
+                "dataset2"));
+
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    int preprocessorCount = 1;
+    int maxBurstSeconds = 1;
+    boolean initializeWarm = false;
+    PreprocessorRateLimiter rateLimiter =
+        new PreprocessorRateLimiter(
+            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
+
+    List<String> upstreamTopics = List.of("upstream1", "upstream2", "upstream3");
+    String downstreamTopic = "downstream";
+    String dataTransformer = "api_log";
+    Topology topology =
+        PreprocessorService.buildTopology(
+            datasetMetadata, rateLimiter, upstreamTopics, downstreamTopic, dataTransformer);
+
+    // we have limited visibility into the topology, so we just verify we have the correct number of
+    // stream processors as we expect
+    assertThat(topology.describe().subtopologies().size()).isEqualTo(upstreamTopics.size());
+  }
+
+  @Test
+  public void shouldThrowOnInvalidTopologyConfigs() {
+    DatasetMetadata datasetMetadata =
+        new DatasetMetadata(
+            "dataset1",
+            "owner1",
+            1000,
+            List.of(new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("1", "2"))),
+            "dataset1");
+
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    int preprocessorCount = 1;
+    int maxBurstSeconds = 1;
+    boolean initializeWarm = false;
+    PreprocessorRateLimiter rateLimiter =
+        new PreprocessorRateLimiter(
+            meterRegistry, preprocessorCount, maxBurstSeconds, initializeWarm);
+    List<String> upstreamTopics = List.of("upstream");
+    String downstreamTopic = "downstream";
+    String dataTransformer = "api_log";
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                PreprocessorService.buildTopology(
+                    List.of(), rateLimiter, upstreamTopics, downstreamTopic, dataTransformer));
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                PreprocessorService.buildTopology(
+                    List.of(datasetMetadata),
+                    rateLimiter,
+                    List.of(),
+                    downstreamTopic,
+                    dataTransformer));
+    assertThatNullPointerException()
+        .isThrownBy(
+            () ->
+                PreprocessorService.buildTopology(
+                    List.of(datasetMetadata),
+                    null,
+                    upstreamTopics,
+                    downstreamTopic,
+                    dataTransformer));
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                PreprocessorService.buildTopology(
+                    List.of(datasetMetadata), rateLimiter, upstreamTopics, "", dataTransformer));
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                PreprocessorService.buildTopology(
+                    List.of(datasetMetadata), rateLimiter, upstreamTopics, downstreamTopic, ""));
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                PreprocessorService.buildTopology(
+                    List.of(datasetMetadata),
+                    rateLimiter,
+                    upstreamTopics,
+                    downstreamTopic,
+                    "invalid"));
+  }
+
+  @Test
+  public void shouldHandleEmptyDatasetMetadata() throws TimeoutException {
+    DatasetMetadataStore datasetMetadataStore = mock(DatasetMetadataStore.class);
+    when(datasetMetadataStore.listSync()).thenReturn(List.of());
+
+    KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
+        KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
+            .setApplicationId("applicationId")
+            .setBootstrapServers("bootstrap")
+            .setNumStreamThreads(1)
+            .build();
+    KaldbConfigs.ServerConfig serverConfig =
+        KaldbConfigs.ServerConfig.newBuilder()
+            .setServerPort(8080)
+            .setServerAddress("localhost")
+            .build();
+    KaldbConfigs.PreprocessorConfig preprocessorConfig =
+        KaldbConfigs.PreprocessorConfig.newBuilder()
+            .setKafkaStreamConfig(kafkaStreamConfig)
+            .setServerConfig(serverConfig)
+            .setPreprocessorInstanceCount(1)
+            .setDataTransformer("api_log")
+            .setRateLimiterMaxBurstSeconds(1)
+            .build();
+
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    PreprocessorService preprocessorService =
+        new PreprocessorService(datasetMetadataStore, preprocessorConfig, meterRegistry);
+
+    preprocessorService.startAsync();
+    preprocessorService.awaitRunning(DEFAULT_START_STOP_DURATION);
+
+    assertThat(MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry))
+        .isEqualTo(1);
+
+    preprocessorService.stopAsync();
+    preprocessorService.awaitTerminated();
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorValueMapperTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorValueMapperTest.java
@@ -159,9 +159,9 @@ public class PreprocessorValueMapperTest {
                     .build())
             .build();
 
-    assertThat(PreprocessorValueMapper.getDatasetName(span1)).isEqualTo(service1);
+    assertThat(PreprocessorValueMapper.getServiceName(span1)).isEqualTo(service1);
 
     Trace.Span span2 = Trace.Span.newBuilder().build();
-    assertThat(PreprocessorValueMapper.getDatasetName(span2)).isNull();
+    assertThat(PreprocessorValueMapper.getServiceName(span2)).isNull();
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
@@ -123,7 +123,12 @@ public class KaldbTest {
         new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("0", "1"));
     final List<DatasetPartitionMetadata> partitionConfigs = Collections.singletonList(partition);
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(MessageUtil.TEST_DATASET_NAME, "serviceOwner", 1000, partitionConfigs);
+        new DatasetMetadata(
+            MessageUtil.TEST_DATASET_NAME,
+            "serviceOwner",
+            1000,
+            partitionConfigs,
+            MessageUtil.TEST_DATASET_NAME);
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.listSync().size() == 1);
   }

--- a/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
@@ -501,6 +501,7 @@ public class ManagerApiGrpcTest {
                         ManagerApi.CreateDatasetMetadataRequest.newBuilder()
                             .setName(datasetName)
                             .setOwner(datasetOwner)
+                            .setServiceNamePattern(datasetName)
                             .build()));
 
     assertThat(throwableCreate.getStatus().getCode()).isEqualTo(Status.UNKNOWN.getCode());

--- a/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceTest.java
@@ -89,7 +89,8 @@ public class ZipkinServiceTest {
         new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("0", "1"));
     final List<DatasetPartitionMetadata> partitionConfigs = Collections.singletonList(partition);
     DatasetMetadata datasetMetadata =
-        new DatasetMetadata(TEST_DATASET_NAME, "serviceOwner", 1000, partitionConfigs);
+        new DatasetMetadata(
+            TEST_DATASET_NAME, "serviceOwner", 1000, partitionConfigs, TEST_DATASET_NAME);
     datasetMetadataStore.createSync(datasetMetadata);
     await().until(() -> datasetMetadataStore.listSync().size() == 1);
   }


### PR DESCRIPTION
Introduce a service name concept within a dataset.

When we read a record from Kafka, today we match the dataset name with the records service name. This meant if we needed to ingest logs with multiple services we need to create N datasets which wasn't what we wanted

In this PR, we introduce a concept of a service name which can be `_all` meaning all services within the dataset will be ingested ( respecting the rate limits ) . One could also ingest only a service by mentioning it's name.

In the future we want to allow for glob matching as well.

This PR should also be back-compat meaning existing clusters will not need service name and just read the dataset name as the service name

This PR is a different approach to https://github.com/slackhq/kaldb/pull/388 and we can close that PR out once this is committed. 