### PR TITLE
Add moving function aggregator

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/opensearch/OpenSearchInternalAggregation.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/opensearch/OpenSearchInternalAggregation.java
@@ -47,6 +47,7 @@ import org.opensearch.search.aggregations.pipeline.InternalSimpleValue;
 import org.opensearch.search.aggregations.pipeline.LinearModel;
 import org.opensearch.search.aggregations.pipeline.MovAvgModel;
 import org.opensearch.search.aggregations.pipeline.MovAvgPipelineAggregationBuilder;
+import org.opensearch.search.aggregations.pipeline.MovFnPipelineAggregationBuilder;
 import org.opensearch.search.aggregations.pipeline.SimpleModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -125,6 +126,10 @@ public class OpenSearchInternalAggregation {
                   CumulativeSumPipelineAggregationBuilder.class,
                   CumulativeSumPipelineAggregationBuilder.NAME,
                   CumulativeSumPipelineAggregationBuilder::new),
+              new NamedWriteableRegistry.Entry(
+                  MovFnPipelineAggregationBuilder.class,
+                  MovFnPipelineAggregationBuilder.NAME,
+                  MovFnPipelineAggregationBuilder::new),
               new NamedWriteableRegistry.Entry(
                   DerivativePipelineAggregationBuilder.class,
                   DerivativePipelineAggregationBuilder.NAME,

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/opensearch/ScriptServiceProvider.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/opensearch/ScriptServiceProvider.java
@@ -2,29 +2,36 @@ package com.slack.kaldb.logstore.opensearch;
 
 import java.nio.file.Path;
 import java.util.List;
-import org.opensearch.common.settings.Settings;
+import org.opensearch.index.IndexSettings;
 import org.opensearch.painless.PainlessPlugin;
 import org.opensearch.plugins.PluginsService;
 import org.opensearch.plugins.ScriptPlugin;
 import org.opensearch.script.ScriptModule;
+import org.opensearch.script.ScriptService;
 
 /**
  * The ScriptModule object appears to only be able to be instantiated once safely. This class makes
  * it a singleton, while attempting to avoid needing to pass parameters. This may eventually be
  * folded into the OpenSearchAdapter class.
  */
-public class ScriptModuleProvider {
-  private static ScriptModule scriptModule = null;
+public class ScriptServiceProvider {
+  private static ScriptService scriptService = null;
 
-  public static ScriptModule getInstance() {
-    if (scriptModule == null) {
+  public static ScriptService getInstance() {
+    if (scriptService == null) {
+      IndexSettings indexSettings = OpenSearchAdapter.buildIndexSettings();
       PluginsService pluginsService =
           new PluginsService(
-              Settings.builder().build(), Path.of(""), null, null, List.of(PainlessPlugin.class));
-      scriptModule =
+              indexSettings.getSettings(), Path.of(""), null, null, List.of(PainlessPlugin.class));
+      ScriptModule scriptModule =
           new ScriptModule(
               pluginsService.updatedSettings(), pluginsService.filterPlugins(ScriptPlugin.class));
+
+      scriptService =
+          new ScriptService(
+              indexSettings.getSettings(), scriptModule.engines, scriptModule.contexts);
+      return scriptService;
     }
-    return scriptModule;
+    return scriptService;
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImpl.java
@@ -3,6 +3,7 @@ package com.slack.kaldb.logstore.search;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.logstore.opensearch.KaldbBigArrays;
 import com.slack.kaldb.logstore.opensearch.OpenSearchAdapter;
+import com.slack.kaldb.logstore.opensearch.ScriptServiceProvider;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -54,11 +55,16 @@ public class SearchResultAggregatorImpl<T extends LogMessage> implements SearchR
             OpenSearchAdapter.getAggregationBuilder(searchQuery.aggBuilder).buildPipelineTree();
         reduceContext =
             InternalAggregation.ReduceContext.forFinalReduction(
-                KaldbBigArrays.getInstance(), null, (s) -> {}, pipelineTree);
+                KaldbBigArrays.getInstance(),
+                ScriptServiceProvider.getInstance(),
+                (s) -> {},
+                pipelineTree);
       } else {
         reduceContext =
             InternalAggregation.ReduceContext.forPartialReduction(
-                KaldbBigArrays.getInstance(), null, () -> PipelineAggregator.PipelineTree.EMPTY);
+                KaldbBigArrays.getInstance(),
+                ScriptServiceProvider.getInstance(),
+                () -> PipelineAggregator.PipelineTree.EMPTY);
       }
       // Using the first element on the list as the basis for the reduce method is per OpenSearch
       // recommendations: "For best efficiency, when implementing, try reusing an existing instance

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/aggregations/MovingFunctionAggBuilder.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/aggregations/MovingFunctionAggBuilder.java
@@ -1,0 +1,82 @@
+package com.slack.kaldb.logstore.search.aggregations;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class MovingFunctionAggBuilder extends PipelineAggBuilder {
+  public static final String TYPE = "moving_fn";
+  private final Integer shift;
+  private final int window;
+  private final String script;
+
+  public MovingFunctionAggBuilder(
+      String name, String bucketsPath, String script, int window, Integer shift) {
+    super(name, Map.of(), List.of(), bucketsPath);
+    this.shift = shift;
+    this.window = window;
+    this.script = script;
+  }
+
+  @Override
+  public String getType() {
+    return TYPE;
+  }
+
+  public Integer getShift() {
+    return shift;
+  }
+
+  public int getWindow() {
+    return window;
+  }
+
+  public String getScript() {
+    return script;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof MovingFunctionAggBuilder)) return false;
+    if (!super.equals(o)) return false;
+
+    MovingFunctionAggBuilder that = (MovingFunctionAggBuilder) o;
+
+    if (window != that.window) return false;
+    if (!Objects.equals(shift, that.shift)) return false;
+    return script.equals(that.script);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + (shift != null ? shift.hashCode() : 0);
+    result = 31 * result + window;
+    result = 31 * result + script.hashCode();
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "MovingFunctionAggBuilder{"
+        + "shift="
+        + shift
+        + ", window="
+        + window
+        + ", script='"
+        + script
+        + '\''
+        + ", bucketsPath='"
+        + bucketsPath
+        + '\''
+        + ", name='"
+        + name
+        + '\''
+        + ", metadata="
+        + metadata
+        + ", subAggregations="
+        + subAggregations
+        + '}';
+  }
+}

