### PR TITLE
Allow conversions to boolean from the different field types we support

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/metadata/schema/FieldType.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/schema/FieldType.java
@@ -176,6 +176,9 @@ public enum FieldType {
           return (float) 0;
         }
       }
+      if (toType == FieldType.BOOLEAN) {
+        return ((String) value).equals("1") || ((String) value).equalsIgnoreCase("true");
+      }
     }
 
     // Int type
@@ -191,6 +194,9 @@ public enum FieldType {
       }
       if (toType == FieldType.DOUBLE) {
         return ((Integer) value).doubleValue();
+      }
+      if (toType == FieldType.BOOLEAN) {
+        return ((Integer) value) != 0;
       }
     }
 
@@ -208,6 +214,9 @@ public enum FieldType {
       if (toType == FieldType.DOUBLE) {
         return ((Long) value).doubleValue();
       }
+      if (toType == FieldType.BOOLEAN) {
+        return ((Long) value) != 0;
+      }
     }
 
     // Float type
@@ -224,6 +233,9 @@ public enum FieldType {
       if (toType == FieldType.DOUBLE) {
         return ((Float) value).doubleValue();
       }
+      if (toType == FieldType.BOOLEAN) {
+        return ((Float) value) != 0;
+      }
     }
 
     // Double type
@@ -239,6 +251,9 @@ public enum FieldType {
       }
       if (toType == FieldType.FLOAT) {
         return ((Double) value).floatValue();
+      }
+      if (toType == FieldType.BOOLEAN) {
+        return ((Double) value) != 0;
       }
     }
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/schema/ConvertFieldValueAndDuplicateTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/schema/ConvertFieldValueAndDuplicateTest.java
@@ -320,7 +320,7 @@ public class ConvertFieldValueAndDuplicateTest {
                 conflictingFieldName,
                 "random"));
     Document msg2Doc = convertFieldBuilder.fromMessage(msg2);
-    assertThat(msg2Doc.getFields().size()).isEqualTo(14);
+    assertThat(msg2Doc.getFields().size()).isEqualTo(15);
     String additionalCreatedFieldName = makeNewFieldOfType(conflictingFieldName, FieldType.TEXT);
     // Value converted and new field is added.
     assertThat(
@@ -332,8 +332,8 @@ public class ConvertFieldValueAndDuplicateTest {
                         f.name().equals(conflictingFieldName)
                             || f.name().equals(additionalCreatedFieldName))
                 .count())
-        .isEqualTo(1);
-    assertThat(msg2Doc.getField(conflictingFieldName)).isNull();
+        .isEqualTo(2);
+    assertThat(msg2Doc.getField(conflictingFieldName).stringValue()).isEqualTo("false");
     // Field value is null since we don't store the int field anymore.
     assertThat(msg2Doc.getField(additionalCreatedFieldName).stringValue()).isEqualTo("random");
     assertThat(convertFieldBuilder.getSchema().size()).isEqualTo(20);
