### PR TITLE
Fix timestamp indexing type

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
@@ -69,7 +69,10 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder<LogMes
             false,
             true,
             true));
-    addTextField(fieldDefBuilder, LogMessage.ReservedField.TIMESTAMP.fieldName, false, true);
+    fieldDefBuilder.put(
+        LogMessage.ReservedField.TIMESTAMP.fieldName,
+        new LuceneFieldDef(
+            LogMessage.ReservedField.TIMESTAMP.fieldName, FieldType.LONG.name, false, true, true));
     fieldDefBuilder.put(
         LogMessage.ReservedField.TYPE.fieldName,
         new LuceneFieldDef(


### PR DESCRIPTION
Timetamp should be indexed as a long, and not a string so that we can perform aggregations on this field field.