### PR TITLE
Do not validate older timestamp

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/writer/SpanFormatter.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/SpanFormatter.java
@@ -135,12 +135,6 @@ public class SpanFormatter {
       throw new IllegalArgumentException(
           "span id=" + id + " is more than 1 hour ahead timestamp=" + timestamp.toEpochMilli());
     }
-    // cannot be more than 12 hours in the past
-    if (timestamp.isBefore(currentTime)
-        && timestamp.plus(12, ChronoUnit.HOURS).isBefore(currentTime)) {
-      throw new IllegalArgumentException(
-          "span id=" + id + " is more than 12 hours behind timestamp=" + timestamp.toEpochMilli());
-    }
   }
 
   // TODO: Make this function more memory efficient?

--- a/kaldb/src/test/java/com/slack/kaldb/writer/SpanFormatterTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/SpanFormatterTest.java
@@ -260,21 +260,5 @@ public class SpanFormatterTest {
             () ->
                 SpanFormatter.validateTimestamp(
                     "1", currentTime.plus(59, ChronoUnit.MINUTES), currentTime));
-
-    assertThatThrownBy(
-            () ->
-                SpanFormatter.validateTimestamp(
-                    "1", currentTime.minus(721, ChronoUnit.MINUTES), currentTime))
-        .isInstanceOf(IllegalArgumentException.class);
-    assertThatNoException()
-        .isThrownBy(
-            () ->
-                SpanFormatter.validateTimestamp(
-                    "1", currentTime.minus(720, ChronoUnit.MINUTES), currentTime));
-    assertThatNoException()
-        .isThrownBy(
-            () ->
-                SpanFormatter.validateTimestamp(
-                    "1", currentTime.minus(719, ChronoUnit.MINUTES), currentTime));
   }
 }


### PR DESCRIPTION
Do not validate older timestamp's in documents. This gets tricky when we bootstrap a cluster and start reading messages from the start. Also if a recovery task gets scheduled after 12 hours ( in the scenario where there are lots of recovery task) this can be a problem as well

For now, let's remove this check