### PR TITLE
Convert node-based shard metrics to snapshot data

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/ChunkManagerBase.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/ChunkManagerBase.java
@@ -81,7 +81,7 @@ public abstract class ChunkManagerBase<T> extends AbstractIdleService implements
    */
   public SearchResult<T> query(SearchQuery query, Duration queryTimeout) {
     SearchResult<T> errorResult =
-        new SearchResult<>(new ArrayList<>(), 0, 0, new ArrayList<>(), 0, 1, 0);
+        new SearchResult<>(new ArrayList<>(), 0, 0, new ArrayList<>(), 0, 0, 1, 0);
 
     CurrentTraceContext currentTraceContext = Tracing.current().currentTraceContext();
 
@@ -163,7 +163,11 @@ public abstract class ChunkManagerBase<T> extends AbstractIdleService implements
 
       //noinspection unchecked
       return ((SearchResultAggregator<T>) new SearchResultAggregatorImpl<>(query))
-          .aggregate(searchResults, chunkList.size());
+          .aggregate(
+              searchResults,
+              chunkList.size(),
+              chunkList.size() - chunksMatchingQuery.size(),
+              chunksMatchingQuery.size());
     } catch (Exception e) {
       LOG.error("Error searching across chunks ", e);
       throw new RuntimeException(e);

--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/ChunkManagerBase.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/ChunkManagerBase.java
@@ -81,7 +81,7 @@ public abstract class ChunkManagerBase<T> extends AbstractIdleService implements
    */
   public SearchResult<T> query(SearchQuery query, Duration queryTimeout) {
     SearchResult<T> errorResult =
-        new SearchResult<>(new ArrayList<>(), 0, 0, new ArrayList<>(), 0, 0, 1, 0);
+        new SearchResult<>(new ArrayList<>(), 0, 0, new ArrayList<>(), 0, 1, 0);
 
     CurrentTraceContext currentTraceContext = Tracing.current().currentTraceContext();
 
@@ -162,10 +162,8 @@ public abstract class ChunkManagerBase<T> extends AbstractIdleService implements
       }
 
       //noinspection unchecked
-      SearchResult<T> aggregatedResults =
-          ((SearchResultAggregator<T>) new SearchResultAggregatorImpl<>(query))
-              .aggregate(searchResults);
-      return incrementNodeCount(aggregatedResults);
+      return ((SearchResultAggregator<T>) new SearchResultAggregatorImpl<>(query))
+          .aggregate(searchResults, chunkList.size());
     } catch (Exception e) {
       LOG.error("Error searching across chunks ", e);
       throw new RuntimeException(e);
@@ -175,18 +173,6 @@ public abstract class ChunkManagerBase<T> extends AbstractIdleService implements
       // mayInterruptIfRunning has no effect
       searchResultFuture.cancel(true);
     }
-  }
-
-  private SearchResult<T> incrementNodeCount(SearchResult<T> searchResult) {
-    return new SearchResult<>(
-        searchResult.hits,
-        searchResult.tookMicros,
-        searchResult.totalCount,
-        searchResult.buckets,
-        searchResult.failedNodes,
-        searchResult.totalNodes + 1,
-        searchResult.totalSnapshots,
-        searchResult.snapshotsWithReplicas);
   }
 
   @VisibleForTesting

