### PR TITLE
Unique count aggregation

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/aggregations/UniqueCountAggBuilder.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/aggregations/UniqueCountAggBuilder.java
@@ -1,0 +1,80 @@
+package com.slack.kaldb.logstore.search.aggregations;
+
+import java.util.Objects;
+
+public class UniqueCountAggBuilder extends ValueSourceAggBuilder {
+  public static final String TYPE = "cardinality";
+  private final Long precisionThreshold;
+
+  public UniqueCountAggBuilder(String name, String field, Object missing, Long precisionThreshold) {
+    super(name, field, missing);
+
+    this.precisionThreshold = precisionThreshold;
+  }
+
+  @Override
+  public String getType() {
+    return TYPE;
+  }
+
+  public Long getPrecisionThreshold() {
+    return precisionThreshold;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    UniqueCountAggBuilder that = (UniqueCountAggBuilder) o;
+
+    // AggBuilderBase
+    if (!Objects.equals(super.name, that.name)) return false;
+    if (!Objects.equals(super.metadata, that.metadata)) return false;
+    if (!Objects.equals(super.subAggregations, that.subAggregations)) return false;
+
+    // ValueSourceAggBuilder
+    if (!Objects.equals(super.field, that.field)) return false;
+    if (!Objects.equals(super.missing, that.missing)) return false;
+
+    // UniqueCountAggBuilder
+    return Objects.equals(precisionThreshold, that.precisionThreshold);
+  }
+
+  @Override
+  public int hashCode() {
+    // UniqueCountAggBuilder
+    int result = precisionThreshold != null ? precisionThreshold.hashCode() : 0;
+
+    // ValueSourceAggBuilder
+    result = 31 * result + (field != null ? field.hashCode() : 0);
+    result = 31 * result + (missing != null ? missing.hashCode() : 0);
+
+    // AggBuilderBase
+    result = 31 * result + (name != null ? name.hashCode() : 0);
+    result = 31 * result + (metadata != null ? metadata.hashCode() : 0);
+    result = 31 * result + (subAggregations != null ? subAggregations.hashCode() : 0);
+
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "UniqueCountAggBuilder{"
+        + "precisionThreshold="
+        + precisionThreshold
+        + ", field='"
+        + field
+        + '\''
+        + ", missing="
+        + missing
+        + ", name='"
+        + name
+        + '\''
+        + ", metadata="
+        + metadata
+        + ", subAggregations="
+        + subAggregations
+        + '}';
+  }
+}

--- a/kaldb/src/main/proto/kaldb_search.proto
+++ b/kaldb/src/main/proto/kaldb_search.proto
@@ -43,6 +43,7 @@ message SearchRequest {
       oneof type {
         DateHistogramAggregation date_histogram = 11;
         TermsAggregation terms = 12;
+        UniqueCountAggregation unique_count = 16;
       }
 
       // Unique fields specific to the date histogram aggregation request
@@ -71,6 +72,12 @@ message SearchRequest {
         // Minimum documents per bucket required
         int64 min_doc_count = 3;
       }
+
+      // Unique fields specific to the unique count (cardinality) aggregation request
+      message UniqueCountAggregation {
+        // Precision threshold for cardinality
+        Value precision_threshold = 1;
+      }
     }
   }
 }
@@ -97,6 +104,7 @@ message Value {
     bool bool_value = 5;
     Struct struct_value = 6;
     ListValue list_value = 7;
+    NullValue null_value = 8;
   }
 }
 
