### PR TITLE
Log uncaught exceptions in recovery tasks

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
@@ -263,10 +263,11 @@ public class KaldbKafkaConsumer {
             TimeUnit.MILLISECONDS,
             queue,
             new ThreadFactoryBuilder()
-                    .setUncaughtExceptionHandler(
-                            (t, e) -> LOG.error("Exception in recovery task on thread {}: {}", t.getName(), e))
-                    .setNameFormat("recovery-task-%d")
-                    .build());
+                .setUncaughtExceptionHandler(
+                    (t, e) ->
+                        LOG.error("Exception in recovery task on thread {}: {}", t.getName(), e))
+                .setNameFormat("recovery-task-%d")
+                .build());
 
     final long messagesToIndex = endOffsetInclusive - startOffsetInclusive;
     long messagesIndexed = 0;

--- a/kaldb/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
@@ -262,7 +262,11 @@ public class KaldbKafkaConsumer {
             0L,
             TimeUnit.MILLISECONDS,
             queue,
-            new ThreadFactoryBuilder().setNameFormat("recovery-task-%d").build());
+            new ThreadFactoryBuilder()
+                    .setUncaughtExceptionHandler(
+                            (t, e) -> LOG.error("Exception in recovery task on thread {}: {}", t.getName(), e))
+                    .setNameFormat("recovery-task-%d")
+                    .build());
 
     final long messagesToIndex = endOffsetInclusive - startOffsetInclusive;
     long messagesIndexed = 0;
@@ -273,7 +277,7 @@ public class KaldbKafkaConsumer {
       LOG.debug("Fetched records={} from partition:{}", recordCount, topicPartition.partition());
       if (recordCount > 0) {
         messagesIndexed += recordCount;
-        executor.submit(
+        executor.execute(
             () -> {
               LOG.info("Ingesting batch: [{}/{}]", topicPartition.partition(), recordCount);
               for (ConsumerRecord<String, byte[]> record : records) {


### PR DESCRIPTION
We'll almost certainly want some more sophisticated retry and error handling, but this is the first step in understanding why some recoveries are failing.
