### PR TITLE
allow for kafkaPartitionStickyTimeoutMs to be 0 and expose as a config as well

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -127,3 +127,4 @@ preprocessorConfig:
   preprocessorInstanceCount: ${PREPROCESSOR_INSTANCE_COUNT:-1}
   dataTransformer: ${PREPROCESSOR_TRANSFORMER:-api_log}
   rateLimiterMaxBurstSeconds: ${PREPROCESSOR_RATE_LIMITER_MAX_BURST_SECONDS:-1}
+  kafkaPartitionStickyTimeoutMs: ${KAFKA_PARTITION_STICKY_TIMEOUT_MS:-0}

--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorService.java
@@ -190,7 +190,7 @@ public class PreprocessorService extends AbstractService {
     checkArgument(upstreamTopics.size() > 0, "upstream topic list must not be empty");
     checkArgument(!downstreamTopic.isEmpty(), "downstream topic must not be empty");
     checkArgument(!dataTransformer.isEmpty(), "data transformer must not be empty");
-    checkArgument(kafkaPartitionStickyTimeoutMs > 0, "kafkaPartitionStickyTimeoutMs must not be 0");
+    checkArgument(kafkaPartitionStickyTimeoutMs >= 0, "kafkaPartitionStickyTimeoutMs must be >=0");
 
     StreamsBuilder builder = new StreamsBuilder();
 


### PR DESCRIPTION
expose kafkaPartitionStickyTimeoutMs in the config and keep the default to 10ms