--- a/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
@@ -115,8 +115,9 @@ public class ElasticsearchApiService {
     span.tag("resultHitsCount", String.valueOf(searchResult.getHitsCount()));
     span.tag("resultBucketCount", String.valueOf(searchResult.getBucketsCount()));
     span.tag("resultTookMicros", String.valueOf(searchResult.getTookMicros()));
-    span.tag("resultFailedSnapshots", String.valueOf(searchResult.getFailedSnapshots()));
     span.tag("resultTotalSnapshots", String.valueOf(searchResult.getTotalSnapshots()));
+    span.tag("resultSkippedSnapshots", String.valueOf(searchResult.getSkippedSnapshots()));
+    span.tag("resultFailedSnapshots", String.valueOf(searchResult.getFailedSnapshots()));
     span.tag("resultSuccessfulSnapshots", String.valueOf(searchResult.getSuccessfulSnapshots()));
 
     try {
@@ -130,6 +131,7 @@ public class ElasticsearchApiService {
           .took(Duration.of(searchResult.getTookMicros(), ChronoUnit.MICROS).toMillis())
           .shardsMetadata(
               searchResult.getTotalSnapshots(),
+              searchResult.getSkippedSnapshots(),
               searchResult.getFailedSnapshots(),
               searchResult.getSuccessfulSnapshots())
           .status(200)
@@ -141,6 +143,7 @@ public class ElasticsearchApiService {
           .took(Duration.of(searchResult.getTookMicros(), ChronoUnit.MICROS).toMillis())
           .shardsMetadata(
               searchResult.getTotalSnapshots(),
+              searchResult.getSkippedSnapshots(),
               searchResult.getFailedSnapshots(),
               searchResult.getSuccessfulSnapshots())
           .status(500)

--- a/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
@@ -115,11 +115,9 @@ public class ElasticsearchApiService {
     span.tag("resultHitsCount", String.valueOf(searchResult.getHitsCount()));
     span.tag("resultBucketCount", String.valueOf(searchResult.getBucketsCount()));
     span.tag("resultTookMicros", String.valueOf(searchResult.getTookMicros()));
-    span.tag("resultFailedNodes", String.valueOf(searchResult.getFailedNodes()));
-    span.tag("resultTotalNodes", String.valueOf(searchResult.getTotalNodes()));
-    span.tag("resultTotalSnapshots", String.valueOf(searchResult.getTotalNodes()));
-    span.tag(
-        "resultSnapshotsWithReplicas", String.valueOf(searchResult.getSnapshotsWithReplicas()));
+    span.tag("resultFailedSnapshots", String.valueOf(searchResult.getFailedSnapshots()));
+    span.tag("resultTotalSnapshots", String.valueOf(searchResult.getTotalSnapshots()));
+    span.tag("resultSuccessfulSnapshots", String.valueOf(searchResult.getSuccessfulSnapshots()));
 
     try {
       HitsMetadata hits = getHits(searchResult);
@@ -130,7 +128,10 @@ public class ElasticsearchApiService {
           .hits(hits)
           .aggregations(aggregations)
           .took(Duration.of(searchResult.getTookMicros(), ChronoUnit.MICROS).toMillis())
-          .shardsMetadata(searchResult.getTotalNodes(), searchResult.getFailedNodes())
+          .shardsMetadata(
+              searchResult.getTotalSnapshots(),
+              searchResult.getFailedSnapshots(),
+              searchResult.getSuccessfulSnapshots())
           .status(200)
           .build();
     } catch (Exception e) {
@@ -138,7 +139,10 @@ public class ElasticsearchApiService {
       span.error(e);
       return new EsSearchResponse.Builder()
           .took(Duration.of(searchResult.getTookMicros(), ChronoUnit.MICROS).toMillis())
-          .shardsMetadata(searchResult.getTotalNodes(), searchResult.getFailedNodes())
+          .shardsMetadata(
+              searchResult.getTotalSnapshots(),
+              searchResult.getFailedSnapshots(),
+              searchResult.getSuccessfulSnapshots())
           .status(500)
           .build();
     } finally {

--- a/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/searchResponse/EsSearchResponse.java
+++ b/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/searchResponse/EsSearchResponse.java
@@ -96,6 +96,11 @@ public class EsSearchResponse {
       return this;
     }
 
+    public Builder shardsMetadata(int total, int failed, int successful) {
+      this.shardsMetadata = Map.of("total", total, "failed", failed, "successful", successful);
+      return this;
+    }
+
     public Builder debugMetadata(Map<String, String> debugMetadata) {
       this.debugMetadata = debugMetadata;
       return this;

--- a/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/searchResponse/EsSearchResponse.java
+++ b/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/searchResponse/EsSearchResponse.java
@@ -88,16 +88,9 @@ public class EsSearchResponse {
       return this;
     }
 
-    public Builder shardsMetadata(int total, int failed) {
+    public Builder shardsMetadata(int total, int skipped, int failed, int successful) {
       this.shardsMetadata =
-          Map.of(
-              "total", total,
-              "failed", failed);
-      return this;
-    }
-
-    public Builder shardsMetadata(int total, int failed, int successful) {
-      this.shardsMetadata = Map.of("total", total, "failed", failed, "successful", successful);
+          Map.of("total", total, "skipped", skipped, "failed", failed, "successful", successful);
       return this;
     }
 

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbLocalQueryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbLocalQueryService.java
@@ -30,8 +30,9 @@ public class KaldbLocalQueryService<T> extends KaldbQueryServiceBase {
     // we'll use that over defaultQueryTimeout
     SearchResult<T> searchResult = chunkManager.query(query, defaultQueryTimeout);
     KaldbSearch.SearchResult result = SearchResultUtils.toSearchResultProto(searchResult);
-    span.tag("totalNodes", String.valueOf(result.getTotalNodes()));
-    span.tag("failedNodes", String.valueOf(result.getFailedNodes()));
+    span.tag("totalSnapshots", String.valueOf(result.getTotalSnapshots()));
+    span.tag("failedSnapshots", String.valueOf(result.getFailedSnapshots()));
+    span.tag("successfulSnapshots", String.valueOf(result.getSuccessfulSnapshots()));
     span.tag("hitCount", String.valueOf(result.getHitsCount()));
     span.finish();
     LOG.info("Finished search request: {}", request);

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbLocalQueryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbLocalQueryService.java
@@ -31,6 +31,7 @@ public class KaldbLocalQueryService<T> extends KaldbQueryServiceBase {
     SearchResult<T> searchResult = chunkManager.query(query, defaultQueryTimeout);
     KaldbSearch.SearchResult result = SearchResultUtils.toSearchResultProto(searchResult);
     span.tag("totalSnapshots", String.valueOf(result.getTotalSnapshots()));
+    span.tag("skippedSnapshots", String.valueOf(result.getSkippedSnapshots()));
     span.tag("failedSnapshots", String.valueOf(result.getFailedSnapshots()));
     span.tag("successfulSnapshots", String.valueOf(result.getSuccessfulSnapshots()));
     span.tag("hitCount", String.valueOf(result.getHitsCount()));

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/LogIndexSearcherImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/LogIndexSearcherImpl.java
@@ -149,9 +149,8 @@ public class LogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
             elapsedTime.elapsed(TimeUnit.MICROSECONDS),
             bucketCount > 0 ? histogram.count() : results.size(),
             histogram.getBuckets(),
-            0,
-            0,
             1,
+            0,
             1);
       } finally {
         searcherManager.release(searcher);

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/LogIndexSearcherImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/LogIndexSearcherImpl.java
@@ -151,6 +151,7 @@ public class LogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
             histogram.getBuckets(),
             1,
             0,
+            0,
             1);
       } finally {
         searcherManager.release(searcher);

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResult.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResult.java
@@ -10,7 +10,7 @@ import java.util.List;
 public class SearchResult<T> {
 
   private static final SearchResult EMPTY =
-      new SearchResult<>(Collections.emptyList(), 0, 0, Collections.emptyList(), 0, 0, 0);
+      new SearchResult<>(Collections.emptyList(), 0, 0, Collections.emptyList(), 0, 0, 0, 0);
 
   public final long totalCount;
 
@@ -26,6 +26,9 @@ public class SearchResult<T> {
   // the total of possible snapshots present - requested or not
   public final int totalSnapshots;
 
+  // the number of snapshots we did not try to lookup
+  public final int skippedSnapshots;
+
   // the number of snapshots that failed in a request
   public final int failedSnapshots;
 
@@ -38,6 +41,7 @@ public class SearchResult<T> {
     this.totalCount = 0;
     this.buckets = new ArrayList<>();
     this.totalSnapshots = 0;
+    this.skippedSnapshots = 0;
     this.failedSnapshots = 0;
     this.successfulSnapshots = 0;
   }
@@ -49,6 +53,7 @@ public class SearchResult<T> {
       long totalCount,
       List<HistogramBucket> buckets,
       int totalSnapshots,
+      int skippedSnapshots,
       int failedSnapshots,
       int successfulSnapshots) {
     this.hits = hits;
@@ -56,6 +61,7 @@ public class SearchResult<T> {
     this.totalCount = totalCount;
     this.buckets = buckets;
     this.totalSnapshots = totalSnapshots;
+    this.skippedSnapshots = skippedSnapshots;
     this.failedSnapshots = failedSnapshots;
     this.successfulSnapshots = successfulSnapshots;
   }
@@ -68,6 +74,7 @@ public class SearchResult<T> {
     return totalCount == that.totalCount
         && tookMicros == that.tookMicros
         && totalSnapshots == that.totalSnapshots
+        && skippedSnapshots == that.skippedSnapshots
         && failedSnapshots == that.failedSnapshots
         && successfulSnapshots == that.successfulSnapshots
         && Objects.equal(hits, that.hits)
@@ -82,6 +89,7 @@ public class SearchResult<T> {
         tookMicros,
         buckets,
         totalSnapshots,
+        skippedSnapshots,
         failedSnapshots,
         successfulSnapshots);
   }
@@ -103,6 +111,8 @@ public class SearchResult<T> {
         + buckets
         + ", totalSnapshots="
         + totalSnapshots
+        + ", skippedSnapshots="
+        + skippedSnapshots
         + ", failedSnapshots="
         + failedSnapshots
         + ", successfulSnapshots="

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResult.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResult.java
@@ -10,7 +10,7 @@ import java.util.List;
 public class SearchResult<T> {
 
   private static final SearchResult EMPTY =
-      new SearchResult<>(Collections.emptyList(), 0, 0, Collections.emptyList(), 1, 1, 0, 0);
+      new SearchResult<>(Collections.emptyList(), 0, 0, Collections.emptyList(), 0, 0, 0);
 
   public final long totalCount;
 
@@ -23,20 +23,23 @@ public class SearchResult<T> {
   // TODO: Instead of histogram bucket, return tuple.
   public final List<HistogramBucket> buckets;
 
-  public final int failedNodes;
-  public final int totalNodes;
+  // the total of possible snapshots present - requested or not
   public final int totalSnapshots;
-  public final int snapshotsWithReplicas;
+
+  // the number of snapshots that failed in a request
+  public final int failedSnapshots;
+
+  // the number of snapshots that succeeded a request
+  public final int successfulSnapshots;
 
   public SearchResult() {
     this.hits = new ArrayList<>();
     this.tookMicros = 0;
     this.totalCount = 0;
     this.buckets = new ArrayList<>();
-    this.failedNodes = 0;
-    this.totalNodes = 0;
     this.totalSnapshots = 0;
-    this.snapshotsWithReplicas = 0;
+    this.failedSnapshots = 0;
+    this.successfulSnapshots = 0;
   }
 
   // TODO: Move stats into a separate struct.
@@ -45,18 +48,16 @@ public class SearchResult<T> {
       long tookMicros,
       long totalCount,
       List<HistogramBucket> buckets,
-      int failedNodes,
-      int totalNodes,
       int totalSnapshots,
-      int snapshotsWithReplicas) {
+      int failedSnapshots,
+      int successfulSnapshots) {
     this.hits = hits;
     this.tookMicros = tookMicros;
     this.totalCount = totalCount;
     this.buckets = buckets;
-    this.failedNodes = failedNodes;
-    this.totalNodes = totalNodes;
     this.totalSnapshots = totalSnapshots;
-    this.snapshotsWithReplicas = snapshotsWithReplicas;
+    this.failedSnapshots = failedSnapshots;
+    this.successfulSnapshots = successfulSnapshots;
   }
 
   @Override
@@ -66,10 +67,9 @@ public class SearchResult<T> {
     SearchResult<?> that = (SearchResult<?>) o;
     return totalCount == that.totalCount
         && tookMicros == that.tookMicros
-        && failedNodes == that.failedNodes
-        && totalNodes == that.totalNodes
         && totalSnapshots == that.totalSnapshots
-        && snapshotsWithReplicas == that.snapshotsWithReplicas
+        && failedSnapshots == that.failedSnapshots
+        && successfulSnapshots == that.successfulSnapshots
         && Objects.equal(hits, that.hits)
         && Objects.equal(buckets, that.buckets);
   }
@@ -81,10 +81,9 @@ public class SearchResult<T> {
         hits,
         tookMicros,
         buckets,
-        failedNodes,
-        totalNodes,
         totalSnapshots,
-        snapshotsWithReplicas);
+        failedSnapshots,
+        successfulSnapshots);
   }
 
   public static SearchResult<LogMessage> empty() {
@@ -102,14 +101,12 @@ public class SearchResult<T> {
         + tookMicros
         + ", buckets="
         + buckets
-        + ", failedNodes="
-        + failedNodes
-        + ", totalNodes="
-        + totalNodes
         + ", totalSnapshots="
         + totalSnapshots
-        + ", snapshotsWithReplicas="
-        + snapshotsWithReplicas
+        + ", failedSnapshots="
+        + failedSnapshots
+        + ", successfulSnapshots="
+        + successfulSnapshots
         + '}';
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultAggregator.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultAggregator.java
@@ -4,5 +4,5 @@ import java.util.List;
 
 public interface SearchResultAggregator<T> {
 
-  SearchResult<T> aggregate(List<SearchResult<T>> searchResults);
+  SearchResult<T> aggregate(List<SearchResult<T>> searchResults, int totalSnapshots);
 }

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultAggregator.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultAggregator.java
@@ -4,5 +4,9 @@ import java.util.List;
 
 public interface SearchResultAggregator<T> {
 
-  SearchResult<T> aggregate(List<SearchResult<T>> searchResults, int totalSnapshots);
+  SearchResult<T> aggregate(
+      List<SearchResult<T>> searchResults,
+      int totalSnapshots,
+      int skippedSnapshots,
+      int requestedSnapshots);
 }

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImpl.java
@@ -23,12 +23,10 @@ public class SearchResultAggregatorImpl<T extends LogMessage> implements SearchR
   }
 
   @Override
-  public SearchResult<T> aggregate(List<SearchResult<T>> searchResults) {
+  public SearchResult<T> aggregate(List<SearchResult<T>> searchResults, int totalSnapshots) {
     long tookMicros = 0;
-    int failedNodes = 0;
-    int totalNodes = 0;
-    int totalSnapshots = 0;
-    int snapshpotReplicas = 0;
+    int failedSnapshots = 0;
+    int successfulSnapshots = 0;
     int totalCount = 0;
     Optional<Histogram> histogram =
         searchQuery.bucketCount > 0
@@ -41,10 +39,8 @@ public class SearchResultAggregatorImpl<T extends LogMessage> implements SearchR
 
     for (SearchResult<T> searchResult : searchResults) {
       tookMicros = Math.max(tookMicros, searchResult.tookMicros);
-      failedNodes += searchResult.failedNodes;
-      totalNodes += searchResult.totalNodes;
-      totalSnapshots += searchResult.totalSnapshots;
-      snapshpotReplicas += searchResult.snapshotsWithReplicas;
+      failedSnapshots += searchResult.failedSnapshots;
+      successfulSnapshots += searchResult.successfulSnapshots;
       totalCount += searchResult.totalCount;
       histogram.ifPresent(value -> value.mergeHistogram(searchResult.buckets));
     }
@@ -63,9 +59,8 @@ public class SearchResultAggregatorImpl<T extends LogMessage> implements SearchR
         tookMicros,
         totalCount,
         histogram.isPresent() ? histogram.get().getBuckets() : Collections.emptyList(),
-        failedNodes,
-        totalNodes,
         totalSnapshots,
-        snapshpotReplicas);
+        failedSnapshots,
+        successfulSnapshots);
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultUtils.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultUtils.java
@@ -56,6 +56,7 @@ public class SearchResultUtils {
         protoSearchResult.getTotalCount(),
         histogramBuckets,
         protoSearchResult.getTotalSnapshots(),
+        protoSearchResult.getSkippedSnapshots(),
         protoSearchResult.getFailedSnapshots(),
         protoSearchResult.getSuccessfulSnapshots());
   }
@@ -66,6 +67,7 @@ public class SearchResultUtils {
     span.tag("totalCount", String.valueOf(searchResult.totalCount));
     span.tag("tookMicros", String.valueOf(searchResult.tookMicros));
     span.tag("totalSnapshots", String.valueOf(searchResult.totalSnapshots));
+    span.tag("skippedSnapshots", String.valueOf(searchResult.skippedSnapshots));
     span.tag("failedSnapshots", String.valueOf(searchResult.failedSnapshots));
     span.tag("successfulSnapshots", String.valueOf(searchResult.successfulSnapshots));
     span.tag("hits", String.valueOf(searchResult.hits.size()));
@@ -75,6 +77,7 @@ public class SearchResultUtils {
     searchResultBuilder.setTotalCount(searchResult.totalCount);
     searchResultBuilder.setTookMicros(searchResult.tookMicros);
     searchResultBuilder.setTotalSnapshots(searchResult.totalSnapshots);
+    searchResultBuilder.setSkippedSnapshots(searchResult.skippedSnapshots);
     searchResultBuilder.setFailedSnapshots(searchResult.failedSnapshots);
     searchResultBuilder.setSuccessfulSnapshots(searchResult.successfulSnapshots);
     searchResultBuilder.setTotalSnapshots(searchResult.totalSnapshots);

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultUtils.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultUtils.java
@@ -55,10 +55,9 @@ public class SearchResultUtils {
         protoSearchResult.getTookMicros(),
         protoSearchResult.getTotalCount(),
         histogramBuckets,
-        protoSearchResult.getFailedNodes(),
-        protoSearchResult.getTotalNodes(),
         protoSearchResult.getTotalSnapshots(),
-        protoSearchResult.getSnapshotsWithReplicas());
+        protoSearchResult.getFailedSnapshots(),
+        protoSearchResult.getSuccessfulSnapshots());
   }
 
   public static <T> KaldbSearch.SearchResult toSearchResultProto(SearchResult<T> searchResult) {
@@ -66,20 +65,19 @@ public class SearchResultUtils {
         Tracing.currentTracer().startScopedSpan("SearchResultUtils.toSearchResultProto");
     span.tag("totalCount", String.valueOf(searchResult.totalCount));
     span.tag("tookMicros", String.valueOf(searchResult.tookMicros));
-    span.tag("failedNodes", String.valueOf(searchResult.failedNodes));
-    span.tag("totalNodes", String.valueOf(searchResult.totalNodes));
     span.tag("totalSnapshots", String.valueOf(searchResult.totalSnapshots));
-    span.tag("snapshotsWithReplicas", String.valueOf(searchResult.snapshotsWithReplicas));
+    span.tag("failedSnapshots", String.valueOf(searchResult.failedSnapshots));
+    span.tag("successfulSnapshots", String.valueOf(searchResult.successfulSnapshots));
     span.tag("hits", String.valueOf(searchResult.hits.size()));
     span.tag("buckets", String.valueOf(searchResult.buckets.size()));
 
     KaldbSearch.SearchResult.Builder searchResultBuilder = KaldbSearch.SearchResult.newBuilder();
     searchResultBuilder.setTotalCount(searchResult.totalCount);
     searchResultBuilder.setTookMicros(searchResult.tookMicros);
-    searchResultBuilder.setFailedNodes(searchResult.failedNodes);
-    searchResultBuilder.setTotalNodes(searchResult.totalNodes);
     searchResultBuilder.setTotalSnapshots(searchResult.totalSnapshots);
-    searchResultBuilder.setSnapshotsWithReplicas(searchResult.snapshotsWithReplicas);
+    searchResultBuilder.setFailedSnapshots(searchResult.failedSnapshots);
+    searchResultBuilder.setSuccessfulSnapshots(searchResult.successfulSnapshots);
+    searchResultBuilder.setTotalSnapshots(searchResult.totalSnapshots);
 
     // Set hits
     ArrayList<String> protoHits = new ArrayList<>(searchResult.hits.size());

--- a/kaldb/src/main/proto/kaldb_search.proto
+++ b/kaldb/src/main/proto/kaldb_search.proto
@@ -23,10 +23,9 @@ message SearchResult {
   repeated HistogramBucket buckets = 4;
   int64 took_micros = 5;
 
-  int32 failed_nodes = 6;
-  int32 total_nodes = 7;
-  int32 total_snapshots = 8;
-  int32 snapshots_with_replicas = 9;
+  int32 total_snapshots = 6;
+  int32 failed_snapshots = 7;
+  int32 successful_snapshots = 8;
 }
 
 message HistogramBucket {

--- a/kaldb/src/main/proto/kaldb_search.proto
+++ b/kaldb/src/main/proto/kaldb_search.proto
@@ -24,8 +24,9 @@ message SearchResult {
   int64 took_micros = 5;
 
   int32 total_snapshots = 6;
-  int32 failed_snapshots = 7;
-  int32 successful_snapshots = 8;
+  int32 skipped_snapshots = 7;
+  int32 failed_snapshots = 8;
+  int32 successful_snapshots = 9;
 }
 
 message HistogramBucket {

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
@@ -305,6 +305,7 @@ public class RecoveryChunkManagerTest {
     assertThat(result.hits.size()).isEqualTo(expectedHitCount);
 
     assertThat(result.totalSnapshots).isEqualTo(1);
+    assertThat(result.skippedSnapshots).isEqualTo(0);
     assertThat(result.successfulSnapshots).isEqualTo(1);
     assertThat(result.failedSnapshots).isEqualTo(0);
   }

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
@@ -303,8 +303,10 @@ public class RecoveryChunkManagerTest {
     SearchResult<LogMessage> result = chunkManager.query(searchQuery, Duration.ofMillis(3000));
 
     assertThat(result.hits.size()).isEqualTo(expectedHitCount);
+
     assertThat(result.totalSnapshots).isEqualTo(1);
-    assertThat(result.snapshotsWithReplicas).isEqualTo(1);
+    assertThat(result.successfulSnapshots).isEqualTo(1);
+    assertThat(result.failedSnapshots).isEqualTo(0);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
@@ -205,6 +205,7 @@ public class DiskOrMessageCountBasedRolloverStrategyTest {
     assertThat(response.getHitsCount()).isEqualTo(1);
     assertThat(response.getTookMicros()).isNotZero();
     assertThat(response.getTotalCount()).isEqualTo(1);
+    assertThat(response.getSkippedSnapshots()).isZero();
     assertThat(response.getFailedSnapshots()).isZero();
     assertThat(response.getTotalSnapshots()).isEqualTo(3);
     assertThat(response.getSuccessfulSnapshots()).isEqualTo(3);
@@ -268,6 +269,7 @@ public class DiskOrMessageCountBasedRolloverStrategyTest {
     assertThat(response.getHitsCount()).isEqualTo(1);
     assertThat(response.getTookMicros()).isNotZero();
     assertThat(response.getTotalCount()).isEqualTo(1);
+    assertThat(response.getSkippedSnapshots()).isZero();
     assertThat(response.getFailedSnapshots()).isZero();
     assertThat(response.getTotalSnapshots()).isEqualTo(3);
     assertThat(response.getTotalSnapshots()).isEqualTo(3);

--- a/kaldb/src/test/java/com/slack/kaldb/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
@@ -205,10 +205,10 @@ public class DiskOrMessageCountBasedRolloverStrategyTest {
     assertThat(response.getHitsCount()).isEqualTo(1);
     assertThat(response.getTookMicros()).isNotZero();
     assertThat(response.getTotalCount()).isEqualTo(1);
-    assertThat(response.getFailedNodes()).isZero();
-    assertThat(response.getTotalNodes()).isEqualTo(1);
+    assertThat(response.getFailedSnapshots()).isZero();
     assertThat(response.getTotalSnapshots()).isEqualTo(3);
-    assertThat(response.getSnapshotsWithReplicas()).isEqualTo(3);
+    assertThat(response.getSuccessfulSnapshots()).isEqualTo(3);
+    assertThat(response.getTotalSnapshots()).isEqualTo(3);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -268,10 +268,10 @@ public class DiskOrMessageCountBasedRolloverStrategyTest {
     assertThat(response.getHitsCount()).isEqualTo(1);
     assertThat(response.getTookMicros()).isNotZero();
     assertThat(response.getTotalCount()).isEqualTo(1);
-    assertThat(response.getFailedNodes()).isZero();
-    assertThat(response.getTotalNodes()).isEqualTo(1);
+    assertThat(response.getFailedSnapshots()).isZero();
     assertThat(response.getTotalSnapshots()).isEqualTo(3);
-    assertThat(response.getSnapshotsWithReplicas()).isEqualTo(3);
+    assertThat(response.getTotalSnapshots()).isEqualTo(3);
+    assertThat(response.getTotalSnapshots()).isEqualTo(3);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbLocalQueryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbLocalQueryServiceTest.java
@@ -110,10 +110,10 @@ public class KaldbLocalQueryServiceTest {
     assertThat(response.getHitsCount()).isEqualTo(1);
     assertThat(response.getTookMicros()).isNotZero();
     assertThat(response.getTotalCount()).isEqualTo(1);
-    assertThat(response.getFailedNodes()).isZero();
-    assertThat(response.getTotalNodes()).isEqualTo(1);
     assertThat(response.getTotalSnapshots()).isEqualTo(1);
-    assertThat(response.getSnapshotsWithReplicas()).isEqualTo(1);
+    assertThat(response.getFailedSnapshots()).isZero();
+    assertThat(response.getSuccessfulSnapshots()).isEqualTo(1);
+    assertThat(response.getTotalSnapshots()).isEqualTo(1);
 
     // Test hit contents
     assertThat(response.getHits(0)).contains("Message100");
@@ -177,10 +177,10 @@ public class KaldbLocalQueryServiceTest {
     assertThat(response.getTookMicros()).isNotZero();
     assertThat(response.getTotalCount()).isZero();
     assertThat(response.getHitsList().asByteStringList().size()).isZero();
-    assertThat(response.getFailedNodes()).isZero();
-    assertThat(response.getTotalNodes()).isEqualTo(1);
     assertThat(response.getTotalSnapshots()).isEqualTo(1);
-    assertThat(response.getSnapshotsWithReplicas()).isEqualTo(1);
+    assertThat(response.getFailedSnapshots()).isZero();
+    assertThat(response.getSuccessfulSnapshots()).isEqualTo(1);
+    assertThat(response.getTotalSnapshots()).isEqualTo(1);
 
     // Test histogram buckets
     assertThat(response.getBucketsList().size()).isEqualTo(2);
@@ -228,10 +228,10 @@ public class KaldbLocalQueryServiceTest {
     assertThat(response.getHitsCount()).isEqualTo(0);
     assertThat(response.getTotalCount()).isEqualTo(1);
     assertThat(response.getTookMicros()).isNotZero();
-    assertThat(response.getFailedNodes()).isZero();
-    assertThat(response.getTotalNodes()).isEqualTo(1);
     assertThat(response.getTotalSnapshots()).isEqualTo(1);
-    assertThat(response.getSnapshotsWithReplicas()).isEqualTo(1);
+    assertThat(response.getFailedSnapshots()).isZero();
+    assertThat(response.getSuccessfulSnapshots()).isEqualTo(1);
+    assertThat(response.getTotalSnapshots()).isEqualTo(1);
     assertThat(response.getHitsList().asByteStringList().size()).isZero();
 
     // Test histogram buckets
@@ -278,10 +278,10 @@ public class KaldbLocalQueryServiceTest {
     assertThat(response.getHitsCount()).isEqualTo(1);
     assertThat(response.getTotalCount()).isEqualTo(1);
     assertThat(response.getTookMicros()).isNotZero();
-    assertThat(response.getFailedNodes()).isZero();
-    assertThat(response.getTotalNodes()).isEqualTo(1);
     assertThat(response.getTotalSnapshots()).isEqualTo(1);
-    assertThat(response.getSnapshotsWithReplicas()).isEqualTo(1);
+    assertThat(response.getFailedSnapshots()).isZero();
+    assertThat(response.getSuccessfulSnapshots()).isEqualTo(1);
+    assertThat(response.getTotalSnapshots()).isEqualTo(1);
 
     // Test hit contents
     assertThat(response.getHitsList().asByteStringList().size()).isEqualTo(1);
@@ -384,10 +384,10 @@ public class KaldbLocalQueryServiceTest {
     assertThat(response.getHitsCount()).isEqualTo(1);
     assertThat(response.getTookMicros()).isNotZero();
     assertThat(response.getTotalCount()).isEqualTo(1);
-    assertThat(response.getFailedNodes()).isZero();
-    assertThat(response.getTotalNodes()).isEqualTo(1);
     assertThat(response.getTotalSnapshots()).isEqualTo(1);
-    assertThat(response.getSnapshotsWithReplicas()).isEqualTo(1);
+    assertThat(response.getFailedSnapshots()).isZero();
+    assertThat(response.getSuccessfulSnapshots()).isEqualTo(1);
+    assertThat(response.getTotalSnapshots()).isEqualTo(1);
 
     // Test hit contents
     assertThat(response.getHits(0)).contains("Message1");

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbLocalQueryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbLocalQueryServiceTest.java
@@ -111,6 +111,7 @@ public class KaldbLocalQueryServiceTest {
     assertThat(response.getTookMicros()).isNotZero();
     assertThat(response.getTotalCount()).isEqualTo(1);
     assertThat(response.getTotalSnapshots()).isEqualTo(1);
+    assertThat(response.getSkippedSnapshots()).isZero();
     assertThat(response.getFailedSnapshots()).isZero();
     assertThat(response.getSuccessfulSnapshots()).isEqualTo(1);
     assertThat(response.getTotalSnapshots()).isEqualTo(1);
@@ -179,6 +180,7 @@ public class KaldbLocalQueryServiceTest {
     assertThat(response.getHitsList().asByteStringList().size()).isZero();
     assertThat(response.getTotalSnapshots()).isEqualTo(1);
     assertThat(response.getFailedSnapshots()).isZero();
+    assertThat(response.getSkippedSnapshots()).isZero();
     assertThat(response.getSuccessfulSnapshots()).isEqualTo(1);
     assertThat(response.getTotalSnapshots()).isEqualTo(1);
 
@@ -229,6 +231,7 @@ public class KaldbLocalQueryServiceTest {
     assertThat(response.getTotalCount()).isEqualTo(1);
     assertThat(response.getTookMicros()).isNotZero();
     assertThat(response.getTotalSnapshots()).isEqualTo(1);
+    assertThat(response.getSkippedSnapshots()).isZero();
     assertThat(response.getFailedSnapshots()).isZero();
     assertThat(response.getSuccessfulSnapshots()).isEqualTo(1);
     assertThat(response.getTotalSnapshots()).isEqualTo(1);
@@ -279,6 +282,7 @@ public class KaldbLocalQueryServiceTest {
     assertThat(response.getTotalCount()).isEqualTo(1);
     assertThat(response.getTookMicros()).isNotZero();
     assertThat(response.getTotalSnapshots()).isEqualTo(1);
+    assertThat(response.getSkippedSnapshots()).isZero();
     assertThat(response.getFailedSnapshots()).isZero();
     assertThat(response.getSuccessfulSnapshots()).isEqualTo(1);
     assertThat(response.getTotalSnapshots()).isEqualTo(1);
@@ -385,6 +389,7 @@ public class KaldbLocalQueryServiceTest {
     assertThat(response.getTookMicros()).isNotZero();
     assertThat(response.getTotalCount()).isEqualTo(1);
     assertThat(response.getTotalSnapshots()).isEqualTo(1);
+    assertThat(response.getSkippedSnapshots()).isZero();
     assertThat(response.getFailedSnapshots()).isZero();
     assertThat(response.getSuccessfulSnapshots()).isEqualTo(1);
     assertThat(response.getTotalSnapshots()).isEqualTo(1);

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImplTest.java
@@ -25,6 +25,7 @@ public class SearchResultAggregatorImplTest {
       long totalCount,
       List<HistogramBucket> buckets,
       int totalSnapshots,
+      int skippedSnapshots,
       int failedSnapshots,
       int successfulSnapshots) {
     return new SearchResult<>(
@@ -33,6 +34,7 @@ public class SearchResultAggregatorImplTest {
         totalCount,
         buckets,
         totalSnapshots,
+        skippedSnapshots,
         failedSnapshots,
         successfulSnapshots);
   }
@@ -62,9 +64,9 @@ public class SearchResultAggregatorImplTest {
     Histogram histogram2 = makeHistogram(histogramStartMs, histogramEndMs, bucketCount, messages2);
 
     SearchResult<LogMessage> searchResult1 =
-        makeSearchResult(messages1, tookMs, 10, histogram1.getBuckets(), 1, 0, 1);
+        makeSearchResult(messages1, tookMs, 10, histogram1.getBuckets(), 1, 0, 0, 1);
     SearchResult<LogMessage> searchResult2 =
-        makeSearchResult(messages2, tookMs + 1, 10, histogram2.getBuckets(), 1, 0, 1);
+        makeSearchResult(messages2, tookMs + 1, 10, histogram2.getBuckets(), 1, 0, 0, 1);
 
     SearchQuery searchQuery =
         new SearchQuery(
@@ -81,11 +83,12 @@ public class SearchResultAggregatorImplTest {
 
     SearchResult<LogMessage> aggSearchResult =
         new SearchResultAggregatorImpl<>(searchQuery)
-            .aggregate(searchResults, searchResults.size());
+            .aggregate(searchResults, searchResults.size(), 0, searchResults.size());
 
     assertThat(aggSearchResult.tookMicros).isEqualTo(tookMs + 1);
     assertThat(aggSearchResult.hits.size()).isEqualTo(howMany);
     assertThat(aggSearchResult.totalSnapshots).isEqualTo(2);
+    assertThat(aggSearchResult.skippedSnapshots).isEqualTo(0);
     assertThat(aggSearchResult.failedSnapshots).isEqualTo(0);
     assertThat(aggSearchResult.successfulSnapshots).isEqualTo(2);
 
@@ -119,9 +122,9 @@ public class SearchResultAggregatorImplTest {
     Histogram histogram2 = makeHistogram(histogramStartMs, histogramEndMs, bucketCount, messages2);
 
     SearchResult<LogMessage> searchResult1 =
-        makeSearchResult(messages1, tookMs, 10, histogram1.getBuckets(), 1, 0, 1);
+        makeSearchResult(messages1, tookMs, 10, histogram1.getBuckets(), 1, 0, 0, 1);
     SearchResult<LogMessage> searchResult2 =
-        makeSearchResult(messages2, tookMs + 1, 10, histogram2.getBuckets(), 1, 0, 1);
+        makeSearchResult(messages2, tookMs + 1, 10, histogram2.getBuckets(), 1, 0, 0, 1);
 
     SearchQuery searchQuery =
         new SearchQuery(
@@ -138,11 +141,12 @@ public class SearchResultAggregatorImplTest {
 
     SearchResult<LogMessage> aggSearchResult =
         new SearchResultAggregatorImpl<>(searchQuery)
-            .aggregate(searchResults, searchResults.size());
+            .aggregate(searchResults, searchResults.size(), 0, searchResults.size());
 
     assertThat(aggSearchResult.tookMicros).isEqualTo(tookMs + 1);
     assertThat(aggSearchResult.hits.size()).isEqualTo(howMany);
     assertThat(aggSearchResult.totalSnapshots).isEqualTo(2);
+    assertThat(aggSearchResult.skippedSnapshots).isEqualTo(0);
     assertThat(aggSearchResult.failedSnapshots).isEqualTo(0);
     assertThat(aggSearchResult.successfulSnapshots).isEqualTo(2);
 
@@ -183,13 +187,13 @@ public class SearchResultAggregatorImplTest {
     Histogram histogram4 = makeHistogram(histogramStartMs, histogramEndMs, bucketCount, messages4);
 
     SearchResult<LogMessage> searchResult1 =
-        makeSearchResult(messages1, tookMs, 10, histogram1.getBuckets(), 1, 0, 1);
+        makeSearchResult(messages1, tookMs, 10, histogram1.getBuckets(), 1, 0, 0, 1);
     SearchResult<LogMessage> searchResult2 =
-        makeSearchResult(messages2, tookMs + 1, 10, histogram2.getBuckets(), 1, 1, 0);
+        makeSearchResult(messages2, tookMs + 1, 10, histogram2.getBuckets(), 1, 0, 1, 0);
     SearchResult<LogMessage> searchResult3 =
-        makeSearchResult(messages3, tookMs + 2, 10, histogram3.getBuckets(), 1, 0, 1);
+        makeSearchResult(messages3, tookMs + 2, 10, histogram3.getBuckets(), 1, 0, 0, 1);
     SearchResult<LogMessage> searchResult4 =
-        makeSearchResult(messages4, tookMs + 3, 10, histogram4.getBuckets(), 1, 0, 1);
+        makeSearchResult(messages4, tookMs + 3, 10, histogram4.getBuckets(), 1, 0, 0, 1);
 
     SearchQuery searchQuery =
         new SearchQuery(
@@ -204,11 +208,12 @@ public class SearchResultAggregatorImplTest {
         List.of(searchResult1, searchResult4, searchResult3, searchResult2);
     SearchResult<LogMessage> aggSearchResult =
         new SearchResultAggregatorImpl<>(searchQuery)
-            .aggregate(searchResults, searchResults.size());
+            .aggregate(searchResults, searchResults.size(), 0, searchResults.size());
 
     assertThat(aggSearchResult.tookMicros).isEqualTo(tookMs + 3);
     assertThat(aggSearchResult.hits.size()).isEqualTo(howMany);
     assertThat(aggSearchResult.totalSnapshots).isEqualTo(4);
+    assertThat(aggSearchResult.skippedSnapshots).isEqualTo(0);
     assertThat(aggSearchResult.failedSnapshots).isEqualTo(1);
     assertThat(aggSearchResult.successfulSnapshots).isEqualTo(3);
 
@@ -238,9 +243,9 @@ public class SearchResultAggregatorImplTest {
         MessageUtil.makeMessagesWithTimeDifference(11, 20, 1000 * 60, startTime2);
 
     SearchResult<LogMessage> searchResult1 =
-        makeSearchResult(messages1, tookMs, 10, Collections.emptyList(), 1, 0, 1);
+        makeSearchResult(messages1, tookMs, 10, Collections.emptyList(), 1, 0, 0, 1);
     SearchResult<LogMessage> searchResult2 =
-        makeSearchResult(messages2, tookMs + 1, 10, Collections.emptyList(), 1, 0, 1);
+        makeSearchResult(messages2, tookMs + 1, 10, Collections.emptyList(), 1, 0, 0, 1);
 
     SearchQuery searchQuery =
         new SearchQuery(
@@ -257,11 +262,12 @@ public class SearchResultAggregatorImplTest {
 
     SearchResult<LogMessage> aggSearchResult =
         new SearchResultAggregatorImpl<>(searchQuery)
-            .aggregate(searchResults, searchResults.size());
+            .aggregate(searchResults, searchResults.size(), 0, searchResults.size());
 
     assertThat(aggSearchResult.tookMicros).isEqualTo(tookMs + 1);
     assertThat(aggSearchResult.hits.size()).isEqualTo(howMany);
     assertThat(aggSearchResult.totalSnapshots).isEqualTo(2);
+    assertThat(aggSearchResult.skippedSnapshots).isEqualTo(0);
     assertThat(aggSearchResult.successfulSnapshots).isEqualTo(2);
     assertThat(aggSearchResult.failedSnapshots).isEqualTo(0);
 
@@ -292,9 +298,10 @@ public class SearchResultAggregatorImplTest {
     Histogram histogram2 = makeHistogram(histogramStartMs, histogramEndMs, bucketCount, messages2);
 
     SearchResult<LogMessage> searchResult1 =
-        makeSearchResult(Collections.emptyList(), tookMs, 7, histogram1.getBuckets(), 2, 0, 2);
+        makeSearchResult(Collections.emptyList(), tookMs, 7, histogram1.getBuckets(), 2, 0, 0, 2);
     SearchResult<LogMessage> searchResult2 =
-        makeSearchResult(Collections.emptyList(), tookMs + 1, 8, histogram2.getBuckets(), 1, 0, 0);
+        makeSearchResult(
+            Collections.emptyList(), tookMs + 1, 8, histogram2.getBuckets(), 1, 0, 0, 0);
 
     SearchQuery searchQuery =
         new SearchQuery(
@@ -310,11 +317,12 @@ public class SearchResultAggregatorImplTest {
     searchResults.add(searchResult2);
 
     SearchResult<LogMessage> aggSearchResult =
-        new SearchResultAggregatorImpl<>(searchQuery).aggregate(searchResults, 3);
+        new SearchResultAggregatorImpl<>(searchQuery).aggregate(searchResults, 3, 1, 2);
 
     assertThat(aggSearchResult.hits.size()).isZero();
     assertThat(aggSearchResult.tookMicros).isEqualTo(tookMs + 1);
     assertThat(aggSearchResult.totalSnapshots).isEqualTo(3);
+    assertThat(aggSearchResult.skippedSnapshots).isEqualTo(1);
     assertThat(aggSearchResult.failedSnapshots).isEqualTo(0);
     assertThat(aggSearchResult.successfulSnapshots).isEqualTo(2);
     assertThat(aggSearchResult.totalCount).isEqualTo(15);
@@ -341,9 +349,9 @@ public class SearchResultAggregatorImplTest {
     Histogram histogram1 = makeHistogram(startTimeMs, endTimeMs, 2, messages1);
 
     SearchResult<LogMessage> searchResult1 =
-        makeSearchResult(messages1, tookMs, 10, histogram1.getBuckets(), 1, 1, 0);
+        makeSearchResult(messages1, tookMs, 10, histogram1.getBuckets(), 1, 0, 1, 0);
     SearchResult<LogMessage> searchResult2 =
-        makeSearchResult(messages2, tookMs + 1, 11, Collections.emptyList(), 1, 0, 0);
+        makeSearchResult(messages2, tookMs + 1, 11, Collections.emptyList(), 1, 0, 0, 0);
 
     SearchQuery searchQuery =
         new SearchQuery(
@@ -360,11 +368,12 @@ public class SearchResultAggregatorImplTest {
 
     SearchResult<LogMessage> aggSearchResult =
         new SearchResultAggregatorImpl<>(searchQuery)
-            .aggregate(searchResults, searchResults.size());
+            .aggregate(searchResults, searchResults.size(), 1, 1);
 
     assertThat(aggSearchResult.tookMicros).isEqualTo(tookMs + 1);
     assertThat(aggSearchResult.hits.size()).isEqualTo(howMany);
     assertThat(aggSearchResult.totalSnapshots).isEqualTo(2);
+    assertThat(aggSearchResult.skippedSnapshots).isEqualTo(1);
     assertThat(aggSearchResult.failedSnapshots).isEqualTo(1);
     assertThat(aggSearchResult.successfulSnapshots).isEqualTo(0);
 
@@ -395,9 +404,10 @@ public class SearchResultAggregatorImplTest {
     Histogram histogram2 = makeHistogram(histogramStartMs, histogramEndMs, bucketCount, messages2);
 
     SearchResult<LogMessage> searchResult1 =
-        makeSearchResult(messages1, tookMs, 7, histogram1.getBuckets(), 2, 0, 1);
+        makeSearchResult(messages1, tookMs, 7, histogram1.getBuckets(), 2, 0, 0, 1);
     SearchResult<LogMessage> searchResult2 =
-        makeSearchResult(Collections.emptyList(), tookMs + 1, 8, histogram2.getBuckets(), 1, 0, 1);
+        makeSearchResult(
+            Collections.emptyList(), tookMs + 1, 8, histogram2.getBuckets(), 1, 0, 0, 1);
 
     SearchQuery searchQuery =
         new SearchQuery(
@@ -413,11 +423,12 @@ public class SearchResultAggregatorImplTest {
     searchResults.add(searchResult2);
 
     SearchResult<LogMessage> aggSearchResult =
-        new SearchResultAggregatorImpl<>(searchQuery).aggregate(searchResults, 3);
+        new SearchResultAggregatorImpl<>(searchQuery).aggregate(searchResults, 3, 1, 2);
 
     assertThat(aggSearchResult.hits.size()).isZero();
     assertThat(aggSearchResult.tookMicros).isEqualTo(tookMs + 1);
     assertThat(aggSearchResult.totalSnapshots).isEqualTo(3);
+    assertThat(aggSearchResult.skippedSnapshots).isEqualTo(1);
     assertThat(aggSearchResult.failedSnapshots).isEqualTo(0);
     assertThat(aggSearchResult.successfulSnapshots).isEqualTo(2);
     assertThat(aggSearchResult.totalCount).isEqualTo(15);

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -707,6 +707,7 @@ public class KaldbIndexerTest {
     assertThat(searchResult.tookMicros).isNotZero();
     assertThat(searchResult.totalCount).isEqualTo(1);
     assertThat(searchResult.totalSnapshots).isEqualTo(1);
+    assertThat(searchResult.skippedSnapshots).isEqualTo(0);
     assertThat(searchResult.failedSnapshots).isEqualTo(0);
     assertThat(searchResult.successfulSnapshots).isEqualTo(1);
   }

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -706,9 +706,8 @@ public class KaldbIndexerTest {
     assertThat(searchResult.hits.size()).isEqualTo(1);
     assertThat(searchResult.tookMicros).isNotZero();
     assertThat(searchResult.totalCount).isEqualTo(1);
-    assertThat(searchResult.failedNodes).isZero();
-    assertThat(searchResult.totalNodes).isEqualTo(1);
     assertThat(searchResult.totalSnapshots).isEqualTo(1);
-    assertThat(searchResult.snapshotsWithReplicas).isEqualTo(1);
+    assertThat(searchResult.failedSnapshots).isEqualTo(0);
+    assertThat(searchResult.successfulSnapshots).isEqualTo(1);
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
@@ -255,7 +255,7 @@ public class KaldbTest {
         LocalDateTime.of(2020, 10, 1, 10, 10, 0).atZone(ZoneOffset.UTC).toInstant();
     // if you look at the produceMessages code the last document for this chunk will be this
     // timestamp
-    final Instant end1Time = startTime.plusNanos(1000 * 1000 * 1000L * 99);
+    final Instant end1Time = startTime.plusSeconds(99);
     PrometheusMeterRegistry indexerMeterRegistry =
         new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
     Kaldb indexer =
@@ -272,8 +272,9 @@ public class KaldbTest {
 
     KaldbSearch.SearchResult indexerSearchResponse =
         searchUsingGrpcApi("*:*", indexerPort, 0, end1Time.toEpochMilli());
-    assertThat(indexerSearchResponse.getTotalNodes()).isEqualTo(1);
-    assertThat(indexerSearchResponse.getFailedNodes()).isEqualTo(0);
+    assertThat(indexerSearchResponse.getTotalSnapshots()).isEqualTo(1);
+    assertThat(indexerSearchResponse.getFailedSnapshots()).isEqualTo(0);
+    assertThat(indexerSearchResponse.getSuccessfulSnapshots()).isEqualTo(1);
     assertThat(indexerSearchResponse.getTotalCount()).isEqualTo(100);
     assertThat(indexerSearchResponse.getHitsCount()).isEqualTo(100);
     Thread.sleep(2000);
@@ -282,8 +283,9 @@ public class KaldbTest {
     KaldbSearch.SearchResult queryServiceSearchResponse =
         searchUsingGrpcApi("*:*", queryServicePort, 0, 1601547099000L);
 
-    assertThat(queryServiceSearchResponse.getTotalNodes()).isEqualTo(1);
-    assertThat(queryServiceSearchResponse.getFailedNodes()).isEqualTo(0);
+    assertThat(queryServiceSearchResponse.getTotalSnapshots()).isEqualTo(1);
+    assertThat(queryServiceSearchResponse.getFailedSnapshots()).isEqualTo(0);
+    assertThat(queryServiceSearchResponse.getSuccessfulSnapshots()).isEqualTo(1);
     assertThat(queryServiceSearchResponse.getTotalCount()).isEqualTo(100);
     assertThat(queryServiceSearchResponse.getHitsCount()).isEqualTo(100);
 
@@ -304,8 +306,9 @@ public class KaldbTest {
     queryServiceSearchResponse =
         searchUsingGrpcApi("*:*", queryServicePort, 0, end1Time.toEpochMilli());
 
-    assertThat(queryServiceSearchResponse.getTotalNodes()).isEqualTo(1);
-    assertThat(queryServiceSearchResponse.getFailedNodes()).isEqualTo(0);
+    assertThat(queryServiceSearchResponse.getTotalSnapshots()).isEqualTo(2);
+    assertThat(queryServiceSearchResponse.getFailedSnapshots()).isEqualTo(0);
+    assertThat(queryServiceSearchResponse.getSuccessfulSnapshots()).isEqualTo(1);
     assertThat(queryServiceSearchResponse.getTotalCount()).isEqualTo(100);
     assertThat(queryServiceSearchResponse.getHitsCount()).isEqualTo(100);
 
@@ -314,16 +317,18 @@ public class KaldbTest {
         searchUsingGrpcApi(
             "*:*", queryServicePort, start2Time.toEpochMilli(), end2Time.toEpochMilli());
 
-    assertThat(queryServiceSearchResponse.getTotalNodes()).isEqualTo(1);
-    assertThat(queryServiceSearchResponse.getFailedNodes()).isEqualTo(0);
+    assertThat(queryServiceSearchResponse.getTotalSnapshots()).isEqualTo(2);
+    assertThat(queryServiceSearchResponse.getFailedSnapshots()).isEqualTo(0);
+    assertThat(queryServiceSearchResponse.getSuccessfulSnapshots()).isEqualTo(1);
     assertThat(queryServiceSearchResponse.getTotalCount()).isEqualTo(100);
     assertThat(queryServiceSearchResponse.getHitsCount()).isEqualTo(100);
 
     queryServiceSearchResponse =
         searchUsingGrpcApi("Message1", queryServicePort, 0, end1Time.toEpochMilli());
 
-    assertThat(queryServiceSearchResponse.getTotalNodes()).isEqualTo(1);
-    assertThat(queryServiceSearchResponse.getFailedNodes()).isEqualTo(0);
+    assertThat(queryServiceSearchResponse.getTotalSnapshots()).isEqualTo(2);
+    assertThat(queryServiceSearchResponse.getFailedSnapshots()).isEqualTo(0);
+    assertThat(queryServiceSearchResponse.getSuccessfulSnapshots()).isEqualTo(1);
     assertThat(queryServiceSearchResponse.getTotalCount()).isEqualTo(1);
     assertThat(queryServiceSearchResponse.getHitsCount()).isEqualTo(1);
 
@@ -331,8 +336,9 @@ public class KaldbTest {
         searchUsingGrpcApi(
             "Message1", queryServicePort, end1Time.toEpochMilli() + 1, end2Time.toEpochMilli());
 
-    assertThat(queryServiceSearchResponse.getTotalNodes()).isEqualTo(1);
-    assertThat(queryServiceSearchResponse.getFailedNodes()).isEqualTo(0);
+    assertThat(queryServiceSearchResponse.getTotalSnapshots()).isEqualTo(2);
+    assertThat(queryServiceSearchResponse.getFailedSnapshots()).isEqualTo(0);
+    assertThat(queryServiceSearchResponse.getSuccessfulSnapshots()).isEqualTo(1);
     assertThat(queryServiceSearchResponse.getTotalCount()).isEqualTo(1);
     assertThat(queryServiceSearchResponse.getHitsCount()).isEqualTo(1);
 
@@ -341,8 +347,9 @@ public class KaldbTest {
         searchUsingGrpcApi(
             "*:*", queryServicePort, startTime.toEpochMilli(), end2Time.toEpochMilli());
 
-    assertThat(queryServiceSearchResponse.getTotalNodes()).isEqualTo(1);
-    assertThat(queryServiceSearchResponse.getFailedNodes()).isEqualTo(0);
+    assertThat(queryServiceSearchResponse.getTotalSnapshots()).isEqualTo(2);
+    assertThat(queryServiceSearchResponse.getFailedSnapshots()).isEqualTo(0);
+    assertThat(queryServiceSearchResponse.getSuccessfulSnapshots()).isEqualTo(2);
     assertThat(queryServiceSearchResponse.getTotalCount()).isEqualTo(200);
     assertThat(queryServiceSearchResponse.getHitsCount()).isEqualTo(100);
 
@@ -446,15 +453,17 @@ public class KaldbTest {
 
     KaldbSearch.SearchResult indexerSearchResponse =
         searchUsingGrpcApi("*:*", indexerPort, 0L, 1601547099000L);
-    assertThat(indexerSearchResponse.getTotalNodes()).isEqualTo(1);
-    assertThat(indexerSearchResponse.getFailedNodes()).isEqualTo(0);
+    assertThat(indexerSearchResponse.getTotalSnapshots()).isEqualTo(1);
+    assertThat(indexerSearchResponse.getFailedSnapshots()).isEqualTo(0);
+    assertThat(indexerSearchResponse.getSuccessfulSnapshots()).isEqualTo(1);
     assertThat(indexerSearchResponse.getTotalCount()).isEqualTo(100);
     assertThat(indexerSearchResponse.getHitsCount()).isEqualTo(100);
 
     KaldbSearch.SearchResult indexer2SearchResponse =
         searchUsingGrpcApi("*:*", indexerPort2, 1633083000000L, 1633083099000L);
-    assertThat(indexer2SearchResponse.getTotalNodes()).isEqualTo(1);
-    assertThat(indexer2SearchResponse.getFailedNodes()).isEqualTo(0);
+    assertThat(indexer2SearchResponse.getTotalSnapshots()).isEqualTo(1);
+    assertThat(indexer2SearchResponse.getFailedSnapshots()).isEqualTo(0);
+    assertThat(indexer2SearchResponse.getSuccessfulSnapshots()).isEqualTo(1);
     assertThat(indexer2SearchResponse.getTotalCount()).isEqualTo(100);
     assertThat(indexer2SearchResponse.getHitsCount()).isEqualTo(100);
 
@@ -463,16 +472,18 @@ public class KaldbTest {
     KaldbSearch.SearchResult queryServiceSearchResponse =
         searchUsingGrpcApi("*:*", queryServicePort, 0, 1601547099000L);
 
-    assertThat(queryServiceSearchResponse.getTotalNodes()).isEqualTo(1);
-    assertThat(queryServiceSearchResponse.getFailedNodes()).isEqualTo(0);
+    assertThat(queryServiceSearchResponse.getTotalSnapshots()).isEqualTo(2);
+    assertThat(queryServiceSearchResponse.getFailedSnapshots()).isEqualTo(0);
+    assertThat(queryServiceSearchResponse.getSuccessfulSnapshots()).isEqualTo(1);
     assertThat(queryServiceSearchResponse.getTotalCount()).isEqualTo(100);
     assertThat(queryServiceSearchResponse.getHitsCount()).isEqualTo(100);
 
-    // When we query with a limited timeline (0,MAX_VALUE) we will only query index 1 AND indexer 2
+    // When we query with a limited timeline (0,MAX_VALUE) we will query index 1 AND indexer 2
     queryServiceSearchResponse = searchUsingGrpcApi("*:*", queryServicePort, 0, Long.MAX_VALUE);
 
-    assertThat(queryServiceSearchResponse.getTotalNodes()).isEqualTo(2);
-    assertThat(queryServiceSearchResponse.getFailedNodes()).isEqualTo(0);
+    assertThat(queryServiceSearchResponse.getTotalSnapshots()).isEqualTo(2);
+    assertThat(queryServiceSearchResponse.getFailedSnapshots()).isEqualTo(0);
+    assertThat(queryServiceSearchResponse.getSuccessfulSnapshots()).isEqualTo(2);
     assertThat(queryServiceSearchResponse.getTotalCount()).isEqualTo(200);
     assertThat(queryServiceSearchResponse.getHitsCount()).isEqualTo(100);
 
@@ -480,8 +491,9 @@ public class KaldbTest {
     KaldbSearch.SearchResult queryServiceSearchResponse2 =
         searchUsingGrpcApi("Message100", queryServicePort, 0, Long.MAX_VALUE);
 
-    assertThat(queryServiceSearchResponse2.getTotalNodes()).isEqualTo(2);
-    assertThat(queryServiceSearchResponse2.getFailedNodes()).isEqualTo(0);
+    assertThat(queryServiceSearchResponse2.getTotalSnapshots()).isEqualTo(2);
+    assertThat(queryServiceSearchResponse2.getFailedSnapshots()).isEqualTo(0);
+    assertThat(queryServiceSearchResponse2.getSuccessfulSnapshots()).isEqualTo(2);
     assertThat(queryServiceSearchResponse2.getTotalCount()).isEqualTo(2);
     assertThat(queryServiceSearchResponse2.getHitsCount()).isEqualTo(2);
 

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
@@ -273,6 +273,7 @@ public class KaldbTest {
     KaldbSearch.SearchResult indexerSearchResponse =
         searchUsingGrpcApi("*:*", indexerPort, 0, end1Time.toEpochMilli());
     assertThat(indexerSearchResponse.getTotalSnapshots()).isEqualTo(1);
+    assertThat(indexerSearchResponse.getSkippedSnapshots()).isEqualTo(0);
     assertThat(indexerSearchResponse.getFailedSnapshots()).isEqualTo(0);
     assertThat(indexerSearchResponse.getSuccessfulSnapshots()).isEqualTo(1);
     assertThat(indexerSearchResponse.getTotalCount()).isEqualTo(100);
@@ -284,6 +285,7 @@ public class KaldbTest {
         searchUsingGrpcApi("*:*", queryServicePort, 0, 1601547099000L);
 
     assertThat(queryServiceSearchResponse.getTotalSnapshots()).isEqualTo(1);
+    assertThat(queryServiceSearchResponse.getSkippedSnapshots()).isEqualTo(0);
     assertThat(queryServiceSearchResponse.getFailedSnapshots()).isEqualTo(0);
     assertThat(queryServiceSearchResponse.getSuccessfulSnapshots()).isEqualTo(1);
     assertThat(queryServiceSearchResponse.getTotalCount()).isEqualTo(100);
@@ -307,6 +309,7 @@ public class KaldbTest {
         searchUsingGrpcApi("*:*", queryServicePort, 0, end1Time.toEpochMilli());
 
     assertThat(queryServiceSearchResponse.getTotalSnapshots()).isEqualTo(2);
+    assertThat(queryServiceSearchResponse.getSkippedSnapshots()).isEqualTo(1);
     assertThat(queryServiceSearchResponse.getFailedSnapshots()).isEqualTo(0);
     assertThat(queryServiceSearchResponse.getSuccessfulSnapshots()).isEqualTo(1);
     assertThat(queryServiceSearchResponse.getTotalCount()).isEqualTo(100);
@@ -318,6 +321,7 @@ public class KaldbTest {
             "*:*", queryServicePort, start2Time.toEpochMilli(), end2Time.toEpochMilli());
 
     assertThat(queryServiceSearchResponse.getTotalSnapshots()).isEqualTo(2);
+    assertThat(queryServiceSearchResponse.getSkippedSnapshots()).isEqualTo(1);
     assertThat(queryServiceSearchResponse.getFailedSnapshots()).isEqualTo(0);
     assertThat(queryServiceSearchResponse.getSuccessfulSnapshots()).isEqualTo(1);
     assertThat(queryServiceSearchResponse.getTotalCount()).isEqualTo(100);
@@ -327,6 +331,7 @@ public class KaldbTest {
         searchUsingGrpcApi("Message1", queryServicePort, 0, end1Time.toEpochMilli());
 
     assertThat(queryServiceSearchResponse.getTotalSnapshots()).isEqualTo(2);
+    assertThat(queryServiceSearchResponse.getSkippedSnapshots()).isEqualTo(1);
     assertThat(queryServiceSearchResponse.getFailedSnapshots()).isEqualTo(0);
     assertThat(queryServiceSearchResponse.getSuccessfulSnapshots()).isEqualTo(1);
     assertThat(queryServiceSearchResponse.getTotalCount()).isEqualTo(1);
@@ -337,6 +342,7 @@ public class KaldbTest {
             "Message1", queryServicePort, end1Time.toEpochMilli() + 1, end2Time.toEpochMilli());
 
     assertThat(queryServiceSearchResponse.getTotalSnapshots()).isEqualTo(2);
+    assertThat(queryServiceSearchResponse.getSkippedSnapshots()).isEqualTo(1);
     assertThat(queryServiceSearchResponse.getFailedSnapshots()).isEqualTo(0);
     assertThat(queryServiceSearchResponse.getSuccessfulSnapshots()).isEqualTo(1);
     assertThat(queryServiceSearchResponse.getTotalCount()).isEqualTo(1);
@@ -348,6 +354,7 @@ public class KaldbTest {
             "*:*", queryServicePort, startTime.toEpochMilli(), end2Time.toEpochMilli());
 
     assertThat(queryServiceSearchResponse.getTotalSnapshots()).isEqualTo(2);
+    assertThat(queryServiceSearchResponse.getSkippedSnapshots()).isEqualTo(0);
     assertThat(queryServiceSearchResponse.getFailedSnapshots()).isEqualTo(0);
     assertThat(queryServiceSearchResponse.getSuccessfulSnapshots()).isEqualTo(2);
     assertThat(queryServiceSearchResponse.getTotalCount()).isEqualTo(200);
@@ -454,6 +461,7 @@ public class KaldbTest {
     KaldbSearch.SearchResult indexerSearchResponse =
         searchUsingGrpcApi("*:*", indexerPort, 0L, 1601547099000L);
     assertThat(indexerSearchResponse.getTotalSnapshots()).isEqualTo(1);
+    assertThat(indexerSearchResponse.getSkippedSnapshots()).isEqualTo(0);
     assertThat(indexerSearchResponse.getFailedSnapshots()).isEqualTo(0);
     assertThat(indexerSearchResponse.getSuccessfulSnapshots()).isEqualTo(1);
     assertThat(indexerSearchResponse.getTotalCount()).isEqualTo(100);
@@ -462,6 +470,7 @@ public class KaldbTest {
     KaldbSearch.SearchResult indexer2SearchResponse =
         searchUsingGrpcApi("*:*", indexerPort2, 1633083000000L, 1633083099000L);
     assertThat(indexer2SearchResponse.getTotalSnapshots()).isEqualTo(1);
+    assertThat(indexer2SearchResponse.getSkippedSnapshots()).isEqualTo(0);
     assertThat(indexer2SearchResponse.getFailedSnapshots()).isEqualTo(0);
     assertThat(indexer2SearchResponse.getSuccessfulSnapshots()).isEqualTo(1);
     assertThat(indexer2SearchResponse.getTotalCount()).isEqualTo(100);
@@ -473,6 +482,7 @@ public class KaldbTest {
         searchUsingGrpcApi("*:*", queryServicePort, 0, 1601547099000L);
 
     assertThat(queryServiceSearchResponse.getTotalSnapshots()).isEqualTo(2);
+    assertThat(queryServiceSearchResponse.getSkippedSnapshots()).isEqualTo(1);
     assertThat(queryServiceSearchResponse.getFailedSnapshots()).isEqualTo(0);
     assertThat(queryServiceSearchResponse.getSuccessfulSnapshots()).isEqualTo(1);
     assertThat(queryServiceSearchResponse.getTotalCount()).isEqualTo(100);
@@ -482,6 +492,7 @@ public class KaldbTest {
     queryServiceSearchResponse = searchUsingGrpcApi("*:*", queryServicePort, 0, Long.MAX_VALUE);
 
     assertThat(queryServiceSearchResponse.getTotalSnapshots()).isEqualTo(2);
+    assertThat(queryServiceSearchResponse.getSkippedSnapshots()).isEqualTo(0);
     assertThat(queryServiceSearchResponse.getFailedSnapshots()).isEqualTo(0);
     assertThat(queryServiceSearchResponse.getSuccessfulSnapshots()).isEqualTo(2);
     assertThat(queryServiceSearchResponse.getTotalCount()).isEqualTo(200);
@@ -492,6 +503,7 @@ public class KaldbTest {
         searchUsingGrpcApi("Message100", queryServicePort, 0, Long.MAX_VALUE);
 
     assertThat(queryServiceSearchResponse2.getTotalSnapshots()).isEqualTo(2);
+    assertThat(queryServiceSearchResponse2.getSkippedSnapshots()).isEqualTo(0);
     assertThat(queryServiceSearchResponse2.getFailedSnapshots()).isEqualTo(0);
     assertThat(queryServiceSearchResponse2.getSuccessfulSnapshots()).isEqualTo(2);
     assertThat(queryServiceSearchResponse2.getTotalCount()).isEqualTo(2);

--- a/kaldb/src/test/java/com/slack/kaldb/server/SearchResultTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/SearchResultTest.java
@@ -35,14 +35,15 @@ public class SearchResultTest {
     buckets.add(new HistogramBucket(1, 2));
 
     SearchResult<LogMessage> searchResult =
-        new SearchResult<>(logMessages, 1, 1000, buckets, 7, 1, 5);
+        new SearchResult<>(logMessages, 1, 1000, buckets, 10, 2, 1, 5);
     KaldbSearch.SearchResult protoSearchResult =
         SearchResultUtils.toSearchResultProto(searchResult);
 
     assertThat(protoSearchResult.getHitsCount()).isEqualTo(numDocs);
     assertThat(protoSearchResult.getTookMicros()).isEqualTo(1);
     assertThat(protoSearchResult.getTotalCount()).isEqualTo(1000);
-    assertThat(protoSearchResult.getTotalSnapshots()).isEqualTo(7);
+    assertThat(protoSearchResult.getTotalSnapshots()).isEqualTo(10);
+    assertThat(protoSearchResult.getSkippedSnapshots()).isEqualTo(2);
     assertThat(protoSearchResult.getFailedSnapshots()).isEqualTo(1);
     assertThat(protoSearchResult.getSuccessfulSnapshots()).isEqualTo(5);
     assertThat(protoSearchResult.getBucketsCount()).isEqualTo(1);

--- a/kaldb/src/test/java/com/slack/kaldb/server/SearchResultTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/SearchResultTest.java
@@ -35,17 +35,16 @@ public class SearchResultTest {
     buckets.add(new HistogramBucket(1, 2));
 
     SearchResult<LogMessage> searchResult =
-        new SearchResult<>(logMessages, 1, 1000, buckets, 1, 5, 7, 7);
+        new SearchResult<>(logMessages, 1, 1000, buckets, 7, 1, 5);
     KaldbSearch.SearchResult protoSearchResult =
         SearchResultUtils.toSearchResultProto(searchResult);
 
     assertThat(protoSearchResult.getHitsCount()).isEqualTo(numDocs);
     assertThat(protoSearchResult.getTookMicros()).isEqualTo(1);
     assertThat(protoSearchResult.getTotalCount()).isEqualTo(1000);
-    assertThat(protoSearchResult.getFailedNodes()).isEqualTo(1);
-    assertThat(protoSearchResult.getTotalNodes()).isEqualTo(5);
     assertThat(protoSearchResult.getTotalSnapshots()).isEqualTo(7);
-    assertThat(protoSearchResult.getSnapshotsWithReplicas()).isEqualTo(7);
+    assertThat(protoSearchResult.getFailedSnapshots()).isEqualTo(1);
+    assertThat(protoSearchResult.getSuccessfulSnapshots()).isEqualTo(5);
     assertThat(protoSearchResult.getBucketsCount()).isEqualTo(1);
 
     SearchResult<LogMessage> convertedSearchResult =

--- a/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceTest.java
@@ -244,6 +244,7 @@ public class ZipkinServiceTest {
 
     assertThat(queryServiceSearchResponse.getTotalSnapshots()).isEqualTo(1);
     assertThat(queryServiceSearchResponse.getSuccessfulSnapshots()).isEqualTo(1);
+    assertThat(queryServiceSearchResponse.getSkippedSnapshots()).isEqualTo(0);
     assertThat(queryServiceSearchResponse.getFailedSnapshots()).isEqualTo(0);
     assertThat(queryServiceSearchResponse.getTotalCount()).isEqualTo(indexedMessagesCount);
     assertThat(queryServiceSearchResponse.getHitsCount()).isEqualTo(indexedMessagesCount);

--- a/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceTest.java
@@ -242,8 +242,9 @@ public class ZipkinServiceTest {
     KaldbSearch.SearchResult queryServiceSearchResponse =
         searchUsingGrpcApi("*:*", queryServicePort, 0, Instant.now().toEpochMilli());
 
-    assertThat(queryServiceSearchResponse.getTotalNodes()).isEqualTo(1);
-    assertThat(queryServiceSearchResponse.getFailedNodes()).isEqualTo(0);
+    assertThat(queryServiceSearchResponse.getTotalSnapshots()).isEqualTo(1);
+    assertThat(queryServiceSearchResponse.getSuccessfulSnapshots()).isEqualTo(1);
+    assertThat(queryServiceSearchResponse.getFailedSnapshots()).isEqualTo(0);
     assertThat(queryServiceSearchResponse.getTotalCount()).isEqualTo(indexedMessagesCount);
     assertThat(queryServiceSearchResponse.getHitsCount()).isEqualTo(indexedMessagesCount);
 


### PR DESCRIPTION
This PR updates the functionality of the `_shard` metrics to match that of Opensearch. These stats now map to _snapshots/chunks_ instead of _pods_, and definitions are as follows:
* total - the number of snapshots/chunks in the entire system (ie matches zookeeper znodes)
* skipped - the number of snapshots not queried due to query parameters (ie, time window)
* successful - the number of snapshots returned successfully
* failed - the number of snapshots that failed to return

The combination of these stats also allows us to infer the amount of snapshots that exist in the system that we should have queried, but were not assigned an executor. This is reported as the counter `DISTRIBUTED_QUERY_UNAVAILABLE_SNAPSHOTS`.

Note this PR does **not** address the larger issue of code structure of these metrics as identified in the todo here [slackhq/kaldb/blame/fe25172e41ec45ebb31ef6994c54ecc2be15ac34/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResult.java](https://github.com/slackhq/kaldb/blame/fe25172e41ec45ebb31ef6994c54ecc2be15ac34/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResult.java#L42). This effort is focused on just swapping the node-level stats for chunk-level stats, and the larger refactor can follow as a separate PR if needed.

Example payload:
![Screenshot 2022-11-28 at 3 58 22 PM](https://user-images.githubusercontent.com/771133/204398519-380e93dc-7bfe-455a-84a8-2c4e00a269ba.png)
![Screenshot 2022-11-28 at 4 05 54 PM](https://user-images.githubusercontent.com/771133/204399499-09ef2fcd-ee02-4e57-b891-e1f2a1d6c0b4.png)
