### PR TITLE
Fix flakey `ManagerApiGrpcTest.shouldRestoreGivenSnapshotIds` test

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaRestoreService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaRestoreService.java
@@ -117,7 +117,7 @@ public class ReplicaRestoreService extends AbstractScheduledService {
           "Number of replicas requested exceeds maxReplicasPerRequest limit");
     }
     queue.addAll(snapshotsToRestore);
-    LOG.info("Current size of Snapshot restoration queue: " + queue.size());
+    LOG.info("Current size of Snapshot restoration queue: {} ", queue.size());
     runOneIteration();
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/server/ManagerApiGrpc.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ManagerApiGrpc.java
@@ -213,13 +213,13 @@ public class ManagerApiGrpc extends ManagerApiServiceGrpc.ManagerApiServiceImplB
           ManagerApi.RestoreReplicaResponse.newBuilder().setStatus("success").build());
       responseObserver.onCompleted();
     } catch (SizeLimitExceededException e) {
-      LOG.info(
+      LOG.error(
           "Error handling request: number of replicas requested exceeds maxReplicasPerRequest limit",
           e);
       responseObserver.onError(
           Status.RESOURCE_EXHAUSTED.withDescription(e.getMessage()).asException());
     } catch (Exception e) {
-      LOG.info("Error handling request", e);
+      LOG.error("Error handling request", e);
       responseObserver.onError(Status.UNKNOWN.withDescription(e.getMessage()).asException());
     }
   }
@@ -239,13 +239,13 @@ public class ManagerApiGrpc extends ManagerApiServiceGrpc.ManagerApiServiceImplB
           ManagerApi.RestoreReplicaIdsResponse.newBuilder().setStatus("success").build());
       responseObserver.onCompleted();
     } catch (SizeLimitExceededException e) {
-      LOG.info(
+      LOG.error(
           "Error handling request: number of replicas requested exceeds maxReplicasPerRequest limit",
           e);
       responseObserver.onError(
           Status.RESOURCE_EXHAUSTED.withDescription(e.getMessage()).asException());
     } catch (Exception e) {
-      LOG.info("Error handling request", e);
+      LOG.error("Error handling request", e);
       responseObserver.onError(Status.UNKNOWN.withDescription(e.getMessage()).asException());
     }
   }

--- a/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
@@ -1,5 +1,6 @@
 package com.slack.kaldb.server;
 
