### PR TITLE
move to com.spotify.fmt

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,8 +26,8 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Ensure code is formatted
-      run: mvn com.coveo:fmt-maven-plugin:check --file kaldb/pom.xml
+      run: mvn com.spotify.fmt:fmt-maven-plugin:check --file kaldb/pom.xml
     - name: Ensure jmh benchmark code is formatted
-      run: mvn com.coveo:fmt-maven-plugin:check --file benchmarks/pom.xml
+      run: mvn com.spotify.fmt:fmt-maven-plugin:check --file benchmarks/pom.xml
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -48,9 +48,20 @@
         <plugins>
             <!-- Format code automatically during build using google's style guide.-->
             <plugin>
-                <groupId>com.coveo</groupId>
+                <groupId>com.spotify.fmt</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
-                <version>2.6.0</version>
+                <version>2.20</version>
+                <configuration>
+                    <sourceDirectory>src/main/java</sourceDirectory>
+                    <testSourceDirectory>src/test/java</testSourceDirectory>
+                    <verbose>true</verbose>
+                    <filesNamePattern>.*\.java</filesNamePattern>
+                    <skip>false</skip>
+                    <skipSourceDirectory>false</skipSourceDirectory>
+                    <skipTestSourceDirectory>false</skipTestSourceDirectory>
+                    <skipSortingImports>false</skipSortingImports>
+                    <style>google</style>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -590,10 +590,22 @@
             </plugin>
 
             <!-- Format code automatically during build using google's style guide.-->
+            <!-- https://github.com/spotify/fmt-maven-plugin/blob/main/README.md -->
             <plugin>
