### PR TITLE
Make `_all` field the default search field.

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/LogIndexSearcherImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/LogIndexSearcherImpl.java
@@ -12,7 +12,6 @@ import com.slack.kaldb.histogram.FixedIntervalHistogramImpl;
 import com.slack.kaldb.histogram.Histogram;
 import com.slack.kaldb.histogram.NoOpHistogramImpl;
 import com.slack.kaldb.logstore.LogMessage;
-import com.slack.kaldb.logstore.LogMessage.ReservedField;
 import com.slack.kaldb.logstore.LogMessage.SystemField;
 import com.slack.kaldb.logstore.LogWireMessage;
 import com.slack.kaldb.util.JsonUtil;
@@ -78,7 +77,7 @@ public class LogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
 
   // Lucene's query parsers are not thread safe. So, create a new one for every request.
   private QueryParser buildQueryParser() {
-    return new QueryParser(ReservedField.MESSAGE.fieldName, analyzer);
+    return new QueryParser(SystemField.ALL.fieldName, analyzer);
   }
 
   public SearchResult<LogMessage> search(

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
@@ -10,6 +10,7 @@ import static com.slack.kaldb.testlib.MetricsUtil.getCount;
 import static com.slack.kaldb.testlib.MetricsUtil.getTimerCount;
 import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.MAX_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import brave.Tracing;
 import com.slack.kaldb.logstore.LogMessage;
@@ -498,8 +499,14 @@ public class LogIndexSearcherImplTest {
                 .size())
         .isEqualTo(3);
 
-    // Currently, returns empty since we don't parse wild card queries.
-    // TODO: One we start parsing wild card queries this should return 3.
+    assertThat(
+            strictLogStore
+                .logSearcher
+                .search(TEST_DATASET_NAME, "app*", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isEqualTo(2);
+
     assertThat(
             strictLogStore
                 .logSearcher
@@ -507,6 +514,24 @@ public class LogIndexSearcherImplTest {
                 .hits
                 .size())
         .isEqualTo(0);
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                strictLogStore
+                    .logSearcher
+                    .search(TEST_DATASET_NAME, "*", 0, MAX_TIME, 1000, 1)
+                    .hits
+                    .size());
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                strictLogStore
+                    .logSearcher
+                    .search(TEST_DATASET_NAME, "?", 0, MAX_TIME, 1000, 1)
+                    .hits
+                    .size());
 
     // Returns baby or car, 2 messages.
     assertThat(

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
@@ -525,6 +525,23 @@ public class LogIndexSearcherImplTest {
                 .hits
                 .size())
         .isEqualTo(0);
+
+    // Without the _all field as default.
+    assertThat(
+            strictLogStoreWithoutFts
+                .logSearcher
+                .search(TEST_DATASET_NAME, "baby", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isEqualTo(0);
+
+    assertThat(
+            strictLogStoreWithoutFts
+                .logSearcher
+                .search(TEST_DATASET_NAME, "1234", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isEqualTo(0);
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
@@ -586,7 +586,7 @@ public class LogIndexSearcherImplTest {
                 .search(TEST_DATASET_NAME, "_all:baby", 0, MAX_TIME, 1000, 1)
                 .hits
                 .size())
-        .isEqualTo(0);
+        .isZero();
 
     assertThat(
             strictLogStoreWithoutFts
@@ -594,7 +594,7 @@ public class LogIndexSearcherImplTest {
                 .search(TEST_DATASET_NAME, "_all:1234", 0, MAX_TIME, 1000, 1)
                 .hits
                 .size())
-        .isEqualTo(0);
+        .isZero();
 
     // Without the _all field as default.
     assertThat(
@@ -603,7 +603,7 @@ public class LogIndexSearcherImplTest {
                 .search(TEST_DATASET_NAME, "baby", 0, MAX_TIME, 1000, 1)
                 .hits
                 .size())
-        .isEqualTo(0);
+        .isZero();
 
     assertThat(
             strictLogStoreWithoutFts
@@ -611,7 +611,76 @@ public class LogIndexSearcherImplTest {
                 .search(TEST_DATASET_NAME, "1234", 0, MAX_TIME, 1000, 1)
                 .hits
                 .size())
+        .isZero();
+
+    // empty string
+    assertThat(
+            strictLogStore
+                .logSearcher
+                .search(TEST_DATASET_NAME, "", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isZero();
+
+    assertThat(
+            strictLogStore
+                .logSearcher
+                .search(TEST_DATASET_NAME, "app*", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isZero();
+
+    assertThat(
+            strictLogStore
+                .logSearcher
+                .search(TEST_DATASET_NAME, ".*", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
         .isEqualTo(0);
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                strictLogStore
+                    .logSearcher
+                    .search(TEST_DATASET_NAME, "*", 0, MAX_TIME, 1000, 1)
+                    .hits
+                    .size());
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                strictLogStore
+                    .logSearcher
+                    .search(TEST_DATASET_NAME, "?", 0, MAX_TIME, 1000, 1)
+                    .hits
+                    .size());
+
+    // Returns baby or car, 2 messages.
+    assertThat(
+            strictLogStore
+                .logSearcher
+                .search(TEST_DATASET_NAME, "baby car", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isZero();
+
+    // Test numbers
+    assertThat(
+            strictLogStore
+                .logSearcher
+                .search(TEST_DATASET_NAME, "apple 1234", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isZero();
+
+    assertThat(
+            strictLogStore
+                .logSearcher
+                .search(TEST_DATASET_NAME, "123", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isZero();
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
@@ -492,47 +492,47 @@ public class LogIndexSearcherImplTest {
     // empty string
     assertThat(
             strictLogStore
-                    .logSearcher
-                    .search(TEST_DATASET_NAME, "", 0, MAX_TIME, 1000, 1)
-                    .hits
-                    .size())
-            .isEqualTo(3);
+                .logSearcher
+                .search(TEST_DATASET_NAME, "", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isEqualTo(3);
 
     // Currently, returns empty since we don't parse wild card queries.
     // TODO: One we start parsing wild card queries this should return 3.
     assertThat(
             strictLogStore
-                    .logSearcher
-                    .search(TEST_DATASET_NAME, ".*", 0, MAX_TIME, 1000, 1)
-                    .hits
-                    .size())
-            .isEqualTo(0);
+                .logSearcher
+                .search(TEST_DATASET_NAME, ".*", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isEqualTo(0);
 
     // Returns baby or car, 2 messages.
     assertThat(
             strictLogStore
-                    .logSearcher
-                    .search(TEST_DATASET_NAME, "baby car", 0, MAX_TIME, 1000, 1)
-                    .hits
-                    .size())
-            .isEqualTo(2);
+                .logSearcher
+                .search(TEST_DATASET_NAME, "baby car", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isEqualTo(2);
 
     // Test numbers
     assertThat(
             strictLogStore
-                    .logSearcher
-                    .search(TEST_DATASET_NAME, "apple 1234", 0, MAX_TIME, 1000, 1)
-                    .hits
-                    .size())
-            .isEqualTo(3);
+                .logSearcher
+                .search(TEST_DATASET_NAME, "apple 1234", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isEqualTo(3);
 
     assertThat(
             strictLogStore
-                    .logSearcher
-                    .search(TEST_DATASET_NAME, "123", 0, MAX_TIME, 1000, 1)
-                    .hits
-                    .size())
-            .isEqualTo(0);
+                .logSearcher
+                .search(TEST_DATASET_NAME, "123", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isEqualTo(0);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
@@ -40,7 +40,7 @@ public class LogIndexSearcherImplTest {
   public LogIndexSearcherImplTest() throws IOException {}
 
   @BeforeClass
-  public static void beforeClass() throws Exception {
+  public static void beforeClass() {
     Tracing.newBuilder().build();
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
@@ -488,6 +488,51 @@ public class LogIndexSearcherImplTest {
                 .hits
                 .size())
         .isEqualTo(3);
+
+    // empty string
+    assertThat(
+            strictLogStore
+                    .logSearcher
+                    .search(TEST_DATASET_NAME, "", 0, MAX_TIME, 1000, 1)
+                    .hits
+                    .size())
+            .isEqualTo(3);
+
+    // Currently, returns empty since we don't parse wild card queries.
+    // TODO: One we start parsing wild card queries this should return 3.
+    assertThat(
+            strictLogStore
+                    .logSearcher
+                    .search(TEST_DATASET_NAME, ".*", 0, MAX_TIME, 1000, 1)
+                    .hits
+                    .size())
+            .isEqualTo(0);
+
+    // Returns baby or car, 2 messages.
+    assertThat(
+            strictLogStore
+                    .logSearcher
+                    .search(TEST_DATASET_NAME, "baby car", 0, MAX_TIME, 1000, 1)
+                    .hits
+                    .size())
+            .isEqualTo(2);
+
+    // Test numbers
+    assertThat(
+            strictLogStore
+                    .logSearcher
+                    .search(TEST_DATASET_NAME, "apple 1234", 0, MAX_TIME, 1000, 1)
+                    .hits
+                    .size())
+            .isEqualTo(3);
+
+    assertThat(
+            strictLogStore
+                    .logSearcher
+                    .search(TEST_DATASET_NAME, "123", 0, MAX_TIME, 1000, 1)
+                    .hits
+                    .size())
+            .isEqualTo(0);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
@@ -382,11 +382,75 @@ public class LogIndexSearcherImplTest {
         makeMessageWithIndexAndTimestamp(1, "apple", TEST_DATASET_NAME, time.plusSeconds(4));
     msg1.addProperty("field1", "1234");
     strictLogStore.logStore.addMessage(msg1);
+    strictLogStore.logStore.commit();
+    strictLogStore.logStore.refresh();
+    // Search using _all field.
+    assertThat(
+            strictLogStore
+                .logSearcher
+                .search(TEST_DATASET_NAME, "_all:baby", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isEqualTo(0);
+    assertThat(
+            strictLogStore
+                .logSearcher
+                .search(TEST_DATASET_NAME, "_all:1234", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isEqualTo(1);
+    // Default all field search.
+    assertThat(
+            strictLogStore
+                .logSearcher
+                .search(TEST_DATASET_NAME, "baby", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isEqualTo(0);
+    assertThat(
+            strictLogStore
+                .logSearcher
+                .search(TEST_DATASET_NAME, "1234", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isEqualTo(1);
 
     final LogMessage msg2 =
         makeMessageWithIndexAndTimestamp(2, "apple baby", TEST_DATASET_NAME, time.plusSeconds(4));
     msg2.addProperty("field2", "1234");
     strictLogStore.logStore.addMessage(msg2);
+    strictLogStore.logStore.commit();
+    strictLogStore.logStore.refresh();
+    // Search using _all field.
+    assertThat(
+            strictLogStore
+                .logSearcher
+                .search(TEST_DATASET_NAME, "_all:baby", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isEqualTo(1);
+    assertThat(
+            strictLogStore
+                .logSearcher
+                .search(TEST_DATASET_NAME, "_all:1234", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isEqualTo(2);
+    // Default all field search.
+    assertThat(
+            strictLogStore
+                .logSearcher
+                .search(TEST_DATASET_NAME, "baby", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isEqualTo(1);
+    assertThat(
+            strictLogStore
+                .logSearcher
+                .search(TEST_DATASET_NAME, "1234", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isEqualTo(2);
 
     final LogMessage msg3 =
         makeMessageWithIndexAndTimestamp(
@@ -394,14 +458,36 @@ public class LogIndexSearcherImplTest {
     strictLogStore.logStore.addMessage(msg3);
     strictLogStore.logStore.commit();
     strictLogStore.logStore.refresh();
-
-    SearchResult<LogMessage> babyInAll =
-        strictLogStore.logSearcher.search(TEST_DATASET_NAME, "_all:baby", 0, MAX_TIME, 1000, 1);
-    assertThat(babyInAll.hits.size()).isEqualTo(2);
-
-    SearchResult<LogMessage> numberInAll =
-        strictLogStore.logSearcher.search(TEST_DATASET_NAME, "_all:1234", 0, MAX_TIME, 1000, 1);
-    assertThat(numberInAll.hits.size()).isEqualTo(3);
+    // Search using _all field.
+    assertThat(
+            strictLogStore
+                .logSearcher
+                .search(TEST_DATASET_NAME, "_all:baby", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isEqualTo(2);
+    assertThat(
+            strictLogStore
+                .logSearcher
+                .search(TEST_DATASET_NAME, "_all:1234", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isEqualTo(3);
+    // Default all field search.
+    assertThat(
+            strictLogStore
+                .logSearcher
+                .search(TEST_DATASET_NAME, "baby", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isEqualTo(2);
+    assertThat(
+            strictLogStore
+                .logSearcher
+                .search(TEST_DATASET_NAME, "1234", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isEqualTo(3);
   }
 
   @Test
@@ -424,15 +510,21 @@ public class LogIndexSearcherImplTest {
     strictLogStoreWithoutFts.logStore.commit();
     strictLogStoreWithoutFts.logStore.refresh();
 
-    SearchResult<LogMessage> babyInAll =
-        strictLogStoreWithoutFts.logSearcher.search(
-            TEST_DATASET_NAME, "_all:baby", 0, MAX_TIME, 1000, 1);
-    assertThat(babyInAll.hits.size()).isEqualTo(0);
+    assertThat(
+            strictLogStoreWithoutFts
+                .logSearcher
+                .search(TEST_DATASET_NAME, "_all:baby", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isEqualTo(0);
 
-    SearchResult<LogMessage> numberInAll =
-        strictLogStoreWithoutFts.logSearcher.search(
-            TEST_DATASET_NAME, "_all:1234", 0, MAX_TIME, 1000, 1);
-    assertThat(numberInAll.hits.size()).isEqualTo(0);
+    assertThat(
+            strictLogStoreWithoutFts
+                .logSearcher
+                .search(TEST_DATASET_NAME, "_all:1234", 0, MAX_TIME, 1000, 1)
+                .hits
+                .size())
+        .isEqualTo(0);
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Make `_all` field the default search field so we don't have to enter it every time we have to do a full text search on logs. 