### PR TITLE
Update to JUnit5

### DIFF
--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -142,6 +142,16 @@
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-test-framework</artifactId>
             <version>${lucene.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
@@ -341,9 +351,9 @@
 
         <!-- Test dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.9.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -357,6 +367,12 @@
             <artifactId>grpc-testing</artifactId>
             <version>${grpc.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -365,6 +381,7 @@
             <version>3.24.2</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -395,7 +412,7 @@
         <!-- BlobFs test dependencies -->
         <dependency>
             <groupId>com.adobe.testing</groupId>
-            <artifactId>s3mock-junit4</artifactId>
+            <artifactId>s3mock-junit5</artifactId>
             <version>2.11.0</version>
             <scope>test</scope>
             <exclusions>
@@ -457,6 +474,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
                 <!--
                     We do not currently require the scala module, and it causes issues
                     when attempting to use newer versions of databind
@@ -517,7 +538,7 @@
                     <fork>true</fork>
                     <compilerArgs>
                         <arg>-XDcompilePolicy=simple</arg>
-                        <arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode -XepExcludedPaths:.*/protobuf/.* -Xep:WildcardImport:ERROR</arg>
+                        <arg> -Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode -XepExcludedPaths:.*/protobuf/.* -Xep:WildcardImport:ERROR -Xep:AssertEqualsArgumentOrderChecker:ERROR</arg>
                         <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                         <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
                         <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
@@ -684,7 +705,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>3.1.0</version>
                     <configuration>
                         <trimStackTrace>false</trimStackTrace>
                         <systemPropertyVariables>

--- a/kaldb/src/test/java/com/slack/kaldb/blobfs/LocalBlobFsTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/blobfs/LocalBlobFsTest.java
@@ -188,7 +188,7 @@ public class LocalBlobFsTest {
     assertTrue(nonExistingFile.exists());
     long currentTime = System.currentTimeMillis();
     assertTrue(localBlobFs.lastModified(nonExistingFile.toURI()) <= currentTime);
-    Thread.sleep(1000L);
+    Thread.sleep(1L);
     // update last modified.
     localBlobFs.touch(nonExistingFile.toURI());
     assertTrue(localBlobFs.lastModified(nonExistingFile.toURI()) > currentTime);

--- a/kaldb/src/test/java/com/slack/kaldb/blobfs/LocalBlobFsTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/blobfs/LocalBlobFsTest.java
@@ -1,15 +1,18 @@
 package com.slack.kaldb.blobfs;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Fail.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LocalBlobFsTest {
   private File testFile;
@@ -17,17 +20,17 @@ public class LocalBlobFsTest {
   private File newTmpDir;
   private File nonExistentTmpFolder;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     absoluteTmpDirPath =
         new File(
             System.getProperty("java.io.tmpdir"), LocalBlobFsTest.class.getSimpleName() + "first");
     FileUtils.deleteQuietly(absoluteTmpDirPath);
-    Assert.assertTrue(
-        "Could not make directory " + absoluteTmpDirPath.getPath(), absoluteTmpDirPath.mkdir());
+    assertTrue(
+        absoluteTmpDirPath.mkdir(), "Could not make directory " + absoluteTmpDirPath.getPath());
     try {
       testFile = new File(absoluteTmpDirPath, "testFile");
-      Assert.assertTrue("Could not create file " + testFile.getPath(), testFile.createNewFile());
+      assertTrue(testFile.createNewFile(), "Could not create file " + testFile.getPath());
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -36,7 +39,7 @@ public class LocalBlobFsTest {
         new File(
             System.getProperty("java.io.tmpdir"), LocalBlobFsTest.class.getSimpleName() + "second");
     FileUtils.deleteQuietly(newTmpDir);
-    Assert.assertTrue("Could not make directory " + newTmpDir.getPath(), newTmpDir.mkdir());
+    assertTrue(newTmpDir.mkdir(), "Could not make directory " + newTmpDir.getPath());
 
     nonExistentTmpFolder =
         new File(
@@ -48,7 +51,7 @@ public class LocalBlobFsTest {
     nonExistentTmpFolder.deleteOnExit();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     absoluteTmpDirPath.delete();
     newTmpDir.delete();
@@ -59,144 +62,142 @@ public class LocalBlobFsTest {
     LocalBlobFs localBlobFs = new LocalBlobFs();
     URI testFileUri = testFile.toURI();
     // Check whether a directory exists
-    Assert.assertTrue(localBlobFs.exists(absoluteTmpDirPath.toURI()));
-    Assert.assertTrue(localBlobFs.lastModified(absoluteTmpDirPath.toURI()) > 0L);
-    Assert.assertTrue(localBlobFs.isDirectory(absoluteTmpDirPath.toURI()));
+    assertTrue(localBlobFs.exists(absoluteTmpDirPath.toURI()));
+    assertTrue(localBlobFs.lastModified(absoluteTmpDirPath.toURI()) > 0L);
+    assertTrue(localBlobFs.isDirectory(absoluteTmpDirPath.toURI()));
     // Check whether a file exists
-    Assert.assertTrue(localBlobFs.exists(testFileUri));
-    Assert.assertFalse(localBlobFs.isDirectory(testFileUri));
+    assertTrue(localBlobFs.exists(testFileUri));
+    assertFalse(localBlobFs.isDirectory(testFileUri));
 
     File file = new File(absoluteTmpDirPath, "secondTestFile");
     URI secondTestFileUri = file.toURI();
     // Check that file does not exist
-    Assert.assertTrue(!localBlobFs.exists(secondTestFileUri));
+    assertTrue(!localBlobFs.exists(secondTestFileUri));
 
     localBlobFs.copy(testFileUri, secondTestFileUri);
-    Assert.assertEquals(2, localBlobFs.listFiles(absoluteTmpDirPath.toURI(), true).length);
+    assertEquals(2, localBlobFs.listFiles(absoluteTmpDirPath.toURI(), true).length);
 
     // Check file copy worked when file was not created
-    Assert.assertTrue(localBlobFs.exists(secondTestFileUri));
+    assertTrue(localBlobFs.exists(secondTestFileUri));
 
     // Create another file in the same path
     File thirdTestFile = new File(absoluteTmpDirPath, "thirdTestFile");
-    Assert.assertTrue(
-        "Could not create file " + thirdTestFile.getPath(), thirdTestFile.createNewFile());
+    assertTrue(thirdTestFile.createNewFile(), "Could not create file " + thirdTestFile.getPath());
 
     File newAbsoluteTempDirPath = new File(absoluteTmpDirPath, "absoluteTwo");
-    Assert.assertTrue(newAbsoluteTempDirPath.mkdir());
+    assertTrue(newAbsoluteTempDirPath.mkdir());
 
     // Create a testDir and file underneath directory
     File testDir = new File(newAbsoluteTempDirPath, "testDir");
-    Assert.assertTrue("Could not make directory " + testDir.getAbsolutePath(), testDir.mkdir());
+    assertTrue(testDir.mkdir(), "Could not make directory " + testDir.getAbsolutePath());
     File testDirFile = new File(testDir, "testFile");
     // Assert that recursive list files and nonrecursive list files are as expected
-    Assert.assertTrue(
-        "Could not create file " + testDir.getAbsolutePath(), testDirFile.createNewFile());
-    Assert.assertEquals(
+    assertTrue(testDirFile.createNewFile(), "Could not create file " + testDir.getAbsolutePath());
+    assertArrayEquals(
         localBlobFs.listFiles(newAbsoluteTempDirPath.toURI(), false),
         new String[] {testDir.getAbsolutePath()});
-    Assert.assertEquals(
+    assertArrayEquals(
         localBlobFs.listFiles(newAbsoluteTempDirPath.toURI(), true),
         new String[] {testDir.getAbsolutePath(), testDirFile.getAbsolutePath()});
 
     // Create another parent dir so we can test recursive move
     File newAbsoluteTempDirPath3 = new File(absoluteTmpDirPath, "absoluteThree");
-    Assert.assertTrue(newAbsoluteTempDirPath3.mkdir());
-    Assert.assertEquals(newAbsoluteTempDirPath3.listFiles().length, 0);
+    assertTrue(newAbsoluteTempDirPath3.mkdir());
+    assertEquals(newAbsoluteTempDirPath3.listFiles().length, 0);
 
     localBlobFs.move(newAbsoluteTempDirPath.toURI(), newAbsoluteTempDirPath3.toURI(), true);
-    Assert.assertFalse(localBlobFs.exists(newAbsoluteTempDirPath.toURI()));
-    Assert.assertTrue(localBlobFs.exists(newAbsoluteTempDirPath3.toURI()));
-    Assert.assertTrue(localBlobFs.exists(new File(newAbsoluteTempDirPath3, "testDir").toURI()));
-    Assert.assertTrue(
+    assertFalse(localBlobFs.exists(newAbsoluteTempDirPath.toURI()));
+    assertTrue(localBlobFs.exists(newAbsoluteTempDirPath3.toURI()));
+    assertTrue(localBlobFs.exists(new File(newAbsoluteTempDirPath3, "testDir").toURI()));
+    assertTrue(
         localBlobFs.exists(
             new File(new File(newAbsoluteTempDirPath3, "testDir"), "testFile").toURI()));
 
     // Check if using a different scheme on URI still works
     URI uri = URI.create("hdfs://localhost:9999" + newAbsoluteTempDirPath.getPath());
     localBlobFs.move(newAbsoluteTempDirPath3.toURI(), uri, true);
-    Assert.assertFalse(localBlobFs.exists(newAbsoluteTempDirPath3.toURI()));
-    Assert.assertTrue(localBlobFs.exists(newAbsoluteTempDirPath.toURI()));
-    Assert.assertTrue(localBlobFs.exists(new File(newAbsoluteTempDirPath, "testDir").toURI()));
-    Assert.assertTrue(
+    assertFalse(localBlobFs.exists(newAbsoluteTempDirPath3.toURI()));
+    assertTrue(localBlobFs.exists(newAbsoluteTempDirPath.toURI()));
+    assertTrue(localBlobFs.exists(new File(newAbsoluteTempDirPath, "testDir").toURI()));
+    assertTrue(
         localBlobFs.exists(
             new File(new File(newAbsoluteTempDirPath, "testDir"), "testFile").toURI()));
 
     // Check file copy to location where something already exists still works
     localBlobFs.copy(testFileUri, thirdTestFile.toURI());
     // Check length of file
-    Assert.assertEquals(0, localBlobFs.length(secondTestFileUri));
-    Assert.assertTrue(localBlobFs.exists(thirdTestFile.toURI()));
+    assertEquals(0, localBlobFs.length(secondTestFileUri));
+    assertTrue(localBlobFs.exists(thirdTestFile.toURI()));
 
     // Check that method deletes dst directory during move and is successful by overwriting dir
-    Assert.assertTrue(newTmpDir.exists());
+    assertTrue(newTmpDir.exists());
     // create a file in the dst folder
     File dstFile = new File(newTmpDir.getPath() + "/newFile");
     dstFile.createNewFile();
 
     // Expected that a move without overwrite will not succeed
-    Assert.assertFalse(localBlobFs.move(absoluteTmpDirPath.toURI(), newTmpDir.toURI(), false));
+    assertFalse(localBlobFs.move(absoluteTmpDirPath.toURI(), newTmpDir.toURI(), false));
 
     int files = absoluteTmpDirPath.listFiles().length;
-    Assert.assertTrue(localBlobFs.move(absoluteTmpDirPath.toURI(), newTmpDir.toURI(), true));
-    Assert.assertEquals(absoluteTmpDirPath.length(), 0);
-    Assert.assertEquals(newTmpDir.listFiles().length, files);
-    Assert.assertFalse(dstFile.exists());
+    assertTrue(localBlobFs.move(absoluteTmpDirPath.toURI(), newTmpDir.toURI(), true));
+    assertEquals(absoluteTmpDirPath.length(), 0);
+    assertEquals(newTmpDir.listFiles().length, files);
+    assertFalse(dstFile.exists());
 
     // Check that a moving a file to a non-existent destination folder will work
     FileUtils.deleteQuietly(nonExistentTmpFolder);
-    Assert.assertFalse(nonExistentTmpFolder.exists());
+    assertFalse(nonExistentTmpFolder.exists());
     File srcFile = new File(absoluteTmpDirPath, "srcFile");
     localBlobFs.mkdir(absoluteTmpDirPath.toURI());
-    Assert.assertTrue(srcFile.createNewFile());
+    assertTrue(srcFile.createNewFile());
     dstFile = new File(nonExistentTmpFolder.getPath() + "/newFile");
-    Assert.assertFalse(dstFile.exists());
-    Assert.assertTrue(
+    assertFalse(dstFile.exists());
+    assertTrue(
         localBlobFs.move(srcFile.toURI(), dstFile.toURI(), true)); // overwrite flag has no impact
-    Assert.assertFalse(srcFile.exists());
-    Assert.assertTrue(dstFile.exists());
+    assertFalse(srcFile.exists());
+    assertTrue(dstFile.exists());
 
     // Check that moving a folder to a non-existent destination folder works
     FileUtils.deleteQuietly(nonExistentTmpFolder);
-    Assert.assertFalse(nonExistentTmpFolder.exists());
+    assertFalse(nonExistentTmpFolder.exists());
     srcFile = new File(absoluteTmpDirPath, "srcFile");
     localBlobFs.mkdir(absoluteTmpDirPath.toURI());
-    Assert.assertTrue(srcFile.createNewFile());
+    assertTrue(srcFile.createNewFile());
     dstFile = new File(nonExistentTmpFolder.getPath() + "/srcFile");
-    Assert.assertFalse(dstFile.exists());
-    Assert.assertTrue(
+    assertFalse(dstFile.exists());
+    assertTrue(
         localBlobFs.move(
             absoluteTmpDirPath.toURI(),
             nonExistentTmpFolder.toURI(),
             true)); // overwrite flag has no impact
-    Assert.assertTrue(dstFile.exists());
+    assertTrue(dstFile.exists());
 
     localBlobFs.delete(secondTestFileUri, true);
     // Check deletion from final location worked
-    Assert.assertTrue(!localBlobFs.exists(secondTestFileUri));
+    assertTrue(!localBlobFs.exists(secondTestFileUri));
 
     File firstTempDir = new File(absoluteTmpDirPath, "firstTempDir");
     File secondTempDir = new File(absoluteTmpDirPath, "secondTempDir");
     localBlobFs.mkdir(firstTempDir.toURI());
-    Assert.assertTrue("Could not make directory " + firstTempDir.getPath(), firstTempDir.exists());
+    assertTrue(firstTempDir.exists(), "Could not make directory " + firstTempDir.getPath());
 
     // Check that touching a file works
     File nonExistingFile = new File(absoluteTmpDirPath, "nonExistingFile");
-    Assert.assertFalse(nonExistingFile.exists());
+    assertFalse(nonExistingFile.exists());
     localBlobFs.touch(nonExistingFile.toURI());
-    Assert.assertTrue(nonExistingFile.exists());
+    assertTrue(nonExistingFile.exists());
     long currentTime = System.currentTimeMillis();
-    Assert.assertTrue(localBlobFs.lastModified(nonExistingFile.toURI()) <= currentTime);
+    assertTrue(localBlobFs.lastModified(nonExistingFile.toURI()) <= currentTime);
     Thread.sleep(1000L);
     // update last modified.
     localBlobFs.touch(nonExistingFile.toURI());
-    Assert.assertTrue(localBlobFs.lastModified(nonExistingFile.toURI()) > currentTime);
+    assertTrue(localBlobFs.lastModified(nonExistingFile.toURI()) > currentTime);
     FileUtils.deleteQuietly(nonExistingFile);
 
     // Check that touch an file in a directory that doesn't exist should throw an exception.
     File nonExistingFileUnderNonExistingDir =
         new File(absoluteTmpDirPath, "nonExistingDir/nonExistingFile");
-    Assert.assertFalse(nonExistingFileUnderNonExistingDir.exists());
+    assertFalse(nonExistingFileUnderNonExistingDir.exists());
     try {
       localBlobFs.touch(nonExistingFileUnderNonExistingDir.toURI());
       fail("Touch method should throw an IOException");
@@ -206,41 +207,39 @@ public class LocalBlobFsTest {
 
     // Check that directory only copy worked
     localBlobFs.copy(firstTempDir.toURI(), secondTempDir.toURI());
-    Assert.assertTrue(localBlobFs.exists(secondTempDir.toURI()));
+    assertTrue(localBlobFs.exists(secondTempDir.toURI()));
 
     // Copying directory with files to directory with files
     File testFile = new File(firstTempDir, "testFile");
-    Assert.assertTrue("Could not create file " + testFile.getPath(), testFile.createNewFile());
+    assertTrue(testFile.createNewFile(), "Could not create file " + testFile.getPath());
     File newTestFile = new File(secondTempDir, "newTestFile");
-    Assert.assertTrue(
-        "Could not create file " + newTestFile.getPath(), newTestFile.createNewFile());
+    assertTrue(newTestFile.createNewFile(), "Could not create file " + newTestFile.getPath());
 
     localBlobFs.copy(firstTempDir.toURI(), secondTempDir.toURI());
-    Assert.assertEquals(localBlobFs.listFiles(secondTempDir.toURI(), true).length, 1);
+    assertEquals(localBlobFs.listFiles(secondTempDir.toURI(), true).length, 1);
 
     // Copying directory with files under another directory.
     File firstTempDirUnderSecondTempDir = new File(secondTempDir, firstTempDir.getName());
     localBlobFs.copy(firstTempDir.toURI(), firstTempDirUnderSecondTempDir.toURI());
-    Assert.assertTrue(localBlobFs.exists(firstTempDirUnderSecondTempDir.toURI()));
+    assertTrue(localBlobFs.exists(firstTempDirUnderSecondTempDir.toURI()));
     // There're two files/directories under secondTempDir.
-    Assert.assertEquals(localBlobFs.listFiles(secondTempDir.toURI(), false).length, 2);
+    assertEquals(localBlobFs.listFiles(secondTempDir.toURI(), false).length, 2);
     // The file under src directory also got copied under dst directory.
-    Assert.assertEquals(
-        localBlobFs.listFiles(firstTempDirUnderSecondTempDir.toURI(), true).length, 1);
+    assertEquals(localBlobFs.listFiles(firstTempDirUnderSecondTempDir.toURI(), true).length, 1);
 
     // len of dir = exception
     try {
       localBlobFs.length(firstTempDir.toURI());
-      fail();
+      fail("Exception expected that did not occur");
     } catch (IllegalArgumentException e) {
 
     }
 
-    Assert.assertTrue(testFile.exists());
+    assertTrue(testFile.exists());
 
     localBlobFs.copyFromLocalFile(testFile, secondTestFileUri);
-    Assert.assertTrue(localBlobFs.exists(secondTestFileUri));
+    assertTrue(localBlobFs.exists(secondTestFileUri));
     localBlobFs.copyToLocalFile(testFile.toURI(), new File(secondTestFileUri));
-    Assert.assertTrue(localBlobFs.exists(secondTestFileUri));
+    assertTrue(localBlobFs.exists(secondTestFileUri));
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ChunkInfoTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ChunkInfoTest.java
@@ -6,10 +6,11 @@ import static com.slack.kaldb.chunk.ChunkInfo.containsDataInTimeRange;
 import static com.slack.kaldb.chunk.ChunkInfo.fromSnapshotMetadata;
 import static com.slack.kaldb.chunk.ChunkInfo.toSnapshotMetadata;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ChunkInfoTest {
   private static final String TEST_KAFKA_PARTITION_ID = "10";
@@ -253,54 +254,62 @@ public class ChunkInfoTest {
         .isTrue();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNegativeStartTimeInDateRange() {
     final ChunkInfo info =
         new ChunkInfo(TEST_CHUNK_NAME, 1000, TEST_KAFKA_PARTITION_ID, TEST_SNAPSHOT_PATH);
     info.updateDataTimeRange(980);
     info.updateDataTimeRange(1020);
 
-    assertThat(info.containsDataInTimeRange(-1, 980)).isTrue();
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> info.containsDataInTimeRange(-1, 980));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNegativeEndTimeInDateRange() {
     final ChunkInfo info =
         new ChunkInfo(TEST_CHUNK_NAME, 1000, TEST_KAFKA_PARTITION_ID, TEST_SNAPSHOT_PATH);
     info.updateDataTimeRange(980);
     info.updateDataTimeRange(1020);
 
-    assertThat(info.containsDataInTimeRange(960, -1)).isTrue();
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> info.containsDataInTimeRange(960, -1));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNegativeIntervalInDateRange() {
     final ChunkInfo info =
         new ChunkInfo(TEST_CHUNK_NAME, 1000, TEST_KAFKA_PARTITION_ID, TEST_SNAPSHOT_PATH);
     info.updateDataTimeRange(980);
     info.updateDataTimeRange(1020);
 
-    assertThat(info.containsDataInTimeRange(960, 950)).isTrue();
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> info.containsDataInTimeRange(960, 950));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInvalidChunkName() {
-    new ChunkInfo(null, 100, TEST_KAFKA_PARTITION_ID, TEST_SNAPSHOT_PATH);
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> new ChunkInfo(null, 100, TEST_KAFKA_PARTITION_ID, TEST_SNAPSHOT_PATH));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testEmptyChunkName() {
-    new ChunkInfo("", 100, TEST_KAFKA_PARTITION_ID, TEST_SNAPSHOT_PATH);
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> new ChunkInfo("", 100, TEST_KAFKA_PARTITION_ID, TEST_SNAPSHOT_PATH));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNegativeChunkCreationTime() {
-    new ChunkInfo(TEST_CHUNK_NAME, -1, TEST_KAFKA_PARTITION_ID, TEST_SNAPSHOT_PATH);
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () -> new ChunkInfo(TEST_CHUNK_NAME, -1, TEST_KAFKA_PARTITION_ID, TEST_SNAPSHOT_PATH));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testEmptyKafkaPartitionId() {
-    new ChunkInfo(TEST_CHUNK_NAME, 100, "", TEST_SNAPSHOT_PATH);
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> new ChunkInfo(TEST_CHUNK_NAME, 100, "", TEST_SNAPSHOT_PATH));
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -11,12 +11,12 @@ import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.REFRESHES_TIMER;
 import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LOGS_LUCENE9;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
 import static com.slack.kaldb.testlib.MetricsUtil.getTimerCount;
-import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.addMessages;
+import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherExtension.addMessages;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import brave.Tracing;
-import com.adobe.testing.s3mock.junit4.S3MockRule;
+import com.adobe.testing.s3mock.junit5.S3MockExtension;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.slack.kaldb.blobfs.LocalBlobFs;
 import com.slack.kaldb.blobfs.s3.S3BlobFs;
@@ -57,10 +57,10 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.curator.test.TestingServer;
 import org.apache.lucene.index.IndexCommit;
 import org.assertj.core.util.Files;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import software.amazon.awssdk.services.s3.S3Client;
 
 public class ReadOnlyChunkImplTest {
@@ -70,21 +70,25 @@ public class ReadOnlyChunkImplTest {
   private MeterRegistry meterRegistry;
   private S3BlobFs s3BlobFs;
 
-  @ClassRule
-  public static final S3MockRule S3_MOCK_RULE =
-      S3MockRule.builder().withInitialBuckets(TEST_S3_BUCKET).silent().build();
+  @RegisterExtension
+  public static final S3MockExtension S3_MOCK_EXTENSION =
+      S3MockExtension.builder()
+          .withInitialBuckets(TEST_S3_BUCKET)
+          .silent()
+          .withSecureConnection(false)
+          .build();
 
-  @Before
+  @BeforeEach
   public void startup() throws Exception {
     Tracing.newBuilder().build();
     meterRegistry = new SimpleMeterRegistry();
     testingServer = new TestingServer();
 
-    S3Client s3Client = S3_MOCK_RULE.createS3ClientV2();
+    S3Client s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
     s3BlobFs = new S3BlobFs(s3Client);
   }
 
-  @After
+  @AfterEach
   public void shutdown() throws IOException {
     s3BlobFs.close();
     testingServer.close();

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/SearchContextTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/SearchContextTest.java
@@ -1,8 +1,9 @@
 package com.slack.kaldb.chunk;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SearchContextTest {
 
@@ -16,19 +17,22 @@ public class SearchContextTest {
     assertThat(searchContext.port).isEqualTo(PORT);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNegativePort() {
-    new SearchContext(HOSTNAME, -1);
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> new SearchContext(HOSTNAME, -1));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testEmptyHostname() {
-    new SearchContext("", 1000);
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> new SearchContext("", 1000));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNullHostname() {
-    new SearchContext(null, 1000);
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> new SearchContext(null, 1000));
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
@@ -18,15 +18,16 @@ import static com.slack.kaldb.testlib.ChunkManagerUtil.fetchNonLiveSnapshot;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
 import static com.slack.kaldb.testlib.MetricsUtil.getTimerCount;
 import static com.slack.kaldb.testlib.MetricsUtil.getValue;
-import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.MAX_TIME;
+import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherExtension.MAX_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.awaitility.Awaitility.await;
 
 import brave.Tracing;
-import com.adobe.testing.s3mock.junit4.S3MockRule;
+import com.adobe.testing.s3mock.junit5.S3MockExtension;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
@@ -59,6 +60,7 @@ import com.slack.kaldb.testlib.KaldbConfigUtil;
 import com.slack.kaldb.testlib.MessageUtil;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -77,25 +79,28 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import org.apache.curator.test.TestingServer;
 import org.assertj.core.data.Offset;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 import software.amazon.awssdk.services.s3.S3Client;
 
 public class IndexingChunkManagerTest {
 
   private static final String S3_TEST_BUCKET = "test-kaldb-logs";
 
-  @ClassRule
-  public static final S3MockRule S3_MOCK_RULE =
-      S3MockRule.builder().withInitialBuckets(S3_TEST_BUCKET).silent().build();
+  @RegisterExtension
+  public static final S3MockExtension S3_MOCK_EXTENSION =
+      S3MockExtension.builder()
+          .withInitialBuckets(S3_TEST_BUCKET)
+          .silent()
+          .withSecureConnection(false)
+          .build();
 
   private static final String TEST_KAFKA_PARTITION_ID = "10";
-  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir private Path tmpPath;
 
   private IndexingChunkManager<LogMessage> chunkManager = null;
 
@@ -109,12 +114,12 @@ public class IndexingChunkManagerTest {
   private SnapshotMetadataStore snapshotMetadataStore;
   private SearchMetadataStore searchMetadataStore;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     Tracing.newBuilder().build();
     metricsRegistry = new SimpleMeterRegistry();
     // create an S3 client and a bucket for test
-    s3Client = S3_MOCK_RULE.createS3ClientV2();
+    s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
 
     s3BlobFs = new S3BlobFs(s3Client);
 
@@ -135,7 +140,7 @@ public class IndexingChunkManagerTest {
     searchMetadataStore = new SearchMetadataStore(metadataStore, false);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws TimeoutException, IOException {
     metricsRegistry.close();
     if (chunkManager != null) {
@@ -156,7 +161,7 @@ public class IndexingChunkManagerTest {
     chunkManager =
         new IndexingChunkManager<>(
             "testData",
-            temporaryFolder.newFolder().getAbsolutePath(),
+            tmpPath.toFile().getAbsolutePath(),
             chunkRollOverStrategy,
             metricsRegistry,
             s3BlobFs,
@@ -170,7 +175,7 @@ public class IndexingChunkManagerTest {
   }
 
   @Test
-  @Ignore
+  @Disabled
   // Todo: this test needs to be refactored as it currently does not reliably replicate the race
   //   condition Additionally, this test as currently written is extremely slow, and accounts
   //   for over 10% of our test runtime
@@ -611,7 +616,7 @@ public class IndexingChunkManagerTest {
         .isEqualTo(expectedInfinitySnapshotsCount);
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testMessagesAddedToActiveChunks() throws Exception {
     ChunkRollOverStrategy chunkRollOverStrategy =
         new DiskOrMessageCountBasedRolloverStrategy(metricsRegistry, 10 * 1024 * 1024 * 1024L, 2L);
@@ -659,7 +664,8 @@ public class IndexingChunkManagerTest {
 
     checkMetadata(3, 2, 1, 2, 1);
     // Inserting in an older chunk throws an exception. So, additions go to active chunks only.
-    chunk1.addMessage(msg4, TEST_KAFKA_PARTITION_ID, 1);
+    assertThatExceptionOfType(IllegalStateException.class)
+        .isThrownBy(() -> chunk1.addMessage(msg4, TEST_KAFKA_PARTITION_ID, 1));
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
@@ -687,7 +687,7 @@ public class IndexingChunkManagerTest {
     // Main chunk is already committed. Commit the new chunk so we can search it.
     chunkManager.getActiveChunk().commit();
     // Wait for roll over.
-    rollOverExecutor.awaitTermination(10, TimeUnit.SECONDS);
+    await().until(() -> getCount(ROLLOVERS_COMPLETED, metricsRegistry) == 1);
 
     assertThat(chunkManager.getChunkList().size()).isEqualTo(2);
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, metricsRegistry)).isEqualTo(11);

--- a/kaldb/src/test/java/com/slack/kaldb/chunkrollover/MessageSizeOrCountBasedRolloverStrategyTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkrollover/MessageSizeOrCountBasedRolloverStrategyTest.java
@@ -1,26 +1,27 @@
 package com.slack.kaldb.chunkrollover;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import com.slack.kaldb.proto.config.KaldbConfigs;
 import com.slack.kaldb.testlib.KaldbConfigUtil;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class MessageSizeOrCountBasedRolloverStrategyTest {
 
   private SimpleMeterRegistry metricsRegistry;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     metricsRegistry = new SimpleMeterRegistry();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws TimeoutException, IOException {
     metricsRegistry.close();
   }
@@ -36,14 +37,16 @@ public class MessageSizeOrCountBasedRolloverStrategyTest {
     assertThat(chunkRollOverStrategy.getMaxMessagesPerChunk()).isEqualTo(100);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNegativeMaxMessagesPerChunk() {
-    new MessageSizeOrCountBasedRolloverStrategy(metricsRegistry, 100, -1);
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> new MessageSizeOrCountBasedRolloverStrategy(metricsRegistry, 100, -1));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNegativeMaxBytesPerChunk() {
-    new MessageSizeOrCountBasedRolloverStrategy(metricsRegistry, -100, 1);
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> new MessageSizeOrCountBasedRolloverStrategy(metricsRegistry, -100, 1));
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/chunkrollover/NeverRolloverChunkStrategyTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkrollover/NeverRolloverChunkStrategyTest.java
@@ -2,7 +2,7 @@ package com.slack.kaldb.chunkrollover;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class NeverRolloverChunkStrategyTest {
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentServiceTest.java
@@ -2,6 +2,7 @@ package com.slack.kaldb.clusterManager;
 
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -29,10 +30,10 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.curator.test.TestingServer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class RecoveryTaskAssignmentServiceTest {
 
@@ -43,7 +44,7 @@ public class RecoveryTaskAssignmentServiceTest {
   private RecoveryTaskMetadataStore recoveryTaskMetadataStore;
   private RecoveryNodeMetadataStore recoveryNodeMetadataStore;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     Tracing.newBuilder().build();
     meterRegistry = new SimpleMeterRegistry();
@@ -63,7 +64,7 @@ public class RecoveryTaskAssignmentServiceTest {
     recoveryNodeMetadataStore = spy(new RecoveryNodeMetadataStore(metadataStore, true));
   }
 
-  @After
+  @AfterEach
   public void shutdown() throws IOException {
     recoveryNodeMetadataStore.close();
     recoveryTaskMetadataStore.close();
@@ -73,7 +74,7 @@ public class RecoveryTaskAssignmentServiceTest {
     meterRegistry.close();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void shouldCheckInvalidEventAggregation() {
     KaldbConfigs.ManagerConfig.RecoveryTaskAssignmentServiceConfig
         recoveryTaskAssignmentServiceConfig =
@@ -88,11 +89,17 @@ public class RecoveryTaskAssignmentServiceTest {
             .setEventAggregationSecs(-1)
             .build();
 
-    new RecoveryTaskAssignmentService(
-        recoveryTaskMetadataStore, recoveryNodeMetadataStore, managerConfig, meterRegistry);
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () ->
+                new RecoveryTaskAssignmentService(
+                    recoveryTaskMetadataStore,
+                    recoveryNodeMetadataStore,
+                    managerConfig,
+                    meterRegistry));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void shouldCheckInvalidPeriod() {
     KaldbConfigs.ManagerConfig.RecoveryTaskAssignmentServiceConfig
         recoveryTaskAssignmentServiceConfig =
@@ -107,9 +114,15 @@ public class RecoveryTaskAssignmentServiceTest {
             .setEventAggregationSecs(1)
             .build();
 
-    new RecoveryTaskAssignmentService(
-            recoveryTaskMetadataStore, recoveryNodeMetadataStore, managerConfig, meterRegistry)
-        .scheduler();
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () ->
+                new RecoveryTaskAssignmentService(
+                        recoveryTaskMetadataStore,
+                        recoveryNodeMetadataStore,
+                        managerConfig,
+                        meterRegistry)
+                    .scheduler());
   }
 
   @Test
@@ -811,7 +824,7 @@ public class RecoveryTaskAssignmentServiceTest {
   }
 
   @Test
-  @Ignore // Flakey, occasionally throws InternalMetadataStore on the recoveryNodeMetadataStore
+  @Disabled // Flakey, occasionally throws InternalMetadataStore on the recoveryNodeMetadataStore
   public void shouldHandleTasksAvailableFirstLifecycle() throws Exception {
     KaldbConfigs.ManagerConfig.RecoveryTaskAssignmentServiceConfig
         recoveryTaskAssignmentServiceConfig =

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
@@ -3,6 +3,7 @@ package com.slack.kaldb.clusterManager;
 import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LOGS_LUCENE9;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -31,9 +32,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import org.apache.curator.test.TestingServer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ReplicaAssignmentServiceTest {
 
@@ -46,7 +47,7 @@ public class ReplicaAssignmentServiceTest {
   private CacheSlotMetadataStore cacheSlotMetadataStore;
   private ReplicaMetadataStore replicaMetadataStore;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     Tracing.newBuilder().build();
     meterRegistry = new SimpleMeterRegistry();
@@ -66,7 +67,7 @@ public class ReplicaAssignmentServiceTest {
     replicaMetadataStore = spy(new ReplicaMetadataStore(metadataStore, true));
   }
 
-  @After
+  @AfterEach
   public void shutdown() throws IOException {
     cacheSlotMetadataStore.close();
     replicaMetadataStore.close();
@@ -76,7 +77,7 @@ public class ReplicaAssignmentServiceTest {
     meterRegistry.close();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void shouldCheckInvalidEventAggregation() {
     KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig replicaAssignmentServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig.newBuilder()
@@ -89,11 +90,14 @@ public class ReplicaAssignmentServiceTest {
             .setReplicaAssignmentServiceConfig(replicaAssignmentServiceConfig)
             .build();
 
-    new ReplicaAssignmentService(
-        cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () ->
+                new ReplicaAssignmentService(
+                    cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void shouldCheckInvalidSchedulePeriod() {
     KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig replicaAssignmentServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig.newBuilder()
@@ -106,9 +110,12 @@ public class ReplicaAssignmentServiceTest {
             .setReplicaAssignmentServiceConfig(replicaAssignmentServiceConfig)
             .build();
 
-    new ReplicaAssignmentService(
-            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry)
-        .scheduler();
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () ->
+                new ReplicaAssignmentService(
+                        cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry)
+                    .scheduler());
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaCreationServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaCreationServiceTest.java
@@ -3,6 +3,7 @@ package com.slack.kaldb.clusterManager;
 import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LOGS_LUCENE9;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -35,9 +36,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.curator.test.TestingServer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ReplicaCreationServiceTest {
   private TestingServer testingServer;
@@ -47,7 +48,7 @@ public class ReplicaCreationServiceTest {
   private SnapshotMetadataStore snapshotMetadataStore;
   private ReplicaMetadataStore replicaMetadataStore;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     Tracing.newBuilder().build();
     meterRegistry = new SimpleMeterRegistry();
@@ -67,7 +68,7 @@ public class ReplicaCreationServiceTest {
     replicaMetadataStore = spy(new ReplicaMetadataStore(metadataStore, true));
   }
 
-  @After
+  @AfterEach
   public void shutdown() throws IOException {
     snapshotMetadataStore.close();
     replicaMetadataStore.close();
@@ -666,7 +667,7 @@ public class ReplicaCreationServiceTest {
     timeoutServiceExecutor.shutdown();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void shouldThrowOnInvalidAggregationSecs() {
     KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
@@ -682,11 +683,14 @@ public class ReplicaCreationServiceTest {
             .setScheduleInitialDelayMins(0)
             .build();
 
-    new ReplicaCreationService(
-        replicaMetadataStore, snapshotMetadataStore, managerConfig, meterRegistry);
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () ->
+                new ReplicaCreationService(
+                    replicaMetadataStore, snapshotMetadataStore, managerConfig, meterRegistry));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void shouldThrowOnInvalidLifespanMins() {
     KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
@@ -702,11 +706,14 @@ public class ReplicaCreationServiceTest {
             .setScheduleInitialDelayMins(0)
             .build();
 
-    new ReplicaCreationService(
-        replicaMetadataStore, snapshotMetadataStore, managerConfig, meterRegistry);
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () ->
+                new ReplicaCreationService(
+                    replicaMetadataStore, snapshotMetadataStore, managerConfig, meterRegistry));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void shouldThrowOnInvalidReplicasPerSnapshot() {
     KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
@@ -722,7 +729,10 @@ public class ReplicaCreationServiceTest {
             .setScheduleInitialDelayMins(0)
             .build();
 
-    new ReplicaCreationService(
-        replicaMetadataStore, snapshotMetadataStore, managerConfig, meterRegistry);
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () ->
+                new ReplicaCreationService(
+                    replicaMetadataStore, snapshotMetadataStore, managerConfig, meterRegistry));
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaRestoreServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaRestoreServiceTest.java
@@ -2,9 +2,9 @@ package com.slack.kaldb.clusterManager;
 
 import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LOGS_LUCENE9;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.AssertionsForClassTypes.fail;
 import static org.awaitility.Awaitility.await;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
@@ -27,9 +27,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import javax.naming.SizeLimitExceededException;
 import org.apache.curator.test.TestingServer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ReplicaRestoreServiceTest {
 
@@ -39,7 +39,7 @@ public class ReplicaRestoreServiceTest {
   private KaldbConfigs.ManagerConfig managerConfig;
   private ReplicaMetadataStore replicaMetadataStore;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     Tracing.newBuilder().build();
     meterRegistry = new SimpleMeterRegistry();
@@ -71,7 +71,7 @@ public class ReplicaRestoreServiceTest {
     replicaMetadataStore = spy(new ReplicaMetadataStore(metadataStore, true));
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     meterRegistry.close();
     testingServer.close();
@@ -135,7 +135,7 @@ public class ReplicaRestoreServiceTest {
                 replicaRestoreService.queueSnapshotsForRestoration(List.of(snapshotIncluded));
                 Thread.sleep(300);
               } catch (Exception e) {
-                fail();
+                fail("Error in queueSnapshotsForRestoration", e);
               }
             }
           });
@@ -224,8 +224,7 @@ public class ReplicaRestoreServiceTest {
       snapshots.add(new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LOGS_LUCENE9));
     }
 
-    assertThrows(
-        SizeLimitExceededException.class,
-        () -> replicaRestoreService.queueSnapshotsForRestoration(snapshots));
+    assertThatExceptionOfType(SizeLimitExceededException.class)
+        .isThrownBy(() -> replicaRestoreService.queueSnapshotsForRestoration(snapshots));
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/elasticsearchApi/OpenSearchRequestTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/elasticsearchApi/OpenSearchRequestTest.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OpenSearchRequestTest {
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/FieldConflictsTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/FieldConflictsTest.java
@@ -1,29 +1,29 @@
 package com.slack.kaldb.logstore;
 
-import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.findAllMessages;
+import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherExtension.findAllMessages;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import brave.Tracing;
 import com.slack.kaldb.testlib.MessageUtil;
-import com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule;
+import com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherExtension;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Map;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class FieldConflictsTest {
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Tracing.newBuilder().build();
   }
 
-  @Rule
-  public TemporaryLogStoreAndSearcherRule strictLogStore =
-      new TemporaryLogStoreAndSearcherRule(true);
+  @RegisterExtension
+  public TemporaryLogStoreAndSearcherExtension strictLogStore =
+      new TemporaryLogStoreAndSearcherExtension(true);
 
   public FieldConflictsTest() throws IOException {}
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/LogMessageTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/LogMessageTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.slack.kaldb.logstore.LogMessage.ReservedField;
 import com.slack.kaldb.logstore.LogMessage.SystemField;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LogMessageTest {
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreConfigTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreConfigTest.java
@@ -1,28 +1,48 @@
 package com.slack.kaldb.logstore;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
 import java.time.Duration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LuceneIndexStoreConfigTest {
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testZeroCommitDuration() {
-    new LuceneIndexStoreConfig(Duration.ZERO, Duration.ofSeconds(10), "indexRoot", "logfile", true);
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () ->
+                new LuceneIndexStoreConfig(
+                    Duration.ZERO, Duration.ofSeconds(10), "indexRoot", "logfile", true));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testZeroRefreshDuration() {
-    new LuceneIndexStoreConfig(Duration.ofSeconds(10), Duration.ZERO, "indexRoot", "logfile", true);
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () ->
+                new LuceneIndexStoreConfig(
+                    Duration.ofSeconds(10), Duration.ZERO, "indexRoot", "logfile", true));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNegativeCommitDuration() {
-    new LuceneIndexStoreConfig(
-        Duration.ofSeconds(-10), Duration.ofSeconds(10), "indexRoot", "logfile", true);
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () ->
+                new LuceneIndexStoreConfig(
+                    Duration.ofSeconds(-10), Duration.ofSeconds(10), "indexRoot", "logfile", true));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNegativeRefreshDuration() {
-    new LuceneIndexStoreConfig(
-        Duration.ofSeconds(10), Duration.ofSeconds(-100), "indexRoot", "logfile", true);
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () ->
+                new LuceneIndexStoreConfig(
+                    Duration.ofSeconds(10),
+                    Duration.ofSeconds(-100),
+                    "indexRoot",
+                    "logfile",
+                    true));
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
@@ -10,13 +10,13 @@ import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.MESSAGES_RECEIVED_CO
 import static com.slack.kaldb.logstore.LuceneIndexStoreImpl.REFRESHES_TIMER;
 import static com.slack.kaldb.testlib.MetricsUtil.getCount;
 import static com.slack.kaldb.testlib.MetricsUtil.getTimerCount;
-import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.MAX_TIME;
-import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.addMessages;
-import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule.findAllMessages;
+import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherExtension.MAX_TIME;
+import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherExtension.addMessages;
+import static com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherExtension.findAllMessages;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import brave.Tracing;
-import com.adobe.testing.s3mock.junit4.S3MockRule;
+import com.adobe.testing.s3mock.junit5.S3MockExtension;
 import com.slack.kaldb.blobfs.LocalBlobFs;
 import com.slack.kaldb.blobfs.s3.S3BlobFs;
 import com.slack.kaldb.blobfs.s3.S3TestUtils;
@@ -26,11 +26,10 @@ import com.slack.kaldb.logstore.search.LogIndexSearcherImpl;
 import com.slack.kaldb.logstore.search.SearchResult;
 import com.slack.kaldb.logstore.search.aggregations.DateHistogramAggBuilder;
 import com.slack.kaldb.testlib.MessageUtil;
-import com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule;
+import com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherExtension;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -41,28 +40,27 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.lucene.index.IndexCommit;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 
 @SuppressWarnings("unused")
-@RunWith(Enclosed.class)
 public class LuceneIndexStoreImplTest {
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Tracing.newBuilder().build();
   }
 
-  public static class TestsWithConvertAndDuplicateFieldPolicy {
-    @Rule
-    public TemporaryLogStoreAndSearcherRule logStore = new TemporaryLogStoreAndSearcherRule(true);
+  @Nested
+  public class TestsWithConvertAndDuplicateFieldPolicy {
+    @RegisterExtension
+    public TemporaryLogStoreAndSearcherExtension logStore =
+        new TemporaryLogStoreAndSearcherExtension(true);
 
     public TestsWithConvertAndDuplicateFieldPolicy() throws IOException {}
 
@@ -187,10 +185,11 @@ public class LuceneIndexStoreImplTest {
     }
   }
 
-  public static class TestsWithRaiseErrorFieldConflictPolicy {
-    @Rule
-    public TemporaryLogStoreAndSearcherRule logStore =
-        new TemporaryLogStoreAndSearcherRule(
+  @Nested
+  public class TestsWithRaiseErrorFieldConflictPolicy {
+    @RegisterExtension
+    public TemporaryLogStoreAndSearcherExtension logStore =
+        new TemporaryLogStoreAndSearcherExtension(
             Duration.of(5, ChronoUnit.MINUTES),
             Duration.of(5, ChronoUnit.MINUTES),
             true,
@@ -311,10 +310,11 @@ public class LuceneIndexStoreImplTest {
     }
   }
 
-  public static class SuppressExceptionsOnClosedWriter {
-    @Rule
-    public TemporaryLogStoreAndSearcherRule testLogStore =
-        new TemporaryLogStoreAndSearcherRule(true);
+  @Nested
+  public class SuppressExceptionsOnClosedWriter {
+    @RegisterExtension
+    public TemporaryLogStoreAndSearcherExtension testLogStore =
+        new TemporaryLogStoreAndSearcherExtension(true);
 
     public SuppressExceptionsOnClosedWriter() throws IOException {}
 
@@ -333,14 +333,20 @@ public class LuceneIndexStoreImplTest {
     }
   }
 
-  public static class SnapshotTester {
-    @Rule
-    public TemporaryLogStoreAndSearcherRule strictLogStore =
-        new TemporaryLogStoreAndSearcherRule(true);
+  @RegisterExtension
+  public static final S3MockExtension S3_MOCK_EXTENSION =
+      S3MockExtension.builder() // .silent()
+          // .withRootFolder()
+          .withSecureConnection(false)
+          .build();
 
-    @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+  @Nested
+  public class SnapshotTester {
+    @RegisterExtension
+    public TemporaryLogStoreAndSearcherExtension strictLogStore =
+        new TemporaryLogStoreAndSearcherExtension(true);
 
-    @ClassRule public static final S3MockRule S3_MOCK_RULE = S3MockRule.builder().silent().build();
+    @TempDir private Path tmpPath;
 
     public SnapshotTester() throws IOException {}
 
@@ -380,7 +386,7 @@ public class LuceneIndexStoreImplTest {
           .isGreaterThanOrEqualTo(activeFiles.size());
 
       // create an S3 client
-      S3Client s3Client = S3_MOCK_RULE.createS3ClientV2();
+      S3Client s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
       S3BlobFs s3BlobFs = new S3BlobFs(s3Client);
       s3Client.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
 
@@ -400,14 +406,13 @@ public class LuceneIndexStoreImplTest {
       }
 
       // Download files from S3 to local FS.
-      String[] s3Files =
-          copyFromS3(bucket, prefix, s3BlobFs, Paths.get(tempFolder.getRoot().getAbsolutePath()));
+      String[] s3Files = copyFromS3(bucket, prefix, s3BlobFs, tmpPath.toAbsolutePath());
       assertThat(s3Files.length).isEqualTo(activeFiles.size());
 
       // Search files in local FS.
       LogIndexSearcherImpl newSearcher =
           new LogIndexSearcherImpl(
-              LogIndexSearcherImpl.searcherManagerFromPath(tempFolder.getRoot().toPath()),
+              LogIndexSearcherImpl.searcherManagerFromPath(tmpPath.toAbsolutePath()),
               logStore.getSchema());
       Collection<LogMessage> newResults =
           findAllMessages(newSearcher, MessageUtil.TEST_DATASET_NAME, "Message1", 100);
@@ -445,12 +450,11 @@ public class LuceneIndexStoreImplTest {
       assertThat(blobFs.listFiles(dirPath.toUri(), false).length)
           .isGreaterThanOrEqualTo(activeFiles.size());
 
-      copyToLocalPath(
-          dirPath, activeFiles, Paths.get(tempFolder.getRoot().getAbsolutePath()), blobFs);
+      copyToLocalPath(dirPath, activeFiles, tmpPath.toAbsolutePath(), blobFs);
 
       LogIndexSearcherImpl newSearcher =
           new LogIndexSearcherImpl(
-              LogIndexSearcherImpl.searcherManagerFromPath(tempFolder.getRoot().toPath()),
+              LogIndexSearcherImpl.searcherManagerFromPath(tmpPath.toAbsolutePath()),
               logStore.getSchema());
 
       Collection<LogMessage> newResults =
@@ -461,10 +465,11 @@ public class LuceneIndexStoreImplTest {
     }
   }
 
-  public static class IndexCleanupTests {
-    @Rule
-    public TemporaryLogStoreAndSearcherRule strictLogStore =
-        new TemporaryLogStoreAndSearcherRule(true);
+  @Nested
+  public class IndexCleanupTests {
+    @RegisterExtension
+    public TemporaryLogStoreAndSearcherExtension strictLogStore =
+        new TemporaryLogStoreAndSearcherExtension(true);
 
     public IndexCleanupTests() throws IOException {}
 
@@ -491,12 +496,13 @@ public class LuceneIndexStoreImplTest {
     }
   }
 
-  public static class AutoCommitTests {
+  @Nested
+  public class AutoCommitTests {
     Duration commitDuration = Duration.ofSeconds(5);
 
-    @Rule
-    public TemporaryLogStoreAndSearcherRule testLogStore =
-        new TemporaryLogStoreAndSearcherRule(
+    @RegisterExtension
+    public TemporaryLogStoreAndSearcherExtension testLogStore =
+        new TemporaryLogStoreAndSearcherExtension(
             commitDuration,
             commitDuration,
             true,

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/opensearch/OpenSearchInternalAggregationTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/opensearch/OpenSearchInternalAggregationTest.java
@@ -9,23 +9,23 @@ import com.slack.kaldb.logstore.search.aggregations.HistogramAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.PercentilesAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.TermsAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.UniqueCountAggBuilder;
-import com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule;
+import com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherExtension;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.IndexSearcher;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.opensearch.search.aggregations.Aggregator;
 import org.opensearch.search.aggregations.InternalAggregation;
 
 public class OpenSearchInternalAggregationTest {
 
-  @Rule
-  public TemporaryLogStoreAndSearcherRule logStoreAndSearcherRule =
-      new TemporaryLogStoreAndSearcherRule(false);
+  @RegisterExtension
+  public TemporaryLogStoreAndSearcherExtension logStoreAndSearcherRule =
+      new TemporaryLogStoreAndSearcherExtension(false);
 
   private final OpenSearchAdapter openSearchAdapter = new OpenSearchAdapter(Map.of());
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/schema/ConvertFieldValueAndDuplicateTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/schema/ConvertFieldValueAndDuplicateTest.java
@@ -24,8 +24,8 @@ import java.util.Map;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.util.BytesRef;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +34,7 @@ public class ConvertFieldValueAndDuplicateTest {
   private SimpleMeterRegistry meterRegistry;
   private static final Logger LOG = LoggerFactory.getLogger(RaiseErrorFieldValueTest.class);
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     meterRegistry = new SimpleMeterRegistry();
   }

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/schema/ConvertFieldValueTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/schema/ConvertFieldValueTest.java
@@ -19,8 +19,8 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import org.apache.lucene.document.Document;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +29,7 @@ public class ConvertFieldValueTest {
   private SimpleMeterRegistry meterRegistry;
   private static final Logger LOG = LoggerFactory.getLogger(RaiseErrorFieldValueTest.class);
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     meterRegistry = new SimpleMeterRegistry();
   }

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/schema/DropPolicyTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/schema/DropPolicyTest.java
@@ -21,8 +21,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.SortedDocValuesField;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +31,7 @@ public class DropPolicyTest {
   private SimpleMeterRegistry meterRegistry;
   private static final Logger LOG = LoggerFactory.getLogger(RaiseErrorFieldValueTest.class);
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     meterRegistry = new SimpleMeterRegistry();
   }

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/schema/RaiseErrorFieldValueTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/schema/RaiseErrorFieldValueTest.java
@@ -18,8 +18,8 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
 import java.util.Map;
 import org.apache.lucene.document.Document;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,7 +27,7 @@ public class RaiseErrorFieldValueTest {
   private SimpleMeterRegistry meterRegistry;
   private static final Logger LOG = LoggerFactory.getLogger(RaiseErrorFieldValueTest.class);
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     meterRegistry = new SimpleMeterRegistry();
   }

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
@@ -46,9 +46,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.curator.test.TestingServer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class KaldbDistributedQueryServiceTest {
 
@@ -67,7 +67,7 @@ public class KaldbDistributedQueryServiceTest {
   private SearchContext cache3SearchContext;
   private SearchContext cache4SearchContext;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     Tracing.newBuilder().build();
 
@@ -98,7 +98,7 @@ public class KaldbDistributedQueryServiceTest {
     cache4SearchContext = new SearchContext("cache_host4", 20003);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     snapshotMetadataStore.close();
     searchMetadataStore.close();

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImplTest.java
@@ -27,13 +27,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.bucket.histogram.InternalDateHistogram;
 
 public class SearchResultAggregatorImplTest {
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     Tracing.newBuilder().build();
   }

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultUtilsTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultUtilsTest.java
@@ -25,7 +25,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SearchResultUtilsTest {
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/StatsCollectorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/StatsCollectorTest.java
@@ -13,23 +13,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 import brave.Tracing;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.logstore.search.aggregations.DateHistogramAggBuilder;
-import com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule;
+import com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherExtension;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Objects;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.opensearch.search.aggregations.bucket.histogram.InternalDateHistogram;
 
 public class StatsCollectorTest {
-  @Rule
-  public TemporaryLogStoreAndSearcherRule strictLogStore =
-      new TemporaryLogStoreAndSearcherRule(true);
+  @RegisterExtension
+  public TemporaryLogStoreAndSearcherExtension strictLogStore =
+      new TemporaryLogStoreAndSearcherExtension(true);
 
   public StatsCollectorTest() throws IOException {}
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     Tracing.newBuilder().build();
   }

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/aggregations/AvgAggBuilderTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/aggregations/AvgAggBuilderTest.java
@@ -2,7 +2,7 @@ package com.slack.kaldb.logstore.search.aggregations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AvgAggBuilderTest {
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/aggregations/DateHistogramAggBuilderTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/aggregations/DateHistogramAggBuilderTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DateHistogramAggBuilderTest {
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/aggregations/MovingAvgAggBuilderTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/aggregations/MovingAvgAggBuilderTest.java
@@ -2,7 +2,7 @@ package com.slack.kaldb.logstore.search.aggregations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MovingAvgAggBuilderTest {
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/aggregations/PercentilesAggBuilderTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/aggregations/PercentilesAggBuilderTest.java
@@ -3,7 +3,7 @@ package com.slack.kaldb.logstore.search.aggregations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PercentilesAggBuilderTest {
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/aggregations/TermsAggBuilderTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/aggregations/TermsAggBuilderTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TermsAggBuilderTest {
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/aggregations/UniqueCountAggBuilderTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/aggregations/UniqueCountAggBuilderTest.java
@@ -2,7 +2,7 @@ package com.slack.kaldb.logstore.search.aggregations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UniqueCountAggBuilderTest {
 

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializerTest.java
@@ -8,7 +8,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.slack.kaldb.proto.metadata.Metadata;
 import java.time.Instant;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CacheSlotMetadataSerializerTest {
   private final CacheSlotMetadataSerializer serDe = new CacheSlotMetadataSerializer();

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStoreTest.java
@@ -16,9 +16,9 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.test.TestingServer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class CacheSlotMetadataStoreTest {
   private static final List<Metadata.IndexType> SUPPORTED_INDEX_TYPES = List.of(LOGS_LUCENE9);
@@ -28,7 +28,7 @@ public class CacheSlotMetadataStoreTest {
   private MeterRegistry meterRegistry;
   private CacheSlotMetadataStore uncachedStore;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     meterRegistry = new SimpleMeterRegistry();
     // NOTE: Sometimes the ZK server fails to start. Handle it more gracefully, if tests are
@@ -48,7 +48,7 @@ public class CacheSlotMetadataStoreTest {
     this.uncachedStore = new CacheSlotMetadataStore(zkMetadataStore, false);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     zkMetadataStore.close();
     testingServer.close();

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataTest.java
@@ -8,7 +8,7 @@ import com.slack.kaldb.proto.metadata.Metadata;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CacheSlotMetadataTest {
 

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
@@ -27,18 +27,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.test.TestingServer;
 import org.apache.zookeeper.ZooKeeper;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@RunWith(Enclosed.class)
 public class KaldbMetadataStoreTest {
-
   private static final SnapshotMetadata ROOT_SNAPSHOT = makeSnapshot("defaultRootSnapshot");
   private static final SnapshotMetadataSerializer snapshotMetadataSerializer =
       new SnapshotMetadataSerializer();
@@ -57,10 +54,11 @@ public class KaldbMetadataStoreTest {
         name, snapshotPath, startTimeUtc, endTimeUtc, maxOffset, partitionId, LOGS_LUCENE9);
   }
 
-  public static class TestPersistentCreatableUpdatableCacheableMetadataStore {
+  @Nested
+  public class TestPersistentCreatableUpdatableCacheableMetadataStore {
     private ZooKeeper zooKeeper;
 
-    private static class DummyPersistentCreatableUpdatableCacheableMetadataStore
+    private class DummyPersistentCreatableUpdatableCacheableMetadataStore
         extends PersistentMutableMetadataStore<SnapshotMetadata> {
       public DummyPersistentCreatableUpdatableCacheableMetadataStore(
           String storeFolder,
@@ -72,7 +70,7 @@ public class KaldbMetadataStoreTest {
       }
     }
 
-    private static final Logger LOG =
+    private final Logger LOG =
         LoggerFactory.getLogger(DummyPersistentCreatableUpdatableCacheableMetadataStore.class);
 
     private TestingServer testingServer;
@@ -81,7 +79,7 @@ public class KaldbMetadataStoreTest {
     private DummyPersistentCreatableUpdatableCacheableMetadataStore store;
     private int expectedCacheErrorCounter = 0;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
       expectedCacheErrorCounter = 0;
       meterRegistry = new SimpleMeterRegistry();
@@ -112,7 +110,7 @@ public class KaldbMetadataStoreTest {
       zooKeeper = zkMetadataStore.getCurator().getZookeeperClient().getZooKeeper();
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws IOException {
       assertThat(getCount(CACHE_ERROR_COUNTER, meterRegistry)).isEqualTo(expectedCacheErrorCounter);
 
@@ -556,7 +554,7 @@ public class KaldbMetadataStoreTest {
     }
 
     @Test
-    @Ignore // flakey test
+    @Disabled // flakey test
     public void testCorruptZkMetadata() throws ExecutionException, InterruptedException {
       assertThat(store.list().get().isEmpty()).isTrue();
 
@@ -600,8 +598,9 @@ public class KaldbMetadataStoreTest {
     }
   }
 
-  public static class TestPersistentCreatableCacheableMetadataStore {
-    private static class DummyPersistentCreatableCacheableMetadataStore
+  @Nested
+  public class TestPersistentCreatableCacheableMetadataStore {
+    private class DummyPersistentCreatableCacheableMetadataStore
         extends PersistentMutableMetadataStore<SnapshotMetadata> {
       public DummyPersistentCreatableCacheableMetadataStore(
           String storeFolder,
@@ -613,7 +612,7 @@ public class KaldbMetadataStoreTest {
       }
     }
 
-    private static final Logger LOG =
+    private final Logger LOG =
         LoggerFactory.getLogger(TestPersistentCreatableCacheableMetadataStore.class);
 
     private TestingServer testingServer;
@@ -621,7 +620,7 @@ public class KaldbMetadataStoreTest {
     private MeterRegistry meterRegistry;
     private DummyPersistentCreatableCacheableMetadataStore store;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
       meterRegistry = new SimpleMeterRegistry();
       // NOTE: Sometimes the ZK server fails to start. Handle it more gracefully, if tests are
@@ -650,7 +649,7 @@ public class KaldbMetadataStoreTest {
               SNAPSHOT_METADATA_STORE_ZK_PATH, zkMetadataStore, snapshotMetadataSerializer, LOG);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws IOException {
       assertThat(getCount(CACHE_ERROR_COUNTER, meterRegistry)).isEqualTo(0);
       zkMetadataStore.close();
@@ -701,8 +700,9 @@ public class KaldbMetadataStoreTest {
     }
   }
 
-  public static class TestPersistentCreatableMetadataStore {
-    private static class DummyPersistentCreatableMetadataStore
+  @Nested
+  public class TestPersistentCreatableMetadataStore {
+    private class DummyPersistentCreatableMetadataStore
         extends PersistentMutableMetadataStore<SnapshotMetadata> {
       public DummyPersistentCreatableMetadataStore(
           String storeFolder,
@@ -714,7 +714,7 @@ public class KaldbMetadataStoreTest {
       }
     }
 
-    private static final Logger LOG =
+    private final Logger LOG =
         LoggerFactory.getLogger(TestPersistentCreatableCacheableMetadataStore.class);
 
     private TestingServer testingServer;
@@ -722,7 +722,7 @@ public class KaldbMetadataStoreTest {
     private MeterRegistry meterRegistry;
     private DummyPersistentCreatableMetadataStore store;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
       meterRegistry = new SimpleMeterRegistry();
       // NOTE: Sometimes the ZK server fails to start. Handle it more gracefully, if tests are
@@ -743,7 +743,7 @@ public class KaldbMetadataStoreTest {
               SNAPSHOT_METADATA_STORE_ZK_PATH, zkMetadataStore, snapshotMetadataSerializer, LOG);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws IOException {
       zkMetadataStore.close();
       testingServer.close();
@@ -827,7 +827,7 @@ public class KaldbMetadataStoreTest {
     private DummyEphemeralCreatableUpdatableCacheableMetadataStore store;
     private int expectedCacheErrorCount = 0;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
       expectedCacheErrorCount = 0;
       meterRegistry = new SimpleMeterRegistry();
@@ -858,7 +858,7 @@ public class KaldbMetadataStoreTest {
       zooKeeper = zkMetadataStore.getCurator().getZookeeperClient().getZooKeeper();
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws IOException {
       assertThat(getCount(CACHE_ERROR_COUNTER, meterRegistry)).isEqualTo(expectedCacheErrorCount);
       zkMetadataStore.close();
@@ -1366,7 +1366,7 @@ public class KaldbMetadataStoreTest {
     private MeterRegistry meterRegistry;
     private DummyEphemeralCreatableCacheableMetadataStore store;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
       meterRegistry = new SimpleMeterRegistry();
       // NOTE: Sometimes the ZK server fails to start. Handle it more gracefully, if tests are
@@ -1395,7 +1395,7 @@ public class KaldbMetadataStoreTest {
               SNAPSHOT_METADATA_STORE_ZK_PATH, zkMetadataStore, snapshotMetadataSerializer, LOG);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws IOException {
       assertThat(getCount(CACHE_ERROR_COUNTER, meterRegistry)).isEqualTo(0);
       zkMetadataStore.close();
@@ -1467,7 +1467,7 @@ public class KaldbMetadataStoreTest {
     private MeterRegistry meterRegistry;
     private DummyEphemeralCreatableMetadataStore store;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
       meterRegistry = new SimpleMeterRegistry();
       // NOTE: Sometimes the ZK server fails to start. Handle it more gracefully, if tests are
@@ -1496,7 +1496,7 @@ public class KaldbMetadataStoreTest {
               SNAPSHOT_METADATA_STORE_ZK_PATH, zkMetadataStore, snapshotMetadataSerializer, LOG);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws IOException {
       zkMetadataStore.close();
       testingServer.close();
@@ -1575,7 +1575,7 @@ public class KaldbMetadataStoreTest {
     private ZookeeperMetadataStoreImpl zkMetadataStore;
     private MeterRegistry meterRegistry;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
       meterRegistry = new SimpleMeterRegistry();
       // NOTE: Sometimes the ZK server fails to start. Handle it more gracefully, if tests are
@@ -1601,7 +1601,7 @@ public class KaldbMetadataStoreTest {
           .isNull();
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws IOException {
       assertThat(getCount(CACHE_ERROR_COUNTER, meterRegistry)).isEqualTo(0);
       zkMetadataStore.close();

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataTest.java
@@ -1,9 +1,10 @@
 package com.slack.kaldb.metadata.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class KaldbMetadataTest {
   private static class DummyMetadata extends KaldbMetadata {
@@ -19,8 +20,9 @@ public class KaldbMetadataTest {
     assertThat(List.of(new DummyMetadata("test1"), new DummyMetadata("test2")).size()).isEqualTo(2);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testEmptyName() {
-    new DummyMetadata("");
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> new DummyMetadata(""));
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetMetadataSerializerTest.java
@@ -9,7 +9,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DatasetMetadataSerializerTest {
   private final DatasetMetadataSerializer serDe = new DatasetMetadataSerializer();

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetMetadataTest.java
@@ -10,7 +10,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DatasetMetadataTest {
 

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetPartitionMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetPartitionMetadataTest.java
@@ -16,9 +16,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.curator.test.TestingServer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DatasetPartitionMetadataTest {
 
@@ -27,7 +27,7 @@ public class DatasetPartitionMetadataTest {
   private DatasetMetadataStore datasetMetadataStore;
   private TestingServer testZKServer;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     Tracing.newBuilder().build();
 
@@ -48,7 +48,7 @@ public class DatasetPartitionMetadataTest {
     datasetMetadataStore = new DatasetMetadataStore(zkMetadataStore, true);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     datasetMetadataStore.close();
     zkMetadataStore.close();

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataSerializerTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.slack.kaldb.proto.metadata.Metadata;
 import java.time.Instant;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RecoveryNodeMetadataSerializerTest {
   private final RecoveryNodeMetadataSerializer serDe = new RecoveryNodeMetadataSerializer();

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 
 import com.slack.kaldb.proto.metadata.Metadata;
 import java.time.Instant;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RecoveryNodeMetadataTest {
 

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataSerializerTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.time.Instant;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RecoveryTaskMetadataSerializerTest {
   private final RecoveryTaskMetadataSerializer serDe = new RecoveryTaskMetadataSerializer();

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import java.time.Instant;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RecoveryTaskMetadataTest {
 

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializerTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.time.Instant;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReplicaMetadataSerializerTest {
   private final ReplicaMetadataSerializer serDe = new ReplicaMetadataSerializer();

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import java.time.Instant;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReplicaMetadataTest {
 

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/schema/ChunkSchemaTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/schema/ChunkSchemaTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import java.util.concurrent.ConcurrentHashMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ChunkSchemaTest {
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/schema/FieldTypeTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/schema/FieldTypeTest.java
@@ -3,7 +3,7 @@ package com.slack.kaldb.metadata.schema;
 import static com.slack.kaldb.metadata.schema.FieldType.convertFieldValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FieldTypeTest {
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/schema/LuceneFieldDefSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/schema/LuceneFieldDefSerializerTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.google.protobuf.InvalidProtocolBufferException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LuceneFieldDefSerializerTest {
   private final LuceneFieldDefSerializer serDe = new LuceneFieldDefSerializer();

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/schema/LuceneFieldDefTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/schema/LuceneFieldDefTest.java
@@ -2,7 +2,7 @@ package com.slack.kaldb.metadata.schema;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LuceneFieldDefTest {
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/search/SearchMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/search/SearchMetadataSerializerTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.google.protobuf.InvalidProtocolBufferException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SearchMetadataSerializerTest {
   private final SearchMetadataSerializer serDe = new SearchMetadataSerializer();

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/search/SearchMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/search/SearchMetadataStoreTest.java
@@ -10,9 +10,9 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.test.TestingServer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SearchMetadataStoreTest {
   private SimpleMeterRegistry meterRegistry;
@@ -20,7 +20,7 @@ public class SearchMetadataStoreTest {
   private MetadataStore zkMetadataStore;
   private SearchMetadataStore store;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     meterRegistry = new SimpleMeterRegistry();
     testingServer = new TestingServer();
@@ -36,7 +36,7 @@ public class SearchMetadataStoreTest {
             meterRegistry);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     if (store != null) store.close();
     zkMetadataStore.close();

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/search/SearchMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/search/SearchMetadataTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SearchMetadataTest {
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataSerializerTest.java
@@ -2,9 +2,10 @@ package com.slack.kaldb.metadata.snapshot;
 
 import static com.slack.kaldb.proto.metadata.Metadata.IndexType.LOGS_LUCENE9;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import com.google.protobuf.InvalidProtocolBufferException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SnapshotMetadataSerializerTest {
   private final SnapshotMetadataSerializer serDe = new SnapshotMetadataSerializer();
@@ -37,23 +38,27 @@ public class SnapshotMetadataSerializerTest {
     assertThat(deserializedSnapshotMetadata.indexType).isEqualTo(LOGS_LUCENE9);
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void serializeNullObject() throws InvalidProtocolBufferException {
-    serDe.toJsonStr(null);
+  @Test
+  public void serializeNullObject() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> serDe.toJsonStr(null));
   }
 
-  @Test(expected = InvalidProtocolBufferException.class)
-  public void deserializeNullObject() throws InvalidProtocolBufferException {
-    serDe.fromJsonStr(null);
+  @Test
+  public void deserializeNullObject() {
+    assertThatExceptionOfType(InvalidProtocolBufferException.class)
+        .isThrownBy(() -> serDe.fromJsonStr(null));
   }
 
-  @Test(expected = InvalidProtocolBufferException.class)
-  public void deserializeEmptyObject() throws InvalidProtocolBufferException {
-    serDe.fromJsonStr("");
+  @Test
+  public void deserializeEmptyObject() {
+    assertThatExceptionOfType(InvalidProtocolBufferException.class)
+        .isThrownBy(() -> serDe.fromJsonStr(""));
   }
 
-  @Test(expected = InvalidProtocolBufferException.class)
-  public void deserializeTestString() throws InvalidProtocolBufferException {
-    serDe.fromJsonStr("test");
+  @Test
+  public void deserializeTestString() {
+    assertThatExceptionOfType(InvalidProtocolBufferException.class)
+        .isThrownBy(() -> serDe.fromJsonStr("test"));
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SnapshotMetadataTest {
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/zookeeper/ZookeeperCachedMetadataStoreImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/zookeeper/ZookeeperCachedMetadataStoreImplTest.java
@@ -25,9 +25,9 @@ import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.test.TestingServer;
 import org.apache.zookeeper.ZooKeeper;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,7 +71,7 @@ public class ZookeeperCachedMetadataStoreImplTest {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     expectedCacheErrorCount = 0;
     meterRegistry = new SimpleMeterRegistry();
@@ -90,7 +90,7 @@ public class ZookeeperCachedMetadataStoreImplTest {
     zooKeeper = metadataStore.getCurator().getZookeeperClient().getZooKeeper();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     assertThat(getCount(CACHE_ERROR_COUNTER, meterRegistry)).isEqualTo(expectedCacheErrorCount);
     metadataStore.close();

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/zookeeper/ZookeeperMetadataStoreImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/zookeeper/ZookeeperMetadataStoreImplTest.java
@@ -9,6 +9,7 @@ import static com.slack.kaldb.testlib.ZkUtils.closeZookeeperClientConnection;
 import static com.slack.kaldb.util.SnapshotUtil.makeSnapshot;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.awaitility.Awaitility.await;
 
 import com.slack.kaldb.metadata.snapshot.SnapshotMetadata;
@@ -22,9 +23,9 @@ import java.util.concurrent.ExecutionException;
 import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.test.TestingServer;
 import org.apache.zookeeper.ZooKeeper;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ZookeeperMetadataStoreImplTest {
   private TestingServer testingServer;
@@ -33,7 +34,7 @@ public class ZookeeperMetadataStoreImplTest {
   private CountingFatalErrorHandler countingFatalErrorHandler;
   private ZooKeeper zooKeeper;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     meterRegistry = new SimpleMeterRegistry();
     // NOTE: Sometimes the ZK server fails to start. Handle it more gracefully, if tests are flaky.
@@ -51,7 +52,7 @@ public class ZookeeperMetadataStoreImplTest {
     zooKeeper = metadataStore.getCurator().getZookeeperClient().getZooKeeper();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException, NoSuchFieldException, IllegalAccessException {
     metadataStore.close();
     testingServer.close();
@@ -517,10 +518,12 @@ public class ZookeeperMetadataStoreImplTest {
     closeZookeeperClientConnection(zooKeeper);
   }
 
-  @Test(expected = NoNodeException.class)
+  @Test
   public void testCacheNodeAndChildrenCreatesMissingPath() throws Exception {
     String root = "/root";
-    metadataStore.cacheNodeAndChildren(root, new SnapshotMetadataSerializer());
+    assertThatExceptionOfType(NoNodeException.class)
+        .isThrownBy(
+            () -> metadataStore.cacheNodeAndChildren(root, new SnapshotMetadataSerializer()));
   }
 
   @SuppressWarnings("OptionalGetWithoutIsPresent")

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/KaldbSerdesTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/KaldbSerdesTest.java
@@ -7,7 +7,7 @@ import com.slack.service.murron.Murron;
 import com.slack.service.murron.trace.Trace;
 import java.time.Instant;
 import org.apache.kafka.common.serialization.Serde;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class KaldbSerdesTest {
 

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiterTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiterTest.java
@@ -13,7 +13,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import org.apache.kafka.streams.kstream.Predicate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PreprocessorRateLimiterTest {
 

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiterTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorRateLimiterTest.java
@@ -406,7 +406,7 @@ public class PreprocessorRateLimiterTest {
             .build();
 
     MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    PreprocessorRateLimiter rateLimiter = new PreprocessorRateLimiter(meterRegistry, 1, 3, false);
+    PreprocessorRateLimiter rateLimiter = new PreprocessorRateLimiter(meterRegistry, 1, 2, false);
 
     long targetThroughput = span.getSerializedSize() - 1;
     DatasetMetadata datasetMetadata =
@@ -422,9 +422,8 @@ public class PreprocessorRateLimiterTest {
     assertThat(predicate.test("key", span)).isTrue();
     assertThat(predicate.test("key", span)).isFalse();
 
-    Thread.sleep(4000);
+    Thread.sleep(2500);
 
-    assertThat(predicate.test("key", span)).isTrue();
     assertThat(predicate.test("key", span)).isTrue();
     assertThat(predicate.test("key", span)).isTrue();
     assertThat(predicate.test("key", span)).isFalse();

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
@@ -23,10 +23,10 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,13 +37,13 @@ public class PreprocessorServiceIntegrationTest {
   private TestKafkaServer kafkaServer;
   private TestingServer zkServer;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     zkServer = new TestingServer();
     kafkaServer = new TestKafkaServer();
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     kafkaServer.close();
     zkServer.close();
@@ -107,7 +107,7 @@ public class PreprocessorServiceIntegrationTest {
   }
 
   // Ignore flaky test. This test can be potentially merged with the above test.
-  @Ignore
+  @Disabled
   @Test
   @SuppressWarnings({"rawtypes", "unchecked"})
   public void shouldProcessMessageStartToFinish() throws Exception {

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
@@ -28,7 +28,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.processor.StreamPartitioner;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PreprocessorServiceUnitTest {
 

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorValueMapperTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorValueMapperTest.java
@@ -10,7 +10,7 @@ import com.slack.service.murron.trace.Trace;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import org.apache.kafka.streams.kstream.ValueMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PreprocessorValueMapperTest {
 

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
@@ -2,6 +2,7 @@ package com.slack.kaldb.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -14,30 +15,32 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class KaldbConfigTest {
 
-  @Before
+  @BeforeEach
   public void setUp() {
     KaldbConfig.reset();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     KaldbConfig.reset();
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testInitWithMissingConfigFile() throws IOException {
-    KaldbConfig.initFromFile(Path.of("missing_config_file.json"));
+  @Test
+  public void testInitWithMissingConfigFile() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> KaldbConfig.initFromFile(Path.of("missing_config_file.json")));
   }
 
-  @Test(expected = InvalidProtocolBufferException.class)
-  public void testEmptyJsonCfgFile() throws InvalidProtocolBufferException {
-    KaldbConfig.fromJsonConfig("");
+  @Test
+  public void testEmptyJsonCfgFile() {
+    assertThatExceptionOfType(InvalidProtocolBufferException.class)
+        .isThrownBy(() -> KaldbConfig.fromJsonConfig(""));
   }
 
   @Test
@@ -467,15 +470,17 @@ public class KaldbConfigTest {
     assertThat(preprocessorKafkaStreamConfig.getProcessingGuarantee()).isEqualTo("at_least_once");
   }
 
-  @Test(expected = RuntimeException.class)
-  public void testParseFormats() throws IOException {
+  @Test
+  public void testParseFormats() {
     // only json/yaml file extentions are supported
-    KaldbConfig.initFromFile(Path.of("README.md"));
+    assertThatExceptionOfType(RuntimeException.class)
+        .isThrownBy(() -> KaldbConfig.initFromFile(Path.of("README.md")));
   }
 
-  @Test(expected = InvalidProtocolBufferException.class)
-  public void testMalformedYaml() throws InvalidProtocolBufferException, JsonProcessingException {
-    KaldbConfig.fromYamlConfig(":test");
+  @Test
+  public void testMalformedYaml() {
+    assertThatExceptionOfType(InvalidProtocolBufferException.class)
+        .isThrownBy(() -> KaldbConfig.fromYamlConfig(":test"));
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
@@ -9,7 +9,7 @@ import static com.slack.kaldb.testlib.TestKafkaServer.produceMessagesToKafka;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-import com.adobe.testing.s3mock.junit4.S3MockRule;
+import com.adobe.testing.s3mock.junit5.S3MockExtension;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
@@ -42,10 +42,10 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -92,19 +92,23 @@ public class KaldbTest {
     return (boolean) map.get("healthy");
   }
 
-  @ClassRule
-  public static final S3MockRule S3_MOCK_RULE =
-      S3MockRule.builder().withInitialBuckets(TEST_S3_BUCKET).silent().build();
+  @RegisterExtension
+  public static final S3MockExtension S3_MOCK_EXTENSION =
+      S3MockExtension.builder()
+          .withInitialBuckets(TEST_S3_BUCKET)
+          .silent()
+          .withSecureConnection(false)
+          .build();
 
   private TestKafkaServer kafkaServer;
   private TestingServer zkServer;
   private S3Client s3Client;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     zkServer = new TestingServer();
     kafkaServer = new TestKafkaServer();
-    s3Client = S3_MOCK_RULE.createS3ClientV2();
+    s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
 
     // We side load a service metadata entry telling it to create an entry with the partitions that
     // we use in test
@@ -133,7 +137,7 @@ public class KaldbTest {
     await().until(() -> datasetMetadataStore.listSync().size() == 1);
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     if (kafkaServer != null) {
       kafkaServer.close();

--- a/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
@@ -25,12 +25,12 @@ import com.slack.kaldb.proto.manager_api.ManagerApi;
 import com.slack.kaldb.proto.manager_api.ManagerApiServiceGrpc;
 import com.slack.kaldb.proto.metadata.Metadata;
 import com.slack.kaldb.testlib.MetricsUtil;
+import com.slack.kaldb.util.GrpcCleanupExtension;
 import io.grpc.ManagedChannel;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
-import io.grpc.testing.GrpcCleanupRule;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
@@ -38,14 +38,15 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.curator.test.TestingServer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 @SuppressWarnings("ResultOfMethodCallIgnored")
 public class ManagerApiGrpcTest {
-  @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  @RegisterExtension public final GrpcCleanupExtension grpcCleanup = new GrpcCleanupExtension();
 
   private TestingServer testingServer;
   private MeterRegistry meterRegistry;
@@ -57,7 +58,7 @@ public class ManagerApiGrpcTest {
   private ReplicaRestoreService replicaRestoreService;
   private ManagerApiServiceGrpc.ManagerApiServiceBlockingStub managerApiStub;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     Tracing.newBuilder().build();
     meterRegistry = new SimpleMeterRegistry();
@@ -107,7 +108,7 @@ public class ManagerApiGrpcTest {
     managerApiStub = ManagerApiServiceGrpc.newBlockingStub(channel);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     replicaRestoreService.stopAsync();
     replicaRestoreService.awaitTerminated(DEFAULT_START_STOP_DURATION);

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -36,9 +36,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.test.TestingServer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("UnstableApiUsage")
 public class RecoveryTaskCreatorTest {
@@ -50,7 +50,7 @@ public class RecoveryTaskCreatorTest {
   private RecoveryTaskMetadataStore recoveryTaskStore;
   private static final String partitionId = "1";
 
-  @Before
+  @BeforeEach
   public void startup() throws Exception {
     Tracing.newBuilder().build();
     meterRegistry = new SimpleMeterRegistry();
@@ -68,7 +68,7 @@ public class RecoveryTaskCreatorTest {
     recoveryTaskStore = spy(new RecoveryTaskMetadataStore(zkMetadataStore, false));
   }
 
-  @After
+  @AfterEach
   public void shutdown() throws IOException {
     if (recoveryTaskStore != null) {
       recoveryTaskStore.close();

--- a/kaldb/src/test/java/com/slack/kaldb/server/SearchResultTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/SearchResultTest.java
@@ -11,22 +11,22 @@ import com.slack.kaldb.logstore.search.SearchResultUtils;
 import com.slack.kaldb.logstore.search.aggregations.DateHistogramAggBuilder;
 import com.slack.kaldb.proto.service.KaldbSearch;
 import com.slack.kaldb.testlib.MessageUtil;
-import com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherRule;
+import com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherExtension;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.opensearch.search.aggregations.Aggregator;
 import org.opensearch.search.aggregations.InternalAggregation;
 
 public class SearchResultTest {
 
-  @Rule
-  public TemporaryLogStoreAndSearcherRule logStoreAndSearcherRule =
-      new TemporaryLogStoreAndSearcherRule(false);
+  @RegisterExtension
+  public TemporaryLogStoreAndSearcherExtension logStoreAndSearcherRule =
+      new TemporaryLogStoreAndSearcherExtension(false);
 
   public SearchResultTest() throws IOException {}
 

--- a/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceSpanConversionTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceSpanConversionTest.java
@@ -8,7 +8,7 @@ import com.slack.kaldb.logstore.LogWireMessage;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ZipkinServiceSpanConversionTest {
 

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/ChunkManagerUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/ChunkManagerUtil.java
@@ -2,7 +2,7 @@ package com.slack.kaldb.testlib;
 
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 
-import com.adobe.testing.s3mock.junit4.S3MockRule;
+import com.adobe.testing.s3mock.junit5.S3MockExtension;
 import com.google.common.io.Files;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.slack.kaldb.blobfs.s3.S3BlobFs;
@@ -44,7 +44,7 @@ public class ChunkManagerUtil<T> {
   private final MetadataStore metadataStore;
 
   public static ChunkManagerUtil<LogMessage> makeChunkManagerUtil(
-      S3MockRule s3MockRule,
+      S3MockExtension s3MockExtension,
       String s3Bucket,
       MeterRegistry meterRegistry,
       long maxBytesPerChunk,
@@ -63,7 +63,7 @@ public class ChunkManagerUtil<T> {
     MetadataStore metadataStore = ZookeeperMetadataStoreImpl.fromConfig(meterRegistry, zkConfig);
 
     return new ChunkManagerUtil<>(
-        s3MockRule,
+        s3MockExtension,
         s3Bucket,
         meterRegistry,
         zkServer,
@@ -75,7 +75,7 @@ public class ChunkManagerUtil<T> {
   }
 
   public ChunkManagerUtil(
-      S3MockRule s3MockRule,
+      S3MockExtension s3MockExtension,
       String s3Bucket,
       MeterRegistry meterRegistry,
       TestingServer zkServer,
@@ -87,7 +87,7 @@ public class ChunkManagerUtil<T> {
       throws Exception {
 
     tempFolder = Files.createTempDir(); // TODO: don't use beta func.
-    s3Client = s3MockRule.createS3ClientV2();
+    s3Client = s3MockExtension.createS3ClientV2();
 
     S3BlobFs s3BlobFs = new S3BlobFs(s3Client);
     this.zkServer = zkServer;

--- a/kaldb/src/test/java/com/slack/kaldb/util/GrpcCleanupExtension.java
+++ b/kaldb/src/test/java/com/slack/kaldb/util/GrpcCleanupExtension.java
@@ -1,0 +1,181 @@
+package com.slack.kaldb.util;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.Lists;
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+
+/**
+ * Variation of the GrpcCleanupRule that has been adapted for JUnit 5. This should be able to go
+ * away once they have updated the underlying implementation.
+ *
+ * @see https://github.com/grpc/grpc-java/issues/5331
+ * @see https://www.stackhawk.com/blog/grpc-cleanup-extension-for-junit-5
+ */
+public class GrpcCleanupExtension implements AfterEachCallback {
+
+  private final List<GrpcCleanupExtension.Resource> resources = new ArrayList<>();
+  private final long timeoutNanos = TimeUnit.SECONDS.toNanos(10L);
+  private final Stopwatch stopwatch = Stopwatch.createUnstarted();
+
+  public GrpcCleanupExtension() {}
+
+  /**
+   * Registers the given channel to the rule. Once registered, the channel will be automatically
+   * shutdown at the end of the test.
+   *
+   * <p>This method need be properly synchronized if used in multiple threads. This method must not
+   * be used during the test teardown.
+   *
+   * @return the input channel
+   */
+  public <T extends ManagedChannel> T register(@Nonnull T channel) {
+    checkNotNull(channel, "channel");
+    register(new GrpcCleanupExtension.ManagedChannelResource(channel));
+    return channel;
+  }
+
+  /**
+   * Registers the given server to the rule. Once registered, the server will be automatically
+   * shutdown at the end of the test.
+   *
+   * <p>This method need be properly synchronized if used in multiple threads. This method must not
+   * be used during the test teardown.
+   *
+   * @return the input server
+   */
+  public <T extends Server> T register(@Nonnull T server) {
+    checkNotNull(server, "server");
+    register(new GrpcCleanupExtension.ServerResource(server));
+    return server;
+  }
+
+  @VisibleForTesting
+  void register(GrpcCleanupExtension.Resource resource) {
+    resources.add(resource);
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) {
+    stopwatch.reset();
+    stopwatch.start();
+
+    InterruptedException interrupted = null;
+
+    for (GrpcCleanupExtension.Resource resource : Lists.reverse(resources)) {
+      resource.cleanUp();
+    }
+
+    for (int i = resources.size() - 1; i >= 0; i--) {
+      try {
+        boolean released =
+            resources
+                .get(i)
+                .awaitReleased(
+                    timeoutNanos - stopwatch.elapsed(TimeUnit.NANOSECONDS), TimeUnit.NANOSECONDS);
+        if (released) {
+          resources.remove(i);
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        interrupted = e;
+        break;
+      }
+    }
+
+    if (!resources.isEmpty()) {
+      for (GrpcCleanupExtension.Resource resource : Lists.reverse(resources)) {
+        resource.forceCleanUp();
+      }
+
+      try {
+        if (interrupted != null) {
+          throw new AssertionError(
+              "Thread interrupted before resources gracefully released", interrupted);
+        } else {
+          throw new AssertionError(
+              "Resources could not be released in time at the end of test: " + resources);
+        }
+      } finally {
+        resources.clear();
+      }
+    }
+  }
+
+  @VisibleForTesting
+  interface Resource {
+    void cleanUp();
+
+    /** Error already happened, try the best to clean up. Never throws. */
+    void forceCleanUp();
+
+    /** Returns true if the resource is released in time. */
+    boolean awaitReleased(long duration, TimeUnit timeUnit) throws InterruptedException;
+  }
+
+  private static final class ManagedChannelResource implements GrpcCleanupExtension.Resource {
+    final ManagedChannel channel;
+
+    ManagedChannelResource(ManagedChannel channel) {
+      this.channel = channel;
+    }
+
+    @Override
+    public void cleanUp() {
+      channel.shutdown();
+    }
+
+    @Override
+    public void forceCleanUp() {
+      channel.shutdownNow();
+    }
+
+    @Override
+    public boolean awaitReleased(long duration, TimeUnit timeUnit) throws InterruptedException {
+      return channel.awaitTermination(duration, timeUnit);
+    }
+
+    @Override
+    public String toString() {
+      return channel.toString();
+    }
+  }
+
+  private static final class ServerResource implements GrpcCleanupExtension.Resource {
+    final Server server;
+
+    ServerResource(Server server) {
+      this.server = server;
+    }
+
+    @Override
+    public void cleanUp() {
+      server.shutdown();
+    }
+
+    @Override
+    public void forceCleanUp() {
+      server.shutdownNow();
+    }
+
+    @Override
+    public boolean awaitReleased(long duration, TimeUnit timeUnit) throws InterruptedException {
+      return server.awaitTermination(duration, timeUnit);
+    }
+
+    @Override
+    public String toString() {
+      return server.toString();
+    }
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/util/GrpcCleanupExtension.java
+++ b/kaldb/src/test/java/com/slack/kaldb/util/GrpcCleanupExtension.java
@@ -14,7 +14,6 @@ import javax.annotation.Nonnull;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-
 /**
  * Variation of the GrpcCleanupRule that has been adapted for JUnit 5. This should be able to go
  * away once they have updated the underlying implementation.

--- a/kaldb/src/test/java/com/slack/kaldb/util/JsonUtilTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/util/JsonUtilTest.java
@@ -6,7 +6,7 @@ import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.logstore.LogWireMessage;
 import com.slack.kaldb.testlib.MessageUtil;
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JsonUtilTest {
 

--- a/kaldb/src/test/java/com/slack/kaldb/util/LocalKafkaSeed.java
+++ b/kaldb/src/test/java/com/slack/kaldb/util/LocalKafkaSeed.java
@@ -17,8 +17,8 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Provides functionality to seed a local instance of Kafka with sample data.
@@ -30,7 +30,7 @@ public class LocalKafkaSeed {
   private static final SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-ddHH:mm:ss.SSSzzz");
 
   /** Initializes local kafka broker with sample messages occurring in the immediate future. */
-  @Ignore
+  @Disabled
   @Test
   public void seedLocalBrokerWithSampleData() throws Exception {
     EphemeralKafkaBroker broker = EphemeralKafkaBroker.create(9092, 2181);
@@ -38,7 +38,7 @@ public class LocalKafkaSeed {
     TestKafkaServer.produceMessagesToKafka(broker, startTime);
   }
 
-  @Ignore
+  @Disabled
   @Test
   public void seedJsonLogsFromFile() throws IOException {
     EphemeralKafkaBroker broker = EphemeralKafkaBroker.create(9092, 2181);
@@ -61,7 +61,7 @@ public class LocalKafkaSeed {
   }
 
   /** Initializes local kafka broker with sample messages replayed from a log file */
-  @Ignore
+  @Disabled
   @Test
   public void seedFromFile() throws IOException {
     EphemeralKafkaBroker broker = EphemeralKafkaBroker.create(9092, 2181);

--- a/kaldb/src/test/java/com/slack/kaldb/writer/JsonLogFormatterTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/JsonLogFormatterTest.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JsonLogFormatterTest {
 

--- a/kaldb/src/test/java/com/slack/kaldb/writer/MurronLogFormatterTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/MurronLogFormatterTest.java
@@ -3,6 +3,7 @@ package com.slack.kaldb.writer;
 import static com.slack.kaldb.writer.MurronLogFormatter.API_LOG_DURATION_FIELD;
 import static com.slack.kaldb.writer.MurronLogFormatter.ENVOY_DURATION_FIELD;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
@@ -12,7 +13,7 @@ import com.slack.service.murron.Murron;
 import com.slack.service.murron.trace.Trace;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MurronLogFormatterTest {
   public Object getTagValue(List<Trace.KeyValue> tags, String key) {
@@ -116,9 +117,10 @@ public class MurronLogFormatterTest {
     MurronLogFormatter.fromApiLog(null);
   }
 
-  @Test(expected = MismatchedInputException.class)
-  public void testEmptyMurronMessage() throws JsonProcessingException {
-    MurronLogFormatter.fromApiLog(Murron.MurronMessage.newBuilder().build());
+  @Test
+  public void testEmptyMurronMessage() {
+    assertThatExceptionOfType(MismatchedInputException.class)
+        .isThrownBy(() -> MurronLogFormatter.fromApiLog(Murron.MurronMessage.newBuilder().build()));
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/writer/SpanFormatterTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/SpanFormatterTest.java
@@ -19,7 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SpanFormatterTest {
   @Test


### PR DESCRIPTION
Updates test suite to JUnit 5. Additionally refactors a handful of tests that had low hanging fruit for runtime optimizations, resulting in a combined execution time reduction of approximately 110s.