@@ -345,7 +345,7 @@ public class ConvertFieldValueAndDuplicateTest {
         .isEqualTo(FieldType.TEXT);
     assertThat(MetricsUtil.getCount(DROP_FIELDS_COUNTER, meterRegistry)).isZero();
     // was not able to parse "random" into a boolean field
-    assertThat(MetricsUtil.getCount(CONVERT_ERROR_COUNTER, meterRegistry)).isEqualTo(1);
+    assertThat(MetricsUtil.getCount(CONVERT_ERROR_COUNTER, meterRegistry)).isEqualTo(0);
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry))
         .isEqualTo(1);

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/schema/FieldTypeTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/schema/FieldTypeTest.java
@@ -14,6 +14,12 @@ public class FieldTypeTest {
     assertThat(convertFieldValue("3", FieldType.TEXT, FieldType.DOUBLE)).isEqualTo(3.0d);
     assertThat(convertFieldValue("4", FieldType.TEXT, FieldType.STRING)).isEqualTo("4");
     assertThat(convertFieldValue("4", FieldType.STRING, FieldType.TEXT)).isEqualTo("4");
+    assertThat(convertFieldValue("1", FieldType.STRING, FieldType.BOOLEAN)).isEqualTo(true);
+    assertThat(convertFieldValue("0", FieldType.STRING, FieldType.BOOLEAN)).isEqualTo(false);
+    assertThat(convertFieldValue("true", FieldType.STRING, FieldType.BOOLEAN)).isEqualTo(true);
+    assertThat(convertFieldValue("false", FieldType.STRING, FieldType.BOOLEAN)).isEqualTo(false);
+    assertThat(convertFieldValue("TRUE", FieldType.STRING, FieldType.BOOLEAN)).isEqualTo(true);
+    assertThat(convertFieldValue("-1", FieldType.STRING, FieldType.BOOLEAN)).isEqualTo(false);
 
     int intValue = 1;
     assertThat(convertFieldValue(intValue, FieldType.INTEGER, FieldType.TEXT)).isEqualTo("1");
@@ -22,6 +28,12 @@ public class FieldTypeTest {
     assertThat(convertFieldValue(intValue + 2, FieldType.INTEGER, FieldType.FLOAT)).isEqualTo(3.0f);
     assertThat(convertFieldValue(intValue + 3, FieldType.INTEGER, FieldType.DOUBLE))
         .isEqualTo(4.0d);
+    assertThat(convertFieldValue(intValue, FieldType.INTEGER, FieldType.BOOLEAN)).isEqualTo(true);
+    assertThat(convertFieldValue(0, FieldType.INTEGER, FieldType.BOOLEAN)).isEqualTo(false);
+    assertThat(convertFieldValue(Integer.MAX_VALUE, FieldType.INTEGER, FieldType.BOOLEAN))
+        .isEqualTo(true);
+    assertThat(convertFieldValue(Integer.MIN_VALUE, FieldType.INTEGER, FieldType.BOOLEAN))
+        .isEqualTo(true);
 
     long longValue = 1L;
     assertThat(convertFieldValue(longValue, FieldType.LONG, FieldType.TEXT)).isEqualTo("1");
@@ -29,6 +41,12 @@ public class FieldTypeTest {
     assertThat(convertFieldValue(longValue + 1, FieldType.LONG, FieldType.INTEGER)).isEqualTo(2);
     assertThat(convertFieldValue(longValue + 2, FieldType.LONG, FieldType.FLOAT)).isEqualTo(3.0f);
     assertThat(convertFieldValue(longValue + 3, FieldType.LONG, FieldType.DOUBLE)).isEqualTo(4.0);
+    assertThat(convertFieldValue(longValue, FieldType.LONG, FieldType.BOOLEAN)).isEqualTo(true);
+    assertThat(convertFieldValue(0L, FieldType.LONG, FieldType.BOOLEAN)).isEqualTo(false);
+    assertThat(convertFieldValue(Long.MAX_VALUE, FieldType.LONG, FieldType.BOOLEAN))
+        .isEqualTo(true);
+    assertThat(convertFieldValue(Long.MIN_VALUE, FieldType.LONG, FieldType.BOOLEAN))
+        .isEqualTo(true);
 
     float floatValue = 1.0f;
     assertThat(convertFieldValue(floatValue, FieldType.FLOAT, FieldType.TEXT)).isEqualTo("1.0");
@@ -38,6 +56,12 @@ public class FieldTypeTest {
     assertThat(convertFieldValue(floatValue + 2.0f, FieldType.FLOAT, FieldType.LONG)).isEqualTo(3L);
     assertThat(convertFieldValue(floatValue + 3.0f, FieldType.FLOAT, FieldType.DOUBLE))
         .isEqualTo(4.0);
+    assertThat(convertFieldValue(floatValue, FieldType.FLOAT, FieldType.BOOLEAN)).isEqualTo(true);
+    assertThat(convertFieldValue(0f, FieldType.FLOAT, FieldType.BOOLEAN)).isEqualTo(false);
+    assertThat(convertFieldValue(Float.MAX_VALUE, FieldType.FLOAT, FieldType.BOOLEAN))
+        .isEqualTo(true);
+    assertThat(convertFieldValue(Float.MIN_VALUE, FieldType.FLOAT, FieldType.BOOLEAN))
+        .isEqualTo(true);
 
     double doubleValue = 1.0;
     assertThat(convertFieldValue(doubleValue, FieldType.DOUBLE, FieldType.TEXT)).isEqualTo("1.0");
@@ -48,6 +72,12 @@ public class FieldTypeTest {
         .isEqualTo(3L);
     assertThat(convertFieldValue(doubleValue + 3.0f, FieldType.DOUBLE, FieldType.FLOAT))
         .isEqualTo(4.0f);
+    assertThat(convertFieldValue(doubleValue, FieldType.DOUBLE, FieldType.BOOLEAN)).isEqualTo(true);
+    assertThat(convertFieldValue(0d, FieldType.DOUBLE, FieldType.BOOLEAN)).isEqualTo(false);
+    assertThat(convertFieldValue(Double.MAX_VALUE, FieldType.DOUBLE, FieldType.BOOLEAN))
+        .isEqualTo(true);
+    assertThat(convertFieldValue(Double.MIN_VALUE, FieldType.DOUBLE, FieldType.BOOLEAN))
+        .isEqualTo(true);
 
     // Test conversion failures
     assertThat(convertFieldValue("testStr1", FieldType.TEXT, FieldType.INTEGER)).isEqualTo(0);


### PR DESCRIPTION
Allow conversions to boolean from the different field types we support

if a value exists that is not the equivalent of 0 , the conversion to boolean should be "true"

We still need to add support for boolean->other field types