### PR TITLE
Increase test timeout

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Tests are occasionally exceeding 10 mins, which is causing timeouts. We need to revisit test durations in general, but until we can get this prioritized we need to bump the amount of time this can take.