@@ -107,6 +115,11 @@ message Struct {
 message ListValue {
   repeated Value values = 1;
 }
+
+enum NullValue {
+  NULL_VALUE = 0;
+}
+
 
 service KaldbService {
   rpc Search (SearchRequest) returns (SearchResult) {}

--- a/kaldb/src/test/java/com/slack/kaldb/elasticsearchApi/OpenSearchRequestTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/elasticsearchApi/OpenSearchRequestTest.java
@@ -68,6 +68,36 @@ public class OpenSearchRequestTest {
   }
 
   @Test
+  public void testUniqueCount() throws Exception {
+    String rawRequest = getRawQueryString("unique_count");
+
+    OpenSearchRequest openSearchRequest = new OpenSearchRequest();
+    List<KaldbSearch.SearchRequest> parsedRequestList =
+        openSearchRequest.parseHttpPostBody(rawRequest);
+
+    assertThat(parsedRequestList.size()).isEqualTo(1);
+
+    KaldbSearch.SearchRequest.SearchAggregation dateHistogramAggBuilder =
+        parsedRequestList.get(0).getAggregations();
+    assertThat(dateHistogramAggBuilder.getSubAggregationsCount()).isEqualTo(1);
+
+    KaldbSearch.SearchRequest.SearchAggregation uniqueCountAggBuilder =
+        parsedRequestList.get(0).getAggregations().getSubAggregations(0);
+
+    assertThat(uniqueCountAggBuilder.getType()).isEqualTo("cardinality");
+    assertThat(uniqueCountAggBuilder.getName()).isEqualTo("1");
+    assertThat(uniqueCountAggBuilder.getValueSource().getField()).isEqualTo("service_name");
+    assertThat(uniqueCountAggBuilder.getValueSource().getMissing().hasNullValue()).isTrue();
+    assertThat(
+            uniqueCountAggBuilder
+                .getValueSource()
+                .getUniqueCount()
+                .getPrecisionThreshold()
+                .getLongValue())
+        .isEqualTo(1);
+  }
+
+  @Test
   public void testHistogramWithNestedAvg() throws Exception {
     String rawRequest = getRawQueryString("nested_datehistogram_avg");
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultUtilsTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultUtilsTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.slack.kaldb.logstore.search.aggregations.AvgAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.DateHistogramAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.TermsAggBuilder;
+import com.slack.kaldb.logstore.search.aggregations.UniqueCountAggBuilder;
 import com.slack.kaldb.proto.service.KaldbSearch;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -62,6 +63,19 @@ public class SearchResultUtilsTest {
         (TermsAggBuilder) SearchResultUtils.fromSearchAggregations(searchAggregation);
 
     assertThat(termsAggBuilder1).isEqualTo(termsAggBuilder2);
+  }
+
+  @Test
+  public void shouldConvertUniqueCountToFromProto() {
+    UniqueCountAggBuilder uniqueCountAggBuilder1 =
+        new UniqueCountAggBuilder("foo", "service_name", "2", 1L);
+
+    KaldbSearch.SearchRequest.SearchAggregation searchAggregation =
+        SearchResultUtils.toSearchAggregationProto(uniqueCountAggBuilder1);
+    UniqueCountAggBuilder uniqueCountAggBuilder2 =
+        (UniqueCountAggBuilder) SearchResultUtils.fromSearchAggregations(searchAggregation);
+
+    assertThat(uniqueCountAggBuilder1).isEqualTo(uniqueCountAggBuilder2);
   }
 
   @Test

--- a/kaldb/src/test/resources/opensearchRequest/unique_count.ndjson
+++ b/kaldb/src/test/resources/opensearchRequest/unique_count.ndjson
@@ -1,0 +1,2 @@
+{"search_type":"query_then_fetch","ignore_unavailable":true,"index":"_all"}
+{"size":0,"query":{"bool":{"filter":[{"range":{"@timestamp":{"gte":1678122148722,"lte":1678125748722,"format":"epoch_millis"}}},{"query_string":{"analyze_wildcard":true,"query":"*"}}]}},"aggs":{"1":{"date_histogram":{"interval":"1s","field":"@timestamp","min_doc_count":0,"extended_bounds":{"min":1678122148722,"max":1678125748722},"format":"epoch_millis"},"aggs":{"1":{"cardinality":{"field":"service_name","precision_threshold":"1"}}}}}}


### PR DESCRIPTION
Adds support for unique count (cardinality) aggregator. Also supports the precision threshold and missing options.