### PR TITLE
ci: use Eclipse Temurin

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: '11'
-        distribution: 'corretto'
+        distribution: 'temurin'
         cache: 'maven'
     - name: Ensure code is formatted
       run: mvn com.coveo:fmt-maven-plugin:check --file kaldb/pom.xml


### PR DESCRIPTION
Shared runners have Temurin pre-installed. That helps to speed up build as the JDK download is no longer needed

For example, rather than :

    Downloading Java 17.0.6+10 (Adopt-Hotspot) from https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.6%2B10/OpenJDK17U-jdk_x64_linux_hotspot_17.0.6_10.tar.gz ...
    Extracting Java archive...
    /usr/bin/tar xz --warning=no-unknown-keyword -C /home/runner/work/_temp/4888a6ec-1ae0-4fb7-9bcd-181c630a2b3c -f /home/runner/work/_temp/855c391a-da2b-4556-9b9c-665a6d0677a6

It will be:

    Installed distributions
    Resolved Java 17.0.6+10 from tool-cache
    Setting Java 17.0.6+10 as the default
    Creating toolchains.xml for JDK version 17 from temurin
    Writing to /home/runner/.m2/toolchains.xml

See https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#hosted-tool-cache