+import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static com.slack.kaldb.server.ManagerApiGrpc.MAX_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -108,6 +109,11 @@ public class ManagerApiGrpcTest {
 
   @After
   public void tearDown() throws Exception {
+    replicaRestoreService.stopAsync();
+    replicaRestoreService.awaitTerminated(DEFAULT_START_STOP_DURATION);
+
+    replicaMetadataStore.close();
+    snapshotMetadataStore.close();
     datasetMetadataStore.close();
     metadataStore.close();
 
@@ -725,6 +731,7 @@ public class ManagerApiGrpcTest {
     snapshotMetadataStore.createSync(snapshotFoo);
     snapshotMetadataStore.createSync(snapshotBar);
     snapshotMetadataStore.createSync(snapshotBaz);
+    await().until(() -> snapshotMetadataStore.getCached().size() == 3);
 
     replicaRestoreService.startAsync();
     replicaRestoreService.awaitRunning();


### PR DESCRIPTION
Addresses a race condition where the snapshot cache could lag, causing too few replicas to be created and resulting in a `ConditionTimeoutException`. Logs confirm the fact that too few snapshots were present in the cache at restore time.

```
[INFO ] 2022-12-06 16:03:46.982 [replica-restore-service-0] ReplicaCreationService - Restored 2 snapshots.
```

<details>

<summary>Logs from replicated failed test</summary>

```
[INFO ] 2022-12-06 16:03:46.749 [Thread-982] QuorumPeerConfig - clientPortAddress is 0.0.0.0:59009
[INFO ] 2022-12-06 16:03:46.749 [Thread-982] QuorumPeerConfig - secureClientPort is not set
[INFO ] 2022-12-06 16:03:46.749 [Thread-982] QuorumPeerConfig - observerMasterPort is not set
[INFO ] 2022-12-06 16:03:46.749 [Thread-982] QuorumPeerConfig - metricsProvider.className is org.apache.zookeeper.metrics.impl.DefaultMetricsProvider
[INFO ] 2022-12-06 16:03:46.749 [Thread-982] TestingZooKeeperMain - Starting server
[INFO ] 2022-12-06 16:03:46.749 [Thread-982] FileTxnSnapLog - zookeeper.snapshot.trust.empty : false
[INFO ] 2022-12-06 16:03:46.749 [Thread-982] RequestPathMetricsCollector - zookeeper.pathStats.slotCapacity = 60
[INFO ] 2022-12-06 16:03:46.749 [Thread-982] RequestPathMetricsCollector - zookeeper.pathStats.slotDuration = 15
[INFO ] 2022-12-06 16:03:46.749 [Thread-982] RequestPathMetricsCollector - zookeeper.pathStats.maxDepth = 6
[INFO ] 2022-12-06 16:03:46.750 [Thread-982] RequestPathMetricsCollector - zookeeper.pathStats.initialDelay = 5
[INFO ] 2022-12-06 16:03:46.750 [Thread-982] RequestPathMetricsCollector - zookeeper.pathStats.delay = 5
[INFO ] 2022-12-06 16:03:46.750 [Thread-982] RequestPathMetricsCollector - zookeeper.pathStats.enabled = false
[INFO ] 2022-12-06 16:03:46.750 [Thread-982] ZooKeeperServer - tickTime set to 1000
[INFO ] 2022-12-06 16:03:46.750 [Thread-982] ZooKeeperServer - minSessionTimeout set to 1000
[INFO ] 2022-12-06 16:03:46.750 [Thread-982] ZooKeeperServer - maxSessionTimeout set to 20000
[INFO ] 2022-12-06 16:03:46.750 [Thread-982] ServerCnxnFactory - Using org.apache.zookeeper.server.NIOServerCnxnFactory as server connection factory
[WARN ] 2022-12-06 16:03:46.750 [Thread-982] ServerCnxnFactory - maxCnxns is not configured, using default value 0.
[INFO ] 2022-12-06 16:03:46.750 [Thread-982] NIOServerCnxnFactory - Configuring NIO connection handler with 10s sessionless connection timeout, 2 selector thread(s), 32 worker threads, and 64 kB direct buffers.
[INFO ] 2022-12-06 16:03:46.750 [Thread-982] NIOServerCnxnFactory - binding to port 0.0.0.0/0.0.0.0:59009
[INFO ] 2022-12-06 16:03:46.750 [Thread-982] WatchManagerFactory - Using org.apache.zookeeper.server.watch.WatchManager as watch manager
[INFO ] 2022-12-06 16:03:46.750 [Thread-982] WatchManagerFactory - Using org.apache.zookeeper.server.watch.WatchManager as watch manager
[INFO ] 2022-12-06 16:03:46.750 [Thread-982] ZKDatabase - zookeeper.snapshotSizeFactor = 0.33
[INFO ] 2022-12-06 16:03:46.750 [Thread-982] ZKDatabase - zookeeper.commitLogCount=500
[INFO ] 2022-12-06 16:03:46.751 [Thread-982] FileTxnSnapLog - Snapshotting: 0x0 to /private/var/folders/_b/fd_kr7vs64q3c4sm9t12wtlr0000gp/T/1670367826748-0/version-2/snapshot.0
[INFO ] 2022-12-06 16:03:46.751 [Thread-982] ZKDatabase - Snapshot loaded in 1 ms, highest zxid is 0x0, digest is 1371985504
[INFO ] 2022-12-06 16:03:46.751 [Thread-982] FileTxnSnapLog - Snapshotting: 0x0 to /private/var/folders/_b/fd_kr7vs64q3c4sm9t12wtlr0000gp/T/1670367826748-0/version-2/snapshot.0
[INFO ] 2022-12-06 16:03:46.751 [Thread-982] ZooKeeperServer - Snapshot taken in 1 ms
[INFO ] 2022-12-06 16:03:46.752 [ProcessThread(sid:0 cport:59009):] PrepRequestProcessor - PrepRequestProcessor (sid:0) started, reconfigEnabled=false
[INFO ] 2022-12-06 16:03:46.752 [Thread-982] ContainerManager - Using checkIntervalMs=60000 maxPerMinute=10000 maxNeverUsedIntervalMs=0
[INFO ] 2022-12-06 16:03:46.752 [main] CuratorFrameworkImpl - Starting
[INFO ] 2022-12-06 16:03:46.752 [main] ZooKeeper - Initiating client connection, connectString=127.0.0.1:59009 sessionTimeout=30000 watcher=org.apache.curator.ConnectionState@63d8590c
[INFO ] 2022-12-06 16:03:46.752 [main] ClientCnxnSocket - jute.maxbuffer value is 1048575 Bytes
[INFO ] 2022-12-06 16:03:46.752 [main] ClientCnxn - zookeeper.request.timeout value is 0. feature enabled=false
[INFO ] 2022-12-06 16:03:46.753 [main] CuratorFrameworkImpl - Default schema
[INFO ] 2022-12-06 16:03:46.753 [main] ZookeeperMetadataStoreImpl - Started curator server with the following config zkhost: 127.0.0.1:59009, path prefix: ManagerApiGrpcTest, connection timeout ms: 30000, session timeout ms 30000 and retry policy org.apache.curator.retry.RetryNTimes@109fff4a
[INFO ] 2022-12-06 16:03:46.753 [kaldb-metadata-store-pool-0] ZookeeperMetadataStoreImpl - Creating a node at /service with data .
[INFO ] 2022-12-06 16:03:46.753 [main-SendThread(127.0.0.1:59009)] ClientCnxn - Opening socket connection to server localhost/127.0.0.1:59009.
[INFO ] 2022-12-06 16:03:46.753 [main-SendThread(127.0.0.1:59009)] ClientCnxn - SASL config status: Will not attempt to authenticate using SASL (unknown error)
[INFO ] 2022-12-06 16:03:46.754 [main-SendThread(127.0.0.1:59009)] ClientCnxn - Socket connection established, initiating session, client: /127.0.0.1:59012, server: localhost/127.0.0.1:59009
[INFO ] 2022-12-06 16:03:46.754 [SyncThread:0] FileTxnLog - Creating new log file: log.1
[INFO ] 2022-12-06 16:03:46.774 [main-SendThread(127.0.0.1:59009)] ClientCnxn - Session establishment complete on server localhost/127.0.0.1:59009, session id = 0x10000e31f6c0000, negotiated timeout = 20000
[INFO ] 2022-12-06 16:03:46.774 [main-EventThread] ConnectionStateManager - State change: CONNECTED
[INFO ] 2022-12-06 16:03:46.774 [Curator-ConnectionStateManager-0] ZookeeperMetadataStoreImpl - Curator connection state changed to CONNECTED
[INFO ] 2022-12-06 16:03:46.775 [main-EventThread] EnsembleTracker - New config event received: {}
[INFO ] 2022-12-06 16:03:46.776 [main-EventThread] EnsembleTracker - New config event received: {}
[DEBUG] 2022-12-06 16:03:46.816 [main] ZookeeperMetadataStoreImpl - Checking existence of a node at path /service
[ERROR] 2022-12-06 16:03:46.821 [zk-metadata-runsafe-0] ZookeeperCachedMetadataStoreImpl - Invalidating key from cache: /service
[DEBUG] 2022-12-06 16:03:46.821 [zk-metadata-runsafe-0] ZookeeperCachedMetadataStoreImpl - initialized
[INFO ] 2022-12-06 16:03:46.821 [main] ZookeeperCachedMetadataStoreImpl - Started caching nodes at path /service/.
[INFO ] 2022-12-06 16:03:46.821 [main] DatasetMetadataStore - Caching nodes for path /service
[ERROR] 2022-12-06 16:03:46.821 [zk-metadata-runsafe-0] MappingListenerManager - Listener (org.apache.curator.framework.recipes.cache.CuratorCacheListenerBuilderImpl$2@3c2d4274) threw an exception
com.slack.kaldb.metadata.zookeeper.InternalMetadataStoreException: Error adding node at path /service
	at com.slack.kaldb.metadata.zookeeper.ZookeeperCachedMetadataStoreImpl.addInstance(ZookeeperCachedMetadataStoreImpl.java:205) ~[classes/:?]
	at com.slack.kaldb.metadata.zookeeper.ZookeeperCachedMetadataStoreImpl.nodeCreated(ZookeeperCachedMetadataStoreImpl.java:111) ~[classes/:?]
	at org.apache.curator.framework.recipes.cache.CuratorCacheListenerBuilderImpl.lambda$forCreates$0(CuratorCacheListenerBuilderImpl.java:45) ~[curator-recipes-5.2.1.jar:5.2.1]
	at org.apache.curator.framework.recipes.cache.CuratorCacheListenerBuilderImpl$2.lambda$event$0(CuratorCacheListenerBuilderImpl.java:149) ~[curator-recipes-5.2.1.jar:5.2.1]
	at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
	at org.apache.curator.framework.recipes.cache.CuratorCacheListenerBuilderImpl$2.event(CuratorCacheListenerBuilderImpl.java:149) ~[curator-recipes-5.2.1.jar:5.2.1]
	at org.apache.curator.framework.recipes.cache.CuratorCacheImpl.lambda$putStorage$6(CuratorCacheImpl.java:287) ~[curator-recipes-5.2.1.jar:5.2.1]
	at org.apache.curator.framework.listen.MappingListenerManager.lambda$forEach$0(MappingListenerManager.java:92) ~[curator-framework-5.2.1.jar:5.2.1]
	at org.apache.curator.framework.listen.MappingListenerManager.forEach(MappingListenerManager.java:89) ~[curator-framework-5.2.1.jar:5.2.1]
	at org.apache.curator.framework.listen.StandardListenerManager.forEach(StandardListenerManager.java:89) ~[curator-framework-5.2.1.jar:5.2.1]
	at org.apache.curator.framework.recipes.cache.CuratorCacheImpl.lambda$callListeners$9(CuratorCacheImpl.java:301) ~[curator-recipes-5.2.1.jar:5.2.1]
	at java.util.concurrent.CompletableFuture$AsyncRun.run$$$capture(CompletableFuture.java:1736) ~[?:?]
	at java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
Caused by: com.google.protobuf.InvalidProtocolBufferException: Expect message object but got: null
	at com.google.protobuf.util.JsonFormat$ParserImpl.mergeMessage(JsonFormat.java:1474) ~[protobuf-java-util-3.21.7.jar:?]
	at com.google.protobuf.util.JsonFormat$ParserImpl.merge(JsonFormat.java:1451) ~[protobuf-java-util-3.21.7.jar:?]
	at com.google.protobuf.util.JsonFormat$ParserImpl.merge(JsonFormat.java:1333) ~[protobuf-java-util-3.21.7.jar:?]
	at com.google.protobuf.util.JsonFormat$Parser.merge(JsonFormat.java:473) ~[protobuf-java-util-3.21.7.jar:?]
	at com.slack.kaldb.metadata.dataset.DatasetMetadataSerializer.fromJsonStr(DatasetMetadataSerializer.java:55) ~[classes/:?]
	at com.slack.kaldb.metadata.dataset.DatasetMetadataSerializer.fromJsonStr(DatasetMetadataSerializer.java:10) ~[classes/:?]
	at com.slack.kaldb.metadata.zookeeper.ZookeeperCachedMetadataStoreImpl.addInstance(ZookeeperCachedMetadataStoreImpl.java:195) ~[classes/:?]
	... 15 more
[INFO ] 2022-12-06 16:03:46.821 [kaldb-metadata-store-pool-0] ZookeeperMetadataStoreImpl - Creating a node at /snapshot with data .
[DEBUG] 2022-12-06 16:03:46.842 [main] ZookeeperMetadataStoreImpl - Checking existence of a node at path /snapshot
[ERROR] 2022-12-06 16:03:46.844 [zk-metadata-runsafe-0] ZookeeperCachedMetadataStoreImpl - Invalidating key from cache: /snapshot
[DEBUG] 2022-12-06 16:03:46.844 [zk-metadata-runsafe-0] ZookeeperCachedMetadataStoreImpl - initialized
[INFO ] 2022-12-06 16:03:46.844 [main] ZookeeperCachedMetadataStoreImpl - Started caching nodes at path /snapshot/.
[INFO ] 2022-12-06 16:03:46.844 [main] SnapshotMetadataStore - Caching nodes for path /snapshot
[INFO ] 2022-12-06 16:03:46.844 [kaldb-metadata-store-pool-0] ZookeeperMetadataStoreImpl - Creating a node at /replica with data .
[ERROR] 2022-12-06 16:03:46.844 [zk-metadata-runsafe-0] MappingListenerManager - Listener (org.apache.curator.framework.recipes.cache.CuratorCacheListenerBuilderImpl$2@ab90b8c) threw an exception
com.slack.kaldb.metadata.zookeeper.InternalMetadataStoreException: Error adding node at path /snapshot
	at com.slack.kaldb.metadata.zookeeper.ZookeeperCachedMetadataStoreImpl.addInstance(ZookeeperCachedMetadataStoreImpl.java:205) ~[classes/:?]
	at com.slack.kaldb.metadata.zookeeper.ZookeeperCachedMetadataStoreImpl.nodeCreated(ZookeeperCachedMetadataStoreImpl.java:111) ~[classes/:?]
	at org.apache.curator.framework.recipes.cache.CuratorCacheListenerBuilderImpl.lambda$forCreates$0(CuratorCacheListenerBuilderImpl.java:45) ~[curator-recipes-5.2.1.jar:5.2.1]
	at org.apache.curator.framework.recipes.cache.CuratorCacheListenerBuilderImpl$2.lambda$event$0(CuratorCacheListenerBuilderImpl.java:149) ~[curator-recipes-5.2.1.jar:5.2.1]
	at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
	at org.apache.curator.framework.recipes.cache.CuratorCacheListenerBuilderImpl$2.event(CuratorCacheListenerBuilderImpl.java:149) ~[curator-recipes-5.2.1.jar:5.2.1]
	at org.apache.curator.framework.recipes.cache.CuratorCacheImpl.lambda$putStorage$6(CuratorCacheImpl.java:287) ~[curator-recipes-5.2.1.jar:5.2.1]
	at org.apache.curator.framework.listen.MappingListenerManager.lambda$forEach$0(MappingListenerManager.java:92) ~[curator-framework-5.2.1.jar:5.2.1]
	at org.apache.curator.framework.listen.MappingListenerManager.forEach(MappingListenerManager.java:89) ~[curator-framework-5.2.1.jar:5.2.1]
	at org.apache.curator.framework.listen.StandardListenerManager.forEach(StandardListenerManager.java:89) ~[curator-framework-5.2.1.jar:5.2.1]
	at org.apache.curator.framework.recipes.cache.CuratorCacheImpl.lambda$callListeners$9(CuratorCacheImpl.java:301) ~[curator-recipes-5.2.1.jar:5.2.1]
	at java.util.concurrent.CompletableFuture$AsyncRun.run$$$capture(CompletableFuture.java:1736) ~[?:?]
	at java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
Caused by: com.google.protobuf.InvalidProtocolBufferException: Expect message object but got: null
	at com.google.protobuf.util.JsonFormat$ParserImpl.mergeMessage(JsonFormat.java:1474) ~[protobuf-java-util-3.21.7.jar:?]
	at com.google.protobuf.util.JsonFormat$ParserImpl.merge(JsonFormat.java:1451) ~[protobuf-java-util-3.21.7.jar:?]
	at com.google.protobuf.util.JsonFormat$ParserImpl.merge(JsonFormat.java:1333) ~[protobuf-java-util-3.21.7.jar:?]
	at com.google.protobuf.util.JsonFormat$Parser.merge(JsonFormat.java:473) ~[protobuf-java-util-3.21.7.jar:?]
	at com.slack.kaldb.metadata.snapshot.SnapshotMetadataSerializer.fromJsonStr(SnapshotMetadataSerializer.java:46) ~[classes/:?]
	at com.slack.kaldb.metadata.snapshot.SnapshotMetadataSerializer.fromJsonStr(SnapshotMetadataSerializer.java:8) ~[classes/:?]
	at com.slack.kaldb.metadata.zookeeper.ZookeeperCachedMetadataStoreImpl.addInstance(ZookeeperCachedMetadataStoreImpl.java:195) ~[classes/:?]
	... 15 more
[DEBUG] 2022-12-06 16:03:46.863 [main] ZookeeperMetadataStoreImpl - Checking existence of a node at path /replica
[ERROR] 2022-12-06 16:03:46.865 [zk-metadata-runsafe-0] ZookeeperCachedMetadataStoreImpl - Invalidating key from cache: /replica
[DEBUG] 2022-12-06 16:03:46.865 [zk-metadata-runsafe-0] ZookeeperCachedMetadataStoreImpl - initialized
[INFO ] 2022-12-06 16:03:46.865 [main] ZookeeperCachedMetadataStoreImpl - Started caching nodes at path /replica/.
[INFO ] 2022-12-06 16:03:46.865 [main] ReplicaMetadataStore - Caching nodes for path /replica
[ERROR] 2022-12-06 16:03:46.865 [zk-metadata-runsafe-0] MappingListenerManager - Listener (org.apache.curator.framework.recipes.cache.CuratorCacheListenerBuilderImpl$2@688884e) threw an exception
com.slack.kaldb.metadata.zookeeper.InternalMetadataStoreException: Error adding node at path /replica
	at com.slack.kaldb.metadata.zookeeper.ZookeeperCachedMetadataStoreImpl.addInstance(ZookeeperCachedMetadataStoreImpl.java:205) ~[classes/:?]
	at com.slack.kaldb.metadata.zookeeper.ZookeeperCachedMetadataStoreImpl.nodeCreated(ZookeeperCachedMetadataStoreImpl.java:111) ~[classes/:?]
	at org.apache.curator.framework.recipes.cache.CuratorCacheListenerBuilderImpl.lambda$forCreates$0(CuratorCacheListenerBuilderImpl.java:45) ~[curator-recipes-5.2.1.jar:5.2.1]
	at org.apache.curator.framework.recipes.cache.CuratorCacheListenerBuilderImpl$2.lambda$event$0(CuratorCacheListenerBuilderImpl.java:149) ~[curator-recipes-5.2.1.jar:5.2.1]
	at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
	at org.apache.curator.framework.recipes.cache.CuratorCacheListenerBuilderImpl$2.event(CuratorCacheListenerBuilderImpl.java:149) ~[curator-recipes-5.2.1.jar:5.2.1]
	at org.apache.curator.framework.recipes.cache.CuratorCacheImpl.lambda$putStorage$6(CuratorCacheImpl.java:287) ~[curator-recipes-5.2.1.jar:5.2.1]
	at org.apache.curator.framework.listen.MappingListenerManager.lambda$forEach$0(MappingListenerManager.java:92) ~[curator-framework-5.2.1.jar:5.2.1]
	at org.apache.curator.framework.listen.MappingListenerManager.forEach(MappingListenerManager.java:89) ~[curator-framework-5.2.1.jar:5.2.1]
	at org.apache.curator.framework.listen.StandardListenerManager.forEach(StandardListenerManager.java:89) ~[curator-framework-5.2.1.jar:5.2.1]
	at org.apache.curator.framework.recipes.cache.CuratorCacheImpl.lambda$callListeners$9(CuratorCacheImpl.java:301) ~[curator-recipes-5.2.1.jar:5.2.1]
	at java.util.concurrent.CompletableFuture$AsyncRun.run$$$capture(CompletableFuture.java:1736) ~[?:?]
	at java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
Caused by: com.google.protobuf.InvalidProtocolBufferException: Expect message object but got: null
	at com.google.protobuf.util.JsonFormat$ParserImpl.mergeMessage(JsonFormat.java:1474) ~[protobuf-java-util-3.21.7.jar:?]
	at com.google.protobuf.util.JsonFormat$ParserImpl.merge(JsonFormat.java:1451) ~[protobuf-java-util-3.21.7.jar:?]
	at com.google.protobuf.util.JsonFormat$ParserImpl.merge(JsonFormat.java:1333) ~[protobuf-java-util-3.21.7.jar:?]
	at com.google.protobuf.util.JsonFormat$Parser.merge(JsonFormat.java:473) ~[protobuf-java-util-3.21.7.jar:?]
	at com.slack.kaldb.metadata.replica.ReplicaMetadataSerializer.fromJsonStr(ReplicaMetadataSerializer.java:41) ~[classes/:?]
	at com.slack.kaldb.metadata.replica.ReplicaMetadataSerializer.fromJsonStr(ReplicaMetadataSerializer.java:8) ~[classes/:?]
	at com.slack.kaldb.metadata.zookeeper.ZookeeperCachedMetadataStoreImpl.addInstance(ZookeeperCachedMetadataStoreImpl.java:195) ~[classes/:?]
	... 15 more
[INFO ] 2022-12-06 16:03:46.866 [kaldb-metadata-store-pool-0] ZookeeperMetadataStoreImpl - Creating a node at /snapshot/foo with data {
  "name": "foo",
  "snapshotId": "foo",
  "snapshotPath": "a",
  "startTimeEpochMs": "1670367826876",
  "endTimeEpochMs": "1670367826881",
  "maxOffset": "0",
  "partitionId": "a",
  "indexType": "LOGS_LUCENE9"
}.
[INFO ] 2022-12-06 16:03:46.886 [kaldb-metadata-store-pool-0] ZookeeperMetadataStoreImpl - Creating a node at /snapshot/bar with data {
  "name": "bar",
  "snapshotId": "bar",
  "snapshotPath": "b",
  "startTimeEpochMs": "1670367826876",
  "endTimeEpochMs": "1670367826881",
  "maxOffset": "0",
  "partitionId": "b",
  "indexType": "LOGS_LUCENE9"
}.
[DEBUG] 2022-12-06 16:03:46.886 [zk-metadata-runsafe-0] ZookeeperCachedMetadataStoreImpl - Notified 1 listeners on node change at /snapshot/
[INFO ] 2022-12-06 16:03:46.909 [kaldb-metadata-store-pool-0] ZookeeperMetadataStoreImpl - Creating a node at /snapshot/baz with data {
  "name": "baz",
  "snapshotId": "baz",
  "snapshotPath": "c",
  "startTimeEpochMs": "1670367826876",
  "endTimeEpochMs": "1670367826881",
  "maxOffset": "0",
  "partitionId": "c",
  "indexType": "LOGS_LUCENE9"
}.
[DEBUG] 2022-12-06 16:03:46.918 [zk-metadata-runsafe-0] ZookeeperCachedMetadataStoreImpl - Notified 1 listeners on node change at /snapshot/
[INFO ] 2022-12-06 16:03:46.937 [ReplicaRestoreService STARTING] ReplicaCreationService - Starting replica restore service
[INFO ] 2022-12-06 16:03:46.939 [main] ReplicaCreationService - Current size of Snapshot restoration queue: 2 
[DEBUG] 2022-12-06 16:03:46.940 [zk-metadata-runsafe-0] ZookeeperCachedMetadataStoreImpl - Notified 1 listeners on node change at /snapshot/
[INFO ] 2022-12-06 16:03:46.940 [replica-restore-service-0] ReplicaCreationService - Restoring replica with ID bar
[INFO ] 2022-12-06 16:03:46.941 [kaldb-metadata-store-pool-0] ZookeeperMetadataStoreImpl - Creating a node at /replica/bar-d3ea4efd-46fd-4546-afc6-eac8f2ef8cef with data {
  "name": "bar-d3ea4efd-46fd-4546-afc6-eac8f2ef8cef",
  "snapshotId": "bar",
  "createdTimeEpochMs": "1670367826940",
  "expireAfterEpochMs": "1670371426940",
  "isRestored": true,
  "indexType": "LOGS_LUCENE9"
}.
[INFO ] 2022-12-06 16:03:46.962 [replica-restore-service-0] ReplicaCreationService - Restoring replica with ID foo
[INFO ] 2022-12-06 16:03:46.963 [kaldb-metadata-store-pool-0] ZookeeperMetadataStoreImpl - Creating a node at /replica/foo-68d886a1-85b8-479d-9e93-f5ce573bc1ee with data {
  "name": "foo-68d886a1-85b8-479d-9e93-f5ce573bc1ee",
  "snapshotId": "foo",
  "createdTimeEpochMs": "1670367826962",
  "expireAfterEpochMs": "1670371426962",
  "isRestored": true,
  "indexType": "LOGS_LUCENE9"
}.
[DEBUG] 2022-12-06 16:03:46.963 [zk-metadata-runsafe-0] ZookeeperCachedMetadataStoreImpl - Notified 1 listeners on node change at /replica/
[INFO ] 2022-12-06 16:03:46.982 [replica-restore-service-0] ReplicaCreationService - Restored 2 snapshots.
[DEBUG] 2022-12-06 16:03:46.983 [zk-metadata-runsafe-0] ZookeeperCachedMetadataStoreImpl - Notified 1 listeners on node change at /replica/
[INFO ] 2022-12-06 16:03:47.038 [SessionTracker] SessionTrackerImpl - SessionTrackerImpl exited loop!
[INFO ] 2022-12-06 16:03:47.038 [SessionTracker] SessionTrackerImpl - SessionTrackerImpl exited loop!
[INFO ] 2022-12-06 16:03:56.954 [main] ZookeeperCachedMetadataStoreImpl - Closing cache for path: /service/
[INFO ] 2022-12-06 16:03:56.954 [main] ZookeeperMetadataStoreImpl - Shutting down metadata executor service
[INFO ] 2022-12-06 16:03:56.954 [main] ZookeeperMetadataStoreImpl - Shutting down metadata runsafe service
[INFO ] 2022-12-06 16:03:56.954 [main] ZookeeperMetadataStoreImpl - Closing curator connection.
[INFO ] 2022-12-06 16:03:56.954 [Curator-Framework-0] CuratorFrameworkImpl - backgroundOperationsLoop exiting
[INFO ] 2022-12-06 16:03:57.079 [main-EventThread] ClientCnxn - EventThread shut down for session: 0x10000e31f6c0000
[INFO ] 2022-12-06 16:03:57.079 [main] ZooKeeper - Session: 0x10000e31f6c0000 closed
[INFO ] 2022-12-06 16:03:57.079 [main] ZookeeperMetadataStoreImpl - Closed curator connection successfully.
[INFO ] 2022-12-06 16:03:57.080 [ConnnectionExpirer] NIOServerCnxnFactory - ConnnectionExpirerThread interrupted
[INFO ] 2022-12-06 16:03:57.080 [NIOServerCxnFactory.SelectorThread-1] NIOServerCnxnFactory - selector thread exitted run method
[INFO ] 2022-12-06 16:03:57.080 [NIOServerCxnFactory.SelectorThread-0] NIOServerCnxnFactory - selector thread exitted run method
[INFO ] 2022-12-06 16:03:57.081 [NIOServerCxnFactory.AcceptThread:0.0.0.0/0.0.0.0:59009] NIOServerCnxnFactory - accept thread exitted run method
[INFO ] 2022-12-06 16:03:57.082 [Thread-982] ZooKeeperServer - shutting down
[INFO ] 2022-12-06 16:03:57.082 [Thread-982] RequestThrottler - Shutting down
[INFO ] 2022-12-06 16:03:57.082 [RequestThrottler] RequestThrottler - Draining request throttler queue
[INFO ] 2022-12-06 16:03:57.082 [RequestThrottler] RequestThrottler - RequestThrottler shutdown. Dropped 0 requests
[INFO ] 2022-12-06 16:03:57.082 [Thread-982] SessionTrackerImpl - Shutting down
[INFO ] 2022-12-06 16:03:57.082 [Thread-982] PrepRequestProcessor - Shutting down
[INFO ] 2022-12-06 16:03:57.082 [Thread-982] SyncRequestProcessor - Shutting down
[INFO ] 2022-12-06 16:03:57.082 [ProcessThread(sid:0 cport:59009):] PrepRequestProcessor - PrepRequestProcessor exited loop!
[INFO ] 2022-12-06 16:03:57.082 [SyncThread:0] SyncRequestProcessor - SyncRequestProcessor exited!
[INFO ] 2022-12-06 16:03:57.083 [Thread-982] FinalRequestProcessor - shutdown of request processor complete

org.awaitility.core.ConditionTimeoutException: Condition with lambda expression in com.slack.kaldb.server.ManagerApiGrpcTest was not fulfilled within 10 seconds.

	at org.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:167)
	at org.awaitility.core.CallableCondition.await(CallableCondition.java:78)
	at org.awaitility.core.CallableCondition.await(CallableCondition.java:26)
	at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:985)
	at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:954)
	at com.slack.kaldb.server.ManagerApiGrpcTest.shouldRestoreGivenSnapshotIds(ManagerApiGrpcTest.java:747)
	at jdk.internal.reflect.GeneratedMethodAccessor100.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at io.grpc.testing.GrpcCleanupRule$1.evaluate(GrpcCleanupRule.java:154)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:235)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:54)
```
</details>