### PR TITLE
Convert field values to boolean

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/metadata/schema/FieldType.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/schema/FieldType.java
@@ -257,6 +257,23 @@ public enum FieldType {
       }
     }
 
+    if (fromType == FieldType.BOOLEAN) {
+      if (toType == FieldType.TEXT || toType == FieldType.STRING) {
+        return value.toString();
+      }
+      if (toType == FieldType.INTEGER) {
+        return (Boolean) value ? 1 : 0;
+      }
+      if (toType == FieldType.LONG) {
+        return (Boolean) value ? 1L : 0L;
+      }
+      if (toType == FieldType.FLOAT) {
+        return (Boolean) value ? 1f : 0f;
+      }
+      if (toType == FieldType.DOUBLE) {
+        return (Boolean) value ? 1d : 0d;
+      }
+    }
     return null;
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/schema/ConvertFieldValueAndDuplicateTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/schema/ConvertFieldValueAndDuplicateTest.java
@@ -344,7 +344,6 @@ public class ConvertFieldValueAndDuplicateTest {
     assertThat(convertFieldBuilder.getSchema().get(additionalCreatedFieldName).fieldType)
         .isEqualTo(FieldType.TEXT);
     assertThat(MetricsUtil.getCount(DROP_FIELDS_COUNTER, meterRegistry)).isZero();
-    // was not able to parse "random" into a boolean field
     assertThat(MetricsUtil.getCount(CONVERT_ERROR_COUNTER, meterRegistry)).isEqualTo(0);
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry))
@@ -366,52 +365,54 @@ public class ConvertFieldValueAndDuplicateTest {
     assertThat(convertFieldBuilder.getSchema().keySet())
         .contains(LogMessage.SystemField.ALL.fieldName);
 
-    // TODO: When we add boolean conversion logic add back this test
-    // should be able to parse "true" as a boolean
-    //    LogMessage msg3 =
-    //            new LogMessage(
-    //                    MessageUtil.TEST_DATASET_NAME,
-    //                    "INFO",
-    //                    "2",
-    //                    Map.of(
-    //                            LogMessage.ReservedField.TIMESTAMP.fieldName,
-    //                            MessageUtil.getCurrentLogDate(),
-    //                            LogMessage.ReservedField.MESSAGE.fieldName,
-    //                            "Test message",
-    //                            LogMessage.ReservedField.TAG.fieldName,
-    //                            "foo-bar",
-    //                            LogMessage.ReservedField.HOSTNAME.fieldName,
-    //                            "host1-dc2.abc.com",
-    //                            conflictingFieldName,
-    //                            "true"));
-    //    Document msg3Doc = convertFieldBuilder.fromMessage(msg3);
-    //    assertThat(msg3Doc.getFields().size()).isEqualTo(15);
-    //    // Value converted and new field is added.
-    //    assertThat(
-    //            msg3Doc
-    //                    .getFields()
-    //                    .stream()
-    //                    .filter(
-    //                            f ->
-    //                                    f.name().equals(conflictingFieldName)
-    //                                            || f.name().equals(additionalCreatedFieldName))
-    //                    .count())
-    //            .isEqualTo(2);
-    //    assertThat(msg2Doc.getField(conflictingFieldName).stringValue()).isEqualTo("true");
-    //    assertThat(msg2Doc.getField(additionalCreatedFieldName).stringValue()).isEqualTo("true");
-    //    assertThat(convertFieldBuilder.getSchema().size()).isEqualTo(20);
-    //    assertThat(convertFieldBuilder.getSchema().keySet())
-    //            .contains(conflictingFieldName, additionalCreatedFieldName);
-    //    assertThat(convertFieldBuilder.getSchema().get(conflictingFieldName).fieldType)
-    //            .isEqualTo(FieldType.BOOLEAN);
-    //    assertThat(convertFieldBuilder.getSchema().get(additionalCreatedFieldName).fieldType)
-    //            .isEqualTo(FieldType.TEXT);
-    //    assertThat(MetricsUtil.getCount(DROP_FIELDS_COUNTER, meterRegistry)).isZero();
-    //    // was not able to parse "random" into a boolean field
-    //    assertThat(MetricsUtil.getCount(CONVERT_ERROR_COUNTER, meterRegistry)).isEqualTo(1);
-    //    assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isZero();
-    //    assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry))
-    //            .isEqualTo(2);
+    // We now want to test conversion of boolean to a text field
+    String additionalCreatedBoolFieldName =
+        makeNewFieldOfType(additionalCreatedFieldName, FieldType.BOOLEAN);
+    LogMessage msg3 =
+        new LogMessage(
+            MessageUtil.TEST_DATASET_NAME,
+            "INFO",
+            "2",
+            Map.of(
+                LogMessage.ReservedField.TIMESTAMP.fieldName,
+                MessageUtil.getCurrentLogDate(),
+                LogMessage.ReservedField.MESSAGE.fieldName,
+                "Test message",
+                LogMessage.ReservedField.TAG.fieldName,
+                "foo-bar",
+                LogMessage.ReservedField.HOSTNAME.fieldName,
+                "host1-dc2.abc.com",
+                additionalCreatedFieldName,
+                true));
+    Document msg3Doc = convertFieldBuilder.fromMessage(msg3);
+    assertThat(msg3Doc.getFields().size()).isEqualTo(15);
+    assertThat(
+            msg3Doc
+                .getFields()
+                .stream()
+                .filter(
+                    f ->
+                        f.name().equals(additionalCreatedBoolFieldName)
+                            || f.name().equals(additionalCreatedFieldName))
+                .count())
+        .isEqualTo(2);
+    assertThat(msg3Doc.getField(additionalCreatedFieldName).stringValue()).isEqualTo("true");
+    assertThat(msg3Doc.getField(additionalCreatedBoolFieldName).stringValue()).isEqualTo("true");
+    assertThat(convertFieldBuilder.getSchema().size()).isEqualTo(21);
+    assertThat(convertFieldBuilder.getSchema().keySet())
+        .contains(conflictingFieldName, additionalCreatedFieldName, additionalCreatedBoolFieldName);
+    assertThat(convertFieldBuilder.getSchema().get(conflictingFieldName).fieldType)
+        .isEqualTo(FieldType.BOOLEAN);
+    assertThat(convertFieldBuilder.getSchema().get(additionalCreatedFieldName).fieldType)
+        .isEqualTo(FieldType.TEXT);
+    assertThat(convertFieldBuilder.getSchema().get(additionalCreatedBoolFieldName).fieldType)
+        .isEqualTo(FieldType.BOOLEAN);
+    assertThat(MetricsUtil.getCount(DROP_FIELDS_COUNTER, meterRegistry)).isZero();
+    // was not able to parse "random" into a boolean field
+    assertThat(MetricsUtil.getCount(CONVERT_ERROR_COUNTER, meterRegistry)).isEqualTo(0);
+    assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isZero();
+    assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry))
+        .isEqualTo(2);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/schema/FieldTypeTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/schema/FieldTypeTest.java
@@ -79,6 +79,19 @@ public class FieldTypeTest {
     assertThat(convertFieldValue(Double.MIN_VALUE, FieldType.DOUBLE, FieldType.BOOLEAN))
         .isEqualTo(true);
 
+    assertThat(convertFieldValue(true, FieldType.BOOLEAN, FieldType.TEXT)).isEqualTo("true");
+    assertThat(convertFieldValue(false, FieldType.BOOLEAN, FieldType.TEXT)).isEqualTo("false");
+    assertThat(convertFieldValue(true, FieldType.BOOLEAN, FieldType.STRING)).isEqualTo("true");
+    assertThat(convertFieldValue(false, FieldType.BOOLEAN, FieldType.STRING)).isEqualTo("false");
+    assertThat(convertFieldValue(true, FieldType.BOOLEAN, FieldType.DOUBLE)).isEqualTo(1.0d);
+    assertThat(convertFieldValue(false, FieldType.BOOLEAN, FieldType.DOUBLE)).isEqualTo(0d);
+    assertThat(convertFieldValue(true, FieldType.BOOLEAN, FieldType.INTEGER)).isEqualTo(1);
+    assertThat(convertFieldValue(false, FieldType.BOOLEAN, FieldType.INTEGER)).isEqualTo(0);
+    assertThat(convertFieldValue(true, FieldType.BOOLEAN, FieldType.FLOAT)).isEqualTo(1f);
+    assertThat(convertFieldValue(false, FieldType.BOOLEAN, FieldType.FLOAT)).isEqualTo(0f);
+    assertThat(convertFieldValue(true, FieldType.BOOLEAN, FieldType.LONG)).isEqualTo(1L);
+    assertThat(convertFieldValue(false, FieldType.BOOLEAN, FieldType.LONG)).isEqualTo(0L);
+
     // Test conversion failures
     assertThat(convertFieldValue("testStr1", FieldType.TEXT, FieldType.INTEGER)).isEqualTo(0);
     assertThat(convertFieldValue("testStr2", FieldType.TEXT, FieldType.LONG)).isEqualTo(0L);


### PR DESCRIPTION
When the first document has a boolean field, and then subsequent values for the field have long/int/etc convert them to boolean while also duplicating the date into the "field_type" new field 

The conversions are kinda ridiculous and don't make any sense , but some of the previous ones also are. So adding for completeness to get rid of errors.

Once done, we can think if we should go down the conversion option and support it. But that's for another PR discussion