### PR TITLE
fix getTraceById timestamp

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/server/ZipkinService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ZipkinService.java
@@ -155,7 +155,8 @@ public class ZipkinService {
   }
 
   private static final Logger LOG = LoggerFactory.getLogger(ZipkinService.class);
-  private static long LOOKBACK_MINS = 60 * 2;
+  private static long LOOKBACK_MINS = 60 * 24;
+  private static long LOOKAHEAD_MINS = 60 * 2;
 
   private static final int MAX_SPANS = 20_000;
 
@@ -213,7 +214,7 @@ public class ZipkinService {
     // system clock and those spans would be stored but can't be queried
     long endTime =
         endTimeEpochMs.orElseGet(
-            () -> Instant.now().plus(LOOKBACK_MINS, ChronoUnit.MINUTES).toEpochMilli());
+            () -> Instant.now().plus(LOOKAHEAD_MINS, ChronoUnit.MINUTES).toEpochMilli());
 
     // TODO: when MAX_SPANS is hit the results will look weird because the index is sorted in
     // reverse timestamp and the spans returned will be the tail. We should support sort in the


### PR DESCRIPTION
1. if we search by traceId query back upto 24 hours instead of the default 2. We keep the lookahead 2 hours ( happy to reduce it, but I believe Suman wanted some lookahead buffer to account for time skew )
2. Re-enable the unit test - I ran to CI test 5 times already and no flakiness ( unsure what changed TBH )