### PR TITLE
Fix flaky distributed query test

### DIFF
--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -678,8 +678,11 @@ public class KaldbIndexerTest {
     assertThat(chunkManagerUtil.chunkManager.getChunkList().size()).isEqualTo(1);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, metricsRegistry)).isEqualTo(0);
     if (rolloversCompleted > 0) {
-      assertThat(getCount(RollOverChunkTask.ROLLOVERS_INITIATED, metricsRegistry))
-          .isEqualTo(rolloversCompleted);
+      await()
+          .until(
+              () ->
+                  getCount(RollOverChunkTask.ROLLOVERS_INITIATED, metricsRegistry)
+                      == rolloversCompleted);
       await()
           .until(
               () ->


### PR DESCRIPTION
Switches an assert to use an await(), as this test seems to be a bit time sensitive (see [1](https://github.com/slackhq/kaldb/actions/runs/5007965043/jobs/8975258616), [2](https://github.com/slackhq/kaldb/actions/runs/5007944839/jobs/8975214664?pr=543), [3](https://github.com/slackhq/kaldb/actions/runs/5015206007/jobs/8990451742)).