### PR TITLE
Log duration of recovery tasks

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
@@ -292,7 +292,7 @@ public class RecoveryService extends AbstractIdleService {
       } finally {
         long endTime = System.nanoTime();
         LOG.info(
-            "Recovery task {} took {}µs, (subtask times {}, {}, {}, {})",
+            "Recovery task {} took {}µs, (subtask times offset validation {}, consumer prep {}, msg consumption {}, rollover {})",
             recoveryTaskMetadata,
             TimeUnit.MICROSECONDS.convert(endTime - startTime, TimeUnit.NANOSECONDS),
             TimeUnit.MICROSECONDS.convert(offsetsValidatedTime - startTime, TimeUnit.NANOSECONDS),

--- a/kaldb/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
@@ -289,11 +289,7 @@ public class KaldbKafkaConsumer {
             () -> {
               long startTime = System.nanoTime();
               try {
-                LOG.info(
-                    "Ingesting batch from {} with {} records on thread {}",
-                    topicPartition,
-                    recordCount,
-                    Thread.currentThread().getId());
+                LOG.info("Ingesting batch from {} with {} records", topicPartition, recordCount);
                 for (ConsumerRecord<String, byte[]> record : records) {
                   if (startOffsetInclusive >= 0 && record.offset() < startOffsetInclusive) {
                     messagesOutsideOffsetRange.incrementAndGet();
@@ -310,26 +306,23 @@ public class KaldbKafkaConsumer {
                       }
                     } catch (IOException e) {
                       LOG.error(
-                          "Encountered exception processing batch from {} with {} records on thread {}: {}",
+                          "Encountered exception processing batch from {} with {} records: {}",
                           topicPartition,
                           recordCount,
-                          Thread.currentThread().getId(),
                           e);
                     }
                   }
                 }
                 LOG.info(
-                    "Finished ingesting batch from {} with {} records on thread {}",
+                    "Finished ingesting batch from {} with {} records",
                     topicPartition,
-                    recordCount,
-                    Thread.currentThread().getId());
+                    recordCount);
               } finally {
                 long endTime = System.nanoTime();
                 LOG.info(
-                    "Batch from {} with {} records on thread {} completed in {}µs",
+                    "Batch from {} with {} records completed in {}µs",
                     topicPartition,
                     recordCount,
-                    Thread.currentThread().getId(),
                     TimeUnit.MICROSECONDS.convert(endTime - startTime, TimeUnit.NANOSECONDS));
               }
             });

--- a/kaldb/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
@@ -289,7 +289,10 @@ public class KaldbKafkaConsumer {
         messagesIndexed += recordCount;
         executor.execute(
             () -> {
-              ScopedSpan span = Tracing.currentTracer().startScopedSpan("KaldbKafkaConsumer.consumeMessagesBetweenOffsetsInParallel");
+              ScopedSpan span =
+                  Tracing.currentTracer()
+                      .startScopedSpan(
+                          "KaldbKafkaConsumer.consumeMessagesBetweenOffsetsInParallel");
               try {
                 LOG.info("Ingesting batch: [{}/{}]", topicPartition, recordCount);
                 span.tag("topic", topicPartition.topic());
@@ -313,10 +316,10 @@ public class KaldbKafkaConsumer {
                       }
                     } catch (IOException e) {
                       LOG.error(
-                              "Encountered exception processing batch [{}/{}]: {}",
-                              topicPartition,
-                              recordCount,
-                              e);
+                          "Encountered exception processing batch [{}/{}]: {}",
+                          topicPartition,
+                          recordCount,
+                          e);
                       span.annotate("record error"); // don't set span error for single record
                     }
                   }


### PR DESCRIPTION
Record durations of some subtasks in the processing of recovery tasks to assist with profiling. These are optional and could be removed later (or now) if they don't have long-term usefulness.
