### PR TITLE
Add more options to provide KafkaConfig parameters

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -16,15 +16,14 @@ indexerConfig:
     serverPort: ${KALDB_INDEX_SERVER_PORT:-8080}
     serverAddress: ${KALDB_INDEX_SERVER_ADDRESS:-localhost}
     requestTimeoutMs: ${KALDB_INDEX_REQUEST_TIMEOUT_MS:-5000}
-
-kafkaConfig:
-  kafkaTopic: ${KAFKA_TOPIC:-test-topic}
-  kafkaTopicPartition: ${KAFKA_TOPIC_PARTITION:-0}
-  kafkaBootStrapServers: ${KAFKA_BOOTSTRAP_SERVERS:-localhost:9092}
-  kafkaClientGroup: ${KAFKA_CLIENT_GROUP:-kaldb-test}
-  enableKafkaAutoCommit: ${KAFKA_AUTO_COMMIT:-true}
-  kafkaAutoCommitInterval: ${KAFKA_AUTO_COMMIT_INTERVAL:-5000}
-  kafkaSessionTimeout: ${KAFKA_SESSION_TIMEOUT:-30000}
+  kafkaConfig:
+    kafkaTopic: ${KAFKA_TOPIC:-test-topic}
+    kafkaTopicPartition: ${KAFKA_TOPIC_PARTITION:-0}
+    kafkaBootStrapServers: ${KAFKA_BOOTSTRAP_SERVERS:-localhost:9092}
+    kafkaClientGroup: ${KAFKA_CLIENT_GROUP:-kaldb-test}
+    enableKafkaAutoCommit: ${KAFKA_AUTO_COMMIT:-true}
+    kafkaAutoCommitInterval: ${KAFKA_AUTO_COMMIT_INTERVAL:-5000}
+    kafkaSessionTimeout: ${KAFKA_SESSION_TIMEOUT:-30000}
 
 s3Config:
   s3AccessKey: ${S3_ACCESS_KEY:-access}
@@ -100,6 +99,14 @@ recoveryConfig:
     serverPort: ${KALDB_RECOVERY_SERVER_PORT:-8085}
     serverAddress: ${KALDB_RECOVERY_SERVER_ADDRESS:-localhost}
     requestTimeoutMs: ${KALDB_RECOVERY_REQUEST_TIMEOUT_MS:-5000}
+  kafkaConfig:
+    kafkaTopic: ${KAFKA_TOPIC:-test-topic}
+    kafkaTopicPartition: ${KAFKA_TOPIC_PARTITION:-0}
+    kafkaBootStrapServers: ${KAFKA_BOOTSTRAP_SERVERS:-localhost:9092}
+    kafkaClientGroup: ${KAFKA_CLIENT_GROUP:-kaldb-test}
+    enableKafkaAutoCommit: ${KAFKA_AUTO_COMMIT:-true}
+    kafkaAutoCommitInterval: ${KAFKA_AUTO_COMMIT_INTERVAL:-5000}
+    kafkaSessionTimeout: ${KAFKA_SESSION_TIMEOUT:-30000}
 
 preprocessorConfig:
   kafkaStreamConfig:

