### PR TITLE
bootstrap indexers can cause no recovery tasks to get created

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
@@ -110,7 +110,10 @@ public class KaldbIndexer extends AbstractExecutionThreadService {
             meterRegistry);
 
     long currentHeadOffsetForPartition = kafkaConsumer.getEndOffSetForPartition();
-    long startOffset = recoveryTaskCreator.determineStartingOffset(currentHeadOffsetForPartition);
+    long beginningOffSetForPartition = kafkaConsumer.getBeginningOffSetForPartition();
+    long startOffset =
+        recoveryTaskCreator.determineStartingOffset(
+            beginningOffSetForPartition, currentHeadOffsetForPartition);
 
     // Close these stores since we don't need them after preStart.
     snapshotMetadataStore.close();

--- a/kaldb/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
@@ -195,8 +195,18 @@ public class KaldbKafkaConsumer {
     return getEndOffSetForPartition(topicPartition);
   }
 
+  public long getBeginningOffSetForPartition() {
+    return getBeginningOffSetForPartition(topicPartition);
+  }
+
   public long getEndOffSetForPartition(TopicPartition topicPartition) {
     return kafkaConsumer.endOffsets(Collections.singletonList(topicPartition)).get(topicPartition);
+  }
+
+  public long getBeginningOffSetForPartition(TopicPartition topicPartition) {
+    return kafkaConsumer
+        .beginningOffsets(Collections.singletonList(topicPartition))
+        .get(topicPartition);
   }
 
   public long getConsumerPositionForPartition() {


### PR DESCRIPTION
Imagine we are running the kaldb preprocessor for a few hours and then bootstrap the indexer service while setting up a new cluster.

We won't have any durable offsets (because there are no snapshots or recovery tasks). The right behaviour in this situation should be we start consuming the latest data and create recovery tasks for the data that is already in the preprocessor topic till now.

The current behaviour is it starts consuming data from the beginning and if the kafka retention is old enough and the preprocessor has been say running for several days will index data that is multiple days old.

This is just some dummy code meant to discuss if we need to fix this and then I'll go ahead and fix existing tests and add a couple of new ones if needed.