--- a/kaldb/src/main/proto/kaldb_search.proto
+++ b/kaldb/src/main/proto/kaldb_search.proto
@@ -109,6 +109,7 @@ message SearchRequest {
         MovingAverageAggregation moving_average = 11;
         DerivativeAggregation derivative = 12;
         CumulativeSumAggregation cumulative_sum = 13;
+        MovingFunctionAggregation moving_function = 14;
       }
 
       message MovingAverageAggregation {
@@ -149,6 +150,17 @@ message SearchRequest {
       message DerivativeAggregation {
         // Optional unit for derivative
         Value unit = 1;
+      }
+
+      message MovingFunctionAggregation {
+        // Moving function window, required
+        int32 window = 1;
+
+        // Moving function shift, optional
+        int32 shift = 2;
+
+        // Script to execute, required
+        string script = 3;
       }
     }
   }

--- a/kaldb/src/test/java/com/slack/kaldb/elasticsearchApi/OpenSearchRequestTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/elasticsearchApi/OpenSearchRequestTest.java
@@ -195,6 +195,33 @@ public class OpenSearchRequestTest {
   }
 
   @Test
+  public void testHistogramWithNestedMovingFunction() throws Exception {
+    String rawRequest = getRawQueryString("nested_datehistogram_moving_fn");
+
+    OpenSearchRequest openSearchRequest = new OpenSearchRequest();
+    List<KaldbSearch.SearchRequest> parsedRequestList =
+        openSearchRequest.parseHttpPostBody(rawRequest);
+
+    assertThat(parsedRequestList.size()).isEqualTo(1);
+
+    KaldbSearch.SearchRequest.SearchAggregation dateHistogramAggBuilder =
+        parsedRequestList.get(0).getAggregations();
+    assertThat(dateHistogramAggBuilder.getValueSource().getField())
+        .isEqualTo(LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName);
+
+    assertThat(dateHistogramAggBuilder.getSubAggregationsCount()).isEqualTo(1);
+
+    KaldbSearch.SearchRequest.SearchAggregation movingFunctionAggBuilder =
+        parsedRequestList.get(0).getAggregations().getSubAggregations(0);
+    assertThat(movingFunctionAggBuilder.getName()).isEqualTo("3");
+    assertThat(movingFunctionAggBuilder.getPipeline().getBucketsPath()).isEqualTo("_count");
+    assertThat(movingFunctionAggBuilder.getPipeline().getMovingFunction().getScript())
+        .isEqualTo("return 8;");
+    assertThat(movingFunctionAggBuilder.getPipeline().getMovingFunction().getWindow()).isEqualTo(2);
+    assertThat(movingFunctionAggBuilder.getPipeline().getMovingFunction().getShift()).isEqualTo(3);
+  }
+
+  @Test
   public void testHistogramWithNestedDerivative() throws Exception {
     String rawRequest = getRawQueryString("nested_datehistogram_derivative");
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultUtilsTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultUtilsTest.java
@@ -12,6 +12,7 @@ import com.slack.kaldb.logstore.search.aggregations.DerivativeAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.HistogramAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.MinAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.MovingAvgAggBuilder;
+import com.slack.kaldb.logstore.search.aggregations.MovingFunctionAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.PercentilesAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.SumAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.TermsAggBuilder;
@@ -168,9 +169,28 @@ public class SearchResultUtilsTest {
     CumulativeSumAggBuilder cumulativeSumAggBuilder2 =
         (CumulativeSumAggBuilder) SearchResultUtils.fromSearchAggregations(searchAggregation);
 
+    assertThat(cumulativeSumAggBuilder1).isEqualTo(cumulativeSumAggBuilder2);
     assertThat(cumulativeSumAggBuilder1.getName()).isEqualTo("2");
     assertThat(cumulativeSumAggBuilder1.getBucketsPath()).isEqualTo("_count");
     assertThat(cumulativeSumAggBuilder1.getFormat()).isEqualTo("##0.#####E0");
+  }
+
+  @Test
+  public void shouldConvertMovingFunctionPipelineToFromProto() {
+    MovingFunctionAggBuilder movingFunctionAggBuilder1 =
+        new MovingFunctionAggBuilder("2", "_count", "return 8;", 2, 3);
+
+    KaldbSearch.SearchRequest.SearchAggregation searchAggregation =
+        SearchResultUtils.toSearchAggregationProto(movingFunctionAggBuilder1);
+    MovingFunctionAggBuilder movingFunctionAggBuilder2 =
+        (MovingFunctionAggBuilder) SearchResultUtils.fromSearchAggregations(searchAggregation);
+
+    assertThat(movingFunctionAggBuilder1).isEqualTo(movingFunctionAggBuilder2);
+    assertThat(movingFunctionAggBuilder1.getName()).isEqualTo("2");
+    assertThat(movingFunctionAggBuilder1.getBucketsPath()).isEqualTo("_count");
+    assertThat(movingFunctionAggBuilder1.getScript()).isEqualTo("return 8;");
+    assertThat(movingFunctionAggBuilder1.getWindow()).isEqualTo(2);
+    assertThat(movingFunctionAggBuilder1.getShift()).isEqualTo(3);
   }
 
   @Test

--- a/kaldb/src/test/resources/opensearchRequest/nested_datehistogram_moving_fn.ndjson
+++ b/kaldb/src/test/resources/opensearchRequest/nested_datehistogram_moving_fn.ndjson
@@ -1,0 +1,2 @@
+{"search_type":"query_then_fetch","ignore_unavailable":true,"index":"_all"}
+{"size":0,"query":{"bool":{"filter":[{"range":{"_timesinceepoch":{"gte":1681505425718,"lte":1681509025718,"format":"epoch_millis"}}},{"query_string":{"analyze_wildcard":true,"query":"*"}}]}},"aggs":{"2":{"date_histogram":{"interval":"2s","field":"_timesinceepoch","min_doc_count":0,"extended_bounds":{"min":1681505425718,"max":1681509025718},"format":"epoch_millis"},"aggs":{"3":{"moving_fn":{"buckets_path":"_count","window":"2","shift":"3","script":"return 8;"}}}}}}


### PR DESCRIPTION
This PR also refactors the script module provider to a script service provider, as that is the singleton we need to use in both the adapter and aggregators.

A few built-in script examples can be seen here - https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-movfn-aggregation.html