### PR TITLE
Update dependencies

### DIFF
--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -16,8 +16,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <javac.target>17</javac.target>
         <uberjar.name>kaldb</uberjar.name>
-        <http.client.version>4.5.13</http.client.version>
-        <http.core.version>4.4.15</http.core.version>
+        <http.client.version>4.5.14</http.client.version>
+        <http.core.version>4.4.16</http.core.version>
         <protobuf.version>3.23.1</protobuf.version>
         <grpc.version>1.55.1</grpc.version>
         <micrometer.version>1.11.0</micrometer.version>
@@ -46,20 +46,17 @@
     </licenses>
 
     <dependencies>
+        <!-- Logging dependencies -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>2.0.7</version>
         </dependency>
-
-        <!-- Binding for Log4J -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j.version}</version>
         </dependency>
-
-        <!-- Log4j2 -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
@@ -74,12 +71,6 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-layout-template-json</artifactId>
             <version>${log4j.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.lmax</groupId>
-            <artifactId>disruptor</artifactId>
-            <version>3.4.4</version>
         </dependency>
 
         <!-- Armeria dependencies -->
@@ -125,6 +116,11 @@
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
             <version>${curator.version}</version>
         </dependency>
 
@@ -213,13 +209,20 @@
             <version>${jackson.version}</version>
         </dependency>
 
-        <!-- YAML config parsing dependencies -->
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${jackson.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>${jackson.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Misc -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
@@ -232,7 +235,13 @@
             <version>31.1-jre</version>
         </dependency>
 
-        <!-- micrometer dependencies -->
+        <dependency>
+            <groupId>com.lmax</groupId>
+            <artifactId>disruptor</artifactId>
+            <version>3.4.4</version>
+        </dependency>
+
+        <!-- Micrometer dependencies -->
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
@@ -244,12 +253,7 @@
             <version>${micrometer.version}</version>
         </dependency>
 
-        <!-- BlobFs dependencies -->
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.12.0</version>
-        </dependency>
+        <!-- AWS SDK -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
@@ -294,6 +298,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
@@ -355,6 +360,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>4.2.0</version>
@@ -372,14 +383,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.24.2</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -393,21 +402,12 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-            <scope>test</scope>
-        </dependency>
-        
-        <!-- Apache curator dependencies -->
-        <dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-test</artifactId>
-            <version>${curator.version}</version>
-        </dependency>
-
         <!-- BlobFs test dependencies -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.12.0</version>
+        </dependency>
         <dependency>
             <groupId>com.adobe.testing</groupId>
             <artifactId>s3mock-junit5</artifactId>
@@ -435,26 +435,6 @@
                     <artifactId>httpclient</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-xml</artifactId>
-            <version>${jackson.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.1</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.codehaus.woodstox</groupId>
-            <artifactId>stax2-api</artifactId>
-            <version>4.2.1</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.github.charithe/kafka-junit -->
@@ -497,19 +477,19 @@
         <dependency>
             <groupId>io.zipkin.brave</groupId>
             <artifactId>brave-instrumentation-grpc</artifactId>
-            <version>5.13.9</version>
+            <version>5.16.0</version>
         </dependency>
 
         <dependency>
             <groupId>io.zipkin.brave</groupId>
             <artifactId>brave-context-log4j2</artifactId>
-            <version>5.13.9</version>
+            <version>5.16.0</version>
         </dependency>
 
         <dependency>
             <groupId>io.zipkin.reporter2</groupId>
             <artifactId>zipkin-sender-urlconnection</artifactId>
-            <version>2.16.3</version>
+            <version>2.16.4</version>
         </dependency>
 
     </dependencies>

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -179,6 +179,11 @@
         <!-- Kafka writer dependencies -->
         <dependency>
             <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-streams</artifactId>
             <version>${kafka.version}</version>
         </dependency>

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -248,7 +248,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.11.0</version>
+            <version>2.12.0</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -72,6 +72,11 @@
             <artifactId>log4j-layout-template-json</artifactId>
             <version>${log4j.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-transform-maven-shade-plugin-extensions</artifactId>
+            <version>0.1.0</version>
+        </dependency>
 
         <!-- Armeria dependencies -->
         <dependency>
@@ -355,7 +360,7 @@
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <version>5.9.1</version>
             <scope>test</scope>
         </dependency>
@@ -540,12 +545,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.4.1</version>
                 <dependencies>
                     <dependency>
-                        <groupId>com.github.edwgiz</groupId>
-                        <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.15.0</version>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-transform-maven-shade-plugin-extensions</artifactId>
+                        <version>0.1.0</version>
                     </dependency>
                 </dependencies>
                 <executions>
@@ -564,9 +569,8 @@
                                     </manifestEntries>
                                 </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                                <!-- https://github.com/edwgiz/maven-shaded-log4j-transformer -->
                                 <transformer
-                                        implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
+                                        implementation="org.apache.logging.log4j.maven.plugins.shade.transformer.Log4j2PluginCacheFileTransformer">
                                 </transformer>
                             </transformers>
                             <filters>
@@ -643,7 +647,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.3.0</version>
                 <configuration>
                     <rules>
                         <dependencyConvergence/>
@@ -659,11 +663,11 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
@@ -671,15 +675,15 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.3</version>
+                    <version>3.12.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>2.2.1</version>
+                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -25,7 +25,8 @@
         <kafka.version>3.2.3</kafka.version>
         <jackson.version>2.15.0</jackson.version>
         <jackson.databind.version>2.14.1</jackson.databind.version>
-        <lucene.version>9.3.0</lucene.version>
+        <lucene.version>9.5.0</lucene.version>
+        <opensearch.version>2.7.0</opensearch.version>
         <curator.version>5.4.0</curator.version>
         <log4j.version>2.17.2</log4j.version>
         <aws.sdk.version>2.17.209</aws.sdk.version>
@@ -166,12 +167,12 @@
         <dependency>
             <groupId>org.opensearch</groupId>
             <artifactId>opensearch</artifactId>
-            <version>2.3.0</version>
+            <version>${opensearch.version}</version>
         </dependency>
         <dependency>
             <groupId>org.opensearch.plugin</groupId>
             <artifactId>lang-painless</artifactId>
-            <version>2.3.0</version>
+            <version>${opensearch.version}</version>
         </dependency>
 
         <!-- Kafka writer dependencies -->

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -29,7 +29,7 @@
         <opensearch.version>2.7.0</opensearch.version>
         <curator.version>5.4.0</curator.version>
         <log4j.version>2.17.2</log4j.version>
-        <aws.sdk.version>2.17.209</aws.sdk.version>
+        <aws.sdk.version>2.20.67</aws.sdk.version>
         <error.prone.version>2.16</error.prone.version>
     </properties>
 

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -28,7 +28,7 @@
         <lucene.version>9.5.0</lucene.version>
         <opensearch.version>2.7.0</opensearch.version>
         <curator.version>5.4.0</curator.version>
-        <log4j.version>2.17.2</log4j.version>
+        <log4j.version>2.20.0</log4j.version>
         <aws.sdk.version>2.20.67</aws.sdk.version>
         <error.prone.version>2.16</error.prone.version>
     </properties>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.36</version>
+            <version>2.0.7</version>
         </dependency>
 
         <!-- Binding for Log4J -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j.version}</version>
         </dependency>
 

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -23,8 +23,8 @@
         <micrometer.version>1.9.4</micrometer.version>
         <armeria.version>1.23.1</armeria.version>
         <kafka.version>3.4.0</kafka.version>
-        <jackson.version>2.15.0</jackson.version>
-        <jackson.databind.version>2.14.1</jackson.databind.version>
+        <jackson.version>2.15.1</jackson.version>
+        <jackson.databind.version>2.15.1</jackson.databind.version>
         <lucene.version>9.5.0</lucene.version>
         <opensearch.version>2.7.0</opensearch.version>
         <curator.version>5.4.0</curator.version>

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -21,7 +21,7 @@
         <protobuf.version>3.21.7</protobuf.version>
         <grpc.version>1.49.1</grpc.version>
         <micrometer.version>1.9.4</micrometer.version>
-        <armeria.version>1.22.1</armeria.version>
+        <armeria.version>1.23.1</armeria.version>
         <kafka.version>3.4.0</kafka.version>
         <jackson.version>2.15.0</jackson.version>
         <jackson.databind.version>2.14.1</jackson.databind.version>

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -22,7 +22,7 @@
         <grpc.version>1.49.1</grpc.version>
         <micrometer.version>1.9.4</micrometer.version>
         <armeria.version>1.22.1</armeria.version>
-        <kafka.version>3.2.3</kafka.version>
+        <kafka.version>3.4.0</kafka.version>
         <jackson.version>2.15.0</jackson.version>
         <jackson.databind.version>2.14.1</jackson.databind.version>
         <lucene.version>9.5.0</lucene.version>
@@ -176,12 +176,6 @@
         </dependency>
 
         <!-- Kafka writer dependencies -->
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
-            <version>${kafka.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-streams</artifactId>
@@ -464,7 +458,7 @@
         <dependency>
             <groupId>com.github.charithe</groupId>
             <artifactId>kafka-junit</artifactId>
-            <version>4.2.3</version>
+            <version>4.2.4</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -383,13 +383,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.12.4</version>
+            <version>5.3.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>3.12.4</version>
+            <version>5.2.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -20,7 +20,7 @@
         <http.core.version>4.4.15</http.core.version>
         <protobuf.version>3.23.1</protobuf.version>
         <grpc.version>1.55.1</grpc.version>
-        <micrometer.version>1.9.4</micrometer.version>
+        <micrometer.version>1.11.0</micrometer.version>
         <armeria.version>1.23.1</armeria.version>
         <kafka.version>3.4.0</kafka.version>
         <jackson.version>2.15.1</jackson.version>

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -18,8 +18,8 @@
         <uberjar.name>kaldb</uberjar.name>
         <http.client.version>4.5.13</http.client.version>
         <http.core.version>4.4.15</http.core.version>
-        <protobuf.version>3.21.7</protobuf.version>
-        <grpc.version>1.49.1</grpc.version>
+        <protobuf.version>3.23.1</protobuf.version>
+        <grpc.version>1.55.1</grpc.version>
         <micrometer.version>1.9.4</micrometer.version>
         <armeria.version>1.23.1</armeria.version>
         <kafka.version>3.4.0</kafka.version>
@@ -331,10 +331,13 @@
             <artifactId>grpc-stub</artifactId>
             <version>${grpc.version}</version>
         </dependency>
+
+        <!-- https://github.com/grpc/grpc-java/issues/9179 -->
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
             <version>1.3.5</version>
+            <scope>compile</scope>
         </dependency>
 
         <!-- For parsing JSON protobufs. Use jackson? -->

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/opensearch/OpenSearchAdapter.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/opensearch/OpenSearchAdapter.java
@@ -43,9 +43,9 @@ import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.compress.CompressedXContent;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.BigArrays;
-import org.opensearch.common.xcontent.NamedXContentRegistry;
-import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.analysis.AnalyzerScope;
 import org.opensearch.index.analysis.IndexAnalyzers;
@@ -314,7 +314,7 @@ public class OpenSearchAdapter {
         Settings.builder()
             .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
-            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.V_2_3_0)
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.V_2_7_0)
             .put(
                 MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey(), TOTAL_FIELDS_LIMIT)
             .build();


### PR DESCRIPTION
Mostly minor version bumps, a handful of major version bumps that I have bolded below.

* Opensearch 2.3.0 > 2.7.0
* Lucene 9.3.0 > 9.5.0
* Kafka 3.2.3 > 3.4.0
* Armeria 1.22.1 > 1.23.1
* Protobuf 3.21.7 > 3.23.1
* GRPC 1.49.1 > 1.55.1
* Jackson 2.15.0 > 2.15.1
* Jackson databind 2.14.1 > 2.15.1
* Log4j 2.17.2 > 2.20.0
* **Slf4j 1.7.36 > 2.0.7**
* Micrometer 1.9.4 > 1.11.0
* Commons IO 2.11.0 > 2.12.0
* **Mockito 3.12.4 > 5.3.1**
* **Mockito inline 3.12.4 > 5.2.0**
* Apache httpclient 4.5.13 > 4.5.14
* Apache httpcore 4.4.15 > 4.4.16
* **Log4j2-cachefile-transformer com.github.edwige 2.15.0 > org.apache.logging 0.1.0**
* maven-enforcer-plugin 3.2.1 > 3.3.0
* maven-install-plugin 3.1.0 > 3.1.1
* **maven-jar-plugin 2.4 > 3.3.0**
* **maven-resources-plugin 2.6 > 3.3.1**
* maven-site-plugin 3.3 > 3.12.1
* **maven-source-plugin 2.2.1 > 3.2.1**