### PR TITLE
Enable query rewriting, bump field limit

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/opensearch/OpenSearchAdapter.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/opensearch/OpenSearchAdapter.java
@@ -115,6 +115,10 @@ public class OpenSearchAdapter {
 
   private final Map<String, LuceneFieldDef> chunkSchema;
 
+  // we can make this configurable when SchemaAwareLogDocumentBuilderImpl enforces a limit
+  // set this to a high number for now
+  private static final int TOTAL_FIELDS_LIMIT = 2500;
+
   public OpenSearchAdapter(Map<String, LuceneFieldDef> chunkSchema) {
     IndexSettings indexSettings = buildIndexSettings();
     SimilarityService similarityService = new SimilarityService(indexSettings, null, emptyMap());
@@ -311,6 +315,8 @@ public class OpenSearchAdapter {
             .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
             .put(IndexMetadata.SETTING_VERSION_CREATED, Version.V_2_3_0)
+            .put(
+                MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey(), TOTAL_FIELDS_LIMIT)
             .build();
     return new IndexSettings(
         IndexMetadata.builder("index").settings(settings).build(), Settings.EMPTY);

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/opensearch/OpenSearchAdapter.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/opensearch/OpenSearchAdapter.java
@@ -174,7 +174,7 @@ public class OpenSearchAdapter {
         boolQueryBuilder.must(queryStringQueryBuilder);
       }
 
-      return boolQueryBuilder.toQuery(queryShardContext);
+      return boolQueryBuilder.rewrite(queryShardContext).toQuery(queryShardContext);
     } catch (Exception e) {
       LOG.error("Query parse exception", e);
       throw new IllegalArgumentException(e);


### PR DESCRIPTION
Two small fixes - one addresses an exception we've been seeing about missing the query rewriting (exception below). The other bumps the field limit from the default of 1k to 2.5k, due to the fact we had to revert https://github.com/slackhq/kaldb/pull/541.

```java
java.lang.IllegalStateException: Rewrite first
	at org.opensearch.index.query.RangeQueryBuilder.doToQuery(RangeQueryBuilder.java:524)
	at org.opensearch.index.query.AbstractQueryBuilder.toQuery(AbstractQueryBuilder.java:116)
	at org.opensearch.index.query.BoolQueryBuilder.addBooleanClauses(BoolQueryBuilder.java:346)
	at org.opensearch.index.query.BoolQueryBuilder.doToQuery(BoolQueryBuilder.java:326)
	at org.opensearch.index.query.AbstractQueryBuilder.toQuery(AbstractQueryBuilder.java:116)
	at com.slack.kaldb.logstore.opensearch.OpenSearchAdapter.buildQuery(OpenSearchAdapter.java:182)
	at com.slack.kaldb.logstore.search.LogIndexSearcherImpl.search(LogIndexSearcherImpl.java:109)
	at com.slack.kaldb.chunk.ReadOnlyChunkImpl.query(ReadOnlyChunkImpl.java:355)
	at com.slack.kaldb.chunkManager.ChunkManagerBase.lambda$query$4(ChunkManagerBase.java:126)
	at brave.propagation.CurrentTraceContext$1CurrentTraceContextCallable.call(CurrentTraceContext.java:251)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:131)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:74)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:82)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```