### PR TITLE
Fix incorrect indexing for duration_ms field

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/writer/SpanFormatter.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/SpanFormatter.java
@@ -6,7 +6,9 @@ import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.logstore.LogWireMessage;
 import com.slack.service.murron.Murron;
 import com.slack.service.murron.trace.Trace;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
@@ -134,7 +136,9 @@ public class SpanFormatter {
     jsonMap.put(LogMessage.ReservedField.PARENT_ID.fieldName, span.getParentId().toStringUtf8());
     jsonMap.put(LogMessage.ReservedField.TRACE_ID.fieldName, span.getTraceId().toStringUtf8());
     jsonMap.put(LogMessage.ReservedField.NAME.fieldName, span.getName());
-    jsonMap.put(LogMessage.ReservedField.DURATION_MS.fieldName, span.getDuration());
+    jsonMap.put(
+        LogMessage.ReservedField.DURATION_MS.fieldName,
+        Duration.of(span.getDuration(), ChronoUnit.MICROS).toMillis());
 
     // TODO: Use a microsecond resolution, instead of millisecond resolution.
     if (span.getTimestamp() <= 0) {

--- a/kaldb/src/test/java/com/slack/kaldb/writer/SpanFormatterTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/SpanFormatterTest.java
@@ -9,7 +9,9 @@ import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.testlib.SpanUtil;
 import com.slack.service.murron.trace.Trace;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
@@ -49,7 +51,7 @@ public class SpanFormatterTest {
     assertThat(source.get(LogMessage.ReservedField.SERVICE_NAME.fieldName)).isEqualTo(serviceName);
     assertThat(source.get(LogMessage.ReservedField.NAME.fieldName)).isEqualTo(name);
     assertThat(source.get(LogMessage.ReservedField.DURATION_MS.fieldName))
-        .isEqualTo(durationMicros);
+        .isEqualTo(Duration.of(durationMicros, ChronoUnit.MICROS).toMillis());
     assertThat(source.get("http_method")).isEqualTo("POST");
     assertThat(source.get("method")).isEqualTo("callbacks.flannel");
     assertThat(source.get("boolean")).isEqualTo(true);
@@ -87,7 +89,7 @@ public class SpanFormatterTest {
     assertThat(source.get(LogMessage.ReservedField.SERVICE_NAME.fieldName)).isEqualTo(serviceName);
     assertThat(source.get(LogMessage.ReservedField.NAME.fieldName)).isEqualTo(name);
     assertThat(source.get(LogMessage.ReservedField.DURATION_MS.fieldName))
-        .isEqualTo(durationMicros);
+        .isEqualTo(Duration.of(durationMicros, ChronoUnit.MICROS).toMillis());
     assertThat(source.get("http_method")).isEqualTo("POST");
     assertThat(source.get("method")).isEqualTo("callbacks.flannel");
     assertThat(source.get("boolean")).isEqualTo(true);
@@ -163,7 +165,7 @@ public class SpanFormatterTest {
           .isEqualTo(serviceName);
       assertThat((String) source.get(LogMessage.ReservedField.NAME.fieldName)).startsWith(name);
       assertThat(source.get(LogMessage.ReservedField.DURATION_MS.fieldName))
-          .isEqualTo(durationMicros);
+          .isEqualTo(Duration.of(durationMicros, ChronoUnit.MICROS).toMillis());
       assertThat(source.get("http_method")).isEqualTo("POST");
       assertThat(source.get("method")).isEqualTo("callbacks.flannel");
       assertThat(source.get("boolean")).isEqualTo(true);


### PR DESCRIPTION
The current span duration is provided as micros, and then directly put into a field named duration_ms. This causes issues when attempting to run aggregations, as it's indexed as a long and can overflow. 