### PR TITLE
indexer should expose transformer to output a single message

### DIFF
--- a/benchmarks/src/main/java/com/slack/kaldb/IndexAPILog.java
+++ b/benchmarks/src/main/java/com/slack/kaldb/IndexAPILog.java
@@ -112,7 +112,7 @@ public class IndexAPILog {
       // Mimic LogMessageWriterImpl#insertRecord kinda without the chunk rollover logic
       try {
         LogMessage localLogMessage =
-            LogMessageWriterImpl.apiLogTransformer.toLogMessage(kafkaRecord).get(0);
+            LogMessageWriterImpl.apiLogTransformer.toLogMessage(kafkaRecord);
         logStore.addMessage(localLogMessage);
       } catch (Exception e) {
         System.out.println("skipping - cannot transform " + e);
@@ -139,7 +139,7 @@ public class IndexAPILog {
         // Mimic LogMessageWriterImpl#insertRecord kinda without the chunk rollover logic
         try {
           LogMessage localLogMessage =
-              LogMessageWriterImpl.apiLogTransformer.toLogMessage(kafkaRecord).get(0);
+              LogMessageWriterImpl.apiLogTransformer.toLogMessage(kafkaRecord);
           logStore.addMessage(localLogMessage);
           indexCount++;
         } catch (Exception e) {

--- a/benchmarks/src/main/java/com/slack/kaldb/IndexingBenchmark.java
+++ b/benchmarks/src/main/java/com/slack/kaldb/IndexingBenchmark.java
@@ -85,7 +85,7 @@ public class IndexingBenchmark {
             "testKey",
             testMurronMsg.toByteString().toByteArray());
 
-    logMessage = LogMessageWriterImpl.apiLogTransformer.toLogMessage(kafkaRecord).get(0);
+    logMessage = LogMessageWriterImpl.apiLogTransformer.toLogMessage(kafkaRecord);
 
     DocumentBuilder<LogMessage> documentBuilder =
         SchemaAwareLogDocumentBuilderImpl.build(CONVERT_VALUE_AND_DUPLICATE_FIELD, true, registry);
@@ -105,8 +105,7 @@ public class IndexingBenchmark {
   @Benchmark
   public void measureIndexingAsKafkaSerializedDocument() throws Exception {
     // Mimic LogMessageWriterImpl#insertRecord kinda without the chunk rollover logic
-    LogMessage localLogMessage =
-        LogMessageWriterImpl.apiLogTransformer.toLogMessage(kafkaRecord).get(0);
+    LogMessage localLogMessage = LogMessageWriterImpl.apiLogTransformer.toLogMessage(kafkaRecord);
     logStore.addMessage(localLogMessage);
   }
 

--- a/benchmarks/src/main/java/com/slack/kaldb/QueryBenchmark.java
+++ b/benchmarks/src/main/java/com/slack/kaldb/QueryBenchmark.java
@@ -94,7 +94,7 @@ public class QueryBenchmark {
                 // Mimic LogMessageWriterImpl#insertRecord kinda without the chunk rollover logic
                 try {
                   LogMessage localLogMessage =
-                      LogMessageWriterImpl.apiLogTransformer.toLogMessage(kafkaRecord).get(0);
+                      LogMessageWriterImpl.apiLogTransformer.toLogMessage(kafkaRecord);
                   logStore.addMessage(localLogMessage);
                 } catch (Exception e) {
                   // ignored

--- a/kaldb/src/main/java/com/slack/kaldb/writer/LogMessageTransformer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/LogMessageTransformer.java
@@ -1,11 +1,10 @@
 package com.slack.kaldb.writer;
 
 import com.slack.kaldb.logstore.LogMessage;
-import java.util.List;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 /** An interface a ConsumerRecord message from Kafka into a LogMessage. */
 @FunctionalInterface
 public interface LogMessageTransformer {
-  List<LogMessage> toLogMessage(ConsumerRecord<String, byte[]> record) throws Exception;
+  LogMessage toLogMessage(ConsumerRecord<String, byte[]> record) throws Exception;
 }

--- a/kaldb/src/test/java/com/slack/kaldb/writer/LogMessageWriterImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/LogMessageWriterImplTest.java
@@ -4,9 +4,7 @@ import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_FAILED_COUN
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_RECEIVED_COUNTER;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static com.slack.kaldb.testlib.ChunkManagerUtil.makeChunkManagerUtil;
-import static com.slack.kaldb.testlib.MessageUtil.TEST_DATASET_NAME;
 import static com.slack.kaldb.testlib.MessageUtil.TEST_MESSAGE_TYPE;
-import static com.slack.kaldb.testlib.MessageUtil.getCurrentLogDate;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
 import static com.slack.kaldb.testlib.SpanUtil.makeSpan;
 import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.MAX_TIME;
@@ -14,7 +12,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import brave.Tracing;
 import com.adobe.testing.s3mock.junit4.S3MockRule;
-import com.google.common.collect.Maps;
 import com.google.protobuf.ByteString;
 import com.slack.kaldb.chunkManager.IndexingChunkManager;
 import com.slack.kaldb.logstore.LogMessage;
@@ -23,8 +20,6 @@ import com.slack.kaldb.logstore.search.SearchResult;
 import com.slack.kaldb.logstore.search.aggregations.DateHistogramAggBuilder;
 import com.slack.kaldb.testlib.ChunkManagerUtil;
 import com.slack.kaldb.testlib.KaldbConfigUtil;
-import com.slack.kaldb.testlib.MessageUtil;
-import com.slack.kaldb.util.JsonUtil;
 import com.slack.service.murron.Murron;
 import com.slack.service.murron.trace.Trace;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -32,9 +27,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -95,65 +88,6 @@ public class LogMessageWriterImplTest {
                 "1", LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName, "1s"),
             Collections.emptyList()),
         Duration.ofMillis(3000));
-  }
-
-  @Test
-  public void testJSONLogMessageInsertion() throws IOException {
-    LogMessageWriterImpl messageWriter =
-        new LogMessageWriterImpl(
-            chunkManagerUtil.chunkManager, LogMessageWriterImpl.jsonLogMessageTransformer);
-
-    String jsonLogMessge = MessageUtil.makeLogMessageJSON(1);
-    ConsumerRecord<String, byte[]> jsonRecord = consumerRecordWithValue(jsonLogMessge.getBytes());
-
-    assertThat(messageWriter.insertRecord(jsonRecord)).isTrue();
-    assertThat(getCount(MESSAGES_RECEIVED_COUNTER, metricsRegistry)).isEqualTo(1);
-    assertThat(getCount(MESSAGES_FAILED_COUNTER, metricsRegistry)).isEqualTo(0);
-    chunkManagerUtil.chunkManager.getActiveChunk().commit();
-
-    // Search
-    assertThat(searchChunkManager(TEST_DATASET_NAME, "").hits.size()).isEqualTo(1);
-    assertThat(searchChunkManager(TEST_DATASET_NAME, "Message1").hits.size()).isEqualTo(1);
-    assertThat(searchChunkManager(TEST_DATASET_NAME, "Message2").hits.size()).isEqualTo(0);
-    // TODO: Uncomment after query parser is updated to query numerics using schema.
-    // assertThat(searchChunkManager(TEST_DATASET_NAME, "_id:Message1").hits.size()).isEqualTo(1);
-    // assertThat(searchChunkManager(TEST_DATASET_NAME, "intproperty:1").hits.size()).isEqualTo(1);
-    // assertThat(searchChunkManager(TEST_DATASET_NAME, "intproperty:2").hits.size()).isEqualTo(0);
-    // assertThat(
-    //        searchChunkManager(TEST_DATASET_NAME, "longproperty:1 AND intproperty:1").hits.size())
-    //    .isEqualTo(1);
-  }
-
-  @Test
-  public void testFaultyJSONLogMessageInsertion() throws IOException {
-    LogMessageWriterImpl messageWriter =
-        new LogMessageWriterImpl(
-            chunkManagerUtil.chunkManager, LogMessageWriterImpl.jsonLogMessageTransformer);
-
-    Map<String, Object> fieldMap = Maps.newHashMap();
-    String id = "1";
-    fieldMap.put("id", id);
-    fieldMap.put("index", TEST_DATASET_NAME);
-    Map<String, Object> sourceFieldMap = new HashMap<>();
-    sourceFieldMap.put(LogMessage.ReservedField.TIMESTAMP.fieldName, getCurrentLogDate());
-    String message = String.format("The identifier in this message is %s", id);
-    sourceFieldMap.put(LogMessage.ReservedField.MESSAGE.fieldName, message);
-    fieldMap.put("source", sourceFieldMap);
-    String jsonLogMessage = JsonUtil.writeAsString(fieldMap);
-
-    ConsumerRecord<String, byte[]> jsonRecord = consumerRecordWithValue(jsonLogMessage.getBytes());
-    assertThat(messageWriter.insertRecord(jsonRecord)).isFalse();
-  }
-
-  @Test
-  public void testMalformedJSONLogMessageInsertion() throws IOException {
-    LogMessageWriterImpl messageWriter =
-        new LogMessageWriterImpl(
-            chunkManagerUtil.chunkManager, LogMessageWriterImpl.jsonLogMessageTransformer);
-
-    ConsumerRecord<String, byte[]> jsonRecord =
-        consumerRecordWithValue("malformedJsonMessage".getBytes());
-    assertThat(messageWriter.insertRecord(jsonRecord)).isFalse();
   }
 
   @Test


### PR DESCRIPTION
Kaldb Indexer doesn't have any transformer that can multiple messages at once. The preprocessor always writes out once `Trace.Span` proto 

This PR cleans up the interface for the indexer to only read one message at a time - Also incorporates https://github.com/slackhq/kaldb/pull/491 but we can commit them in separate PRs