--- a/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
@@ -285,7 +285,7 @@ public class RecoveryService extends AbstractIdleService {
         LogMessageWriterImpl logMessageWriterImpl =
             new LogMessageWriterImpl(chunkManager, messageTransformer);
         KaldbKafkaConsumer kafkaConsumer =
-            KaldbKafkaConsumer.fromConfig(
+            new KaldbKafkaConsumer(
                 makeKafkaConfig(
                     kaldbConfig.getRecoveryConfig().getKafkaConfig(),
                     validatedRecoveryTask.partitionId),

--- a/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
@@ -103,7 +103,7 @@ public class RecoveryService extends AbstractIdleService {
         AdminClient.create(
             Map.of(
                 AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG,
-                kaldbConfig.getKafkaConfig().getKafkaBootStrapServers(),
+                kaldbConfig.getIndexerConfig().getKafkaConfig().getKafkaBootStrapServers(),
                 AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG,
                 "5000"));
 
@@ -248,7 +248,7 @@ public class RecoveryService extends AbstractIdleService {
 
     PartitionOffsets partitionOffsets =
         validateKafkaOffsets(
-            adminClient, recoveryTaskMetadata, kaldbConfig.getKafkaConfig().getKafkaTopic());
+            adminClient, recoveryTaskMetadata, kaldbConfig.getRecoveryConfig().getKafkaConfig().getKafkaTopic());
     long offsetsValidatedTime = System.nanoTime();
     long consumerPreparedTime = 0, messagesConsumedTime = 0, rolloversCompletedTime = 0;
 
@@ -284,7 +284,9 @@ public class RecoveryService extends AbstractIdleService {
             new LogMessageWriterImpl(chunkManager, messageTransformer);
         KaldbKafkaConsumer kafkaConsumer =
             KaldbKafkaConsumer.fromConfig(
-                makeKafkaConfig(kaldbConfig.getKafkaConfig(), validatedRecoveryTask.partitionId),
+                makeKafkaConfig(
+                    kaldbConfig.getIndexerConfig().getKafkaConfig(),
+                    validatedRecoveryTask.partitionId),
                 logMessageWriterImpl,
                 meterRegistry);
 

--- a/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
@@ -103,7 +103,7 @@ public class RecoveryService extends AbstractIdleService {
         AdminClient.create(
             Map.of(
                 AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG,
-                kaldbConfig.getIndexerConfig().getKafkaConfig().getKafkaBootStrapServers(),
+                kaldbConfig.getRecoveryConfig().getKafkaConfig().getKafkaBootStrapServers(),
                 AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG,
                 "5000"));
 

--- a/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
@@ -248,7 +248,9 @@ public class RecoveryService extends AbstractIdleService {
 
     PartitionOffsets partitionOffsets =
         validateKafkaOffsets(
-            adminClient, recoveryTaskMetadata, kaldbConfig.getRecoveryConfig().getKafkaConfig().getKafkaTopic());
+            adminClient,
+            recoveryTaskMetadata,
+            kaldbConfig.getRecoveryConfig().getKafkaConfig().getKafkaTopic());
     long offsetsValidatedTime = System.nanoTime();
     long consumerPreparedTime = 0, messagesConsumedTime = 0, rolloversCompletedTime = 0;
 

--- a/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
@@ -285,7 +285,7 @@ public class RecoveryService extends AbstractIdleService {
         KaldbKafkaConsumer kafkaConsumer =
             KaldbKafkaConsumer.fromConfig(
                 makeKafkaConfig(
-                    kaldbConfig.getIndexerConfig().getKafkaConfig(),
+                    kaldbConfig.getRecoveryConfig().getKafkaConfig(),
                     validatedRecoveryTask.partitionId),
                 logMessageWriterImpl,
                 meterRegistry);

--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -171,7 +171,7 @@ public class Kaldb {
               chunkManager,
               metadataStore,
               kaldbConfig.getIndexerConfig(),
-              kaldbConfig.getKafkaConfig(),
+              kaldbConfig.getIndexerConfig().getKafkaConfig(),
               meterRegistry);
       services.add(indexer);
 

--- a/kaldb/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
@@ -71,8 +71,7 @@ public class KaldbIndexer extends AbstractExecutionThreadService {
         INDEXER_DATA_TRANSFORMER_MAP.get(indexerConfig.getDataTransformer());
     LogMessageWriterImpl logMessageWriterImpl =
         new LogMessageWriterImpl(chunkManager, messageTransformer);
-    this.kafkaConsumer =
-        KaldbKafkaConsumer.fromConfig(kafkaConfig, logMessageWriterImpl, meterRegistry);
+    this.kafkaConsumer = new KaldbKafkaConsumer(kafkaConfig, logMessageWriterImpl, meterRegistry);
   }
 
   @Override

--- a/kaldb/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
@@ -49,13 +49,6 @@ public class KaldbKafkaConsumer {
           ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
           ConsumerConfig.AUTO_OFFSET_RESET_CONFIG);
 
-  public static KaldbKafkaConsumer fromConfig(
-      KaldbConfigs.KafkaConfig kafkaCfg,
-      LogMessageWriterImpl logMessageWriter,
-      MeterRegistry meterRegistry) {
-    return new KaldbKafkaConsumer(kafkaCfg, logMessageWriter, meterRegistry);
-  }
-
   @VisibleForTesting
   public static Properties makeKafkaConsumerProps(KaldbConfigs.KafkaConfig kafkaConfig) {
 

--- a/kaldb/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
@@ -43,16 +43,7 @@ public class KaldbKafkaConsumer {
       KaldbConfigs.KafkaConfig kafkaCfg,
       LogMessageWriterImpl logMessageWriter,
       MeterRegistry meterRegistry) {
-    return new KaldbKafkaConsumer(
-        kafkaCfg.getKafkaTopic(),
-        kafkaCfg.getKafkaTopicPartition(),
-        kafkaCfg.getKafkaBootStrapServers(),
-        kafkaCfg.getKafkaClientGroup(),
-        kafkaCfg.getEnableKafkaAutoCommit(),
-        kafkaCfg.getKafkaAutoCommitInterval(),
-        kafkaCfg.getKafkaSessionTimeout(),
-        logMessageWriter,
-        meterRegistry);
+    return new KaldbKafkaConsumer(kafkaCfg, logMessageWriter, meterRegistry);
   }
 
   private static Properties makeKafkaConsumerProps(
@@ -99,13 +90,7 @@ public class KaldbKafkaConsumer {
   private final Counter recordsFailedCounter;
 
   public KaldbKafkaConsumer(
-      String kafkaTopic,
-      String kafkaTopicPartitionStr,
-      String kafkaBootStrapServers,
-      String kafkaClientGroup,
-      String enableKafkaAutoCommit,
-      String kafkaAutoCommitInterval,
-      String kafkaSessionTimeout,
+      KaldbConfigs.KafkaConfig kafkaConfig,
       LogMessageWriterImpl logMessageWriterImpl,
       MeterRegistry meterRegistry) {
     this(
@@ -133,6 +118,14 @@ public class KaldbKafkaConsumer {
       LogMessageWriterImpl logMessageWriterImpl,
       MeterRegistry meterRegistry,
       Properties overrideProps) {
+
+    String kafkaTopic = kafkaConfig.getKafkaTopic();
+    String kafkaTopicPartitionStr = kafkaConfig.getKafkaTopicPartition();
+    String kafkaBootStrapServers = kafkaConfig.getKafkaBootStrapServers();
+    String kafkaClientGroup = kafkaConfig.getKafkaClientGroup();
+    String enableKafkaAutoCommit = kafkaConfig.getEnableKafkaAutoCommit();
+    String kafkaAutoCommitInterval = kafkaConfig.getKafkaAutoCommitInterval();
+    String kafkaSessionTimeout = kafkaConfig.getKafkaSessionTimeout();
 
     checkArgument(
         kafkaTopic != null && !kafkaTopic.isEmpty(), "Kafka topic can't be null or " + "empty");

--- a/kaldb/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
@@ -1,6 +1,6 @@
 package com.slack.kaldb.writer.kafka;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.slack.kaldb.util.TimeUtils.nanosToMillis;
 import static java.lang.Integer.parseInt;
 
@@ -103,6 +103,11 @@ public class KaldbKafkaConsumer {
                 key, userValue, value));
         props.setProperty(key, value);
         overridden = true;
+      } else {
+        LOG.warn(
+            String.format(
+                "Property %s is provided but won't be overridden from %s to %s",
+                key, userValue, value));
       }
     } else {
       props.setProperty(key, value);

--- a/kaldb/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
@@ -148,7 +148,7 @@ public class KaldbKafkaConsumer {
     for (String property : props.stringPropertyNames()) {
       Preconditions.checkArgument(
           props.getProperty(property) != null && !props.getProperty(property).isEmpty(),
-          String.format("Property %s cannot be null", property));
+          String.format("Property %s cannot be null or empty", property));
     }
 
     // Check required configs.

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -192,6 +192,7 @@ message ManagerConfig {
 // Config for the recovery node.
 message RecoveryConfig {
   ServerConfig server_config = 1;
+  KafkaConfig kafka_config = 10;
 }
 
 // Config for the preprocessor node.

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -18,7 +18,6 @@ enum NodeRole {
 // KaldbConfig is the uber config object for all of Kaldb.
 // This config object controls the role a node plays and it's config.
 message KaldbConfig {
-  KafkaConfig kafka_config = 1;
   S3Config s3_config = 2;
   IndexerConfig indexer_config = 3;
   QueryServiceConfig query_config = 4;
@@ -40,8 +39,6 @@ message ClusterConfig {
   string env = 2;
 }
 
-// todo - move this to a nested IndexerConfig message, and refactor as KafkaConsumerConfig
-// todo - this is only ever used by the indexer and should have reduced visibility
 // Configuration for Kafka consumer.
 message KafkaConfig {
   string kafka_topic = 1;
@@ -108,6 +105,8 @@ message IndexerConfig {
   // before it needs to create a recovery task to catch up.
   int64 max_offset_delay_messages = 8;
   int32 default_query_timeout_ms = 9;
+
+  KafkaConfig kafka_config = 10;
 }
 
 // A config object containing all the lucene configs.

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -48,6 +48,7 @@ message KafkaConfig {
   string enable_kafka_auto_commit = 5;
   string kafka_auto_commit_interval = 6;
   string kafka_session_timeout = 7;
+  map<string, string> additional_props = 8;
 }
 
 message MetadataStoreConfig {

--- a/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 
 import brave.Tracing;
 import com.adobe.testing.s3mock.junit4.S3MockRule;
+import com.google.common.collect.Maps;
 import com.slack.kaldb.blobfs.BlobFs;
 import com.slack.kaldb.blobfs.s3.S3BlobFs;
 import com.slack.kaldb.logstore.BlobFsUtils;
@@ -188,18 +189,20 @@ public class RecoveryServiceTest {
         ZookeeperMetadataStoreImpl.fromConfig(
             components.meterRegistry, kaldbCfg.getMetadataStoreConfig().getZookeeperConfig());
 
+    KaldbConfigs.KafkaConfig kafkaConfig =
+        KaldbConfigs.KafkaConfig.newBuilder()
+            .setKafkaTopic(topicPartition.topic())
+            .setKafkaTopicPartition(Integer.toString(topicPartition.partition()))
+            .setKafkaBootStrapServers(components.testKafkaServer.getBroker().getBrokerList().get())
+            .setKafkaClientGroup(TEST_KAFKA_CLIENT_GROUP)
+            .setEnableKafkaAutoCommit("true")
+            .setKafkaAutoCommitInterval("500")
+            .setKafkaSessionTimeout("500")
+            .putAllAdditionalProps(Maps.fromProperties(components.consumerOverrideProps))
+            .build();
+
     final KaldbKafkaConsumer localTestConsumer =
-        new KaldbKafkaConsumer(
-            topicPartition.topic(),
-            Integer.toString(topicPartition.partition()),
-            components.testKafkaServer.getBroker().getBrokerList().get(),
-            TEST_KAFKA_CLIENT_GROUP,
-            "true",
-            "500",
-            "500",
-            components.logMessageWriter,
-            components.meterRegistry,
-            components.consumerOverrideProps);
+        new KaldbKafkaConsumer(kafkaConfig, components.logMessageWriter, components.meterRegistry);
     final Instant startTime =
         LocalDateTime.of(2020, 10, 1, 10, 10, 0).atZone(ZoneOffset.UTC).toInstant();
     final long msgsToProduce = 100;
@@ -267,18 +270,20 @@ public class RecoveryServiceTest {
         ZookeeperMetadataStoreImpl.fromConfig(
             components.meterRegistry, kaldbCfg.getMetadataStoreConfig().getZookeeperConfig());
 
+    KaldbConfigs.KafkaConfig kafkaConfig =
+        KaldbConfigs.KafkaConfig.newBuilder()
+            .setKafkaTopic(topicPartition.topic())
+            .setKafkaTopicPartition(Integer.toString(topicPartition.partition()))
+            .setKafkaBootStrapServers(components.testKafkaServer.getBroker().getBrokerList().get())
+            .setKafkaClientGroup(TEST_KAFKA_CLIENT_GROUP)
+            .setEnableKafkaAutoCommit("true")
+            .setKafkaAutoCommitInterval("500")
+            .setKafkaSessionTimeout("500")
+            .putAllAdditionalProps(Maps.fromProperties(components.consumerOverrideProps))
+            .build();
+
     final KaldbKafkaConsumer localTestConsumer =
-        new KaldbKafkaConsumer(
-            topicPartition.topic(),
-            Integer.toString(topicPartition.partition()),
-            components.testKafkaServer.getBroker().getBrokerList().get(),
-            TEST_KAFKA_CLIENT_GROUP,
-            "true",
-            "500",
-            "500",
-            components.logMessageWriter,
-            components.meterRegistry,
-            components.consumerOverrideProps);
+        new KaldbKafkaConsumer(kafkaConfig, components.logMessageWriter, components.meterRegistry);
     final Instant startTime =
         LocalDateTime.of(2020, 10, 1, 10, 10, 0).atZone(ZoneOffset.UTC).toInstant();
     final long msgsToProduce = 100;

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
@@ -182,6 +182,9 @@ public class KaldbConfigTest {
     assertThat(kafkaCfg.getKafkaAutoCommitInterval()).isEqualTo("5000");
     assertThat(kafkaCfg.getKafkaSessionTimeout()).isEqualTo("30000");
 
+    assertThat(kafkaCfg.getAdditionalProps().size()).isGreaterThan(0);
+    assertThat(kafkaCfg.getAdditionalPropsMap().get("fetch.max.bytes")).isEqualTo("100");
+
     final KaldbConfigs.S3Config s3Config = config.getS3Config();
     assertThat(s3Config.getS3AccessKey()).isEqualTo("access");
     assertThat(s3Config.getS3SecretKey()).isEqualTo("secret");
@@ -327,6 +330,9 @@ public class KaldbConfigTest {
     assertThat(kafkaCfg.getEnableKafkaAutoCommit()).isEqualTo("true");
     assertThat(kafkaCfg.getKafkaAutoCommitInterval()).isEqualTo("5000");
     assertThat(kafkaCfg.getKafkaSessionTimeout()).isEqualTo("30000");
+
+    assertThat(kafkaCfg.getAdditionalPropsMap().size()).isGreaterThan(0);
+    assertThat(kafkaCfg.getAdditionalPropsMap().get("fetch.max.bytes")).isEqualTo("100");
 
     final KaldbConfigs.S3Config s3Config = config.getS3Config();
     assertThat(s3Config.getS3AccessKey()).isEqualTo("access");

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
@@ -78,7 +78,7 @@ public class KaldbConfigTest {
 
     final KaldbConfigs.KaldbConfig kalDbConfig = KaldbConfig.fromJsonConfig(missingRequiredField);
 
-    final KaldbConfigs.KafkaConfig kafkaCfg = kalDbConfig.getKafkaConfig();
+    final KaldbConfigs.KafkaConfig kafkaCfg = kalDbConfig.getIndexerConfig().getKafkaConfig();
     assertThat(kafkaCfg.getKafkaTopicPartition()).isEqualTo("1");
     assertThat(kafkaCfg.getKafkaSessionTimeout()).isEqualTo("30000");
   }
@@ -139,7 +139,7 @@ public class KaldbConfigTest {
 
     final KaldbConfigs.KaldbConfig kalDbConfig = KaldbConfig.fromJsonConfig(configWithExtraField);
 
-    final KaldbConfigs.KafkaConfig kafkaCfg = kalDbConfig.getKafkaConfig();
+    final KaldbConfigs.KafkaConfig kafkaCfg = kalDbConfig.getIndexerConfig().getKafkaConfig();
     assertThat(kafkaCfg.getKafkaTopicPartition()).isEqualTo("1");
     assertThat(kafkaCfg.getKafkaSessionTimeout()).isEqualTo("30000");
     assertThat(kafkaCfg.getKafkaTopic()).isEmpty();
@@ -171,7 +171,7 @@ public class KaldbConfigTest {
     assertThat(config.getNodeRolesList().get(2)).isEqualTo(KaldbConfigs.NodeRole.CACHE);
     assertThat(config.getNodeRolesList().get(3)).isEqualTo(KaldbConfigs.NodeRole.MANAGER);
 
-    final KaldbConfigs.KafkaConfig kafkaCfg = config.getKafkaConfig();
+    final KaldbConfigs.KafkaConfig kafkaCfg = config.getIndexerConfig().getKafkaConfig();
     assertThat(kafkaCfg.getKafkaTopic()).isEqualTo("testTopic");
     assertThat(kafkaCfg.getKafkaTopicPartition()).isEqualTo("1");
     assertThat(kafkaCfg.getKafkaBootStrapServers()).isEqualTo("kafka.us-east-1.consul:9094");
@@ -311,7 +311,7 @@ public class KaldbConfigTest {
     assertThat(config.getNodeRolesList().get(2)).isEqualTo(KaldbConfigs.NodeRole.CACHE);
     assertThat(config.getNodeRolesList().get(3)).isEqualTo(KaldbConfigs.NodeRole.MANAGER);
 
-    final KaldbConfigs.KafkaConfig kafkaCfg = config.getKafkaConfig();
+    final KaldbConfigs.KafkaConfig kafkaCfg = config.getIndexerConfig().getKafkaConfig();
 
     // todo - for testing env var substitution we could use something like Mockito (or similar) in
     // the future
@@ -475,7 +475,7 @@ public class KaldbConfigTest {
 
     assertThat(config.getNodeRolesList().size()).isEqualTo(1);
 
-    final KaldbConfigs.KafkaConfig kafkaCfg = config.getKafkaConfig();
+    final KaldbConfigs.KafkaConfig kafkaCfg = config.getIndexerConfig().getKafkaConfig();
     assertThat(kafkaCfg.getKafkaTopicPartition()).isEmpty();
     assertThat(kafkaCfg.getKafkaBootStrapServers()).isEmpty();
     assertThat(kafkaCfg.getKafkaClientGroup()).isEmpty();
@@ -613,7 +613,7 @@ public class KaldbConfigTest {
 
     assertThat(config.getNodeRolesList().size()).isEqualTo(1);
 
-    final KaldbConfigs.KafkaConfig kafkaCfg = config.getKafkaConfig();
+    final KaldbConfigs.KafkaConfig kafkaCfg = config.getIndexerConfig().getKafkaConfig();
     assertThat(kafkaCfg.getKafkaTopicPartition()).isEmpty();
     assertThat(kafkaCfg.getKafkaBootStrapServers()).isEmpty();
     assertThat(kafkaCfg.getKafkaClientGroup()).isEmpty();

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
@@ -69,10 +69,11 @@ public class KaldbConfigTest {
             .set("serverConfig", serverConfig);
     ObjectNode kafkaConfig =
         mapper.createObjectNode().put("kafkaTopicPartition", 1).put("kafkaSessionTimeout", 30000);
+    indexerConfig.set("kafkaConfig", kafkaConfig);
+
     ObjectNode node = mapper.createObjectNode();
     node.set("nodeRoles", mapper.createArrayNode().add("INDEX"));
     node.set("indexerConfig", indexerConfig);
-    node.set("kafkaConfig", kafkaConfig);
     final String missingRequiredField =
         mapper.writerWithDefaultPrettyPrinter().writeValueAsString(node);
 
@@ -113,6 +114,12 @@ public class KaldbConfigTest {
   public void testIgnoreExtraConfigField() throws IOException {
     ObjectMapper mapper = new ObjectMapper();
     ObjectNode serverConfig = mapper.createObjectNode().put("requestTimeoutMs", 3000);
+    ObjectNode kafkaConfig =
+        mapper
+            .createObjectNode()
+            .put("kafkaTopicPartition", 1)
+            .put("kafkaSessionTimeout", 30000)
+            .put("ignoreExtraField", "ignoredField");
     ObjectNode indexerConfig =
         mapper
             .createObjectNode()
@@ -123,16 +130,11 @@ public class KaldbConfigTest {
             .put("defaultQueryTimeoutMs", "2500")
             .put("dataTransformer", "api_log")
             .set("serverConfig", serverConfig);
-    ObjectNode kafkaConfig =
-        mapper
-            .createObjectNode()
-            .put("kafkaTopicPartition", 1)
-            .put("kafkaSessionTimeout", 30000)
-            .put("ignoreExtraField", "ignoredField");
+    indexerConfig.set("kafkaConfig", kafkaConfig);
+
     ObjectNode node = mapper.createObjectNode();
     node.set("nodeRoles", mapper.createArrayNode().add("INDEX"));
     node.set("indexerConfig", indexerConfig);
-    node.set("kafkaConfig", kafkaConfig);
 
     final String configWithExtraField =
         mapper.writerWithDefaultPrettyPrinter().writeValueAsString(node);

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/KaldbConfigUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/KaldbConfigUtil.java
@@ -58,6 +58,7 @@ public class KaldbConfigUtil {
             .setDataTransformer(dataTransformerConfig)
             .setMaxOffsetDelayMessages(maxOffsetDelay)
             .setDefaultQueryTimeoutMs(2500)
+            .setKafkaConfig(kafkaConfig)
             .build();
 
     KaldbConfigs.ZookeeperConfig zkConfig =
@@ -93,7 +94,6 @@ public class KaldbConfigUtil {
             .build();
 
     return KaldbConfigs.KaldbConfig.newBuilder()
-        .setKafkaConfig(kafkaConfig)
         .setS3Config(s3Config)
         .setIndexerConfig(indexerConfig)
         .setRecoveryConfig(recoveryConfig)

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/KaldbConfigUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/KaldbConfigUtil.java
@@ -91,6 +91,7 @@ public class KaldbConfigUtil {
                     .setServerAddress("localhost")
                     .setRequestTimeoutMs(5000)
                     .build())
+            .setKafkaConfig(kafkaConfig)
             .build();
 
     return KaldbConfigs.KaldbConfig.newBuilder()

--- a/kaldb/src/test/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.spy;
 import com.adobe.testing.s3mock.junit4.S3MockRule;
 import com.github.charithe.kafka.EphemeralKafkaBroker;
 import com.slack.kaldb.logstore.LogMessage;
+import com.slack.kaldb.proto.config.KaldbConfigs;
 import com.slack.kaldb.testlib.ChunkManagerUtil;
 import com.slack.kaldb.testlib.KaldbConfigUtil;
 import com.slack.kaldb.testlib.TestKafkaServer;
@@ -89,17 +90,18 @@ public class KaldbKafkaConsumerTest {
       LogMessageWriterImpl logMessageWriter =
           new LogMessageWriterImpl(
               chunkManagerUtil.chunkManager, LogMessageWriterImpl.apiLogTransformer);
-      testConsumer =
-          new KaldbKafkaConsumer(
-              TestKafkaServer.TEST_KAFKA_TOPIC,
-              "0",
-              kafkaServer.getBroker().getBrokerList().get(),
-              TEST_KAFKA_CLIENT_GROUP,
-              "true",
-              "5000",
-              "5000",
-              logMessageWriter,
-              metricsRegistry);
+      KaldbConfigs.KafkaConfig kafkaConfig =
+          KaldbConfigs.KafkaConfig.newBuilder()
+              .setKafkaTopic(TestKafkaServer.TEST_KAFKA_TOPIC)
+              .setKafkaTopicPartition("0")
+              .setKafkaBootStrapServers(kafkaServer.getBroker().getBrokerList().get())
+              .setKafkaClientGroup(TEST_KAFKA_CLIENT_GROUP)
+              .setEnableKafkaAutoCommit("true")
+              .setKafkaAutoCommitInterval("5000")
+              .setKafkaSessionTimeout("5000")
+              .build();
+
+      testConsumer = new KaldbKafkaConsumer(kafkaConfig, logMessageWriter, metricsRegistry);
     }
 
     @After
@@ -385,17 +387,18 @@ public class KaldbKafkaConsumerTest {
 
       TestKafkaServer.produceMessagesToKafka(broker, startTime);
 
-      testConsumer =
-          new KaldbKafkaConsumer(
-              TestKafkaServer.TEST_KAFKA_TOPIC,
-              "0",
-              kafkaServer.getBroker().getBrokerList().get(),
-              TEST_KAFKA_CLIENT_GROUP,
-              "true",
-              "5000",
-              "5000",
-              logMessageWriter,
-              metricsRegistry);
+      KaldbConfigs.KafkaConfig kafkaConfig =
+          KaldbConfigs.KafkaConfig.newBuilder()
+              .setKafkaTopic(TestKafkaServer.TEST_KAFKA_TOPIC)
+              .setKafkaTopicPartition("0")
+              .setKafkaBootStrapServers(kafkaServer.getBroker().getBrokerList().get())
+              .setKafkaClientGroup(TEST_KAFKA_CLIENT_GROUP)
+              .setEnableKafkaAutoCommit("true")
+              .setKafkaAutoCommitInterval("5000")
+              .setKafkaSessionTimeout("5000")
+              .build();
+
+      testConsumer = new KaldbKafkaConsumer(kafkaConfig, logMessageWriter, metricsRegistry);
       KafkaConsumer<String, byte[]> spyConsumer = spy(testConsumer.getKafkaConsumer());
       testConsumer.setKafkaConsumer(spyConsumer);
       await().until(() -> testConsumer.getEndOffSetForPartition() == 100);

--- a/kaldb/src/test/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumerTest.java
@@ -42,8 +42,6 @@ import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.ListOffsetsResult;
 import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import java.util.Properties;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
 import org.apache.kafka.common.TopicPartition;

--- a/kaldb/src/test/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumerTest.java
@@ -42,6 +42,8 @@ import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.ListOffsetsResult;
 import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import java.util.Properties;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
 import org.apache.kafka.common.TopicPartition;
@@ -110,6 +112,40 @@ public class KaldbKafkaConsumerTest {
       testConsumer.close();
       kafkaServer.close();
       metricsRegistry.close();
+    }
+
+    @Test
+    public void testOverridingProperties() {
+      KaldbConfigs.KafkaConfig kafkaConfig =
+          KaldbConfigs.KafkaConfig.newBuilder()
+              .setKafkaTopic(TestKafkaServer.TEST_KAFKA_TOPIC)
+              .setKafkaTopicPartition("0")
+              .setKafkaBootStrapServers("bootstrap_server")
+              .setKafkaClientGroup(TEST_KAFKA_CLIENT_GROUP)
+              .setEnableKafkaAutoCommit("true")
+              .setKafkaAutoCommitInterval("5000")
+              .setKafkaSessionTimeout("5000")
+              .build();
+
+      Properties properties = KaldbKafkaConsumer.makeKafkaConsumerProps(kafkaConfig);
+      assertThat(properties.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG))
+          .isEqualTo("org.apache.kafka.common.serialization.StringDeserializer");
+
+      kafkaConfig =
+          KaldbConfigs.KafkaConfig.newBuilder()
+              .setKafkaTopic(TestKafkaServer.TEST_KAFKA_TOPIC)
+              .setKafkaTopicPartition("0")
+              .setKafkaBootStrapServers("bootstrap_server")
+              .setKafkaClientGroup(TEST_KAFKA_CLIENT_GROUP)
+              .setEnableKafkaAutoCommit("true")
+              .setKafkaAutoCommitInterval("5000")
+              .setKafkaSessionTimeout("5000")
+              .putAdditionalProps(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "test_serializer")
+              .build();
+
+      properties = KaldbKafkaConsumer.makeKafkaConsumerProps(kafkaConfig);
+      assertThat(properties.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG))
+          .isEqualTo("test_serializer");
     }
 
     @Test

--- a/kaldb/src/test/resources/test_config.json
+++ b/kaldb/src/test/resources/test_config.json
@@ -5,15 +5,6 @@
     "CACHE",
     "MANAGER"
   ],
-  "kafkaConfig": {
-    "kafkaTopic": "testTopic",
-    "kafkaTopicPartition": "1",
-    "kafkaBootStrapServers": "kafka.us-east-1.consul:9094",
-    "kafkaClientGroup": "kaldb-test",
-    "enableKafkaAutoCommit": "true",
-    "kafkaAutoCommitInterval": "5000",
-    "kafkaSessionTimeout": "30000"
-  },
   "s3Config": {
     "s3AccessKey": "access",
     "s3SecretKey": "secret",
@@ -43,6 +34,15 @@
       "serverPort": 8080,
       "serverAddress": "localhost",
       "requestTimeoutMs": 3000
+    },
+    "kafkaConfig": {
+      "kafkaTopic": "testTopic",
+      "kafkaTopicPartition": "1",
+      "kafkaBootStrapServers": "kafka.us-east-1.consul:9094",
+      "kafkaClientGroup": "kaldb-test",
+      "enableKafkaAutoCommit": "true",
+      "kafkaAutoCommitInterval": "5000",
+      "kafkaSessionTimeout": "30000"
     },
     "defaultQueryTimeoutMs": 1500
   },
@@ -114,6 +114,15 @@
       "serverPort": 8084,
       "serverAddress": "localhost",
       "requestTimeoutMs": 3000
+    },
+    "kafkaConfig": {
+      "kafkaTopic": "testTopic",
+      "kafkaTopicPartition": "1",
+      "kafkaBootStrapServers": "kafka.us-east-1.consul:9094",
+      "kafkaClientGroup": "kaldb-test",
+      "enableKafkaAutoCommit": "true",
+      "kafkaAutoCommitInterval": "5000",
+      "kafkaSessionTimeout": "30000"
     }
   },
   "preprocessorConfig": {

--- a/kaldb/src/test/resources/test_config.json
+++ b/kaldb/src/test/resources/test_config.json
@@ -42,7 +42,10 @@
       "kafkaClientGroup": "kaldb-test",
       "enableKafkaAutoCommit": "true",
       "kafkaAutoCommitInterval": "5000",
-      "kafkaSessionTimeout": "30000"
+      "kafkaSessionTimeout": "30000",
+      "additionalProps": {
+        "fetch.max.bytes": "100"
+      }
     },
     "defaultQueryTimeoutMs": 1500
   },

--- a/kaldb/src/test/resources/test_config.yaml
+++ b/kaldb/src/test/resources/test_config.yaml
@@ -24,6 +24,8 @@ indexerConfig:
     enableKafkaAutoCommit: "true"
     kafkaAutoCommitInterval: "5000"
     kafkaSessionTimeout: "30000"
+    additionalProps:
+      fetch.max.bytes: "100"
 
 queryConfig:
   serverConfig:

--- a/kaldb/src/test/resources/test_config.yaml
+++ b/kaldb/src/test/resources/test_config.yaml
@@ -16,6 +16,14 @@ indexerConfig:
     serverPort: 8080
     serverAddress: "localhost"
     requestTimeoutMs: 3000
+  kafkaConfig:
+    kafkaTopic: ${KAFKA_TOPIC:-test-topic}
+    kafkaTopicPartition: ${NOT_PRESENT:-0}
+    kafkaBootStrapServers: "localhost:9092"
+    kafkaClientGroup: "kaldb-test"
+    enableKafkaAutoCommit: "true"
+    kafkaAutoCommitInterval: "5000"
+    kafkaSessionTimeout: "30000"
 
 queryConfig:
   serverConfig:
@@ -24,15 +32,6 @@ queryConfig:
     requestTimeoutMs: 3000
   defaultQueryTimeoutMs: 2500
   managerConnectString: localhost:8083
-
-kafkaConfig:
-  kafkaTopic: ${KAFKA_TOPIC:-test-topic}
-  kafkaTopicPartition: ${NOT_PRESENT:-0}
-  kafkaBootStrapServers: "localhost:9092"
-  kafkaClientGroup: "kaldb-test"
-  enableKafkaAutoCommit: "true"
-  kafkaAutoCommitInterval: "5000"
-  kafkaSessionTimeout: "30000"
 
 s3Config:
   s3AccessKey: "access"
@@ -93,6 +92,14 @@ recoveryConfig:
   serverConfig:
     serverPort: 8084
     serverAddress: localhost
+  kafkaConfig:
+    kafkaTopic: ${KAFKA_TOPIC:-test-topic}
+    kafkaTopicPartition: ${NOT_PRESENT:-0}
+    kafkaBootStrapServers: "localhost:9092"
+    kafkaClientGroup: "kaldb-test"
+    enableKafkaAutoCommit: "true"
+    kafkaAutoCommitInterval: "5000"
+    kafkaSessionTimeout: "30000"
 
 preprocessorConfig:
   kafkaStreamConfig:


### PR DESCRIPTION
- Remove the TODOs that wanted to move KafkaConfig to IndexerConfig and RecoveryConfig. We implement that in this PR. When committing we need to change our bedrock.yaml file
- Add additional props to provide params that aren't limited to the named parameters we already support within KafkaConfig. This allows us to experiment with new configs to tune the cluster without code changes. This also folds in the overrideProps 