-                <groupId>com.coveo</groupId>
+                <groupId>com.spotify.fmt</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
-                <version>2.6.0</version>
+                <version>2.20</version>
+                <configuration>
+                    <sourceDirectory>src/main/java</sourceDirectory>
+                    <testSourceDirectory>src/test/java</testSourceDirectory>
+                    <verbose>true</verbose>
+                    <filesNamePattern>.*\.java</filesNamePattern>
+                    <skip>false</skip>
+                    <skipSourceDirectory>false</skipSourceDirectory>
+                    <skipTestSourceDirectory>false</skipTestSourceDirectory>
+                    <skipSortingImports>false</skipSortingImports>
+                    <style>google</style>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/kaldb/src/main/java/com/slack/kaldb/blobfs/s3/S3BlobFs.java
+++ b/kaldb/src/main/java/com/slack/kaldb/blobfs/s3/S3BlobFs.java
@@ -394,8 +394,7 @@ public class S3BlobFs extends BlobFs {
         ListObjectsV2Response listObjectsV2Response = s3Client.listObjectsV2(listObjectsV2Request);
         LOG.debug("Getting ListObjectsV2Response: {}", listObjectsV2Response);
         List<S3Object> filesReturned = listObjectsV2Response.contents();
-        filesReturned
-            .stream()
+        filesReturned.stream()
             .forEach(
                 object -> {
                   // Only add files and not directories

--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
@@ -321,10 +321,7 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
   @Override
   public Map<String, FieldType> getSchema() {
     if (chunkSchema != null) {
-      return chunkSchema
-          .fieldDefMap
-          .entrySet()
-          .stream()
+      return chunkSchema.fieldDefMap.entrySet().stream()
           .collect(
               Collectors.toUnmodifiableMap(Map.Entry::getKey, entry -> entry.getValue().fieldType));
     } else {

--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadWriteChunk.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadWriteChunk.java
@@ -282,10 +282,7 @@ public abstract class ReadWriteChunk<T> implements Chunk<T> {
 
   @Override
   public Map<String, FieldType> getSchema() {
-    return logStore
-        .getSchema()
-        .entrySet()
-        .stream()
+    return logStore.getSchema().entrySet().stream()
         .collect(
             Collectors.toUnmodifiableMap(Map.Entry::getKey, entry -> entry.getValue().fieldType));
   }

--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/ChunkManagerBase.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/ChunkManagerBase.java
@@ -90,14 +90,12 @@ public abstract class ChunkManagerBase<T> extends AbstractIdleService implements
     List<Chunk<T>> chunksMatchingQuery;
     if (query.chunkIds.isEmpty()) {
       chunksMatchingQuery =
-          chunkList
-              .stream()
+          chunkList.stream()
               .filter(c -> c.containsDataInTimeRange(query.startTimeEpochMs, query.endTimeEpochMs))
               .collect(Collectors.toList());
     } else {
       chunksMatchingQuery =
-          chunkList
-              .stream()
+          chunkList.stream()
               .filter(c -> query.chunkIds.contains(c.id()))
               .collect(Collectors.toList());
     }
@@ -110,8 +108,7 @@ public abstract class ChunkManagerBase<T> extends AbstractIdleService implements
     Collections.shuffle(chunksMatchingQuery);
 
     List<ListenableFuture<SearchResult<T>>> queries =
-        chunksMatchingQuery
-            .stream()
+        chunksMatchingQuery.stream()
             .map(
                 (chunk) ->
                     queryExecutorService.submit(

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ClusterMonitorService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ClusterMonitorService.java
@@ -42,9 +42,7 @@ public class ClusterMonitorService extends AbstractIdleService {
           List.of(Tag.of("cacheSlotState", cacheSlotState.toString())),
           cacheSlotMetadataStore,
           store ->
-              store
-                  .getCached()
-                  .stream()
+              store.getCached().stream()
                   .filter(
                       cacheSlotMetadata -> cacheSlotMetadata.cacheSlotState.equals(cacheSlotState))
                   .count());

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentService.java
@@ -136,17 +136,13 @@ public class RecoveryTaskAssignmentService extends AbstractScheduledService {
     Timer.Sample assignmentTimer = Timer.start(meterRegistry);
 
     Set<String> recoveryTasksAlreadyAssigned =
-        recoveryNodeMetadataStore
-            .getCached()
-            .stream()
+        recoveryNodeMetadataStore.getCached().stream()
             .map((recoveryNodeMetadata -> recoveryNodeMetadata.recoveryTaskName))
             .filter((recoveryTaskName) -> !recoveryTaskName.isEmpty())
             .collect(Collectors.toUnmodifiableSet());
 
     List<RecoveryTaskMetadata> recoveryTasksThatNeedAssignment =
-        recoveryTaskMetadataStore
-            .getCached()
-            .stream()
+        recoveryTaskMetadataStore.getCached().stream()
             .filter(recoveryTask -> !recoveryTasksAlreadyAssigned.contains(recoveryTask.name))
             // We are currently starting with the oldest tasks first in an effort to reduce the
             // possibility of data loss, but this is likely opposite of what most users will
@@ -157,9 +153,7 @@ public class RecoveryTaskAssignmentService extends AbstractScheduledService {
             .collect(Collectors.toUnmodifiableList());
 
     List<RecoveryNodeMetadata> availableRecoveryNodes =
-        recoveryNodeMetadataStore
-            .getCached()
-            .stream()
+        recoveryNodeMetadataStore.getCached().stream()
             .filter(
                 (recoveryNodeMetadata ->
                     recoveryNodeMetadata.recoveryNodeState.equals(

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaAssignmentService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaAssignmentService.java
@@ -140,9 +140,7 @@ public class ReplicaAssignmentService extends AbstractScheduledService {
     Timer.Sample assignmentTimer = Timer.start(meterRegistry);
 
     List<CacheSlotMetadata> availableCacheSlots =
-        cacheSlotMetadataStore
-            .getCached()
-            .stream()
+        cacheSlotMetadataStore.getCached().stream()
             .filter(
                 cacheSlotMetadata ->
                     cacheSlotMetadata.cacheSlotState.equals(
@@ -155,18 +153,14 @@ public class ReplicaAssignmentService extends AbstractScheduledService {
     Collections.shuffle(availableCacheSlots);
 
     Set<String> assignedReplicaIds =
-        cacheSlotMetadataStore
-            .getCached()
-            .stream()
+        cacheSlotMetadataStore.getCached().stream()
             .filter(cacheSlotMetadata -> !cacheSlotMetadata.replicaId.isEmpty())
             .map(cacheSlotMetadata -> cacheSlotMetadata.replicaId)
             .collect(Collectors.toUnmodifiableSet());
 
     long nowMilli = Instant.now().toEpochMilli();
     List<String> replicaIdsToAssign =
-        replicaMetadataStore
-            .getCached()
-            .stream()
+        replicaMetadataStore.getCached().stream()
             // only assign replicas that are not expired, and not already assigned
             .filter(
                 replicaMetadata ->

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaCreationService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaCreationService.java
@@ -151,9 +151,7 @@ public class ReplicaCreationService extends AbstractScheduledService {
 
     // build a map of snapshot ID to how many replicas currently exist for that snapshot ID
     Map<String, Long> snapshotToReplicas =
-        replicaMetadataStore
-            .getCached()
-            .stream()
+        replicaMetadataStore.getCached().stream()
             .collect(
                 Collectors.groupingBy(
                     (replicaMetadata) -> replicaMetadata.snapshotId, Collectors.counting()));
@@ -167,9 +165,7 @@ public class ReplicaCreationService extends AbstractScheduledService {
 
     AtomicInteger successCounter = new AtomicInteger(0);
     List<ListenableFuture<?>> createdReplicaMetadataList =
-        snapshotMetadataStore
-            .getCached()
-            .stream()
+        snapshotMetadataStore.getCached().stream()
             // only attempt to create replicas for snapshots that have not expired, and are not live
             .filter(
                 snapshotMetadata ->

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaDeletionService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaDeletionService.java
@@ -98,17 +98,13 @@ public class ReplicaDeletionService extends AbstractScheduledService {
     Timer.Sample deleteTimer = Timer.start(meterRegistry);
 
     Set<String> replicaIdsWithAssignments =
-        cacheSlotMetadataStore
-            .getCached()
-            .stream()
+        cacheSlotMetadataStore.getCached().stream()
             .map(cacheSlotMetadata -> cacheSlotMetadata.replicaId)
             .collect(Collectors.toUnmodifiableSet());
 
     AtomicInteger successCounter = new AtomicInteger(0);
     List<ListenableFuture<?>> replicaDeletions =
-        replicaMetadataStore
-            .getCached()
-            .stream()
+        replicaMetadataStore.getCached().stream()
             .filter(
                 replicaMetadata ->
                     replicaMetadata.expireAfterEpochMs < deleteOlderThan.toEpochMilli()

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaEvictionService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaEvictionService.java
@@ -104,16 +104,12 @@ public class ReplicaEvictionService extends AbstractScheduledService {
     Timer.Sample evictionTimer = Timer.start(meterRegistry);
 
     Map<String, ReplicaMetadata> replicaMetadataByReplicaId =
-        replicaMetadataStore
-            .getCached()
-            .stream()
+        replicaMetadataStore.getCached().stream()
             .collect(Collectors.toUnmodifiableMap(ReplicaMetadata::getName, Function.identity()));
 
     AtomicInteger successCounter = new AtomicInteger(0);
     List<ListenableFuture<?>> replicaEvictions =
-        cacheSlotMetadataStore
-            .getCached()
-            .stream()
+        cacheSlotMetadataStore.getCached().stream()
             .filter(
                 cacheSlotMetadata ->
                     shouldEvictReplica(

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/SnapshotDeletionService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/SnapshotDeletionService.java
@@ -149,9 +149,7 @@ public class SnapshotDeletionService extends AbstractScheduledService {
     Timer.Sample deletionTimer = Timer.start(meterRegistry);
 
     Set<String> snapshotIdsWithReplicas =
-        replicaMetadataStore
-            .getCached()
-            .stream()
+        replicaMetadataStore.getCached().stream()
             .map(replicaMetadata -> replicaMetadata.snapshotId)
             .filter(snapshotId -> snapshotId != null && !snapshotId.isEmpty())
             .collect(Collectors.toUnmodifiableSet());
@@ -165,9 +163,7 @@ public class SnapshotDeletionService extends AbstractScheduledService {
             .toEpochMilli();
     AtomicInteger successCounter = new AtomicInteger(0);
     List<ListenableFuture<?>> deletedSnapshotList =
-        snapshotMetadataStore
-            .getCached()
-            .stream()
+        snapshotMetadataStore.getCached().stream()
             // only snapshots that only contain data prior to our cutoff, and have no replicas
             .filter(
                 snapshotMetadata ->

--- a/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
@@ -91,8 +91,7 @@ public class ElasticsearchApiService {
 
     List<KaldbSearch.SearchRequest> requests = openSearchRequest.parseHttpPostBody(postBody);
     List<ListenableFuture<EsSearchResponse>> responseFutures =
-        requests
-            .stream()
+        requests.stream()
             .map(
                 (request) ->
                     Futures.submit(

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/opensearch/OpenSearchAdapter.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/opensearch/OpenSearchAdapter.java
@@ -780,17 +780,12 @@ public class OpenSearchAdapter {
    */
   protected static TermsAggregationBuilder getTermsAggregationBuilder(TermsAggBuilder builder) {
     List<String> subAggNames =
-        builder
-            .getSubAggregations()
-            .stream()
+        builder.getSubAggregations().stream()
             .map(subagg -> ((AggBuilderBase) subagg).getName())
             .collect(Collectors.toList());
 
     List<BucketOrder> order =
-        builder
-            .getOrder()
-            .entrySet()
-            .stream()
+        builder.getOrder().entrySet().stream()
             .map(
                 (entry) -> {
                   // todo - this potentially needs BucketOrder.compound support

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImpl.java
@@ -85,8 +85,7 @@ public class SearchResultAggregatorImpl<T extends LogMessage> implements SearchR
 
     // TODO: Instead of sorting all hits using a bounded priority queue of size k is more efficient.
     List<T> resultHits =
-        searchResults
-            .stream()
+        searchResults.stream()
             .flatMap(r -> r.hits.stream())
             .sorted(
                 Comparator.comparing(

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultUtils.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultUtils.java
@@ -69,10 +69,7 @@ public class SearchResultUtils {
     } else if (value.hasStructValue()) {
       return fromValueStruct(value.getStructValue());
     } else if (value.hasListValue()) {
-      return value
-          .getListValue()
-          .getValuesList()
-          .stream()
+      return value.getListValue().getValuesList().stream()
           .map(SearchResultUtils::fromValueProto)
           .collect(Collectors.toList());
     } else {
@@ -102,9 +99,7 @@ public class SearchResultUtils {
           KaldbSearch.ListValue.newBuilder()
               .addAllValues(
                   ((List<?>) object)
-                      .stream()
-                      .map(SearchResultUtils::toValueProto)
-                      .collect(Collectors.toList()))
+                      .stream().map(SearchResultUtils::toValueProto).collect(Collectors.toList()))
               .build());
     } else {
       throw new IllegalArgumentException();
@@ -197,9 +192,7 @@ public class SearchResultUtils {
     } else if (searchAggregation.getType().equals(TermsAggBuilder.TYPE)) {
       return new TermsAggBuilder(
           searchAggregation.getName(),
-          searchAggregation
-              .getSubAggregationsList()
-              .stream()
+          searchAggregation.getSubAggregationsList().stream()
               .map(SearchResultUtils::fromSearchAggregations)
               .collect(Collectors.toList()),
           searchAggregation.getValueSource().getField(),
@@ -216,9 +209,7 @@ public class SearchResultUtils {
           searchAggregation.getValueSource().getDateHistogram().getMinDocCount(),
           searchAggregation.getValueSource().getDateHistogram().getFormat(),
           searchAggregation.getValueSource().getDateHistogram().getExtendedBoundsMap(),
-          searchAggregation
-              .getSubAggregationsList()
-              .stream()
+          searchAggregation.getSubAggregationsList().stream()
               .map(SearchResultUtils::fromSearchAggregations)
               .collect(Collectors.toList()));
     } else if (searchAggregation.getType().equals(HistogramAggBuilder.TYPE)) {
@@ -227,9 +218,7 @@ public class SearchResultUtils {
           searchAggregation.getValueSource().getField(),
           searchAggregation.getValueSource().getHistogram().getInterval(),
           searchAggregation.getValueSource().getHistogram().getMinDocCount(),
-          searchAggregation
-              .getSubAggregationsList()
-              .stream()
+          searchAggregation.getSubAggregationsList().stream()
               .map(SearchResultUtils::fromSearchAggregations)
               .collect(Collectors.toList()));
     }
@@ -483,9 +472,7 @@ public class SearchResultUtils {
           .setType(TermsAggBuilder.TYPE)
           .setName(termsAggBuilder.getName())
           .addAllSubAggregations(
-              termsAggBuilder
-                  .getSubAggregations()
-                  .stream()
+              termsAggBuilder.getSubAggregations().stream()
                   .map(SearchResultUtils::toSearchAggregationProto)
                   .collect(Collectors.toList()))
           .setValueSource(valueSourceAggregationBuilder.build())
@@ -516,9 +503,7 @@ public class SearchResultUtils {
           .setType(DateHistogramAggBuilder.TYPE)
           .setName(dateHistogramAggBuilder.getName())
           .addAllSubAggregations(
-              dateHistogramAggBuilder
-                  .getSubAggregations()
-                  .stream()
+              dateHistogramAggBuilder.getSubAggregations().stream()
                   .map(SearchResultUtils::toSearchAggregationProto)
                   .collect(Collectors.toList()))
           .setValueSource(
@@ -542,9 +527,7 @@ public class SearchResultUtils {
           .setType(HistogramAggBuilder.TYPE)
           .setName(histogramAggBuilder.getName())
           .addAllSubAggregations(
-              histogramAggBuilder
-                  .getSubAggregations()
-                  .stream()
+              histogramAggBuilder.getSubAggregations().stream()
                   .map(SearchResultUtils::toSearchAggregationProto)
                   .collect(Collectors.toList()))
           .setValueSource(

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadata.java
@@ -116,8 +116,7 @@ public class DatasetMetadata extends KaldbMetadata {
   private void checkPartitions(
       List<DatasetPartitionMetadata> partitionConfig, String errorMessage) {
     List<DatasetPartitionMetadata> sortedConfigsByStartTime =
-        partitionConfig
-            .stream()
+        partitionConfig.stream()
             .sorted(Comparator.comparingLong(DatasetPartitionMetadata::getStartTimeEpochMs))
             .collect(Collectors.toList());
 

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadataSerializer.java
@@ -11,9 +11,7 @@ public class DatasetMetadataSerializer implements MetadataSerializer<DatasetMeta
   private static DatasetMetadata fromDatasetMetadataProto(
       Metadata.DatasetMetadata datasetMetadataProto) {
     List<DatasetPartitionMetadata> datasetPartitionMetadata =
-        datasetMetadataProto
-            .getPartitionConfigsList()
-            .stream()
+        datasetMetadataProto.getPartitionConfigsList().stream()
             .map(DatasetPartitionMetadata::fromDatasetPartitionMetadataProto)
             .collect(Collectors.toList());
 
@@ -27,9 +25,7 @@ public class DatasetMetadataSerializer implements MetadataSerializer<DatasetMeta
 
   public static Metadata.DatasetMetadata toDatasetMetadataProto(DatasetMetadata metadata) {
     List<Metadata.DatasetPartitionMetadata> datasetPartitionMetadata =
-        metadata
-            .partitionConfigs
-            .stream()
+        metadata.partitionConfigs.stream()
             .map(DatasetPartitionMetadata::toDatasetPartitionMetadataProto)
             .collect(Collectors.toList());
 

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetPartitionMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetPartitionMetadata.java
@@ -100,9 +100,7 @@ public class DatasetPartitionMetadata {
       long endTimeEpochMs,
       String dataset) {
     boolean skipDatasetFilter = (dataset.equals("*") || dataset.equals(MATCH_ALL_DATASET));
-    return datasetMetadataStore
-        .getCached()
-        .stream()
+    return datasetMetadataStore.getCached().stream()
         .filter(serviceMetadata -> skipDatasetFilter || serviceMetadata.name.equals(dataset))
         .flatMap(
             serviceMetadata -> serviceMetadata.partitionConfigs.stream()) // will always return one

--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorService.java
@@ -205,8 +205,7 @@ public class PreprocessorService extends AbstractService {
 
     upstreamTopics.forEach(
         (upstreamTopic ->
-            builder
-                .stream(upstreamTopic, Consumed.with(Serdes.String(), Serdes.ByteArray()))
+            builder.stream(upstreamTopic, Consumed.with(Serdes.String(), Serdes.ByteArray()))
                 .flatMapValues(valueMapper)
                 .filter(rateLimitPredicate)
                 .peek(
@@ -229,8 +228,7 @@ public class PreprocessorService extends AbstractService {
    */
   protected static List<DatasetMetadata> filterValidDatasetMetadata(
       List<DatasetMetadata> datasetMetadataList) {
-    return datasetMetadataList
-        .stream()
+    return datasetMetadataList.stream()
         .filter(datasetMetadata -> datasetMetadata.getThroughputBytes() > 0)
         .filter(datasetMetadata -> getActivePartitionList(datasetMetadata).size() > 0)
         .collect(Collectors.toList());
@@ -239,19 +237,14 @@ public class PreprocessorService extends AbstractService {
   /** Gets the active list of partitions from the provided dataset metadata */
   protected static List<Integer> getActivePartitionList(DatasetMetadata datasetMetadata) {
     Optional<DatasetPartitionMetadata> datasetPartitionMetadata =
-        datasetMetadata
-            .getPartitionConfigs()
-            .stream()
+        datasetMetadata.getPartitionConfigs().stream()
             .filter(partitionMetadata -> partitionMetadata.getEndTimeEpochMs() == MAX_TIME)
             .findFirst();
 
     if (datasetPartitionMetadata.isEmpty()) {
       return Collections.emptyList();
     }
-    return datasetPartitionMetadata
-        .get()
-        .getPartitions()
-        .stream()
+    return datasetPartitionMetadata.get().getPartitions().stream()
         .map(Integer::parseInt)
         .collect(Collectors.toUnmodifiableList());
   }
@@ -260,8 +253,7 @@ public class PreprocessorService extends AbstractService {
   // in the future we can change the ordering from sort to something else
   public static List<DatasetMetadata> sortDatasetsOnThroughput(
       List<DatasetMetadata> datasetMetadataList) {
-    return datasetMetadataList
-        .stream()
+    return datasetMetadataList.stream()
         .sorted(Comparator.comparingLong(DatasetMetadata::getThroughputBytes).reversed())
         .collect(Collectors.toList());
   }

--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorValueMapper.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorValueMapper.java
@@ -76,8 +76,7 @@ public class PreprocessorValueMapper {
    * <p>todo - consider putting the service name into a top-level Trace.Span property
    */
   public static String getServiceName(Trace.Span span) {
-    return span.getTagsList()
-        .stream()
+    return span.getTagsList().stream()
         .filter(tag -> tag.getKey().equals(SERVICE_NAME_KEY))
         .map(Trace.KeyValue::getVStr)
         .findFirst()

--- a/kaldb/src/main/java/com/slack/kaldb/server/ManagerApiGrpc.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ManagerApiGrpc.java
@@ -125,9 +125,7 @@ public class ManagerApiGrpc extends ManagerApiServiceGrpc.ManagerApiServiceImplB
       responseObserver.onNext(
           ManagerApi.ListDatasetMetadataResponse.newBuilder()
               .addAllDatasetMetadata(
-                  datasetMetadataStore
-                      .listSync()
-                      .stream()
+                  datasetMetadataStore.listSync().stream()
                       .map(DatasetMetadataSerializer::toDatasetMetadataProto)
                       .collect(Collectors.toList()))
               .build());
@@ -295,13 +293,11 @@ public class ManagerApiGrpc extends ManagerApiServiceGrpc.ManagerApiServiceImplB
         Sets.intersection(
             Sets.newHashSet(snapshotIds),
             Sets.newHashSet(
-                snapshotMetadataList
-                    .stream()
+                snapshotMetadataList.stream()
                     .map((snapshot) -> snapshot.snapshotId)
                     .collect(Collectors.toList())));
 
-    return snapshotMetadataList
-        .stream()
+    return snapshotMetadataList.stream()
         .filter((snapshot) -> matchingSnapshots.contains(snapshot.snapshotId))
         .collect(Collectors.toList());
   }
@@ -333,16 +329,14 @@ public class ManagerApiGrpc extends ManagerApiServiceGrpc.ManagerApiServiceImplB
     }
 
     Optional<DatasetPartitionMetadata> previousActiveDatasetPartition =
-        existingPartitions
-            .stream()
+        existingPartitions.stream()
             .filter(
                 datasetPartitionMetadata ->
                     datasetPartitionMetadata.getEndTimeEpochMs() == MAX_TIME)
             .findFirst();
 
     List<DatasetPartitionMetadata> remainingDatasetPartitions =
-        existingPartitions
-            .stream()
+        existingPartitions.stream()
             .filter(
                 datasetPartitionMetadata ->
                     datasetPartitionMetadata.getEndTimeEpochMs() != MAX_TIME)

--- a/kaldb/src/main/java/com/slack/kaldb/server/RecoveryTaskCreator.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/RecoveryTaskCreator.java
@@ -71,8 +71,7 @@ public class RecoveryTaskCreator {
   @VisibleForTesting
   public static List<SnapshotMetadata> getStaleLiveSnapshots(
       List<SnapshotMetadata> snapshots, String partitionId) {
-    return snapshots
-        .stream()
+    return snapshots.stream()
         .filter(snapshotMetadata -> snapshotMetadata.partitionId.equals(partitionId))
         .filter(SnapshotMetadata::isLive)
         .collect(Collectors.toUnmodifiableList());
@@ -86,16 +85,14 @@ public class RecoveryTaskCreator {
       String partitionId) {
 
     long maxSnapshotOffset =
-        snapshots
-            .stream()
+        snapshots.stream()
             .filter(snapshot -> snapshot.partitionId.equals(partitionId))
             .mapToLong(snapshot -> snapshot.maxOffset)
             .max()
             .orElse(-1);
 
     long maxRecoveryOffset =
-        recoveryTasks
-            .stream()
+        recoveryTasks.stream()
             .filter(recoveryTaskMetadata -> recoveryTaskMetadata.partitionId.equals(partitionId))
             .mapToLong(recoveryTaskMetadata -> recoveryTaskMetadata.endOffset)
             .max()
@@ -154,8 +151,7 @@ public class RecoveryTaskCreator {
 
     List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSync();
     List<SnapshotMetadata> snapshotsForPartition =
-        snapshots
-            .stream()
+        snapshots.stream()
             .filter(
                 snapshotMetadata -> {
                   if (snapshotMetadata == null || snapshotMetadata.partitionId == null) {
@@ -171,8 +167,7 @@ public class RecoveryTaskCreator {
     List<SnapshotMetadata> deletedSnapshots = deleteStaleLiveSnapshots(snapshotsForPartition);
 
     List<SnapshotMetadata> nonLiveSnapshotsForPartition =
-        snapshotsForPartition
-            .stream()
+        snapshotsForPartition.stream()
             .filter(s -> !deletedSnapshots.contains(s))
             .collect(Collectors.toUnmodifiableList());
 
@@ -278,8 +273,7 @@ public class RecoveryTaskCreator {
       SnapshotMetadataStore snapshotMetadataStore, List<SnapshotMetadata> snapshotsToBeDeleted) {
     AtomicInteger successCounter = new AtomicInteger(0);
     List<? extends ListenableFuture<?>> deletionFutures =
-        snapshotsToBeDeleted
-            .stream()
+        snapshotsToBeDeleted.stream()
             .map(
                 snapshot -> {
                   ListenableFuture<?> future = snapshotMetadataStore.delete(snapshot);

--- a/kaldb/src/test/java/com/slack/kaldb/blobfs/s3/S3BlobFsTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/blobfs/s3/S3BlobFsTest.java
@@ -69,9 +69,7 @@ public class S3BlobFsTest {
         s3Client.listObjectsV2(S3TestUtils.getListObjectRequest(bucket, "", true));
 
     String[] response =
-        listObjectsV2Response
-            .contents()
-            .stream()
+        listObjectsV2Response.contents().stream()
             .map(S3Object::key)
             .filter(x -> x.contains("touch"))
             .toArray(String[]::new);
@@ -94,9 +92,7 @@ public class S3BlobFsTest {
         s3Client.listObjectsV2(S3TestUtils.getListObjectRequest(bucket, folder, false));
 
     String[] response =
-        listObjectsV2Response
-            .contents()
-            .stream()
+        listObjectsV2Response.contents().stream()
             .map(S3Object::key)
             .filter(x -> x.contains("touch"))
             .toArray(String[]::new);
@@ -194,9 +190,7 @@ public class S3BlobFsTest {
     ListObjectsV2Response listObjectsV2Response =
         s3Client.listObjectsV2(S3TestUtils.getListObjectRequest(bucket, "", true));
     String[] actualResponse =
-        listObjectsV2Response
-            .contents()
-            .stream()
+        listObjectsV2Response.contents().stream()
             .map(x -> x.key().substring(1))
             .filter(x -> x.contains("delete"))
             .toArray(String[]::new);
@@ -219,9 +213,7 @@ public class S3BlobFsTest {
     ListObjectsV2Response listObjectsV2Response =
         s3Client.listObjectsV2(S3TestUtils.getListObjectRequest(bucket, "", true));
     String[] actualResponse =
-        listObjectsV2Response
-            .contents()
-            .stream()
+        listObjectsV2Response.contents().stream()
             .map(S3Object::key)
             .filter(x -> x.contains("delete-2"))
             .toArray(String[]::new);

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
@@ -684,9 +684,7 @@ public class IndexingChunkImplTest {
       ListObjectsV2Response objectsResponse =
           s3Client.listObjectsV2(S3TestUtils.getListObjectRequest(bucket, "", true));
       assertThat(
-              objectsResponse
-                  .contents()
-                  .stream()
+              objectsResponse.contents().stream()
                   .filter(o -> o.key().equals(SCHEMA_FILE_NAME))
                   .count())
           .isEqualTo(1);
@@ -700,8 +698,7 @@ public class IndexingChunkImplTest {
       assertThat(afterSnapshots.size()).isEqualTo(2);
       assertThat(afterSnapshots).contains(ChunkInfo.toSnapshotMetadata(chunk.info(), ""));
       SnapshotMetadata liveSnapshot =
-          afterSnapshots
-              .stream()
+          afterSnapshots.stream()
               .filter(s -> s.snapshotPath.equals(SnapshotMetadata.LIVE_SNAPSHOT_PATH))
               .findFirst()
               .get();

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/ChunkCleanerServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/ChunkCleanerServiceTest.java
@@ -265,9 +265,7 @@ public class ChunkCleanerServiceTest {
 
     checkMetadata(4, 2, 2, 2, 0);
     assertThat(
-            snapshotMetadataStore
-                .listSync()
-                .stream()
+            snapshotMetadataStore.listSync().stream()
                 .map(s -> s.maxOffset)
                 .sorted()
                 .collect(Collectors.toList()))
@@ -302,9 +300,7 @@ public class ChunkCleanerServiceTest {
 
     checkMetadata(3, 1, 2, 1, 0);
     assertThat(
-            snapshotMetadataStore
-                .listSync()
-                .stream()
+            snapshotMetadataStore.listSync().stream()
                 .map(s -> s.maxOffset)
                 .sorted()
                 .collect(Collectors.toList()))
@@ -319,9 +315,7 @@ public class ChunkCleanerServiceTest {
 
     checkMetadata(2, 0, 2, 0, 0);
     assertThat(
-            snapshotMetadataStore
-                .listSync()
-                .stream()
+            snapshotMetadataStore.listSync().stream()
                 .map(s -> s.maxOffset)
                 .sorted()
                 .collect(Collectors.toList()))

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
@@ -503,9 +503,7 @@ public class IndexingChunkManagerTest {
     // Contains messages 1-10
     @SuppressWarnings("OptionalGetWithoutIsPresent")
     String firstChunkId =
-        chunkManager
-            .chunkList
-            .stream()
+        chunkManager.chunkList.stream()
             .filter(c -> !c.id().equals(activeChunkId))
             .findFirst()
             .get()
@@ -772,9 +770,7 @@ public class IndexingChunkManagerTest {
     @SuppressWarnings("OptionalGetWithoutIsPresent")
     ReadWriteChunk<LogMessage> chunk =
         (ReadWriteChunk<LogMessage>)
-            chunkManager
-                .getChunkList()
-                .stream()
+            chunkManager.getChunkList().stream()
                 .filter(chunkIterator -> Objects.equals(chunkIterator.id(), secondChunk.chunkId))
                 .findFirst()
                 .get();

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentServiceTest.java
@@ -267,9 +267,7 @@ public class RecoveryTaskAssignmentServiceTest {
     assertThat(recoveryNodeMetadataStore.listSync().size()).isEqualTo(3);
     assertThat(recoveryNodeMetadataStore.listSync().containsAll(ineligibleRecoveryNodes)).isTrue();
     assertThat(
-            recoveryNodeMetadataStore
-                .listSync()
-                .stream()
+            recoveryNodeMetadataStore.listSync().stream()
                 .filter(
                     recoveryNodeMetadata ->
                         recoveryNodeMetadata.recoveryNodeState.equals(
@@ -477,9 +475,7 @@ public class RecoveryTaskAssignmentServiceTest {
     await()
         .until(
             () ->
-                recoveryNodeMetadataStore
-                        .getCached()
-                        .stream()
+                recoveryNodeMetadataStore.getCached().stream()
                         .filter(
                             recoveryNodeMetadata ->
                                 recoveryNodeMetadata.recoveryNodeState.equals(
@@ -495,9 +491,7 @@ public class RecoveryTaskAssignmentServiceTest {
     await()
         .until(
             () ->
-                recoveryNodeMetadataStore
-                        .getCached()
-                        .stream()
+                recoveryNodeMetadataStore.getCached().stream()
                         .filter(
                             recoveryNodeMetadata ->
                                 recoveryNodeMetadata.recoveryNodeState.equals(
@@ -597,9 +591,7 @@ public class RecoveryTaskAssignmentServiceTest {
         .isEqualTo(1);
 
     assertThat(
-            recoveryNodeMetadataStore
-                .listSync()
-                .stream()
+            recoveryNodeMetadataStore.listSync().stream()
                 .filter(
                     recoveryNodeMetadata ->
                         recoveryNodeMetadata.recoveryNodeState.equals(
@@ -607,9 +599,7 @@ public class RecoveryTaskAssignmentServiceTest {
                 .count())
         .isEqualTo(1);
     assertThat(
-            recoveryNodeMetadataStore
-                .listSync()
-                .stream()
+            recoveryNodeMetadataStore.listSync().stream()
                 .filter(
                     recoveryNodeMetadata ->
                         recoveryNodeMetadata.recoveryNodeState.equals(
@@ -684,9 +674,7 @@ public class RecoveryTaskAssignmentServiceTest {
         .isEqualTo(1);
 
     assertThat(
-            recoveryNodeMetadataStore
-                .listSync()
-                .stream()
+            recoveryNodeMetadataStore.listSync().stream()
                 .filter(
                     recoveryNodeMetadata ->
                         recoveryNodeMetadata.recoveryNodeState.equals(
@@ -694,9 +682,7 @@ public class RecoveryTaskAssignmentServiceTest {
                 .count())
         .isEqualTo(1);
     assertThat(
-            recoveryNodeMetadataStore
-                .listSync()
-                .stream()
+            recoveryNodeMetadataStore.listSync().stream()
                 .filter(
                     recoveryNodeMetadata ->
                         recoveryNodeMetadata.recoveryNodeState.equals(
@@ -740,9 +726,7 @@ public class RecoveryTaskAssignmentServiceTest {
     await()
         .until(
             () ->
-                recoveryNodeMetadataStore
-                    .getCached()
-                    .stream()
+                recoveryNodeMetadataStore.getCached().stream()
                     .allMatch(
                         (recoveryNodeMetadata) ->
                             recoveryNodeMetadata.recoveryNodeState.equals(
@@ -760,9 +744,7 @@ public class RecoveryTaskAssignmentServiceTest {
     await()
         .until(
             () ->
-                recoveryNodeMetadataStore
-                    .getCached()
-                    .stream()
+                recoveryNodeMetadataStore.getCached().stream()
                     .allMatch(
                         (recoveryNodeMetadata) ->
                             recoveryNodeMetadata.recoveryNodeState.equals(
@@ -787,9 +769,7 @@ public class RecoveryTaskAssignmentServiceTest {
     await()
         .until(
             () ->
-                recoveryNodeMetadataStore
-                    .getCached()
-                    .stream()
+                recoveryNodeMetadataStore.getCached().stream()
                     .allMatch(
                         (recoveryNodeMetadata) ->
                             recoveryNodeMetadata.recoveryNodeState.equals(
@@ -818,9 +798,7 @@ public class RecoveryTaskAssignmentServiceTest {
     await()
         .until(
             () ->
-                recoveryNodeMetadataStore
-                    .getCached()
-                    .stream()
+                recoveryNodeMetadataStore.getCached().stream()
                     .allMatch(
                         (recoveryNodeMetadata ->
                             recoveryNodeMetadata.updatedTimeEpochMs > before.toEpochMilli()
@@ -875,9 +853,7 @@ public class RecoveryTaskAssignmentServiceTest {
     await()
         .until(
             () ->
-                recoveryNodeMetadataStore
-                    .getCached()
-                    .stream()
+                recoveryNodeMetadataStore.getCached().stream()
                     .allMatch(
                         (recoveryNodeMetadata) ->
                             recoveryNodeMetadata.recoveryNodeState.equals(
@@ -902,9 +878,7 @@ public class RecoveryTaskAssignmentServiceTest {
     await()
         .until(
             () ->
-                recoveryNodeMetadataStore
-                    .getCached()
-                    .stream()
+                recoveryNodeMetadataStore.getCached().stream()
                     .allMatch(
                         (recoveryNodeMetadata) ->
                             recoveryNodeMetadata.recoveryNodeState.equals(
@@ -933,9 +907,7 @@ public class RecoveryTaskAssignmentServiceTest {
     await()
         .until(
             () ->
-                recoveryNodeMetadataStore
-                    .getCached()
-                    .stream()
+                recoveryNodeMetadataStore.getCached().stream()
                     .allMatch(
                         (recoveryNodeMetadata ->
                             recoveryNodeMetadata.updatedTimeEpochMs > before.toEpochMilli()

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
@@ -422,9 +422,7 @@ public class ReplicaAssignmentServiceTest {
     assertThat(cacheSlotMetadataStore.getCached().containsAll(unmutatedSlots)).isTrue();
 
     List<CacheSlotMetadata> mutatedCacheSlots =
-        cacheSlotMetadataStore
-            .getCached()
-            .stream()
+        cacheSlotMetadataStore.getCached().stream()
             .filter(cacheSlotMetadata -> !unmutatedSlots.contains(cacheSlotMetadata))
             .collect(Collectors.toList());
     assertThat(mutatedCacheSlots.size()).isEqualTo(1);
@@ -592,9 +590,7 @@ public class ReplicaAssignmentServiceTest {
     assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(4);
 
     assertThat(
-            cacheSlotMetadataStore
-                .listSync()
-                .stream()
+            cacheSlotMetadataStore.listSync().stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -602,9 +598,7 @@ public class ReplicaAssignmentServiceTest {
                 .count())
         .isEqualTo(1);
     assertThat(
-            cacheSlotMetadataStore
-                .listSync()
-                .stream()
+            cacheSlotMetadataStore.listSync().stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -613,9 +607,7 @@ public class ReplicaAssignmentServiceTest {
         .isEqualTo(3);
     assertThat(
             replicaMetadataExpiredList.containsAll(
-                replicaMetadataStore
-                    .listSync()
-                    .stream()
+                replicaMetadataStore.listSync().stream()
                     .filter(
                         replicaMetadata ->
                             replicaMetadata.createdTimeEpochMs
@@ -691,9 +683,7 @@ public class ReplicaAssignmentServiceTest {
     assertThat(replicaMetadataStore.listSync().size()).isEqualTo(2);
     assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(3);
     assertThat(
-            cacheSlotMetadataStore
-                .listSync()
-                .stream()
+            cacheSlotMetadataStore.listSync().stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -701,9 +691,7 @@ public class ReplicaAssignmentServiceTest {
                 .count())
         .isEqualTo(2);
     assertThat(
-            cacheSlotMetadataStore
-                .listSync()
-                .stream()
+            cacheSlotMetadataStore.listSync().stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -728,9 +716,7 @@ public class ReplicaAssignmentServiceTest {
     assertThat(replicaMetadataStore.listSync().size()).isEqualTo(2);
     assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(3);
     assertThat(
-            cacheSlotMetadataStore
-                .listSync()
-                .stream()
+            cacheSlotMetadataStore.listSync().stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -738,9 +724,7 @@ public class ReplicaAssignmentServiceTest {
                 .count())
         .isEqualTo(2);
     assertThat(
-            cacheSlotMetadataStore
-                .listSync()
-                .stream()
+            cacheSlotMetadataStore.listSync().stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -826,9 +810,7 @@ public class ReplicaAssignmentServiceTest {
     assertThat(replicaMetadataStore.listSync().size()).isEqualTo(2);
     assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(3);
     assertThat(
-            cacheSlotMetadataStore
-                .listSync()
-                .stream()
+            cacheSlotMetadataStore.listSync().stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -836,9 +818,7 @@ public class ReplicaAssignmentServiceTest {
                 .count())
         .isEqualTo(2);
     assertThat(
-            cacheSlotMetadataStore
-                .listSync()
-                .stream()
+            cacheSlotMetadataStore.listSync().stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -916,9 +896,7 @@ public class ReplicaAssignmentServiceTest {
     assertThat(replicaMetadataStore.listSync().size()).isEqualTo(2);
     assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(3);
     assertThat(
-            cacheSlotMetadataStore
-                .listSync()
-                .stream()
+            cacheSlotMetadataStore.listSync().stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -926,9 +904,7 @@ public class ReplicaAssignmentServiceTest {
                 .count())
         .isEqualTo(2);
     assertThat(
-            cacheSlotMetadataStore
-                .listSync()
-                .stream()
+            cacheSlotMetadataStore.listSync().stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -981,9 +957,7 @@ public class ReplicaAssignmentServiceTest {
     await().until(() -> cacheSlotMetadataStore.getCached().size() == 3);
     assertThat(replicaMetadataStore.listSync().size()).isEqualTo(0);
     assertThat(
-            cacheSlotMetadataStore
-                .listSync()
-                .stream()
+            cacheSlotMetadataStore.listSync().stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -1010,9 +984,7 @@ public class ReplicaAssignmentServiceTest {
     await()
         .until(
             () ->
-                cacheSlotMetadataStore
-                        .getCached()
-                        .stream()
+                cacheSlotMetadataStore.getCached().stream()
                         .filter(
                             cacheSlotMetadata ->
                                 cacheSlotMetadata.cacheSlotState.equals(
@@ -1022,9 +994,7 @@ public class ReplicaAssignmentServiceTest {
     await()
         .until(
             () ->
-                cacheSlotMetadataStore
-                        .getCached()
-                        .stream()
+                cacheSlotMetadataStore.getCached().stream()
                         .filter(
                             cacheSlotMetadata ->
                                 cacheSlotMetadata.cacheSlotState.equals(
@@ -1100,9 +1070,7 @@ public class ReplicaAssignmentServiceTest {
     await()
         .until(
             () ->
-                cacheSlotMetadataStore
-                        .getCached()
-                        .stream()
+                cacheSlotMetadataStore.getCached().stream()
                         .filter(
                             cacheSlotMetadata ->
                                 cacheSlotMetadata.cacheSlotState.equals(

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaCreationServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaCreationServiceTest.java
@@ -217,9 +217,7 @@ public class ReplicaCreationServiceTest {
     await().until(() -> replicaMetadataStore.getCached().size() == 4);
     assertThat(
             (int)
-                replicaMetadataStore
-                    .getCached()
-                    .stream()
+                replicaMetadataStore.getCached().stream()
                     .filter(replicaMetadata -> Objects.equals(replicaMetadata.snapshotId, "a"))
                     .count())
         .isEqualTo(4);
@@ -377,8 +375,7 @@ public class ReplicaCreationServiceTest {
     assertThat(snapshotList.size())
         .isEqualTo(eligibleSnapshotsToCreate + ineligibleSnapshotsToCreate + liveSnapshotsToCreate);
     Collections.shuffle(snapshotList);
-    snapshotList
-        .parallelStream()
+    snapshotList.parallelStream()
         .forEach((snapshotMetadata -> snapshotMetadataStore.createSync(snapshotMetadata)));
     List<SnapshotMetadata> snapshotMetadataList = snapshotMetadataStore.listSync();
     assertThat(snapshotMetadataList.size()).isEqualTo(snapshotList.size());
@@ -401,14 +398,11 @@ public class ReplicaCreationServiceTest {
     assertThat(snapshotMetadataList).isEqualTo(snapshotMetadataStore.listSync());
 
     List<String> eligibleSnapshotIds =
-        eligibleSnapshots
-            .stream()
+        eligibleSnapshots.stream()
             .map(snapshotMetadata -> snapshotMetadata.snapshotId)
             .collect(Collectors.toList());
     assertThat(
-            replicaMetadataStore
-                .listSync()
-                .stream()
+            replicaMetadataStore.listSync().stream()
                 .allMatch(
                     (replicaMetadata) -> eligibleSnapshotIds.contains(replicaMetadata.snapshotId)))
         .isTrue();

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
@@ -263,9 +263,7 @@ public class ReplicaEvictionServiceTest {
     await()
         .until(
             () ->
-                cacheSlotMetadataStore
-                    .getCached()
-                    .stream()
+                cacheSlotMetadataStore.getCached().stream()
                     .allMatch(
                         cacheSlot ->
                             cacheSlot.cacheSlotState.equals(
@@ -341,9 +339,7 @@ public class ReplicaEvictionServiceTest {
     await()
         .until(
             () ->
-                cacheSlotMetadataStore
-                    .getCached()
-                    .stream()
+                cacheSlotMetadataStore.getCached().stream()
                     .allMatch(
                         cacheSlot ->
                             cacheSlot.cacheSlotState.equals(
@@ -560,9 +556,7 @@ public class ReplicaEvictionServiceTest {
     await()
         .until(
             () ->
-                cacheSlotMetadataStore
-                    .getCached()
-                    .stream()
+                cacheSlotMetadataStore.getCached().stream()
                     .allMatch(
                         cacheSlot ->
                             cacheSlot.cacheSlotState.equals(
@@ -658,9 +652,7 @@ public class ReplicaEvictionServiceTest {
     await()
         .until(
             () ->
-                cacheSlotMetadataStore
-                        .getCached()
-                        .stream()
+                cacheSlotMetadataStore.getCached().stream()
                         .filter(
                             cacheSlotMetadata ->
                                 cacheSlotMetadata.cacheSlotState.equals(
@@ -670,9 +662,7 @@ public class ReplicaEvictionServiceTest {
     await()
         .until(
             () ->
-                cacheSlotMetadataStore
-                        .getCached()
-                        .stream()
+                cacheSlotMetadataStore.getCached().stream()
                         .filter(
                             cacheSlotMetadata ->
                                 cacheSlotMetadata.cacheSlotState.equals(
@@ -702,9 +692,7 @@ public class ReplicaEvictionServiceTest {
     await()
         .until(
             () ->
-                cacheSlotMetadataStore
-                        .getCached()
-                        .stream()
+                cacheSlotMetadataStore.getCached().stream()
                         .filter(
                             cacheSlotMetadata ->
                                 cacheSlotMetadata.cacheSlotState.equals(
@@ -832,9 +820,7 @@ public class ReplicaEvictionServiceTest {
     await()
         .until(
             () ->
-                cacheSlotMetadataStore
-                        .getCached()
-                        .stream()
+                cacheSlotMetadataStore.getCached().stream()
                         .filter(
                             cacheSlotMetadata ->
                                 cacheSlotMetadata.cacheSlotState.equals(
@@ -854,9 +840,7 @@ public class ReplicaEvictionServiceTest {
 
     @SuppressWarnings("OptionalGetWithoutIsPresent")
     CacheSlotMetadata updatedCacheSlot =
-        cacheSlotMetadataStore
-            .getCached()
-            .stream()
+        cacheSlotMetadataStore.getCached().stream()
             .filter(
                 cacheSlotMetadata ->
                     Objects.equals(cacheSlotMetadata.name, cacheSlotReplicaExpiredOne.name))

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/schema/ConvertFieldValueAndDuplicateTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/schema/ConvertFieldValueAndDuplicateTest.java
@@ -88,9 +88,7 @@ public class ConvertFieldValueAndDuplicateTest {
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();
     assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
     assertThat(
-            testDocument
-                .getFields()
-                .stream()
+            testDocument.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isEqualTo(1);
@@ -147,9 +145,7 @@ public class ConvertFieldValueAndDuplicateTest {
     assertThat(docBuilder.getSchema().keySet())
         .doesNotContain(LogMessage.SystemField.ALL.fieldName);
     assertThat(
-            testDocument
-                .getFields()
-                .stream()
+            testDocument.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isZero();
@@ -183,9 +179,7 @@ public class ConvertFieldValueAndDuplicateTest {
     Document msg1Doc = convertFieldBuilder.fromMessage(msg1);
     assertThat(msg1Doc.getFields().size()).isEqualTo(14);
     assertThat(
-            msg1Doc
-                .getFields()
-                .stream()
+            msg1Doc.getFields().stream()
                 .filter(f -> f.name().equals(conflictingFieldName))
                 .findFirst())
         .isNotEmpty();
@@ -217,9 +211,7 @@ public class ConvertFieldValueAndDuplicateTest {
     String additionalCreatedFieldName = makeNewFieldOfType(conflictingFieldName, FieldType.INTEGER);
     // Value converted and new field is added.
     assertThat(
-            msg2Doc
-                .getFields()
-                .stream()
+            msg2Doc.getFields().stream()
                 .filter(
                     f ->
                         f.name().equals(conflictingFieldName)
@@ -241,16 +233,12 @@ public class ConvertFieldValueAndDuplicateTest {
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry))
         .isEqualTo(1);
     assertThat(
-            msg1Doc
-                .getFields()
-                .stream()
+            msg1Doc.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isEqualTo(1);
     assertThat(
-            msg2Doc
-                .getFields()
-                .stream()
+            msg2Doc.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isEqualTo(1);
@@ -286,9 +274,7 @@ public class ConvertFieldValueAndDuplicateTest {
     Document msg1Doc = convertFieldBuilder.fromMessage(msg1);
     assertThat(msg1Doc.getFields().size()).isEqualTo(14);
     assertThat(
-            msg1Doc
-                .getFields()
-                .stream()
+            msg1Doc.getFields().stream()
                 .filter(f -> f.name().equals(conflictingFieldName))
                 .findFirst())
         .isNotEmpty();
@@ -320,9 +306,7 @@ public class ConvertFieldValueAndDuplicateTest {
     String additionalCreatedFieldName = makeNewFieldOfType(conflictingFieldName, FieldType.STRING);
     // Value converted and new field is added.
     assertThat(
-            msg2Doc
-                .getFields()
-                .stream()
+            msg2Doc.getFields().stream()
                 .filter(
                     f ->
                         f.name().equals(conflictingFieldName)
@@ -345,16 +329,12 @@ public class ConvertFieldValueAndDuplicateTest {
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry))
         .isEqualTo(1);
     assertThat(
-            msg1Doc
-                .getFields()
-                .stream()
+            msg1Doc.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isEqualTo(1);
     assertThat(
-            msg2Doc
-                .getFields()
-                .stream()
+            msg2Doc.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isEqualTo(1);
@@ -382,9 +362,7 @@ public class ConvertFieldValueAndDuplicateTest {
     Document msg3Doc = convertFieldBuilder.fromMessage(msg3);
     assertThat(msg3Doc.getFields().size()).isEqualTo(16);
     assertThat(
-            msg3Doc
-                .getFields()
-                .stream()
+            msg3Doc.getFields().stream()
                 .filter(
                     f ->
                         f.name().equals(additionalCreatedBoolFieldName)
@@ -439,9 +417,7 @@ public class ConvertFieldValueAndDuplicateTest {
     Document msg1Doc = convertFieldBuilder.fromMessage(msg1);
     assertThat(msg1Doc.getFields().size()).isEqualTo(14);
     assertThat(
-            msg1Doc
-                .getFields()
-                .stream()
+            msg1Doc.getFields().stream()
                 .filter(f -> f.name().equals(conflictingFieldName))
                 .findFirst())
         .isNotEmpty();
@@ -474,9 +450,7 @@ public class ConvertFieldValueAndDuplicateTest {
     String additionalCreatedFieldName = makeNewFieldOfType(conflictingFieldName, FieldType.FLOAT);
     // Value converted and new field is added.
     assertThat(
-            msg2Doc
-                .getFields()
-                .stream()
+            msg2Doc.getFields().stream()
                 .filter(
                     f ->
                         f.name().equals(conflictingFieldName)
@@ -498,16 +472,12 @@ public class ConvertFieldValueAndDuplicateTest {
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry))
         .isEqualTo(1);
     assertThat(
-            msg1Doc
-                .getFields()
-                .stream()
+            msg1Doc.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isEqualTo(1);
     assertThat(
-            msg2Doc
-                .getFields()
-                .stream()
+            msg2Doc.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isEqualTo(1);
@@ -607,16 +577,12 @@ public class ConvertFieldValueAndDuplicateTest {
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry))
         .isEqualTo(1);
     assertThat(
-            testDocument1
-                .getFields()
-                .stream()
+            testDocument1.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isEqualTo(1);
     assertThat(
-            testDocument2
-                .getFields()
-                .stream()
+            testDocument2.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isEqualTo(1);
@@ -671,9 +637,7 @@ public class ConvertFieldValueAndDuplicateTest {
             List.of(stringField, "nested.leaf1", "nested.nested.leaf2", "nested.nested.leaf21"));
     // The new field is identified as text, but indexed as String.
     assertThat(
-            testDocument1
-                .getFields()
-                .stream()
+            testDocument1.getFields().stream()
                 .filter(f -> f.name().equals(stringField) && f instanceof SortedDocValuesField)
                 .count())
         .isEqualTo(1);
@@ -727,9 +691,7 @@ public class ConvertFieldValueAndDuplicateTest {
                 "nested.nested.leaf2",
                 "nested.nested.leaf21"));
     assertThat(
-            testDocument2
-                .getFields()
-                .stream()
+            testDocument2.getFields().stream()
                 .filter(
                     f -> f.name().equals(nestedStringField) && f instanceof SortedDocValuesField)
                 .count())
@@ -738,16 +700,12 @@ public class ConvertFieldValueAndDuplicateTest {
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();
     assertThat(
-            testDocument1
-                .getFields()
-                .stream()
+            testDocument1.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isEqualTo(1);
     assertThat(
-            testDocument2
-                .getFields()
-                .stream()
+            testDocument2.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isEqualTo(1);

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/schema/ConvertFieldValueTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/schema/ConvertFieldValueTest.java
@@ -62,9 +62,7 @@ public class ConvertFieldValueTest {
     Document msg1Doc = convertFieldBuilder.fromMessage(msg1);
     assertThat(msg1Doc.getFields().size()).isEqualTo(14);
     assertThat(
-            msg1Doc
-                .getFields()
-                .stream()
+            msg1Doc.getFields().stream()
                 .filter(f -> f.name().equals(conflictingFieldName))
                 .findFirst())
         .isNotEmpty();
@@ -95,9 +93,7 @@ public class ConvertFieldValueTest {
     assertThat(msg2Doc.getFields().size()).isEqualTo(14);
     // Value is converted for conflicting field.
     assertThat(
-            msg2Doc
-                .getFields()
-                .stream()
+            msg2Doc.getFields().stream()
                 .filter(f -> f.name().equals(conflictingFieldName))
                 .findFirst())
         .isNotEmpty();
@@ -110,16 +106,12 @@ public class ConvertFieldValueTest {
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isEqualTo(1);
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();
     assertThat(
-            msg1Doc
-                .getFields()
-                .stream()
+            msg1Doc.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isEqualTo(1);
     assertThat(
-            msg2Doc
-                .getFields()
-                .stream()
+            msg2Doc.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isEqualTo(1);
@@ -201,16 +193,12 @@ public class ConvertFieldValueTest {
         .isEqualTo(FieldType.FLOAT);
     String additionalCreatedFieldName = makeNewFieldOfType(floatStrConflictField, FieldType.TEXT);
     assertThat(
-            testDocument2
-                .getFields()
-                .stream()
+            testDocument2.getFields().stream()
                 .filter(f -> f.name().equals(additionalCreatedFieldName))
                 .count())
         .isZero();
     assertThat(
-            testDocument2
-                .getFields()
-                .stream()
+            testDocument2.getFields().stream()
                 .filter(f -> f.name().equals(floatStrConflictField))
                 .count())
         .isEqualTo(2);
@@ -229,16 +217,12 @@ public class ConvertFieldValueTest {
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isEqualTo(1);
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();
     assertThat(
-            testDocument1
-                .getFields()
-                .stream()
+            testDocument1.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isEqualTo(1);
     assertThat(
-            testDocument2
-                .getFields()
-                .stream()
+            testDocument2.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isEqualTo(1);

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/schema/DropPolicyTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/schema/DropPolicyTest.java
@@ -55,9 +55,7 @@ public class DropPolicyTest {
     // Only string fields have doc values not text fields.
     assertThat(docBuilder.getSchema().get("_id").fieldType.name).isEqualTo(FieldType.STRING.name);
     assertThat(
-            testDocument
-                .getFields()
-                .stream()
+            testDocument.getFields().stream()
                 .filter(
                     f ->
                         f.name().equals(LogMessage.SystemField.ID.fieldName)
@@ -66,17 +64,13 @@ public class DropPolicyTest {
         .isEqualTo(1);
     assertThat(docBuilder.getSchema().get("_index").fieldType.name).isEqualTo(FieldType.TEXT.name);
     assertThat(
-            testDocument
-                .getFields()
-                .stream()
+            testDocument.getFields().stream()
                 .filter(f -> f.name().equals("_index") && f instanceof SortedDocValuesField)
                 .count())
         .isZero();
     assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
     assertThat(
-            testDocument
-                .getFields()
-                .stream()
+            testDocument.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isEqualTo(1);
@@ -106,9 +100,7 @@ public class DropPolicyTest {
     // Only string fields have doc values not text fields.
     assertThat(docBuilder.getSchema().get("_id").fieldType.name).isEqualTo(FieldType.STRING.name);
     assertThat(
-            testDocument
-                .getFields()
-                .stream()
+            testDocument.getFields().stream()
                 .filter(
                     f ->
                         f.name().equals(LogMessage.SystemField.ID.fieldName)
@@ -117,18 +109,14 @@ public class DropPolicyTest {
         .isEqualTo(1);
     assertThat(docBuilder.getSchema().get("_index").fieldType.name).isEqualTo(FieldType.TEXT.name);
     assertThat(
-            testDocument
-                .getFields()
-                .stream()
+            testDocument.getFields().stream()
                 .filter(f -> f.name().equals("_index") && f instanceof SortedDocValuesField)
                 .count())
         .isZero();
     assertThat(docBuilder.getSchema().keySet())
         .doesNotContain(LogMessage.SystemField.ALL.fieldName);
     assertThat(
-            testDocument
-                .getFields()
-                .stream()
+            testDocument.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isZero();
@@ -174,9 +162,7 @@ public class DropPolicyTest {
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();
     assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
     assertThat(
-            testDocument
-                .getFields()
-                .stream()
+            testDocument.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isEqualTo(1);
@@ -239,9 +225,7 @@ public class DropPolicyTest {
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();
     assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
     assertThat(
-            testDocument
-                .getFields()
-                .stream()
+            testDocument.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isEqualTo(1);
@@ -283,9 +267,7 @@ public class DropPolicyTest {
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();
     assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
     assertThat(
-            testDocument
-                .getFields()
-                .stream()
+            testDocument.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isEqualTo(1);
@@ -329,9 +311,7 @@ public class DropPolicyTest {
     assertThat(docBuilder.getSchema().keySet())
         .doesNotContain(LogMessage.SystemField.ALL.fieldName);
     assertThat(
-            testDocument
-                .getFields()
-                .stream()
+            testDocument.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isZero();
@@ -363,9 +343,7 @@ public class DropPolicyTest {
     Document msg1Doc = docBuilder.fromMessage(msg1);
     assertThat(msg1Doc.getFields().size()).isEqualTo(14);
     assertThat(
-            msg1Doc
-                .getFields()
-                .stream()
+            msg1Doc.getFields().stream()
                 .filter(f -> f.name().equals(conflictingFieldName))
                 .findFirst())
         .isNotEmpty();
@@ -396,9 +374,7 @@ public class DropPolicyTest {
     assertThat(msg2Doc.getFields().size()).isEqualTo(12);
     // Conflicting field is dropped.
     assertThat(
-            msg2Doc
-                .getFields()
-                .stream()
+            msg2Doc.getFields().stream()
                 .filter(f -> f.name().equals(conflictingFieldName))
                 .findFirst())
         .isEmpty();
@@ -488,16 +464,12 @@ public class DropPolicyTest {
         .isEqualTo(FieldType.FLOAT);
     String additionalCreatedFieldName = makeNewFieldOfType(floatStrConflictField, FieldType.TEXT);
     assertThat(
-            testDocument2
-                .getFields()
-                .stream()
+            testDocument2.getFields().stream()
                 .filter(f -> f.name().equals(additionalCreatedFieldName))
                 .count())
         .isZero();
     assertThat(
-            testDocument2
-                .getFields()
-                .stream()
+            testDocument2.getFields().stream()
                 .filter(f -> f.name().equals(floatStrConflictField))
                 .count())
         .isZero();
@@ -516,16 +488,12 @@ public class DropPolicyTest {
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();
     assertThat(
-            testDocument
-                .getFields()
-                .stream()
+            testDocument.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isEqualTo(1);
     assertThat(
-            testDocument2
-                .getFields()
-                .stream()
+            testDocument2.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isEqualTo(1);

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/schema/RaiseErrorFieldValueTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/schema/RaiseErrorFieldValueTest.java
@@ -58,9 +58,7 @@ public class RaiseErrorFieldValueTest {
     Document msg1Doc = docBuilder.fromMessage(msg1);
     assertThat(msg1Doc.getFields().size()).isEqualTo(14);
     assertThat(
-            msg1Doc
-                .getFields()
-                .stream()
+            msg1Doc.getFields().stream()
                 .filter(f -> f.name().equals(conflictingFieldName))
                 .findFirst())
         .isNotEmpty();
@@ -129,9 +127,7 @@ public class RaiseErrorFieldValueTest {
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();
     assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
     assertThat(
-            msg1Doc
-                .getFields()
-                .stream()
+            msg1Doc.getFields().stream()
                 .filter(f -> f.name().equals(LogMessage.SystemField.ALL.fieldName))
                 .count())
         .isEqualTo(1);

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
@@ -832,9 +832,7 @@ public class LogIndexSearcherImplTest {
     assertThat(stringTerms.getBuckets().size()).isEqualTo(4);
 
     List<String> bucketKeys =
-        stringTerms
-            .getBuckets()
-            .stream()
+        stringTerms.getBuckets().stream()
             .map(bucket -> (String) bucket.getKey())
             .collect(Collectors.toList());
     assertThat(bucketKeys.contains("String-1")).isTrue();
@@ -891,44 +889,24 @@ public class LogIndexSearcherImplTest {
     // we collect to a set here, because opensearch doubles up the pipeline aggregators for some
     // reason
     assertThat(
-            dateHistogram
-                .getBuckets()
-                .get(0)
-                .getAggregations()
-                .asList()
-                .stream()
+            dateHistogram.getBuckets().get(0).getAggregations().asList().stream()
                 .map(Aggregation::getName)
                 .collect(Collectors.toSet()))
         .containsExactly("avgTimestamp");
     for (int i = 1; i < 6; i++) {
       assertThat(
-              dateHistogram
-                  .getBuckets()
-                  .get(i)
-                  .getAggregations()
-                  .asList()
-                  .stream()
+              dateHistogram.getBuckets().get(i).getAggregations().asList().stream()
                   .map(Aggregation::getName)
                   .collect(Collectors.toSet()))
           .containsExactly("avgTimestamp", "movAvgCount");
     }
     assertThat(
-            dateHistogram
-                .getBuckets()
-                .get(6)
-                .getAggregations()
-                .asList()
-                .stream()
+            dateHistogram.getBuckets().get(6).getAggregations().asList().stream()
                 .map(Aggregation::getName)
                 .collect(Collectors.toSet()))
         .containsExactly("movAvgCount");
     assertThat(
-            dateHistogram
-                .getBuckets()
-                .get(7)
-                .getAggregations()
-                .asList()
-                .stream()
+            dateHistogram.getBuckets().get(7).getAggregations().asList().stream()
                 .map(Aggregation::getName)
                 .collect(Collectors.toSet()))
         .containsExactly("movAvgCount");

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImplTest.java
@@ -94,9 +94,7 @@ public class SearchResultAggregatorImplTest {
     InternalDateHistogram internalDateHistogram =
         Objects.requireNonNull((InternalDateHistogram) aggSearchResult.internalAggregation);
     assertThat(
-            internalDateHistogram
-                .getBuckets()
-                .stream()
+            internalDateHistogram.getBuckets().stream()
                 .collect(Collectors.summarizingLong(InternalDateHistogram.Bucket::getDocCount))
                 .getSum())
         .isEqualTo(messages1.size() + messages2.size());
@@ -158,9 +156,7 @@ public class SearchResultAggregatorImplTest {
     InternalDateHistogram internalDateHistogram =
         Objects.requireNonNull((InternalDateHistogram) aggSearchResult.internalAggregation);
     assertThat(
-            internalDateHistogram
-                .getBuckets()
-                .stream()
+            internalDateHistogram.getBuckets().stream()
                 .collect(Collectors.summarizingLong(InternalDateHistogram.Bucket::getDocCount))
                 .getSum())
         .isEqualTo(messages1.size() + messages2.size());
@@ -234,9 +230,7 @@ public class SearchResultAggregatorImplTest {
     InternalDateHistogram internalDateHistogram =
         Objects.requireNonNull((InternalDateHistogram) aggSearchResult.internalAggregation);
     assertThat(
-            internalDateHistogram
-                .getBuckets()
-                .stream()
+            internalDateHistogram.getBuckets().stream()
                 .collect(Collectors.summarizingLong(InternalDateHistogram.Bucket::getDocCount))
                 .getSum())
         .isEqualTo(messages1.size() + messages2.size() + messages3.size() + messages4.size());
@@ -343,9 +337,7 @@ public class SearchResultAggregatorImplTest {
     InternalDateHistogram internalDateHistogram =
         Objects.requireNonNull((InternalDateHistogram) aggSearchResult.internalAggregation);
     assertThat(
-            internalDateHistogram
-                .getBuckets()
-                .stream()
+            internalDateHistogram.getBuckets().stream()
                 .collect(Collectors.summarizingLong(InternalDateHistogram.Bucket::getDocCount))
                 .getSum())
         .isEqualTo(messages1.size() + messages2.size());
@@ -456,9 +448,7 @@ public class SearchResultAggregatorImplTest {
     InternalDateHistogram internalDateHistogram =
         Objects.requireNonNull((InternalDateHistogram) aggSearchResult.internalAggregation);
     assertThat(
-            internalDateHistogram
-                .getBuckets()
-                .stream()
+            internalDateHistogram.getBuckets().stream()
                 .collect(Collectors.summarizingLong(InternalDateHistogram.Bucket::getDocCount))
                 .getSum())
         .isEqualTo(messages1.size() + messages2.size());

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -1163,9 +1163,7 @@ public class RecoveryTaskCreatorTest {
     List<RecoveryTaskMetadata> recoveryTasks3 = recoveryTaskStore.listSync();
     assertThat(recoveryTasks3.size()).isEqualTo(3);
     RecoveryTaskMetadata recoveryTask3 =
-        recoveryTaskStore
-            .listSync()
-            .stream()
+        recoveryTaskStore.listSync().stream()
             .filter(r -> !r.equals(recoveryTask1) && !r.equals(recoveryTask2))
             .findFirst()
             .get();
@@ -1195,9 +1193,7 @@ public class RecoveryTaskCreatorTest {
     List<RecoveryTaskMetadata> recoveryTasks4 = recoveryTaskStore.listSync();
     assertThat(recoveryTasks4.size()).isEqualTo(4);
     RecoveryTaskMetadata recoveryTask4 =
-        recoveryTaskStore
-            .listSync()
-            .stream()
+        recoveryTaskStore.listSync().stream()
             .filter(r -> !recoveryTasks3.contains(r))
             .findFirst()
             .get();
@@ -1232,9 +1228,7 @@ public class RecoveryTaskCreatorTest {
     assertThat(recoveryTaskCreator.determineStartingOffset(2050)).isEqualTo(2050);
     assertThat(recoveryTaskStore.listSync().size()).isEqualTo(6);
     RecoveryTaskMetadata recoveryTask5 =
-        recoveryTaskStore
-            .listSync()
-            .stream()
+        recoveryTaskStore.listSync().stream()
             .filter(r -> !recoveryTasks4.contains(r) && !r.equals(recoveryTaskPartition2))
             .findFirst()
             .get();

--- a/kaldb/src/test/java/com/slack/kaldb/writer/JsonLogFormatterTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/JsonLogFormatterTest.java
@@ -25,8 +25,7 @@ public class JsonLogFormatterTest {
     span = JsonLogFormatter.fromJsonLog(json.getBytes(StandardCharsets.UTF_8));
     assertThat(span.getTagsList().size()).isEqualTo(3);
     Set<Trace.KeyValue> tags =
-        span.getTagsList()
-            .stream()
+        span.getTagsList().stream()
             .filter(kv -> kv.getKey().equals("field1"))
             .collect(Collectors.toSet());
     assertThat(tags.size()).isEqualTo(1);


### PR DESCRIPTION
> UPDATE 2022-02-14: This plugin has moved from [coveooss](https://github.com/coveooss/) to the [spotify](https://github.com/spotify/) Github org. The new groupId will be com.spotify.fmt, and the master branch has been renamed to main.

Now that we have migrated to Java 17, the new syntaxes were not getting parsed by the format library

I was running into WARNs like this

```
[WARNING] Failed to format file '/Users/vthacker/nobackup/dev/slack-repos/kaldb/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializerTest.java'.
com.google.googlejavaformat.java.FormatterException: 44:16: error: unclosed string literal
    at com.google.googlejavaformat.java.FormatterException.fromJavacDiagnostics (FormatterException.java:50)
    at com.google.googlejavaformat.java.Formatter.format (Formatter.java:151)
    at com.google.googlejavaformat.java.Formatter.getFormatReplacements (Formatter.java:258)
    at com.google.googlejavaformat.java.Formatter.formatSource (Formatter.java:234)
    at com.google.googlejavaformat.java.Formatter.formatSource (Formatter.java:202)
    at com.coveo.AbstractFMT.formatSourceFile (AbstractFMT.java:191)
```

So I went to update the library. Then I realized the last update was 2021 and the project has moved under spotify.

Updating the plugin to spotify and addressing any format changes that got incorporated. This plugin is also able to parse Java 17 syntax and works with Java 16+ strong encapsulation ( https://github.com/spotify/fmt-maven-plugin/pull/150 ) 