### PR TITLE
expose consumer.fetch.min.bytes as a sysprop

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -114,6 +114,9 @@ preprocessorConfig:
     applicationId: ${KAFKA_APPLICATION_ID:-kaldb_preprocessor}
     numStreamThreads: ${KAFKA_STREAM_THREADS:-2}
     processingGuarantee: ${KAFKA_STREAM_PROCESSING_GUARANTEE:-at_least_once}
+    additionalProps:
+      consumer.fetch.min.bytes: ${KAFKA_STREAM_CONSUMER_FETCH_MIN_BYTES:-1}
+
   serverConfig:
     serverPort: ${KALDB_PREPROCESSOR_SERVER_PORT:-8086}
     serverAddress: ${KALDB_PREPROCESSOR_SERVER_ADDRESS:-localhost}


### PR DESCRIPTION
The way we deploy currently, we need to allow for configurable params to be exposed as sysprops.

This is kinda lame, but for now this is the quickest way. To experiment with more kafka tunables, we might want to copy over the default config.yaml to our kube deployment and add more settings there?