### PR TITLE
Reduce cardinality of chunk assignment timers

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
@@ -110,14 +110,11 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
     cacheSlotListenerMetadataStore.addListener(cacheNodeListener());
     cacheSlotLastKnownState = Metadata.CacheSlotMetadata.CacheSlotState.FREE;
 
-    chunkAssignmentTimerSuccess =
-        meterRegistry.timer(CHUNK_ASSIGNMENT_TIMER, "slotName", slotName, "successful", "true");
+    chunkAssignmentTimerSuccess = meterRegistry.timer(CHUNK_ASSIGNMENT_TIMER, "successful", "true");
     chunkAssignmentTimerFailure =
-        meterRegistry.timer(CHUNK_ASSIGNMENT_TIMER, "slotName", slotName, "successful", "false");
-    chunkEvictionTimerSuccess =
-        meterRegistry.timer(CHUNK_EVICTION_TIMER, "slotName", slotName, "successful", "true");
-    chunkEvictionTimerFailure =
-        meterRegistry.timer(CHUNK_EVICTION_TIMER, "slotName", slotName, "successful", "false");
+        meterRegistry.timer(CHUNK_ASSIGNMENT_TIMER, "successful", "false");
+    chunkEvictionTimerSuccess = meterRegistry.timer(CHUNK_EVICTION_TIMER, "successful", "true");
+    chunkEvictionTimerFailure = meterRegistry.timer(CHUNK_EVICTION_TIMER, "successful", "false");
 
     LOG.info("Created a new read only chunk - zkSlotId: {}", slotId);
   }


### PR DESCRIPTION
Reduces the cardinality of the chunk assignment timers by removing the slot information. For sufficiently large kaldb clusters this can result in poor query performance when using these metrics.