### PR TITLE
Persist schema to S3.

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadWriteChunk.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadWriteChunk.java
@@ -65,6 +65,7 @@ public abstract class ReadWriteChunk<T> implements Chunk<T> {
   public static final String INDEX_FILES_UPLOAD_FAILED = "index_files_upload_failed";
   public static final String SNAPSHOT_TIMER = "snapshot.timer";
   public static final String LIVE_SNAPSHOT_PREFIX = SnapshotMetadata.LIVE_SNAPSHOT_PATH + "_";
+  public static final String SCHEMA_FILE_NAME = "schema.json";
 
   private final LogStore<T> logStore;
   private final String kafkaPartitionId;
@@ -220,7 +221,7 @@ public abstract class ReadWriteChunk<T> implements Chunk<T> {
       // Create schema file to upload
       ChunkSchema chunkSchema =
           new ChunkSchema(chunkInfo.chunkId, logStore.getSchema(), new ConcurrentHashMap<>());
-      File schemaFile = new File(dirPath + "/schema.json");
+      File schemaFile = new File(dirPath + "/" + SCHEMA_FILE_NAME);
       ChunkSchema.serializeToFile(chunkSchema, schemaFile);
 
       // Prepare list of files to upload.

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/DocumentBuilder.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/DocumentBuilder.java
@@ -2,7 +2,7 @@ package com.slack.kaldb.logstore;
 
 import com.slack.kaldb.metadata.schema.LuceneFieldDef;
 import java.io.IOException;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.lucene.document.Document;
 
 /**
@@ -12,5 +12,5 @@ import org.apache.lucene.document.Document;
 public interface DocumentBuilder<T> {
   Document fromMessage(T message) throws IOException;
 
-  Map<String, LuceneFieldDef> getSchema();
+  ConcurrentHashMap<String, LuceneFieldDef> getSchema();
 }

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LogDocumentBuilderImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LogDocumentBuilderImpl.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableMap;
 import com.slack.kaldb.metadata.schema.LuceneFieldDef;
 import com.slack.kaldb.util.JsonUtil;
-import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.DoubleDocValuesField;
 import org.apache.lucene.document.DoublePoint;
@@ -388,8 +388,8 @@ public class LogDocumentBuilderImpl implements DocumentBuilder<LogMessage> {
   }
 
   @Override
-  public Map<String, LuceneFieldDef> getSchema() {
+  public ConcurrentHashMap<String, LuceneFieldDef> getSchema() {
     // Report empty map since this class doesn't support schemas.
-    return Collections.emptyMap();
+    return new ConcurrentHashMap<>();
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LogStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LogStore.java
@@ -1,8 +1,10 @@
 package com.slack.kaldb.logstore;
 
+import com.slack.kaldb.metadata.schema.LuceneFieldDef;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.search.SearcherManager;
@@ -42,6 +44,8 @@ public interface LogStore<T> extends Closeable {
 
   public void releaseIndexCommit(IndexCommit indexCommit);
 
-  // TODO: Add an isReadOnly and setReadOnly API here.
+  // Return the Schema used by the log store.
+  public ConcurrentHashMap<String, LuceneFieldDef> getSchema();
 
+  // TODO: Add an isReadOnly and setReadOnly API here.
 }

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreImpl.java
@@ -1,5 +1,6 @@
 package com.slack.kaldb.logstore;
 
+import com.slack.kaldb.metadata.schema.LuceneFieldDef;
 import com.slack.kaldb.proto.config.KaldbConfigs;
 import com.slack.kaldb.util.RuntimeHalterImpl;
 import io.micrometer.core.instrument.Counter;
@@ -13,6 +14,7 @@ import java.util.Optional;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.io.FileUtils;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
@@ -320,5 +322,10 @@ public class LuceneIndexStoreImpl implements LogStore<LogMessage> {
 
   public String getId() {
     return id;
+  }
+
+  @Override
+  public ConcurrentHashMap<String, LuceneFieldDef> getSchema() {
+    return documentBuilder.getSchema();
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/schema/ChunkSchemaManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/schema/ChunkSchemaManager.java
@@ -1,6 +1,0 @@
-package com.slack.kaldb.logstore.schema;
-
-
-
-/** ChunkSchemaManager class manages the schema for a chunk. */
-public class ChunkSchemaManager {}

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/schema/ChunkSchemaManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/schema/ChunkSchemaManager.java
@@ -1,0 +1,6 @@
+package com.slack.kaldb.logstore.schema;
+
+
+
+/** ChunkSchemaManager class manages the schema for a chunk. */
+public class ChunkSchemaManager {}

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
@@ -306,7 +306,7 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder<LogMes
   static final String CONVERT_AND_DUPLICATE_FIELD_COUNTER = "convert_and_duplicate_field";
 
   private final FieldConflictPolicy indexFieldConflictPolicy;
-  private final Map<String, LuceneFieldDef> fieldDefMap = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, LuceneFieldDef> fieldDefMap = new ConcurrentHashMap<>();
   private final Counter droppedFieldsCounter;
   private final Counter convertFieldValueCounter;
   private final Counter convertAndDuplicateFieldCounter;
@@ -344,7 +344,7 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder<LogMes
   }
 
   @Override
-  public Map<String, LuceneFieldDef> getSchema() {
+  public ConcurrentHashMap<String, LuceneFieldDef> getSchema() {
     return fieldDefMap;
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
@@ -548,8 +548,6 @@ public class IndexingChunkImplTest {
           .contains(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
     }
 
-    // TODO: Add a test to check that the data is deleted from the file system on cleanup.
-
     @SuppressWarnings("OptionalGetWithoutIsPresent")
     @Test
     public void testSnapshotToS3UsingChunkApi() throws Exception {

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
@@ -590,7 +590,8 @@ public class IndexingChunkImplTest {
       assertThat(chunk.snapshotToS3(bucket, "", s3BlobFs)).isTrue();
       assertThat(chunk.info().getSnapshotPath()).isNotEmpty();
 
-      assertThat(getCount(INDEX_FILES_UPLOAD, registry)).isEqualTo(4);
+      assertThat(getCount(INDEX_FILES_UPLOAD, registry)).isEqualTo(5);
+      // TODO: Assert schema.json exists in s3
       assertThat(getCount(INDEX_FILES_UPLOAD_FAILED, registry)).isEqualTo(0);
       assertThat(registry.get(SNAPSHOT_TIMER).timer().totalTime(TimeUnit.SECONDS)).isGreaterThan(0);
 

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
@@ -564,7 +564,7 @@ public class RecoveryChunkImplTest {
       assertThat(chunk.snapshotToS3(bucket, "", s3BlobFs)).isTrue();
       assertThat(chunk.info().getSnapshotPath()).isNotEmpty();
 
-      assertThat(getCount(INDEX_FILES_UPLOAD, registry)).isEqualTo(4);
+      assertThat(getCount(INDEX_FILES_UPLOAD, registry)).isEqualTo(5);
       assertThat(getCount(INDEX_FILES_UPLOAD_FAILED, registry)).isEqualTo(0);
       assertThat(registry.get(SNAPSHOT_TIMER).timer().totalTime(TimeUnit.SECONDS)).isGreaterThan(0);
 


### PR DESCRIPTION
Persist the schema of a chunk in `schema.json` file and upload that chunk to S3 along with the chunk data.