### PR TITLE
Add full text search to `SchemaAwareLogDocumentBuilder`. 

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LogDocumentBuilderImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LogDocumentBuilderImpl.java
@@ -101,10 +101,10 @@ public class LogDocumentBuilderImpl implements DocumentBuilder<LogMessage> {
     propertyDescriptionBuilder.put(
         LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName,
         new PropertyDescription(PropertyType.LONG, false, true, false, true));
-    propertyDescriptionBuilder.put(
-        LogMessage.SystemField.TYPE.fieldName,
-        new PropertyDescription(PropertyType.TEXT, false, true, true));
 
+    propertyDescriptionBuilder.put(
+        LogMessage.ReservedField.TYPE.fieldName,
+        new PropertyDescription(PropertyType.TEXT, false, true, true));
     propertyDescriptionBuilder.put(
         LogMessage.ReservedField.HOSTNAME.fieldName,
         new PropertyDescription(PropertyType.TEXT, false, true, true));
@@ -374,7 +374,7 @@ public class LogDocumentBuilderImpl implements DocumentBuilder<LogMessage> {
     addProperty(doc, LogMessage.SystemField.INDEX.fieldName, message.getIndex());
     addProperty(
         doc, LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName, message.timeSinceEpochMilli);
-    addProperty(doc, LogMessage.SystemField.TYPE.fieldName, message.getType());
+    addProperty(doc, LogMessage.ReservedField.TYPE.fieldName, message.getType());
     addProperty(doc, LogMessage.SystemField.ID.fieldName, message.id);
     final String msgString = JsonUtil.writeAsString(message.toWireMessage());
     addProperty(doc, LogMessage.SystemField.SOURCE.fieldName, msgString);

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LogMessage.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LogMessage.java
@@ -29,10 +29,10 @@ public class LogMessage extends LogWireMessage {
   public enum SystemField {
     // The source field contains the input document.
     SOURCE("_source"),
-    ID("id"),
-    INDEX("index"),
+    ID("_id"),
+    INDEX("_index"),
     TIME_SINCE_EPOCH("_timesinceepoch"),
-    TYPE("type"),
+    TYPE("_type"),
     ALL("_all");
 
     public final String fieldName;

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LogMessage.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LogMessage.java
@@ -3,7 +3,6 @@ package com.slack.kaldb.logstore;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -21,9 +20,6 @@ import org.slf4j.LoggerFactory;
 public class LogMessage extends LogWireMessage {
 
   private static final Logger LOG = LoggerFactory.getLogger(LogMessage.class);
-
-  public static final ZoneOffset DEFAULT_TIME_ZONE = ZoneOffset.UTC;
-
   static final Pattern INDEX_NAME_PATTERN = Pattern.compile("^[a-zA-Z][a-zA-Z0-9_./:]*$");
 
   public enum SystemField {
@@ -32,7 +28,6 @@ public class LogMessage extends LogWireMessage {
     ID("_id"),
     INDEX("_index"),
     TIME_SINCE_EPOCH("_timesinceepoch"),
-    TYPE("_type"),
     ALL("_all");
 
     public final String fieldName;
@@ -55,6 +50,7 @@ public class LogMessage extends LogWireMessage {
   }
 
   public enum ReservedField {
+    TYPE("type"),
     HOSTNAME("hostname"),
     PACKAGE("package"),
     MESSAGE("message"),
@@ -117,9 +113,7 @@ public class LogMessage extends LogWireMessage {
 
   private BadMessageFormatException raiseException(Throwable t) {
     throw new BadMessageFormatException(
-        String.format(
-            "Index:%s, Type: %s, Id: %s, Source: %s".format(getIndex(), getType(), id, source)),
-        t);
+        "Index:%s, Type: %s, Id: %s, Source: %s".format(getIndex(), getType(), id, source), t);
   }
 
   // TODO: Use timestamp in micros
@@ -129,7 +123,7 @@ public class LogMessage extends LogWireMessage {
     super(index, type, messageId, source);
     if (!isValid()) {
       throw new BadMessageFormatException(
-          String.format("Index:%s, Type: %s, Id: %s, Source: %s".format(index, type, id, source)));
+          "Index:%s, Type: %s, Id: %s, Source: %s".format(index, type, id, source));
     }
     this.timeSinceEpochMilli = getMillisecondsSinceEpoch();
   }

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LogMessage.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LogMessage.java
@@ -22,6 +22,7 @@ public class LogMessage extends LogWireMessage {
   private static final Logger LOG = LoggerFactory.getLogger(LogMessage.class);
   static final Pattern INDEX_NAME_PATTERN = Pattern.compile("^[a-zA-Z][a-zA-Z0-9_./:]*$");
 
+  // SystemFields are lucene fields created for internal use of KalDB.
   public enum SystemField {
     // The source field contains the input document.
     SOURCE("_source"),
@@ -49,6 +50,7 @@ public class LogMessage extends LogWireMessage {
     }
   }
 
+  // ReservedFields are field with pre-defined definitions created for a consistent experience.
   public enum ReservedField {
     TYPE("type"),
     HOSTNAME("hostname"),

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LogMessage.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LogMessage.java
@@ -37,7 +37,7 @@ public class LogMessage extends LogWireMessage {
       this.fieldName = fieldName;
     }
 
-    static final Set<String> systemFieldNames = new TreeSet<String>();
+    static final Set<String> systemFieldNames = new TreeSet<>();
 
     static {
       for (SystemField f : SystemField.values()) {
@@ -72,7 +72,7 @@ public class LogMessage extends LogWireMessage {
       this.fieldName = fieldName;
     }
 
-    static final Set<String> reservedFieldNames = new TreeSet<String>();
+    static final Set<String> reservedFieldNames = new TreeSet<>();
 
     static {
       for (ReservedField f : ReservedField.values()) {
@@ -91,10 +91,7 @@ public class LogMessage extends LogWireMessage {
 
   public static Optional<LogMessage> fromJSON(String jsonStr) {
     Optional<LogWireMessage> optionalWireMsg = LogWireMessage.fromJson(jsonStr);
-    if (optionalWireMsg.isPresent()) {
-      return Optional.of(fromWireMessage(optionalWireMsg.get()));
-    }
-    return Optional.empty();
+    return optionalWireMsg.map(LogMessage::fromWireMessage);
   }
 
   public static LogMessage fromWireMessage(LogWireMessage wireMessage) {
@@ -115,7 +112,8 @@ public class LogMessage extends LogWireMessage {
 
   private BadMessageFormatException raiseException(Throwable t) {
     throw new BadMessageFormatException(
-        "Index:%s, Type: %s, Id: %s, Source: %s".format(getIndex(), getType(), id, source), t);
+        String.format("Index:%s, Type: %s, Id: %s, Source: %s", getIndex(), getType(), id, source),
+        t);
   }
 
   // TODO: Use timestamp in micros
@@ -125,7 +123,7 @@ public class LogMessage extends LogWireMessage {
     super(index, type, messageId, source);
     if (!isValid()) {
       throw new BadMessageFormatException(
-          "Index:%s, Type: %s, Id: %s, Source: %s".format(index, type, id, source));
+          String.format("Index:%s, Type: %s, Id: %s, Source: %s", index, type, id, source));
     }
     this.timeSinceEpochMilli = getMillisecondsSinceEpoch();
   }

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
@@ -71,9 +71,9 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder<LogMes
             true));
     addTextField(fieldDefBuilder, LogMessage.ReservedField.TIMESTAMP.fieldName, false, true);
     fieldDefBuilder.put(
-        LogMessage.SystemField.TYPE.fieldName,
+        LogMessage.ReservedField.TYPE.fieldName,
         new LuceneFieldDef(
-            LogMessage.SystemField.TYPE.fieldName, FieldType.STRING.name, false, true, true));
+            LogMessage.ReservedField.TYPE.fieldName, FieldType.STRING.name, false, true, true));
 
     addTextField(fieldDefBuilder, LogMessage.ReservedField.HOSTNAME.fieldName, false, true);
     addTextField(fieldDefBuilder, LogMessage.ReservedField.PACKAGE.fieldName, false, true);
@@ -345,7 +345,7 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder<LogMes
     addField(doc, LogMessage.SystemField.INDEX.fieldName, message.getIndex(), "", 0);
     addField(
         doc, LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName, message.timeSinceEpochMilli, "", 0);
-    addField(doc, LogMessage.SystemField.TYPE.fieldName, message.getType(), "", 0);
+    addField(doc, LogMessage.ReservedField.TYPE.fieldName, message.getType(), "", 0);
     addField(doc, LogMessage.SystemField.ID.fieldName, message.id, "", 0);
 
     final String msgString = JsonUtil.writeAsString(message.toWireMessage());

--- a/kaldb/src/main/java/com/slack/kaldb/writer/SpanFormatter.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/SpanFormatter.java
@@ -66,7 +66,7 @@ public class SpanFormatter {
           // Also, add service name to the map so can search by service name also.
           jsonMap.put(LogMessage.ReservedField.SERVICE_NAME.fieldName, indexName);
         }
-        if (key.equals(LogMessage.SystemField.TYPE.fieldName)) {
+        if (key.equals(LogMessage.ReservedField.TYPE.fieldName)) {
           msgType = tag.getVStr();
         }
       } else if (valueType == 1) {

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/LogMessageTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/LogMessageTest.java
@@ -2,6 +2,7 @@ package com.slack.kaldb.logstore;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.slack.kaldb.logstore.LogMessage.ReservedField;
 import com.slack.kaldb.logstore.LogMessage.SystemField;
 import org.junit.Test;
 
@@ -9,28 +10,28 @@ public class LogMessageTest {
 
   @Test
   public void testSystemField() {
-    assertThat(LogMessage.SystemField.values().length).isEqualTo(6);
+    assertThat(SystemField.values().length).isEqualTo(6);
     assertThat(SystemField.systemFieldNames.size()).isEqualTo(6);
-    assertThat(LogMessage.SystemField.isSystemField("_source")).isTrue();
-
-    assertThat(LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName).isEqualTo("_timesinceepoch");
+    assertThat(SystemField.isSystemField("_source")).isTrue();
+    assertThat(SystemField.TIME_SINCE_EPOCH.fieldName).isEqualTo("_timesinceepoch");
     assertThat(SystemField.ALL.fieldName).isEqualTo("_all");
-    for (LogMessage.SystemField f : LogMessage.SystemField.values()) {
-      if (!(f.equals(LogMessage.SystemField.SOURCE)
-          || f.equals(LogMessage.SystemField.TIME_SINCE_EPOCH)
-          || f.equals(LogMessage.SystemField.ALL))) {
-        assertThat(f.fieldName).isEqualTo(f.name().toLowerCase());
-      }
+    assertThat(SystemField.ID.fieldName).isEqualTo("_id");
+    assertThat(SystemField.INDEX.fieldName).isEqualTo("_index");
+    assertThat(SystemField.TYPE.fieldName).isEqualTo("_type");
+    for (SystemField f : SystemField.values()) {
+      String lowerCaseName = f.fieldName.toLowerCase();
+      if (!f.equals(SystemField.TIME_SINCE_EPOCH))
+        assertThat(f.fieldName.equals(lowerCaseName) || f.fieldName.equals("_" + lowerCaseName))
+            .isTrue();
     }
-    assertThat(LogMessage.SystemField.isSystemField("test")).isFalse();
   }
 
   @Test
   public void testReservedField() {
-    assertThat(LogMessage.ReservedField.values().length).isEqualTo(12);
-    assertThat(LogMessage.ReservedField.reservedFieldNames.size()).isEqualTo(12);
-    assertThat(LogMessage.ReservedField.isReservedField("hostname")).isTrue();
-    assertThat(LogMessage.ReservedField.TIMESTAMP.fieldName).isEqualTo("@timestamp");
+    assertThat(ReservedField.values().length).isEqualTo(12);
+    assertThat(ReservedField.reservedFieldNames.size()).isEqualTo(12);
+    assertThat(ReservedField.isReservedField("hostname")).isTrue();
+    assertThat(ReservedField.TIMESTAMP.fieldName).isEqualTo("@timestamp");
     for (LogMessage.ReservedField f : LogMessage.ReservedField.values()) {
       if (!f.equals(LogMessage.ReservedField.TIMESTAMP)) {
         assertThat(f.name().toLowerCase()).isEqualTo(f.fieldName);

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/LogMessageTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/LogMessageTest.java
@@ -17,7 +17,6 @@ public class LogMessageTest {
     assertThat(SystemField.ALL.fieldName).isEqualTo("_all");
     assertThat(SystemField.ID.fieldName).isEqualTo("_id");
     assertThat(SystemField.INDEX.fieldName).isEqualTo("_index");
-    assertThat(SystemField.TYPE.fieldName).isEqualTo("_type");
     for (SystemField f : SystemField.values()) {
       String lowerCaseName = f.fieldName.toLowerCase();
       if (!f.equals(SystemField.TIME_SINCE_EPOCH))

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/LogMessageTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/LogMessageTest.java
@@ -10,8 +10,8 @@ public class LogMessageTest {
 
   @Test
   public void testSystemField() {
-    assertThat(SystemField.values().length).isEqualTo(6);
-    assertThat(SystemField.systemFieldNames.size()).isEqualTo(6);
+    assertThat(SystemField.values().length).isEqualTo(5);
+    assertThat(SystemField.systemFieldNames.size()).isEqualTo(5);
     assertThat(SystemField.isSystemField("_source")).isTrue();
     assertThat(SystemField.TIME_SINCE_EPOCH.fieldName).isEqualTo("_timesinceepoch");
     assertThat(SystemField.ALL.fieldName).isEqualTo("_all");
@@ -27,8 +27,8 @@ public class LogMessageTest {
 
   @Test
   public void testReservedField() {
-    assertThat(ReservedField.values().length).isEqualTo(12);
-    assertThat(ReservedField.reservedFieldNames.size()).isEqualTo(12);
+    assertThat(ReservedField.values().length).isEqualTo(13);
+    assertThat(ReservedField.reservedFieldNames.size()).isEqualTo(13);
     assertThat(ReservedField.isReservedField("hostname")).isTrue();
     assertThat(ReservedField.TIMESTAMP.fieldName).isEqualTo("@timestamp");
     for (LogMessage.ReservedField f : LogMessage.ReservedField.values()) {

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/schema/SchemaAwareLogDocumentBuilderImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/schema/SchemaAwareLogDocumentBuilderImplTest.java
@@ -13,7 +13,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.slack.kaldb.chunkManager.ChunkManagerBase;
 import com.slack.kaldb.logstore.FieldDefMismatchException;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.metadata.schema.FieldType;
@@ -34,7 +33,8 @@ import org.slf4j.LoggerFactory;
 
 public class SchemaAwareLogDocumentBuilderImplTest {
   private SimpleMeterRegistry meterRegistry;
-  private static final Logger LOG = LoggerFactory.getLogger(SchemaAwareLogDocumentBuilderImplTest.class);
+  private static final Logger LOG =
+      LoggerFactory.getLogger(SchemaAwareLogDocumentBuilderImplTest.class);
 
   @Before
   public void setup() throws Exception {

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/schema/SchemaAwareLogDocumentBuilderImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/schema/SchemaAwareLogDocumentBuilderImplTest.java
@@ -28,13 +28,9 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class SchemaAwareLogDocumentBuilderImplTest {
   private SimpleMeterRegistry meterRegistry;
-  private static final Logger LOG =
-      LoggerFactory.getLogger(SchemaAwareLogDocumentBuilderImplTest.class);
 
   @Before
   public void setup() throws Exception {
@@ -46,7 +42,7 @@ public class SchemaAwareLogDocumentBuilderImplTest {
     SchemaAwareLogDocumentBuilderImpl docBuilder = build(DROP_FIELD, true, meterRegistry);
     assertThat(docBuilder.getIndexFieldConflictPolicy()).isEqualTo(DROP_FIELD);
     assertThat(docBuilder.getSchema().size()).isEqualTo(18);
-    LOG.info("schema: {}", docBuilder.getSchema());
+    assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
     final LogMessage message = MessageUtil.makeMessage(0);
     Document testDocument = docBuilder.fromMessage(message);
     assertThat(testDocument.getFields().size()).isEqualTo(19);
@@ -83,13 +79,22 @@ public class SchemaAwareLogDocumentBuilderImplTest {
                 .filter(f -> f.name().equals("_index") && f instanceof SortedDocValuesField)
                 .count())
         .isZero();
+    assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
+    assertThat(
+            testDocument
+                .getFields()
+                .stream()
+                .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
+                .count())
+        .isEqualTo(1);
   }
 
   @Test
   public void testNestedDocumentCreation() throws IOException {
     SchemaAwareLogDocumentBuilderImpl docBuilder = build(DROP_FIELD, true, meterRegistry);
     assertThat(docBuilder.getIndexFieldConflictPolicy()).isEqualTo(DROP_FIELD);
-    assertThat(docBuilder.getSchema().size()).isEqualTo(17);
+    assertThat(docBuilder.getSchema().size()).isEqualTo(18);
+    assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
 
     LogMessage message =
         new LogMessage(
@@ -109,8 +114,8 @@ public class SchemaAwareLogDocumentBuilderImplTest {
                 Map.of("nested1", "value1", "nested2", 2)));
 
     Document testDocument = docBuilder.fromMessage(message);
-    assertThat(testDocument.getFields().size()).isEqualTo(15);
-    assertThat(docBuilder.getSchema().size()).isEqualTo(21);
+    assertThat(testDocument.getFields().size()).isEqualTo(16);
+    assertThat(docBuilder.getSchema().size()).isEqualTo(22);
     assertThat(docBuilder.getSchema().keySet())
         .containsAll(
             List.of(
@@ -124,13 +129,21 @@ public class SchemaAwareLogDocumentBuilderImplTest {
     assertThat(MetricsUtil.getCount(DROP_FIELDS_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();
+    assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
+    assertThat(
+            testDocument
+                .getFields()
+                .stream()
+                .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
+                .count())
+        .isEqualTo(1);
   }
 
   @Test
   public void testMaxRecursionNestedDocumentCreation() throws IOException {
     SchemaAwareLogDocumentBuilderImpl docBuilder = build(DROP_FIELD, true, meterRegistry);
     assertThat(docBuilder.getIndexFieldConflictPolicy()).isEqualTo(DROP_FIELD);
-    assertThat(docBuilder.getSchema().size()).isEqualTo(17);
+    assertThat(docBuilder.getSchema().size()).isEqualTo(18);
 
     LogMessage message =
         new LogMessage(
@@ -160,8 +173,8 @@ public class SchemaAwareLogDocumentBuilderImplTest {
                         Map.of("nested31", 31, "nested32", Map.of("nested41", 41))))));
 
     Document testDocument = docBuilder.fromMessage(message);
-    assertThat(testDocument.getFields().size()).isEqualTo(20);
-    assertThat(docBuilder.getSchema().size()).isEqualTo(24);
+    assertThat(testDocument.getFields().size()).isEqualTo(21);
+    assertThat(docBuilder.getSchema().size()).isEqualTo(25);
     assertThat(docBuilder.getSchema().keySet())
         .containsAll(
             List.of(
@@ -183,13 +196,22 @@ public class SchemaAwareLogDocumentBuilderImplTest {
     assertThat(MetricsUtil.getCount(DROP_FIELDS_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();
+    assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
+    assertThat(
+            testDocument
+                .getFields()
+                .stream()
+                .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
+                .count())
+        .isEqualTo(1);
   }
 
   @Test
   public void testMultiLevelNestedDocumentCreation() throws IOException {
     SchemaAwareLogDocumentBuilderImpl docBuilder = build(DROP_FIELD, true, meterRegistry);
     assertThat(docBuilder.getIndexFieldConflictPolicy()).isEqualTo(DROP_FIELD);
-    assertThat(docBuilder.getSchema().size()).isEqualTo(17);
+    assertThat(docBuilder.getSchema().size()).isEqualTo(18);
+    assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
 
     LogMessage message =
         new LogMessage(
@@ -207,8 +229,8 @@ public class SchemaAwareLogDocumentBuilderImplTest {
                 Map.of("leaf1", "value1", "nested", Map.of("leaf2", "value2", "leaf21", 3))));
 
     Document testDocument = docBuilder.fromMessage(message);
-    assertThat(testDocument.getFields().size()).isEqualTo(15);
-    assertThat(docBuilder.getSchema().size()).isEqualTo(21);
+    assertThat(testDocument.getFields().size()).isEqualTo(16);
+    assertThat(docBuilder.getSchema().size()).isEqualTo(22);
     assertThat(docBuilder.getSchema().keySet())
         .containsAll(
             List.of(
@@ -220,6 +242,14 @@ public class SchemaAwareLogDocumentBuilderImplTest {
     assertThat(MetricsUtil.getCount(DROP_FIELDS_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();
+    assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
+    assertThat(
+            testDocument
+                .getFields()
+                .stream()
+                .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
+                .count())
+        .isEqualTo(1);
   }
 
   @Test
@@ -227,7 +257,8 @@ public class SchemaAwareLogDocumentBuilderImplTest {
     SchemaAwareLogDocumentBuilderImpl docBuilder =
         build(CONVERT_AND_DUPLICATE_FIELD, true, meterRegistry);
     assertThat(docBuilder.getIndexFieldConflictPolicy()).isEqualTo(CONVERT_AND_DUPLICATE_FIELD);
-    assertThat(docBuilder.getSchema().size()).isEqualTo(17);
+    assertThat(docBuilder.getSchema().size()).isEqualTo(18);
+    assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
 
     LogMessage message =
         new LogMessage(
@@ -251,8 +282,8 @@ public class SchemaAwareLogDocumentBuilderImplTest {
                     Map.of("leaf2", "value2", "leaf21", 3, "nestedList", List.of(1)))));
 
     Document testDocument = docBuilder.fromMessage(message);
-    assertThat(testDocument.getFields().size()).isEqualTo(17);
-    assertThat(docBuilder.getSchema().size()).isEqualTo(23);
+    assertThat(testDocument.getFields().size()).isEqualTo(18);
+    assertThat(docBuilder.getSchema().size()).isEqualTo(24);
     assertThat(docBuilder.getSchema().keySet())
         .containsAll(
             List.of(
@@ -269,12 +300,23 @@ public class SchemaAwareLogDocumentBuilderImplTest {
     assertThat(MetricsUtil.getCount(DROP_FIELDS_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();
+    assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
+    assertThat(
+            testDocument
+                .getFields()
+                .stream()
+                .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
+                .count())
+        .isEqualTo(1);
   }
+
+  // TODO: Add a test with _all field disabled
 
   @Test
   public void testRaiseErrorOnConflictingField() throws JsonProcessingException {
     SchemaAwareLogDocumentBuilderImpl docBuilder = build(RAISE_ERROR, true, meterRegistry);
-    assertThat(docBuilder.getSchema().size()).isEqualTo(17);
+    assertThat(docBuilder.getSchema().size()).isEqualTo(18);
+    assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
     String conflictingFieldName = "conflictingField";
 
     LogMessage msg1 =
@@ -295,7 +337,7 @@ public class SchemaAwareLogDocumentBuilderImplTest {
                 1));
 
     Document msg1Doc = docBuilder.fromMessage(msg1);
-    assertThat(msg1Doc.getFields().size()).isEqualTo(14);
+    assertThat(msg1Doc.getFields().size()).isEqualTo(15);
     assertThat(
             msg1Doc
                 .getFields()
@@ -303,7 +345,7 @@ public class SchemaAwareLogDocumentBuilderImplTest {
                 .filter(f -> f.name().equals(conflictingFieldName))
                 .findFirst())
         .isNotEmpty();
-    assertThat(docBuilder.getSchema().size()).isEqualTo(18);
+    assertThat(docBuilder.getSchema().size()).isEqualTo(19);
     assertThat(docBuilder.getSchema().keySet()).contains(conflictingFieldName);
     assertThat(docBuilder.getSchema().get(conflictingFieldName).fieldType)
         .isEqualTo(FieldType.INTEGER);
@@ -333,7 +375,7 @@ public class SchemaAwareLogDocumentBuilderImplTest {
         .isInstanceOf(FieldDefMismatchException.class);
     // NOTE: When a document indexing fails, we still register the types of the fields in this doc.
     // So, the fieldMap may contain an additional item than before.
-    assertThat(docBuilder.getSchema().size()).isGreaterThanOrEqualTo(18);
+    assertThat(docBuilder.getSchema().size()).isGreaterThanOrEqualTo(19);
     assertThat(docBuilder.getSchema().keySet()).contains(conflictingFieldName);
     assertThat(docBuilder.getSchema().get(conflictingFieldName).fieldType)
         .isEqualTo(FieldType.INTEGER);
@@ -358,7 +400,7 @@ public class SchemaAwareLogDocumentBuilderImplTest {
         .isInstanceOf(FieldDefMismatchException.class);
     // NOTE: When a document indexing fails, we still register the types of the fields in this doc.
     // So, the fieldMap may contain an additional item than before.
-    assertThat(docBuilder.getSchema().size()).isGreaterThanOrEqualTo(18);
+    assertThat(docBuilder.getSchema().size()).isGreaterThanOrEqualTo(19);
     assertThat(docBuilder.getSchema().keySet()).contains(conflictingFieldName);
     assertThat(docBuilder.getSchema().get(conflictingFieldName).fieldType)
         .isEqualTo(FieldType.INTEGER);
@@ -368,12 +410,21 @@ public class SchemaAwareLogDocumentBuilderImplTest {
     assertThat(MetricsUtil.getCount(DROP_FIELDS_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();
+    assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
+    assertThat(
+            msg1Doc
+                .getFields()
+                .stream()
+                .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
+                .count())
+        .isEqualTo(1);
   }
 
   @Test
   public void testRaiseErrorOnConflictingReservedField() {
     SchemaAwareLogDocumentBuilderImpl docBuilder = build(RAISE_ERROR, true, meterRegistry);
-    assertThat(docBuilder.getSchema().size()).isEqualTo(17);
+    assertThat(docBuilder.getSchema().size()).isEqualTo(18);
+    assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
     final String hostNameField = LogMessage.ReservedField.HOSTNAME.fieldName;
     assertThat(docBuilder.getSchema().keySet()).contains(hostNameField);
     assertThat(docBuilder.getSchema().get(hostNameField).fieldType).isEqualTo(FieldType.TEXT);
@@ -395,18 +446,20 @@ public class SchemaAwareLogDocumentBuilderImplTest {
 
     assertThatThrownBy(() -> docBuilder.fromMessage(msg1))
         .isInstanceOf(FieldDefMismatchException.class);
-    assertThat(docBuilder.getSchema().size()).isEqualTo(17);
+    assertThat(docBuilder.getSchema().size()).isEqualTo(18);
     assertThat(docBuilder.getSchema().keySet()).contains(hostNameField);
     assertThat(docBuilder.getSchema().get(hostNameField).fieldType).isEqualTo(FieldType.TEXT);
     assertThat(MetricsUtil.getCount(DROP_FIELDS_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();
+    assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
   }
 
   @Test
   public void testDroppingConflictingField() throws JsonProcessingException {
     SchemaAwareLogDocumentBuilderImpl docBuilder = build(DROP_FIELD, true, meterRegistry);
-    assertThat(docBuilder.getSchema().size()).isEqualTo(17);
+    assertThat(docBuilder.getSchema().size()).isEqualTo(18);
+    assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
     String conflictingFieldName = "conflictingField";
 
     LogMessage msg1 =
@@ -427,7 +480,7 @@ public class SchemaAwareLogDocumentBuilderImplTest {
                 "1"));
 
     Document msg1Doc = docBuilder.fromMessage(msg1);
-    assertThat(msg1Doc.getFields().size()).isEqualTo(13);
+    assertThat(msg1Doc.getFields().size()).isEqualTo(14);
     assertThat(
             msg1Doc
                 .getFields()
@@ -435,7 +488,7 @@ public class SchemaAwareLogDocumentBuilderImplTest {
                 .filter(f -> f.name().equals(conflictingFieldName))
                 .findFirst())
         .isNotEmpty();
-    assertThat(docBuilder.getSchema().size()).isEqualTo(18);
+    assertThat(docBuilder.getSchema().size()).isEqualTo(19);
     assertThat(docBuilder.getSchema().keySet()).contains(conflictingFieldName);
     assertThat(docBuilder.getSchema().get(conflictingFieldName).fieldType)
         .isEqualTo(FieldType.TEXT);
@@ -460,7 +513,7 @@ public class SchemaAwareLogDocumentBuilderImplTest {
                 conflictingFieldName,
                 1));
     Document msg2Doc = docBuilder.fromMessage(msg2);
-    assertThat(msg2Doc.getFields().size()).isEqualTo(12);
+    assertThat(msg2Doc.getFields().size()).isEqualTo(13);
     // Conflicting field is dropped.
     assertThat(
             msg2Doc
@@ -469,20 +522,23 @@ public class SchemaAwareLogDocumentBuilderImplTest {
                 .filter(f -> f.name().equals(conflictingFieldName))
                 .findFirst())
         .isEmpty();
-    assertThat(docBuilder.getSchema().size()).isEqualTo(18);
+    assertThat(docBuilder.getSchema().size()).isEqualTo(19);
     assertThat(docBuilder.getSchema().keySet()).contains(conflictingFieldName);
     assertThat(docBuilder.getSchema().get(conflictingFieldName).fieldType)
         .isEqualTo(FieldType.TEXT);
     assertThat(MetricsUtil.getCount(DROP_FIELDS_COUNTER, meterRegistry)).isEqualTo(1);
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();
+    assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
   }
 
   @Test
   public void testConvertingConflictingField() throws JsonProcessingException {
     SchemaAwareLogDocumentBuilderImpl convertFieldBuilder =
         build(CONVERT_FIELD_VALUE, true, meterRegistry);
-    assertThat(convertFieldBuilder.getSchema().size()).isEqualTo(17);
+    assertThat(convertFieldBuilder.getSchema().size()).isEqualTo(18);
+    assertThat(convertFieldBuilder.getSchema().keySet())
+        .contains(LogMessage.SystemField.ALL.fieldName);
     String conflictingFieldName = "conflictingField";
 
     LogMessage msg1 =
@@ -503,7 +559,7 @@ public class SchemaAwareLogDocumentBuilderImplTest {
                 "1"));
 
     Document msg1Doc = convertFieldBuilder.fromMessage(msg1);
-    assertThat(msg1Doc.getFields().size()).isEqualTo(13);
+    assertThat(msg1Doc.getFields().size()).isEqualTo(14);
     assertThat(
             msg1Doc
                 .getFields()
@@ -511,7 +567,7 @@ public class SchemaAwareLogDocumentBuilderImplTest {
                 .filter(f -> f.name().equals(conflictingFieldName))
                 .findFirst())
         .isNotEmpty();
-    assertThat(convertFieldBuilder.getSchema().size()).isEqualTo(18);
+    assertThat(convertFieldBuilder.getSchema().size()).isEqualTo(19);
     assertThat(convertFieldBuilder.getSchema().keySet()).contains(conflictingFieldName);
     assertThat(convertFieldBuilder.getSchema().get(conflictingFieldName).fieldType)
         .isEqualTo(FieldType.TEXT);
@@ -536,7 +592,7 @@ public class SchemaAwareLogDocumentBuilderImplTest {
                 conflictingFieldName,
                 1));
     Document msg2Doc = convertFieldBuilder.fromMessage(msg2);
-    assertThat(msg2Doc.getFields().size()).isEqualTo(13);
+    assertThat(msg2Doc.getFields().size()).isEqualTo(14);
     // Value is converted for conflicting field.
     assertThat(
             msg2Doc
@@ -546,20 +602,38 @@ public class SchemaAwareLogDocumentBuilderImplTest {
                 .findFirst())
         .isNotEmpty();
     assertThat(msg2Doc.getField(conflictingFieldName).stringValue()).isEqualTo("1");
-    assertThat(convertFieldBuilder.getSchema().size()).isEqualTo(18);
+    assertThat(convertFieldBuilder.getSchema().size()).isEqualTo(19);
     assertThat(convertFieldBuilder.getSchema().keySet()).contains(conflictingFieldName);
     assertThat(convertFieldBuilder.getSchema().get(conflictingFieldName).fieldType)
         .isEqualTo(FieldType.TEXT);
     assertThat(MetricsUtil.getCount(DROP_FIELDS_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isEqualTo(1);
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();
+    assertThat(
+            msg1Doc
+                .getFields()
+                .stream()
+                .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
+                .count())
+        .isEqualTo(1);
+    assertThat(
+            msg2Doc
+                .getFields()
+                .stream()
+                .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
+                .count())
+        .isEqualTo(1);
+    assertThat(convertFieldBuilder.getSchema().keySet())
+        .contains(LogMessage.SystemField.ALL.fieldName);
   }
 
   @Test
   public void testConvertingAndDuplicatingConflictingField() throws JsonProcessingException {
     SchemaAwareLogDocumentBuilderImpl convertFieldBuilder =
         build(CONVERT_AND_DUPLICATE_FIELD, true, meterRegistry);
-    assertThat(convertFieldBuilder.getSchema().size()).isEqualTo(17);
+    assertThat(convertFieldBuilder.getSchema().size()).isEqualTo(18);
+    assertThat(convertFieldBuilder.getSchema().keySet())
+        .contains(LogMessage.SystemField.ALL.fieldName);
     String conflictingFieldName = "conflictingField";
 
     LogMessage msg1 =
@@ -580,7 +654,7 @@ public class SchemaAwareLogDocumentBuilderImplTest {
                 "1"));
 
     Document msg1Doc = convertFieldBuilder.fromMessage(msg1);
-    assertThat(msg1Doc.getFields().size()).isEqualTo(13);
+    assertThat(msg1Doc.getFields().size()).isEqualTo(14);
     assertThat(
             msg1Doc
                 .getFields()
@@ -588,7 +662,7 @@ public class SchemaAwareLogDocumentBuilderImplTest {
                 .filter(f -> f.name().equals(conflictingFieldName))
                 .findFirst())
         .isNotEmpty();
-    assertThat(convertFieldBuilder.getSchema().size()).isEqualTo(18);
+    assertThat(convertFieldBuilder.getSchema().size()).isEqualTo(19);
     assertThat(convertFieldBuilder.getSchema().keySet()).contains(conflictingFieldName);
     assertThat(convertFieldBuilder.getSchema().get(conflictingFieldName).fieldType)
         .isEqualTo(FieldType.TEXT);
@@ -613,7 +687,7 @@ public class SchemaAwareLogDocumentBuilderImplTest {
                 conflictingFieldName,
                 1));
     Document msg2Doc = convertFieldBuilder.fromMessage(msg2);
-    assertThat(msg2Doc.getFields().size()).isEqualTo(15);
+    assertThat(msg2Doc.getFields().size()).isEqualTo(16);
     String additionalCreatedFieldName = makeNewFieldOfType(conflictingFieldName, FieldType.INTEGER);
     // Value converted and new field is added.
     assertThat(
@@ -629,7 +703,7 @@ public class SchemaAwareLogDocumentBuilderImplTest {
     assertThat(msg2Doc.getField(conflictingFieldName).stringValue()).isEqualTo("1");
     // Field value is null since we don't store the int field anymore.
     assertThat(msg2Doc.getField(additionalCreatedFieldName).stringValue()).isNull();
-    assertThat(convertFieldBuilder.getSchema().size()).isEqualTo(19);
+    assertThat(convertFieldBuilder.getSchema().size()).isEqualTo(20);
     assertThat(convertFieldBuilder.getSchema().keySet())
         .contains(conflictingFieldName, additionalCreatedFieldName);
     assertThat(convertFieldBuilder.getSchema().get(conflictingFieldName).fieldType)
@@ -640,6 +714,22 @@ public class SchemaAwareLogDocumentBuilderImplTest {
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry))
         .isEqualTo(1);
+    assertThat(
+            msg1Doc
+                .getFields()
+                .stream()
+                .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
+                .count())
+        .isEqualTo(1);
+    assertThat(
+            msg2Doc
+                .getFields()
+                .stream()
+                .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
+                .count())
+        .isEqualTo(1);
+    assertThat(convertFieldBuilder.getSchema().keySet())
+        .contains(LogMessage.SystemField.ALL.fieldName);
   }
 
   @Test
@@ -647,6 +737,8 @@ public class SchemaAwareLogDocumentBuilderImplTest {
     SchemaAwareLogDocumentBuilderImpl convertFieldBuilder =
         build(CONVERT_AND_DUPLICATE_FIELD, true, meterRegistry);
     assertThat(convertFieldBuilder.getSchema().size()).isEqualTo(18);
+    assertThat(convertFieldBuilder.getSchema().keySet())
+        .contains(LogMessage.SystemField.ALL.fieldName);
     String conflictingFieldName = "conflictingField";
 
     LogMessage msg1 =
@@ -667,7 +759,7 @@ public class SchemaAwareLogDocumentBuilderImplTest {
                 "1"));
 
     Document msg1Doc = convertFieldBuilder.fromMessage(msg1);
-    assertThat(msg1Doc.getFields().size()).isEqualTo(13);
+    assertThat(msg1Doc.getFields().size()).isEqualTo(14);
     assertThat(
             msg1Doc
                 .getFields()
@@ -675,7 +767,7 @@ public class SchemaAwareLogDocumentBuilderImplTest {
                 .filter(f -> f.name().equals(conflictingFieldName))
                 .findFirst())
         .isNotEmpty();
-    assertThat(convertFieldBuilder.getSchema().size()).isEqualTo(18);
+    assertThat(convertFieldBuilder.getSchema().size()).isEqualTo(19);
     assertThat(convertFieldBuilder.getSchema().keySet()).contains(conflictingFieldName);
     assertThat(convertFieldBuilder.getSchema().get(conflictingFieldName).fieldType)
         .isEqualTo(FieldType.TEXT);
@@ -701,7 +793,7 @@ public class SchemaAwareLogDocumentBuilderImplTest {
                 conflictingFieldName,
                 conflictingFloatValue));
     Document msg2Doc = convertFieldBuilder.fromMessage(msg2);
-    assertThat(msg2Doc.getFields().size()).isEqualTo(15);
+    assertThat(msg2Doc.getFields().size()).isEqualTo(16);
     String additionalCreatedFieldName = makeNewFieldOfType(conflictingFieldName, FieldType.FLOAT);
     // Value converted and new field is added.
     assertThat(
@@ -717,7 +809,7 @@ public class SchemaAwareLogDocumentBuilderImplTest {
     assertThat(msg2Doc.getField(conflictingFieldName).stringValue()).isEqualTo("100.0");
     assertThat(msg2Doc.getField(additionalCreatedFieldName).numericValue().floatValue())
         .isEqualTo(conflictingFloatValue);
-    assertThat(convertFieldBuilder.getSchema().size()).isEqualTo(19);
+    assertThat(convertFieldBuilder.getSchema().size()).isEqualTo(20);
     assertThat(convertFieldBuilder.getSchema().keySet())
         .contains(conflictingFieldName, additionalCreatedFieldName);
     assertThat(convertFieldBuilder.getSchema().get(conflictingFieldName).fieldType)
@@ -728,6 +820,22 @@ public class SchemaAwareLogDocumentBuilderImplTest {
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry))
         .isEqualTo(1);
+    assertThat(
+            msg1Doc
+                .getFields()
+                .stream()
+                .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
+                .count())
+        .isEqualTo(1);
+    assertThat(
+            msg2Doc
+                .getFields()
+                .stream()
+                .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
+                .count())
+        .isEqualTo(1);
+    assertThat(convertFieldBuilder.getSchema().keySet())
+        .contains(LogMessage.SystemField.ALL.fieldName);
   }
 
   @Test
@@ -736,6 +844,7 @@ public class SchemaAwareLogDocumentBuilderImplTest {
         build(CONVERT_AND_DUPLICATE_FIELD, true, meterRegistry);
     assertThat(docBuilder.getIndexFieldConflictPolicy()).isEqualTo(CONVERT_AND_DUPLICATE_FIELD);
     assertThat(docBuilder.getSchema().size()).isEqualTo(18);
+    assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
 
     final String floatStrConflictField = "floatStrConflictField";
     LogMessage msg1 =
@@ -823,6 +932,21 @@ public class SchemaAwareLogDocumentBuilderImplTest {
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry))
         .isEqualTo(1);
+    assertThat(
+            testDocument1
+                .getFields()
+                .stream()
+                .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
+                .count())
+        .isEqualTo(1);
+    assertThat(
+            testDocument2
+                .getFields()
+                .stream()
+                .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
+                .count())
+        .isEqualTo(1);
+    assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
   }
 
   @Test
@@ -830,6 +954,7 @@ public class SchemaAwareLogDocumentBuilderImplTest {
     SchemaAwareLogDocumentBuilderImpl docBuilder = build(CONVERT_FIELD_VALUE, true, meterRegistry);
     assertThat(docBuilder.getIndexFieldConflictPolicy()).isEqualTo(CONVERT_FIELD_VALUE);
     assertThat(docBuilder.getSchema().size()).isEqualTo(18);
+    assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
 
     final String floatStrConflictField = "floatStrConflictField";
     LogMessage msg1 =
@@ -929,6 +1054,21 @@ public class SchemaAwareLogDocumentBuilderImplTest {
     assertThat(MetricsUtil.getCount(DROP_FIELDS_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isEqualTo(1);
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();
+    assertThat(
+            testDocument1
+                .getFields()
+                .stream()
+                .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
+                .count())
+        .isEqualTo(1);
+    assertThat(
+            testDocument2
+                .getFields()
+                .stream()
+                .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
+                .count())
+        .isEqualTo(1);
+    assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
   }
 
   @Test
@@ -936,6 +1076,7 @@ public class SchemaAwareLogDocumentBuilderImplTest {
     SchemaAwareLogDocumentBuilderImpl docBuilder = build(DROP_FIELD, true, meterRegistry);
     assertThat(docBuilder.getIndexFieldConflictPolicy()).isEqualTo(DROP_FIELD);
     assertThat(docBuilder.getSchema().size()).isEqualTo(18);
+    assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
 
     final String floatStrConflictField = "floatStrConflictField";
     LogMessage message =
@@ -1037,6 +1178,21 @@ public class SchemaAwareLogDocumentBuilderImplTest {
     assertThat(MetricsUtil.getCount(DROP_FIELDS_COUNTER, meterRegistry)).isEqualTo(1);
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();
+    assertThat(
+            testDocument
+                .getFields()
+                .stream()
+                .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
+                .count())
+        .isEqualTo(1);
+    assertThat(
+            testDocument2
+                .getFields()
+                .stream()
+                .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
+                .count())
+        .isEqualTo(1);
+    assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
   }
 
   @Test
@@ -1044,7 +1200,8 @@ public class SchemaAwareLogDocumentBuilderImplTest {
     SchemaAwareLogDocumentBuilderImpl docBuilder =
         build(CONVERT_AND_DUPLICATE_FIELD, true, meterRegistry);
     assertThat(docBuilder.getIndexFieldConflictPolicy()).isEqualTo(CONVERT_AND_DUPLICATE_FIELD);
-    assertThat(docBuilder.getSchema().size()).isEqualTo(17);
+    assertThat(docBuilder.getSchema().size()).isEqualTo(18);
+    assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
 
     // Set stringField is a String
     final String stringField = "stringField";
@@ -1052,7 +1209,7 @@ public class SchemaAwareLogDocumentBuilderImplTest {
         .getSchema()
         .put(
             stringField, new LuceneFieldDef(stringField, FieldType.STRING.name, false, true, true));
-    assertThat(docBuilder.getSchema().size()).isEqualTo(18);
+    assertThat(docBuilder.getSchema().size()).isEqualTo(19);
 
     LogMessage msg1 =
         new LogMessage(
@@ -1076,9 +1233,9 @@ public class SchemaAwareLogDocumentBuilderImplTest {
                     Map.of("leaf2", "value2", "leaf21", 3, "nestedList", List.of(1)))));
 
     Document testDocument1 = docBuilder.fromMessage(msg1);
-    final int expectedDocFieldsAfterMsg1 = 18;
+    final int expectedDocFieldsAfterMsg1 = 19;
     assertThat(testDocument1.getFields().size()).isEqualTo(expectedDocFieldsAfterMsg1);
-    final int expectedFieldsAfterMsg1 = 23;
+    final int expectedFieldsAfterMsg1 = 24;
     assertThat(docBuilder.getSchema().size()).isEqualTo(expectedFieldsAfterMsg1);
     assertThat(docBuilder.getSchema().get(stringField).fieldType).isEqualTo(FieldType.STRING);
     assertThat(docBuilder.getSchema().keySet())
@@ -1154,5 +1311,20 @@ public class SchemaAwareLogDocumentBuilderImplTest {
     assertThat(MetricsUtil.getCount(DROP_FIELDS_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();
+    assertThat(
+            testDocument1
+                .getFields()
+                .stream()
+                .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
+                .count())
+        .isEqualTo(1);
+    assertThat(
+            testDocument2
+                .getFields()
+                .stream()
+                .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
+                .count())
+        .isEqualTo(1);
+    assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/schema/SchemaAwareLogDocumentBuilderImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/schema/SchemaAwareLogDocumentBuilderImplTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.junit.Before;
@@ -87,6 +88,10 @@ public class SchemaAwareLogDocumentBuilderImplTest {
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isEqualTo(1);
+    // Ensure lucene field name and the name in schema match.
+    assertThat(docBuilder.getSchema().keySet())
+        .containsAll(
+            docBuilder.getSchema().values().stream().map(f -> f.name).collect(Collectors.toList()));
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/SpanUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/SpanUtil.java
@@ -98,7 +98,7 @@ public class SpanUtil {
 
     tags.add(
         Trace.KeyValue.newBuilder()
-            .setKey(LogMessage.SystemField.TYPE.fieldName)
+            .setKey(LogMessage.ReservedField.TYPE.fieldName)
             .setVTypeValue(Trace.ValueType.STRING.getNumber())
             .setVStr(msgType)
             .build());

--- a/kaldb/src/test/java/com/slack/kaldb/writer/LogMessageWriterImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/LogMessageWriterImplTest.java
@@ -106,7 +106,7 @@ public class LogMessageWriterImplTest {
     assertThat(searchChunkManager(TEST_DATASET_NAME, "").hits.size()).isEqualTo(1);
     assertThat(searchChunkManager(TEST_DATASET_NAME, "Message1").hits.size()).isEqualTo(1);
     assertThat(searchChunkManager(TEST_DATASET_NAME, "Message2").hits.size()).isEqualTo(0);
-    assertThat(searchChunkManager(TEST_DATASET_NAME, "id:Message1").hits.size()).isEqualTo(1);
+    assertThat(searchChunkManager(TEST_DATASET_NAME, "_id:Message1").hits.size()).isEqualTo(1);
     assertThat(searchChunkManager(TEST_DATASET_NAME, "intproperty:1").hits.size()).isEqualTo(1);
     assertThat(searchChunkManager(TEST_DATASET_NAME, "intproperty:2").hits.size()).isEqualTo(0);
     assertThat(
@@ -344,8 +344,8 @@ public class LogMessageWriterImplTest {
     assertThat(searchChunkManager(serviceName, "").hits.size()).isEqualTo(2);
     assertThat(searchChunkManager(serviceName, "http_method:POST").hits.size()).isEqualTo(2);
     assertThat(searchChunkManager(serviceName, "trace_id:t1").hits.size()).isEqualTo(2);
-    assertThat(searchChunkManager(serviceName, "id:1").hits.size()).isEqualTo(1);
-    assertThat(searchChunkManager(serviceName, "id:2").hits.size()).isEqualTo(1);
+    assertThat(searchChunkManager(serviceName, "_id:1").hits.size()).isEqualTo(1);
+    assertThat(searchChunkManager(serviceName, "_id:2").hits.size()).isEqualTo(1);
     assertThat(searchChunkManager(serviceName, "parent_id:1").hits.size()).isEqualTo(1);
     assertThat(searchChunkManager(serviceName, "parent_id:0").hits.size()).isEqualTo(1);
     assertThat(searchChunkManager(serviceName, "name:test_span").hits.size()).isEqualTo(1);
@@ -413,8 +413,8 @@ public class LogMessageWriterImplTest {
     assertThat(searchChunkManager(serviceName, "").hits.size()).isEqualTo(1);
     assertThat(searchChunkManager(serviceName, "http_method:POST").hits.size()).isEqualTo(1);
     assertThat(searchChunkManager(serviceName, "trace_id:t1").hits.size()).isEqualTo(1);
-    assertThat(searchChunkManager(serviceName, "id:1").hits.size()).isEqualTo(1);
-    assertThat(searchChunkManager(serviceName, "id:2").hits.size()).isZero();
+    assertThat(searchChunkManager(serviceName, "_id:1").hits.size()).isEqualTo(1);
+    assertThat(searchChunkManager(serviceName, "_id:2").hits.size()).isZero();
     assertThat(searchChunkManager(serviceName, "parent_id:0").hits.size()).isEqualTo(1);
     assertThat(searchChunkManager(serviceName, "http_method:GET OR method:callbacks*").hits.size())
         .isEqualTo(1);


### PR DESCRIPTION
Add full text search to `SchemaAwareLogDocumentBuilder`.  Also, fixed a bug in lucene field definition. Added new tests.

Pre-fixed internal fields with '_' following ES conventions. Moved Type into reserved field. Updated tests. 