### PR TITLE
ZK Partitioning Store

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/CachingChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/CachingChunkManager.java
@@ -71,10 +71,10 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
   protected void startUp() throws Exception {
     LOG.info("Starting caching chunk manager");
 
-    replicaMetadataStore = new ReplicaMetadataStore(curatorFramework, false);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, false);
+    replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
+    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
     searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
-    cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework, false);
+    cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
 
     for (int i = 0; i < slotCountPerInstance; i++) {
       chunkList.add(

--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/IndexingChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/IndexingChunkManager.java
@@ -319,7 +319,7 @@ public class IndexingChunkManager<T> extends ChunkManagerBase<T> {
     LOG.info("Starting indexing chunk manager");
 
     searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, false);
+    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
 
     stopIngestion = false;
   }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadata.java
@@ -2,7 +2,7 @@ package com.slack.kaldb.metadata.cache;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.slack.kaldb.metadata.core.KaldbMetadata;
+import com.slack.kaldb.metadata.core.KaldbPartitionedMetadata;
 import com.slack.kaldb.proto.metadata.Metadata;
 import java.util.Collections;
 import java.util.List;
@@ -11,7 +11,7 @@ import java.util.List;
  * TODO: Currently, application code directly manipulates cache slot states which is error prone.
  * Make transitions more controlled via a state machine like API.
  */
-public class CacheSlotMetadata extends KaldbMetadata {
+public class CacheSlotMetadata extends KaldbPartitionedMetadata {
   public final String hostname;
   public final Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState;
   public final String replicaId;
@@ -92,5 +92,10 @@ public class CacheSlotMetadata extends KaldbMetadata {
         + name
         + '\''
         + '}';
+  }
+
+  @Override
+  public String getPartition() {
+    return hostname;
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbPartitionedMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbPartitionedMetadata.java
@@ -1,0 +1,24 @@
+package com.slack.kaldb.metadata.core;
+
+public abstract class KaldbPartitionedMetadata extends KaldbMetadata {
+  public KaldbPartitionedMetadata(String name) {
+    super(name);
+  }
+
+  /**
+   * Returns a string identifying the partition to store this metadata under.
+   *
+   * <p>The deciding on a partition identifier for a metadata care should taken to ensure it is a
+   * stable identifier, and cannot change as the metadata is mutated. If the partition identifier
+   * were to be based off a mutable field this would cause problems updating the znode, as this
+   * would require a different znode path.
+   *
+   * <p>Changing the logic for a partition identifier should always be backward compatible, to
+   * ensure previously stored data can still be located for operations.
+   *
+   * <p>The amount of partitions directly maps to the number of potential metadata stores that must
+   * be maintained in memory. The amount of partitions should be targeted such that each partition
+   * comes close to the configured jute.maxbuffer, but is not at risk of exceeding this threshold.
+   */
+  public abstract String getPartition();
+}

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbPartitioningMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbPartitioningMetadataStore.java
@@ -1,0 +1,303 @@
+package com.slack.kaldb.metadata.core;
+
+import static com.slack.kaldb.server.KaldbConfig.DEFAULT_ZK_TIMEOUT_SECS;
+
+import com.google.common.collect.Sets;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import org.apache.curator.x.async.AsyncCuratorFramework;
+import org.apache.curator.x.async.modeled.ModelSerializer;
+import org.apache.zookeeper.AddWatchMode;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The KaldbPartitioningMetadataStore is a variation of the KaldbMetadataStore that allows for
+ * scaling a metadata store that exceeds Zookeepers ideal child node count. This is generally
+ * encountered when attempting to list children or adding a listener encounters an issue exceeding
+ * the jute.maxbuffer.
+ *
+ * <p>This partitioning store enables scaling by introducing an intermediate path to the existing
+ * metadata stores, such that "foo/bar" becomes "/foo/{partitionIdentifier}/bar". For each
+ * partitionIdentifier a separate instance of a KaldbMetadataStore is managed within a map. The
+ * partitioning store transparently handles registration and discovery of these partitions, and
+ * passes the various metadata store methods directly to the appropriate partition instance.
+ *
+ * <p>Switching to the partitioning store is not backward compatible with existing non-partitioned
+ * metadata. This could potentially be addressed using a manager api to read and copy the metadata
+ * to the new store path, using the non-partitioned and partitioning stores respectively.
+ */
+public class KaldbPartitioningMetadataStore<T extends KaldbPartitionedMetadata>
+    implements Closeable {
+
+  // Threshold after at which a warning is emitted every time a new store is added. This is intended
+  // to help troubleshoot excessive of metadata stores managed in memory.
+  private static final int STORE_COUNT_WARNING_THRESHOLD = 300;
+  private static final Logger LOG = LoggerFactory.getLogger(KaldbPartitioningMetadataStore.class);
+  private final Map<String, KaldbMetadataStore<T>> metadataStoreMap = new ConcurrentHashMap<>();
+  private final List<KaldbMetadataStoreChangeListener<T>> listeners = new CopyOnWriteArrayList<>();
+
+  protected final AsyncCuratorFramework curator;
+  protected final String storeFolder;
+  private final CreateMode createMode;
+  protected final ModelSerializer<T> modelSerializer;
+  private final Watcher watcher;
+
+  public KaldbPartitioningMetadataStore(
+      AsyncCuratorFramework curator,
+      CreateMode createMode,
+      ModelSerializer<T> modelSerializer,
+      String storeFolder) {
+    this.curator = curator;
+    this.storeFolder = storeFolder;
+    this.createMode = createMode;
+    this.modelSerializer = modelSerializer;
+    this.watcher = buildWatcher();
+
+    // register watchers for when partitions are added or removed
+    curator
+        .addWatch()
+        .withMode(AddWatchMode.PERSISTENT) // intentionally NOT recursive
+        .usingWatcher(watcher)
+        .forPath(storeFolder);
+
+    // init stores for each existing partition
+    curator
+        .getChildren()
+        .forPath(storeFolder)
+        .exceptionallyCompose(
+            (throwable) -> {
+              if (throwable instanceof KeeperException.NoNodeException) {
+                // This is thrown because the storeFolder does not yet exist in ZK
+                // This isn't a problem, as the node will be created once the first operation is
+                // attempted
+                return CompletableFuture.completedFuture(List.of());
+              } else {
+                return CompletableFuture.failedFuture(throwable);
+              }
+            })
+        .thenAccept((children) -> children.forEach(this::getOrCreateMetadataStore))
+        .toCompletableFuture()
+        // wait for all the stores to be initialized prior to exiting the constructor
+        .join();
+  }
+
+  /**
+   * Builds a watcher that is responsible for updating our internal metadata stores to match that is
+   * stored in ZK. As we create parent nodes as containers, we do not need to be responsible for
+   * deleting these intermediate nodes as this will be handled by ZK.
+   *
+   * <p>This method creates stores internally when they are detected in ZK storing them to the store
+   * map, and removes stores that are in the map that no longer exist in ZK.
+   *
+   * @see KaldbMetadataStore#KaldbMetadataStore(AsyncCuratorFramework, CreateMode, boolean,
+   *     ModelSerializer, String)
+   */
+  private Watcher buildWatcher() {
+    return event -> {
+      if (event.getType().equals(Watcher.Event.EventType.NodeChildrenChanged)) {
+        curator
+            .getChildren()
+            .forPath(storeFolder)
+            .thenAcceptAsync(
+                (partitions) -> {
+                  // create internal stores foreach partition that do not already exist
+                  partitions.forEach(this::getOrCreateMetadataStore);
+
+                  // remove metadata stores that exist in memory but no longer exist on ZK
+                  Set<String> partitionsToRemove =
+                      Sets.difference(metadataStoreMap.keySet(), Sets.newHashSet(partitions));
+                  partitionsToRemove.forEach(
+                      partition -> {
+                        LOG.info("Closing unused store for partition - {}", partition);
+                        KaldbMetadataStore<T> store = metadataStoreMap.remove(partition);
+                        store.close();
+                      });
+                });
+      }
+    };
+  }
+
+  public CompletionStage<String> createAsync(T metadataNode) {
+    return getOrCreateMetadataStore(metadataNode.getPartition()).createAsync(metadataNode);
+  }
+
+  public void createSync(T metadataNode) {
+    try {
+      createAsync(metadataNode)
+          .toCompletableFuture()
+          .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error creating node " + metadataNode, e);
+    }
+  }
+
+  public CompletionStage<T> getAsync(String partition, String path) {
+    return getOrCreateMetadataStore(partition).getAsync(path);
+  }
+
+  public T getSync(String partition, String path) {
+    try {
+      return getAsync(partition, path)
+          .toCompletableFuture()
+          .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error fetching node at path " + path, e);
+    }
+  }
+
+  /**
+   * Attempts to find the metadata without knowledge of the partition it exists in. Use of this
+   * should be avoided if possible, preferring the getAsync.
+   *
+   * @see KaldbPartitioningMetadataStore#getAsync(String, String)
+   */
+  public CompletionStage<T> findAsync(String path) {
+    return getOrCreateMetadataStore(findPartition(path)).getAsync(path);
+  }
+
+  /**
+   * Attempts to find the metadata without knowledge of the partition it exists in. Use of this
+   * should be avoided if possible, preferring the getSync.
+   *
+   * @see KaldbPartitioningMetadataStore#getSync(String, String)
+   */
+  public T findSync(String path) {
+    try {
+      return findAsync(path).toCompletableFuture().get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error fetching node at path " + path, e);
+    }
+  }
+
+  public CompletionStage<Stat> updateAsync(T metadataNode) {
+    return getOrCreateMetadataStore(metadataNode.getPartition()).updateAsync(metadataNode);
+  }
+
+  public void updateSync(T metadataNode) {
+    try {
+      updateAsync(metadataNode)
+          .toCompletableFuture()
+          .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error updating node: " + metadataNode, e);
+    }
+  }
+
+  public CompletionStage<Void> deleteAsync(T metadataNode) {
+    return getOrCreateMetadataStore(metadataNode.getPartition()).deleteAsync(metadataNode);
+  }
+
+  public void deleteSync(T metadataNode) {
+    try {
+      deleteAsync(metadataNode)
+          .toCompletableFuture()
+          .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+    } catch (ExecutionException | InterruptedException | TimeoutException e) {
+      throw new InternalMetadataStoreException(
+          "Error deleting node under at path: " + metadataNode.name, e);
+    }
+  }
+
+  public CompletableFuture<List<T>> listAsync() {
+    List<CompletableFuture<List<T>>> completionStages = new ArrayList<>();
+    for (Map.Entry<String, KaldbMetadataStore<T>> metadataStoreEntry :
+        metadataStoreMap.entrySet()) {
+      completionStages.add(metadataStoreEntry.getValue().listAsync().toCompletableFuture());
+    }
+
+    return CompletableFuture.allOf(completionStages.toArray(new CompletableFuture[0]))
+        .thenApply(
+            (unused) ->
+                completionStages.stream()
+                    .map(f -> f.toCompletableFuture().join())
+                    .flatMap(List::stream)
+                    .collect(Collectors.toList()));
+  }
+
+  public List<T> listSync() {
+    try {
+      return listAsync().toCompletableFuture().get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+    } catch (ExecutionException | InterruptedException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error listing nodes", e);
+    }
+  }
+
+  private KaldbMetadataStore<T> getOrCreateMetadataStore(String partition) {
+    if (metadataStoreMap.size() > STORE_COUNT_WARNING_THRESHOLD) {
+      LOG.warn(
+          "The current partitioned metadata store contains {} partitions, which is above the warning threshold of {}",
+          metadataStoreMap.size(),
+          STORE_COUNT_WARNING_THRESHOLD);
+    }
+
+    return metadataStoreMap.computeIfAbsent(
+        partition,
+        (p1) -> {
+          String path = String.format("%s/%s", storeFolder, p1);
+          LOG.info("Creating new metadata store for partition - {}, at path - {}", partition, path);
+
+          KaldbMetadataStore<T> newStore =
+              new KaldbMetadataStore<>(curator, createMode, true, modelSerializer, path);
+          listeners.forEach(newStore::addListener);
+
+          return newStore;
+        });
+  }
+
+  /**
+   * Attempts to locate the partition containing the sub-path. If no partition is found this will
+   * throw an InternalMetadataStoreException. Use of this method should be carefully considered due
+   * to performance implications of potentially invoking N hasSync calls.
+   */
+  private String findPartition(String path) {
+    for (Map.Entry<String, KaldbMetadataStore<T>> metadataStoreEntry :
+        metadataStoreMap.entrySet()) {
+      // We may consider switching this to execute in parallel in the future. Even though this would
+      // be faster, it would put quite a bit more load on ZK, and some of it unnecessary
+      if (metadataStoreEntry.getValue().hasSync(path)) {
+        return metadataStoreEntry.getKey();
+      }
+    }
+    throw new InternalMetadataStoreException("Error finding node at path " + path);
+  }
+
+  public void addListener(KaldbMetadataStoreChangeListener<T> watcher) {
+    listeners.add(watcher);
+    metadataStoreMap.forEach((partition, store) -> listeners.forEach(store::addListener));
+  }
+
+  public void removeListener(KaldbMetadataStoreChangeListener<T> watcher) {
+    listeners.remove(watcher);
+    metadataStoreMap.forEach((partition, store) -> store.removeListener(watcher));
+  }
+
+  @Override
+  public void close() throws IOException {
+    LOG.info(
+        "Closing the partitioning metadata store, {} listeners to remove, {} partitions to close",
+        listeners.size(),
+        metadataStoreMap.size());
+
+    // only remove the watcher we created, since this curator instance is a singleton
+    curator.removeWatches().removing(watcher);
+    listeners.forEach(this::removeListener);
+    metadataStoreMap.forEach((partition, store) -> store.close());
+  }
+}

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/core/MetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/core/MetadataSerializer.java
@@ -23,6 +23,10 @@ public interface MetadataSerializer<T extends KaldbMetadata> {
     return new ModelSerializer<>() {
       @Override
       public byte[] serialize(T model) {
+        if (model == null) {
+          return null;
+        }
+
         try {
           return toJsonStr(model).getBytes();
         } catch (Exception e) {
@@ -32,6 +36,10 @@ public interface MetadataSerializer<T extends KaldbMetadata> {
 
       @Override
       public T deserialize(byte[] bytes) {
+        if (bytes == null || bytes.length == 0) {
+          return null;
+        }
+
         try {
           return fromJsonStr(new String(bytes));
         } catch (Exception e) {

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadataStore.java
@@ -1,18 +1,16 @@
 package com.slack.kaldb.metadata.replica;
 
-import com.slack.kaldb.metadata.core.KaldbMetadataStore;
+import com.slack.kaldb.metadata.core.KaldbPartitioningMetadataStore;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.zookeeper.CreateMode;
 
-public class ReplicaMetadataStore extends KaldbMetadataStore<ReplicaMetadata> {
-  public static final String REPLICA_STORE_ZK_PATH = "/replica";
+public class ReplicaMetadataStore extends KaldbPartitioningMetadataStore<ReplicaMetadata> {
+  public static final String REPLICA_STORE_ZK_PATH = "/partitioned_replica";
 
-  public ReplicaMetadataStore(AsyncCuratorFramework curatorFramework, boolean shouldCache)
-      throws Exception {
+  public ReplicaMetadataStore(AsyncCuratorFramework curatorFramework) throws Exception {
     super(
         curatorFramework,
         CreateMode.PERSISTENT,
-        shouldCache,
         new ReplicaMetadataSerializer().toModelSerializer(),
         REPLICA_STORE_ZK_PATH);
   }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadata.java
@@ -2,8 +2,12 @@ package com.slack.kaldb.metadata.snapshot;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.slack.kaldb.metadata.core.KaldbMetadata;
+import com.slack.kaldb.metadata.core.KaldbPartitionedMetadata;
 import com.slack.kaldb.proto.metadata.Metadata;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoField;
 
 /**
  * The SnapshotMetadata class contains all the metadata related to a snapshot.
@@ -18,7 +22,7 @@ import com.slack.kaldb.proto.metadata.Metadata;
  * for now, this should be fine. If this is inconvenient, consider adding a startOffset field also
  * here.
  */
-public class SnapshotMetadata extends KaldbMetadata {
+public class SnapshotMetadata extends KaldbPartitionedMetadata {
   public static final String LIVE_SNAPSHOT_PATH = "LIVE";
 
   public static boolean isLive(SnapshotMetadata snapshotMetadata) {
@@ -141,5 +145,21 @@ public class SnapshotMetadata extends KaldbMetadata {
         + ", indexType="
         + indexType
         + '}';
+  }
+
+  @Override
+  public String getPartition() {
+    if (isLive(this)) {
+      // this keeps all the live snapshots in a single partition - this is important as their stored
+      // startTimeEpochMs is not stable, and will be updated. This would cause an update to a live
+      // node to fail with a partitioned metadata store as it cannot change the path of the znode.
+      return "LIVE";
+    } else {
+      ZonedDateTime snapshotTime = Instant.ofEpochMilli(startTimeEpochMs).atZone(ZoneOffset.UTC);
+      return String.format(
+          "%s_%s",
+          snapshotTime.getLong(ChronoField.EPOCH_DAY),
+          snapshotTime.getLong(ChronoField.HOUR_OF_DAY));
+    }
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataStore.java
@@ -1,20 +1,18 @@
 package com.slack.kaldb.metadata.snapshot;
 
-import com.slack.kaldb.metadata.core.KaldbMetadataStore;
+import com.slack.kaldb.metadata.core.KaldbPartitioningMetadataStore;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.zookeeper.CreateMode;
 
-public class SnapshotMetadataStore extends KaldbMetadataStore<SnapshotMetadata> {
-  public static final String SNAPSHOT_METADATA_STORE_ZK_PATH = "/snapshot";
+public class SnapshotMetadataStore extends KaldbPartitioningMetadataStore<SnapshotMetadata> {
+  public static final String SNAPSHOT_METADATA_STORE_ZK_PATH = "/partitioned_snapshot";
 
   // TODO: Consider restricting the update methods to only update live nodes only?
 
-  public SnapshotMetadataStore(AsyncCuratorFramework curatorFramework, boolean shouldCache)
-      throws Exception {
+  public SnapshotMetadataStore(AsyncCuratorFramework curatorFramework) throws Exception {
     super(
         curatorFramework,
         CreateMode.PERSISTENT,
-        shouldCache,
         new SnapshotMetadataSerializer().toModelSerializer(),
         SNAPSHOT_METADATA_STORE_ZK_PATH);
   }

--- a/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
@@ -139,7 +139,7 @@ public class RecoveryService extends AbstractIdleService {
 
     recoveryNodeMetadataStore = new RecoveryNodeMetadataStore(curatorFramework, false);
     recoveryTaskMetadataStore = new RecoveryTaskMetadataStore(curatorFramework, false);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, false);
+    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
     searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
 
     recoveryNodeMetadataStore.createSync(

--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -193,8 +193,7 @@ public class Kaldb {
 
     if (roles.contains(KaldbConfigs.NodeRole.QUERY)) {
       SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
-      SnapshotMetadataStore snapshotMetadataStore =
-          new SnapshotMetadataStore(curatorFramework, true);
+      SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
       DatasetMetadataStore datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
 
       services.add(
@@ -256,15 +255,13 @@ public class Kaldb {
       final KaldbConfigs.ManagerConfig managerConfig = kaldbConfig.getManagerConfig();
       final int serverPort = managerConfig.getServerConfig().getServerPort();
 
-      ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework, true);
-      SnapshotMetadataStore snapshotMetadataStore =
-          new SnapshotMetadataStore(curatorFramework, true);
+      ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
+      SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
       RecoveryTaskMetadataStore recoveryTaskMetadataStore =
           new RecoveryTaskMetadataStore(curatorFramework, true);
       RecoveryNodeMetadataStore recoveryNodeMetadataStore =
           new RecoveryNodeMetadataStore(curatorFramework, true);
-      CacheSlotMetadataStore cacheSlotMetadataStore =
-          new CacheSlotMetadataStore(curatorFramework, true);
+      CacheSlotMetadataStore cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
       DatasetMetadataStore datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
 
       Duration requestTimeout =

--- a/kaldb/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
@@ -91,7 +91,7 @@ public class KaldbIndexer extends AbstractExecutionThreadService {
    */
   private long indexerPreStart() throws Exception {
     LOG.info("Starting Kaldb indexer pre start.");
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
+    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
     RecoveryTaskMetadataStore recoveryTaskMetadataStore =
         new RecoveryTaskMetadataStore(curatorFramework, true);
 

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
@@ -112,8 +112,7 @@ public class IndexingChunkImplTest {
 
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
-      SnapshotMetadataStore snapshotMetadataStore =
-          new SnapshotMetadataStore(curatorFramework, true);
+      SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
       SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
 
       final LuceneIndexStoreImpl logStore =
@@ -459,8 +458,7 @@ public class IndexingChunkImplTest {
 
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
-      SnapshotMetadataStore snapshotMetadataStore =
-          new SnapshotMetadataStore(curatorFramework, true);
+      SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
       SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
 
       final LuceneIndexStoreImpl logStore =
@@ -544,7 +542,7 @@ public class IndexingChunkImplTest {
 
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
-      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
+      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
       searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
 
       final LuceneIndexStoreImpl logStore =

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
@@ -91,7 +91,7 @@ public class RecoveryChunkImplTest {
               .build();
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
-      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
+      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
       searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
 
       final LuceneIndexStoreImpl logStore =
@@ -446,7 +446,7 @@ public class RecoveryChunkImplTest {
               .build();
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
-      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
+      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
       searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
 
       final LuceneIndexStoreImpl logStore =
@@ -532,7 +532,7 @@ public class RecoveryChunkImplTest {
 
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
-      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
+      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
       searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
 
       final LuceneIndexStoreImpl logStore =

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/ChunkCleanerServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/ChunkCleanerServiceTest.java
@@ -73,7 +73,7 @@ public class ChunkCleanerServiceTest {
     chunkManagerUtil.chunkManager.startAsync();
     chunkManagerUtil.chunkManager.awaitRunning(DEFAULT_START_STOP_DURATION);
     searchMetadataStore = new SearchMetadataStore(chunkManagerUtil.getCuratorFramework(), false);
-    snapshotMetadataStore = new SnapshotMetadataStore(chunkManagerUtil.getCuratorFramework(), true);
+    snapshotMetadataStore = new SnapshotMetadataStore(chunkManagerUtil.getCuratorFramework());
   }
 
   @AfterEach
@@ -206,7 +206,7 @@ public class ChunkCleanerServiceTest {
     assertThat(snapshotNodes.get(0).partitionId).isEqualTo(TEST_KAFKA_PARTITION_ID);
     assertThat(snapshotNodes.get(0).snapshotId).startsWith(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
     assertThat(snapshotNodes.get(0).startTimeEpochMs)
-        .isCloseTo(creationTime.toEpochMilli(), Offset.offset(2500L));
+        .isCloseTo(creationTime.toEpochMilli(), Offset.offset(3000L));
     assertThat(snapshotNodes.get(0).endTimeEpochMs).isEqualTo(MAX_FUTURE_TIME);
     final List<SearchMetadata> searchNodes =
         KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore);

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
@@ -105,7 +105,7 @@ public class RecoveryChunkManagerTest {
 
     curatorFramework = CuratorBuilder.build(metricsRegistry, zkConfig);
     searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
+    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
   }
 
   @AfterEach

--- a/kaldb/src/test/java/com/slack/kaldb/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
@@ -96,7 +96,7 @@ public class DiskOrMessageCountBasedRolloverStrategyTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(metricsRegistry, zkConfig);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
+    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
     searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
@@ -726,22 +726,28 @@ public class ReplicaAssignmentServiceTest {
 
     assertThat(KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore).size()).isEqualTo(2);
     assertThat(KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).size()).isEqualTo(3);
-    assertThat(
-            KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).stream()
-                .filter(
-                    cacheSlotMetadata ->
-                        cacheSlotMetadata.cacheSlotState.equals(
-                            Metadata.CacheSlotMetadata.CacheSlotState.FREE))
-                .count())
-        .isEqualTo(2);
-    assertThat(
-            KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).stream()
-                .filter(
-                    cacheSlotMetadata ->
-                        cacheSlotMetadata.cacheSlotState.equals(
-                            Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED))
-                .count())
-        .isEqualTo(1);
+
+    await()
+        .until(
+            () ->
+                cacheSlotMetadataStore.listSync().stream()
+                        .filter(
+                            cacheSlotMetadata ->
+                                cacheSlotMetadata.cacheSlotState.equals(
+                                    Metadata.CacheSlotMetadata.CacheSlotState.FREE))
+                        .count()
+                    == 2);
+
+    await()
+        .until(
+            () ->
+                cacheSlotMetadataStore.listSync().stream()
+                        .filter(
+                            cacheSlotMetadata ->
+                                cacheSlotMetadata.cacheSlotState.equals(
+                                    Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED))
+                        .count()
+                    == 1);
 
     assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(1);

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
@@ -68,8 +68,8 @@ public class ReplicaAssignmentServiceTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework, true));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, true));
+    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
   }
 
   @AfterEach

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaCreationServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaCreationServiceTest.java
@@ -68,8 +68,8 @@ public class ReplicaCreationServiceTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, true));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, true));
+    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
   }
 
   @AfterEach
@@ -84,8 +84,8 @@ public class ReplicaCreationServiceTest {
 
   @Test
   public void shouldDoNothingIfReplicasAlreadyExist() throws Exception {
-    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework, true);
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
+    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
+    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
 
     SnapshotMetadata snapshotA =
         new SnapshotMetadata(
@@ -541,7 +541,7 @@ public class ReplicaCreationServiceTest {
         .until(
             () -> MetricsUtil.getCount(ReplicaCreationService.REPLICAS_FAILED, meterRegistry) == 1);
 
-    // reset the replica metdata store to work as expected
+    // reset the replica metadata store to work as expected
     doCallRealMethod().when(replicaMetadataStore).createAsync(any(ReplicaMetadata.class));
 
     // manually trigger the next run and see if it creates the missing replica

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaDeletionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaDeletionServiceTest.java
@@ -65,8 +65,8 @@ public class ReplicaDeletionServiceTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework, true));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, true));
+    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
   }
 
   @AfterEach

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
@@ -66,8 +66,8 @@ public class ReplicaEvictionServiceTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework, true));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, true));
+    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
   }
 
   @AfterEach

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaRestoreServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaRestoreServiceTest.java
@@ -68,7 +68,7 @@ public class ReplicaRestoreServiceTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, true));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
   }
 
   @AfterEach

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/SnapshotDeletionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/SnapshotDeletionServiceTest.java
@@ -86,8 +86,8 @@ public class SnapshotDeletionServiceTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, true));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, true));
+    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
 
     s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
@@ -88,7 +88,7 @@ public class KaldbDistributedQueryServiceTest {
 
     curatorFramework = spy(CuratorBuilder.build(metricsRegistry, zkConfig));
 
-    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, true));
+    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
     searchMetadataStore = spy(new SearchMetadataStore(curatorFramework, true));
     datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
 

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataTestUtils.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataTestUtils.java
@@ -2,12 +2,14 @@ package com.slack.kaldb.metadata.core;
 
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_ZK_TIMEOUT_SECS;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import org.apache.curator.x.async.modeled.ZPath;
+import org.apache.zookeeper.KeeperException;
 
 /**
  * This is a collection of helpful methods for writing Kaldb tests that use the KaldbMetadataStores
@@ -16,7 +18,7 @@ import org.apache.curator.x.async.modeled.ZPath;
 public class KaldbMetadataTestUtils {
 
   /**
-   * Listing an uncached directory is very expensive, and not recommended for production code. For a
+   * Listing an uncached directory is very expensive, and NOT recommended for production code. For a
    * directory containing 100 znodes this would result in 100 additional zookeeper queries after the
    * initial listing.
    *
@@ -36,6 +38,64 @@ public class KaldbMetadataTestUtils {
           .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
     } catch (ExecutionException | InterruptedException | TimeoutException e) {
       throw new InternalMetadataStoreException("Error listing node", e);
+    }
+  }
+
+  /**
+   * Variation of the listSyncUncached method allowing for a partitioning metadata store to be used.
+   * This is known to be very slow, as each call is done synchronously to build the resulting data.
+   * As this is a test-only method and operates with an in-memory ZK instance, performance here is
+   * not a significant concern. This implementation may be revisited in the future if this method
+   * becomes a bottleneck to test performance.
+   *
+   * @see KaldbMetadataTestUtils#listSyncUncached(KaldbMetadataStore store)
+   */
+  public static <T extends KaldbPartitionedMetadata> List<T> listSyncUncached(
+      KaldbPartitioningMetadataStore<T> store) {
+    try {
+      List<String> children;
+      try {
+        children =
+            store
+                .curator
+                .getChildren()
+                .forPath(store.storeFolder)
+                .toCompletableFuture()
+                .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+      } catch (ExecutionException executionException) {
+        if (executionException.getCause() instanceof KeeperException.NoNodeException) {
+          return new ArrayList<>();
+        } else {
+          throw executionException;
+        }
+      }
+
+      List<T> results = new ArrayList<>();
+      for (String child : children) {
+        String path = String.format("%s/%s", store.storeFolder, child);
+        List<String> grandchildren =
+            store
+                .curator
+                .getChildren()
+                .forPath(path)
+                .toCompletableFuture()
+                .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+
+        for (String grandchild : grandchildren) {
+          String grandchildPath = String.format("%s/%s/%s", store.storeFolder, child, grandchild);
+          results.add(
+              store.modelSerializer.deserialize(
+                  store
+                      .curator
+                      .getData()
+                      .forPath(grandchildPath)
+                      .toCompletableFuture()
+                      .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS)));
+        }
+      }
+      return results;
+    } catch (ExecutionException | InterruptedException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error listing nodes", e);
     }
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbPartitioningMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbPartitioningMetadataStoreTest.java
@@ -1,0 +1,539 @@
+package com.slack.kaldb.metadata.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.awaitility.Awaitility.await;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.slack.kaldb.proto.config.KaldbConfigs;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.curator.test.TestingServer;
+import org.apache.curator.x.async.AsyncCuratorFramework;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.server.EphemeralType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class KaldbPartitioningMetadataStoreTest {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(KaldbPartitioningMetadataStoreTest.class);
+
+  private SimpleMeterRegistry meterRegistry;
+  private TestingServer testingServer;
+  private AsyncCuratorFramework curatorFramework;
+
+  private KaldbConfigs.ZookeeperConfig zookeeperConfig;
+
+  private static final String ZNODE_CONTAINER_CHECK_INTERVAL_MS = "znode.container.checkIntervalMs";
+  private final Integer checkInterval = Integer.getInteger(ZNODE_CONTAINER_CHECK_INTERVAL_MS);
+
+  private static class ExampleMetadata extends KaldbPartitionedMetadata {
+
+    private String extraField = null;
+
+    public ExampleMetadata(String name) {
+      super(name);
+    }
+
+    @JsonCreator
+    public ExampleMetadata(
+        @JsonProperty("name") String name, @JsonProperty("extraField") String extraField) {
+      super(name);
+      this.extraField = extraField;
+    }
+
+    public void setExtraField(String extraField) {
+      this.extraField = extraField;
+    }
+
+    public String getExtraField() {
+      return extraField;
+    }
+
+    @Override
+    @JsonIgnore
+    public String getPartition() {
+      // Use up to 10 partitions
+      return String.valueOf(Math.abs(name.hashCode() % 10));
+    }
+  }
+
+  private static class ExampleMetadataSerializer implements MetadataSerializer<ExampleMetadata> {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String toJsonStr(ExampleMetadata metadata) {
+      try {
+        return objectMapper.writeValueAsString(metadata);
+      } catch (JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    public ExampleMetadata fromJsonStr(String data) {
+      try {
+        return objectMapper.readValue(data, ExampleMetadata.class);
+      } catch (JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    System.setProperty(ZNODE_CONTAINER_CHECK_INTERVAL_MS, "100");
+
+    meterRegistry = new SimpleMeterRegistry();
+    testingServer = new TestingServer();
+
+    zookeeperConfig =
+        KaldbConfigs.ZookeeperConfig.newBuilder()
+            // .setZkConnectString("127.0.0.1:2181")
+            .setZkConnectString(testingServer.getConnectString())
+            .setZkPathPrefix("Test")
+            .setZkSessionTimeoutMs(1000)
+            .setZkConnectionTimeoutMs(1000)
+            .setSleepBetweenRetriesMs(500)
+            .build();
+    this.curatorFramework = CuratorBuilder.build(meterRegistry, zookeeperConfig);
+  }
+
+  @AfterEach
+  public void tearDown() throws IOException {
+    curatorFramework.unwrap().close();
+    testingServer.close();
+    meterRegistry.close();
+
+    System.setProperty(ZNODE_CONTAINER_CHECK_INTERVAL_MS, String.valueOf(checkInterval));
+  }
+
+  @Test
+  void testLargeNumberOfZNodes() throws IOException {
+    try (KaldbPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
+        new KaldbPartitioningMetadataStore<>(
+            curatorFramework,
+            CreateMode.PERSISTENT,
+            new ExampleMetadataSerializer().toModelSerializer(),
+            "/partitioned_znodes")) {
+
+      int size = 50_000;
+
+      for (int i = 1; i <= (size / 1000); i++) {
+        for (int j = 0; j < 1000; j++) {
+          partitionedMetadataStore.createAsync(new ExampleMetadata("id" + i + "_" + j));
+        }
+
+        int finalI = i;
+        await().until(() -> partitionedMetadataStore.listSync().size() == (finalI * 1000));
+
+        LOG.info("current batch iterator {}", i);
+      }
+
+      await()
+          .atMost(Duration.ofSeconds(30))
+          .until(
+              () -> {
+                int cacheSize = partitionedMetadataStore.listSync().size();
+                LOG.info("current cache size {}", cacheSize);
+                return cacheSize == size;
+              });
+    }
+  }
+
+  @Test
+  void testCreate() throws IOException {
+    try (KaldbPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
+        new KaldbPartitioningMetadataStore<>(
+            curatorFramework,
+            CreateMode.PERSISTENT,
+            new ExampleMetadataSerializer().toModelSerializer(),
+            "/partitioned_create")) {
+
+      ExampleMetadata exampleMetadata = new ExampleMetadata("id");
+      partitionedMetadataStore.createSync(exampleMetadata);
+
+      await().until(() -> partitionedMetadataStore.listSync().size() == 1);
+      await()
+          .until(
+              () -> {
+                List<ExampleMetadata> snapshotMetadataList = partitionedMetadataStore.listSync();
+                return snapshotMetadataList.contains(exampleMetadata)
+                    && snapshotMetadataList.size() == 1;
+              });
+    }
+  }
+
+  @Test
+  void testUpdate() throws IOException {
+    try (KaldbPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
+        new KaldbPartitioningMetadataStore<>(
+            curatorFramework,
+            CreateMode.PERSISTENT,
+            new ExampleMetadataSerializer().toModelSerializer(),
+            "/partitioned_update")) {
+
+      ExampleMetadata exampleMetadata = new ExampleMetadata("id");
+      partitionedMetadataStore.createAsync(exampleMetadata);
+
+      AtomicReference<List<ExampleMetadata>> exampleMetadataList = new AtomicReference<>();
+      await()
+          .until(
+              () -> {
+                exampleMetadataList.set(partitionedMetadataStore.listSync());
+                return exampleMetadataList.get().size() == 1;
+              });
+      assertThat(exampleMetadataList.get()).containsExactly(exampleMetadata);
+
+      exampleMetadata.setExtraField("foo");
+      partitionedMetadataStore.updateSync(exampleMetadata);
+
+      await()
+          .until(
+              () ->
+                  Objects.equals(
+                      partitionedMetadataStore.listSync().get(0).getExtraField(), "foo"));
+    }
+  }
+
+  @Test
+  void testDelete() throws IOException {
+    try (KaldbPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
+        new KaldbPartitioningMetadataStore<>(
+            curatorFramework,
+            CreateMode.PERSISTENT,
+            new ExampleMetadataSerializer().toModelSerializer(),
+            "/partitioned_delete")) {
+
+      ExampleMetadata exampleMetadata = new ExampleMetadata("id");
+      partitionedMetadataStore.createSync(exampleMetadata);
+
+      await().until(() -> partitionedMetadataStore.listSync().size() == 1);
+      await()
+          .until(
+              () -> {
+                List<ExampleMetadata> snapshotMetadataList = partitionedMetadataStore.listSync();
+                return snapshotMetadataList.contains(exampleMetadata)
+                    && snapshotMetadataList.size() == 1;
+              });
+
+      partitionedMetadataStore.deleteSync(exampleMetadata);
+      await().until(() -> partitionedMetadataStore.listSync().isEmpty());
+    }
+  }
+
+  @Test
+  void testFind() throws IOException {
+    try (KaldbPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
+        new KaldbPartitioningMetadataStore<>(
+            curatorFramework,
+            CreateMode.PERSISTENT,
+            new ExampleMetadataSerializer().toModelSerializer(),
+            "/partitioned_find")) {
+
+      String nodeName = "findme";
+      ExampleMetadata exampleMetadataToFindLater = new ExampleMetadata(nodeName);
+      partitionedMetadataStore.createSync(exampleMetadataToFindLater);
+      for (int i = 0; i < 19; i++) {
+        partitionedMetadataStore.createSync(new ExampleMetadata("node" + i));
+      }
+      await().until(() -> partitionedMetadataStore.listSync().size() == 20);
+
+      ExampleMetadata exampleMetadataFound = partitionedMetadataStore.findSync(nodeName);
+      assertThat(exampleMetadataToFindLater).isEqualTo(exampleMetadataFound);
+    }
+  }
+
+  @Test
+  void testFindMissingNode() throws IOException {
+    try (KaldbPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
+        new KaldbPartitioningMetadataStore<>(
+            curatorFramework,
+            CreateMode.PERSISTENT,
+            new ExampleMetadataSerializer().toModelSerializer(),
+            "/partitioned_find_missing")) {
+
+      assertThatExceptionOfType(InternalMetadataStoreException.class)
+          .isThrownBy(() -> partitionedMetadataStore.findSync("missing"));
+    }
+  }
+
+  @Test
+  void testDuplicateCreate() throws IOException {
+    try (KaldbPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
+        new KaldbPartitioningMetadataStore<>(
+            curatorFramework,
+            CreateMode.PERSISTENT,
+            new ExampleMetadataSerializer().toModelSerializer(),
+            "/partitioned_snapshot_duplicate_create")) {
+      ExampleMetadata exampleMetadata = new ExampleMetadata("name", "field");
+      partitionedMetadataStore.createSync(exampleMetadata);
+      await().until(() -> partitionedMetadataStore.listSync().size() == 1);
+
+      assertThatExceptionOfType(InternalMetadataStoreException.class)
+          .isThrownBy(() -> partitionedMetadataStore.createSync(exampleMetadata));
+    }
+  }
+
+  @Test
+  void testEphemeralNodeBehavior() throws IOException {
+    class PersistentMetadataStore extends KaldbPartitioningMetadataStore<ExampleMetadata> {
+      public PersistentMetadataStore() {
+        super(
+            curatorFramework,
+            CreateMode.PERSISTENT,
+            new ExampleMetadataSerializer().toModelSerializer(),
+            "/partitioned_persistent");
+      }
+    }
+
+    class EphemeralMetadataStore extends KaldbPartitioningMetadataStore<ExampleMetadata> {
+      public EphemeralMetadataStore() {
+        super(
+            curatorFramework,
+            CreateMode.EPHEMERAL,
+            new ExampleMetadataSerializer().toModelSerializer(),
+            "/partitioned_ephemeral");
+      }
+    }
+
+    ExampleMetadata metadata1 = new ExampleMetadata("foo", "va1");
+    try (KaldbPartitioningMetadataStore<ExampleMetadata> persistentStore =
+        new PersistentMetadataStore()) {
+      // create metadata
+      persistentStore.createSync(metadata1);
+
+      // do a non-cached list to ensure node has been persisted
+      assertThat(KaldbMetadataTestUtils.listSyncUncached(persistentStore))
+          .containsExactly(metadata1);
+    }
+
+    ExampleMetadata metadata2 = new ExampleMetadata("foo", "val1");
+    try (KaldbPartitioningMetadataStore<ExampleMetadata> ephemeralStore =
+        new EphemeralMetadataStore()) {
+      // create metadata
+      ephemeralStore.createSync(metadata2);
+
+      // do a non-cached list to ensure node has been persisted
+      assertThat(KaldbMetadataTestUtils.listSyncUncached(ephemeralStore))
+          .containsExactly(metadata2);
+    }
+
+    // close curator, and then instantiate a new copy
+    // This is because we cannot restart the closed curator.
+    curatorFramework.unwrap().close();
+    curatorFramework = CuratorBuilder.build(meterRegistry, zookeeperConfig);
+
+    try (KaldbPartitioningMetadataStore<ExampleMetadata> persistentStore =
+        new PersistentMetadataStore()) {
+      assertThat(persistentStore.getSync(metadata1.getPartition(), "foo")).isEqualTo(metadata1);
+    }
+
+    try (KaldbPartitioningMetadataStore<ExampleMetadata> ephemeralStore =
+        new EphemeralMetadataStore()) {
+      assertThatExceptionOfType(InternalMetadataStoreException.class)
+          .isThrownBy(() -> ephemeralStore.getSync(metadata2.getPartition(), "foo"));
+    }
+  }
+
+  @Test
+  void testListenersWithZkReconnect() throws Exception {
+    class TestMetadataStore extends KaldbPartitioningMetadataStore<ExampleMetadata> {
+      public TestMetadataStore() {
+        super(
+            curatorFramework,
+            CreateMode.PERSISTENT,
+            new ExampleMetadataSerializer().toModelSerializer(),
+            "/partitioned_zk_reconnect");
+      }
+    }
+
+    try (KaldbPartitioningMetadataStore<ExampleMetadata> store = new TestMetadataStore()) {
+      AtomicInteger counter = new AtomicInteger(0);
+      KaldbMetadataStoreChangeListener<ExampleMetadata> listener =
+          (testMetadata) -> counter.incrementAndGet();
+      store.addListener(listener);
+
+      await().until(() -> counter.get() == 0);
+
+      // create metadata
+      ExampleMetadata metadata1 = new ExampleMetadata("foo", "val1");
+      store.createSync(metadata1);
+
+      await().until(() -> counter.get() == 1);
+
+      testingServer.restart();
+
+      assertThat(store.getSync(metadata1.getPartition(), metadata1.name)).isEqualTo(metadata1);
+      assertThat(counter.get()).isEqualTo(1);
+
+      metadata1.setExtraField("val2");
+      store.updateSync(metadata1);
+
+      await().until(() -> counter.get() == 2);
+    }
+  }
+
+  @Test
+  void testListenersOnAddRemoveNodes()
+      throws ExecutionException, InterruptedException, IOException {
+    try (KaldbPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
+        new KaldbPartitioningMetadataStore<>(
+            curatorFramework,
+            CreateMode.PERSISTENT,
+            new ExampleMetadataSerializer().toModelSerializer(),
+            "/partitioned_snapshot_listeners")) {
+
+      AtomicInteger counter = new AtomicInteger(0);
+      partitionedMetadataStore.addListener(
+          (metadata) -> {
+            counter.incrementAndGet();
+          });
+
+      int size = 100;
+      Queue<ExampleMetadata> addedMetadata = new ArrayBlockingQueue<>(size);
+      for (int i = 1; i <= size; i++) {
+        ExampleMetadata exampleMetadata = new ExampleMetadata("id" + i);
+        partitionedMetadataStore.createAsync(exampleMetadata);
+        addedMetadata.add(exampleMetadata);
+      }
+
+      await()
+          .until(
+              () -> {
+                int currentSize = partitionedMetadataStore.listSync().size();
+                LOG.info("Current size - {}", currentSize);
+                return currentSize == size;
+              });
+
+      // this can be higher than 100, due to container znodes contributing events during clean
+      assertThat(counter.get()).isGreaterThanOrEqualTo(size);
+
+      List<String> partitions =
+          curatorFramework
+              .getChildren()
+              .forPath("/partitioned_snapshot_listeners")
+              .toCompletableFuture()
+              .get();
+
+      partitions.forEach(
+          partition -> {
+            curatorFramework
+                .checkExists()
+                .forPath("/partitioned_snapshot_listeners/" + partition)
+                .thenAccept(
+                    stat -> {
+                      EphemeralType ephemeralType = EphemeralType.get(stat.getEphemeralOwner());
+                      // This is not clear why this is reported as a VOID type when inspecting the
+                      // nodes created. The persisted type is correct, but upon fetching later it
+                      // appears unset. This behavior is consistent directly using ZK or via
+                      // Curator, so we cannot do asserts on the node type here.
+                      LOG.info("Curator checked ephemeralType - {}", ephemeralType.toString());
+                    });
+          });
+
+      LOG.info("Deleting nodes");
+      for (int i = 0; i < 50; i++) {
+        ExampleMetadata toRemove = addedMetadata.remove();
+        partitionedMetadataStore.deleteAsync(toRemove);
+      }
+
+      await().until(() -> partitionedMetadataStore.listSync().size() == 50);
+      // this can be higher than 150, due to container znodes contributing events during clean
+      assertThat(counter.get()).isGreaterThanOrEqualTo(150);
+
+      for (int i = 0; i < 50; i++) {
+        ExampleMetadata toRemove = addedMetadata.remove();
+        partitionedMetadataStore.deleteAsync(toRemove);
+      }
+
+      await().until(() -> partitionedMetadataStore.listSync().size() == 0);
+      // this can be higher than 200, due to container znodes contributing events during clean
+      await().until(counter::get, (value) -> value >= 200);
+
+      await()
+          .until(
+              () -> {
+                if (curatorFramework
+                        .checkExists()
+                        .forPath("/partitioned_snapshot_listeners")
+                        .toCompletableFuture()
+                        .get()
+                    == null) {
+                  LOG.info("Parent node no longer exists");
+                  return true;
+                }
+
+                int childrenSize =
+                    curatorFramework
+                        .getChildren()
+                        .forPath("/partitioned_snapshot_listeners")
+                        .toCompletableFuture()
+                        .get()
+                        .size();
+                LOG.info("Children size - {}", childrenSize);
+                return childrenSize == 0;
+              });
+    }
+  }
+
+  @Test
+  void testAddRemoveListener() throws Exception {
+    class TestMetadataStore extends KaldbPartitioningMetadataStore<ExampleMetadata> {
+      public TestMetadataStore() {
+        super(
+            curatorFramework,
+            CreateMode.PERSISTENT,
+            new ExampleMetadataSerializer().toModelSerializer(),
+            "/partitioned_add_remove_listeners");
+      }
+    }
+
+    try (KaldbPartitioningMetadataStore<ExampleMetadata> store = new TestMetadataStore()) {
+      AtomicInteger counter = new AtomicInteger(0);
+      KaldbMetadataStoreChangeListener<ExampleMetadata> listener =
+          (testMetadata) -> counter.incrementAndGet();
+      store.addListener(listener);
+
+      await().until(() -> counter.get() == 0);
+
+      // create metadata
+      ExampleMetadata metadata1 = new ExampleMetadata("foo", "val1");
+      store.createSync(metadata1);
+
+      await().until(() -> counter.get() == 1);
+
+      assertThat(store.getSync(metadata1.getPartition(), metadata1.name)).isEqualTo(metadata1);
+      assertThat(counter.get()).isEqualTo(1);
+
+      metadata1.setExtraField("val2");
+      store.updateSync(metadata1);
+
+      await().until(() -> counter.get() == 2);
+
+      store.removeListener(listener);
+      metadata1.setExtraField("val3");
+      store.updateSync(metadata1);
+
+      Thread.sleep(2000);
+      assertThat(counter.get()).isEqualTo(2);
+    }
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbPartitioningMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbPartitioningMetadataStoreTest.java
@@ -118,11 +118,10 @@ class KaldbPartitioningMetadataStoreTest {
 
   @AfterEach
   public void tearDown() throws IOException {
+    System.setProperty(ZNODE_CONTAINER_CHECK_INTERVAL_MS, String.valueOf(checkInterval));
     curatorFramework.unwrap().close();
     testingServer.close();
     meterRegistry.close();
-
-    System.setProperty(ZNODE_CONTAINER_CHECK_INTERVAL_MS, String.valueOf(checkInterval));
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbPartitioningMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbPartitioningMetadataStoreTest.java
@@ -531,6 +531,7 @@ class KaldbPartitioningMetadataStoreTest {
       metadata1.setExtraField("val3");
       store.updateSync(metadata1);
 
+      // Sleep here to verify that we're not still firing and it's just slow / another thread
       Thread.sleep(2000);
       assertThat(counter.get()).isEqualTo(2);
     }

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -119,7 +119,7 @@ public class KaldbIndexerTest {
     chunkManagerUtil.chunkManager.startAsync();
     chunkManagerUtil.chunkManager.awaitRunning(DEFAULT_START_STOP_DURATION);
 
-    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, true));
+    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
     recoveryTaskStore = spy(new RecoveryTaskMetadataStore(curatorFramework, false));
     searchMetadataStore = spy(new SearchMetadataStore(curatorFramework, false));
 

--- a/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
@@ -78,8 +78,8 @@ public class ManagerApiGrpcTest {
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
     datasetMetadataStore = spy(new DatasetMetadataStore(curatorFramework, true));
-    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, true));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, true));
+    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
 
     KaldbConfigs.ManagerConfig.ReplicaRestoreServiceConfig replicaRecreationServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaRestoreServiceConfig.newBuilder()
@@ -351,6 +351,13 @@ public class ManagerApiGrpcTest {
             .setThroughputBytes(throughputBytes)
             .addAllPartitionIds(List.of("1", "2"))
             .build());
+    await()
+        .until(
+            () ->
+                datasetMetadataStore.listSync().size() == 1
+                    && datasetMetadataStore.listSync().get(0).getThroughputBytes()
+                        == throughputBytes);
+
     Metadata.DatasetMetadata firstAssignment =
         managerApiStub.getDatasetMetadata(
             ManagerApi.GetDatasetMetadataRequest.newBuilder().setName(datasetName).build());


### PR DESCRIPTION
###  Summary

Introduces a new ZK partitioning store. This works on the principle that the metadata classes will define a partitioning logic specific to their data, and then the new partitioning store will handle mapping these partitions to separate caches. This results in a slightly higher [[1]](#known-tradeoffs) memory pressure in favor of enabling scalability. For stores not operating on znodes by path this is an entirely transparent swap.

#### Example

SnapshotMetadata used to be stored to `/snapshot/{name}`. We now implement the following partitioning method:

```java
  @Override
  public String getPartition() {
    if (isLive(this)) {
      return "LIVE";
    } else {
      ZonedDateTime snapshotTime = Instant.ofEpochMilli(startTimeEpochMs).atZone(ZoneOffset.UTC);
      return String.format(
          "%s_%s",
          snapshotTime.getLong(ChronoField.EPOCH_DAY),
          snapshotTime.getLong(ChronoField.HOUR_OF_DAY));
    }
  }
```

This results in partitions that look like `/snapshot/19508_0/{name1}`, where the first portion is the days since epoch, and the second portion is the current hour of the day (0 - 23). For metadata that doesn't contain date information (for example, cache slots) a different partitioning logic can be used (ie, `/cacheSlot/{hostname}/{slotId}`).

#### Implementation

Switching a specific metadata store to use the partitioning should need the following steps performed:

1. Change the target metadata to extend a `KaldbPartionedMetadata` and implement the new `getPartition()` method
2. Change the metadata store to extend a `KaldbPartitioningMetadataStore`, making changes as required (constructor, some methods).
3. (_optional - recommended_) Change the zk path to something different, such as `/partitioned_{foo}`. This is because the new store is not backwards compatible with the existing ZK data.

#### Known tradeoffs
1. This will result in higher memory pressure. The entire dataset will be cached in memory regardless if the partitioning logic is used or not, but extra overhead comes from the separate modeled frameworks, and associated listeners.
2. This removes the strict guarantee preventing duplicate node names. Since these can exist in separate paths now, we do not atomically ensure that the sibling paths do not contain a matching node ID.

#### References
https://github.com/slackhq/kaldb/pull/543
https://github.com/slackhq/kaldb/pull/566
https://github.com/slackhq/kaldb/pull/562
https://github.com/slackhq/kaldb/pull/564
https://github.com/slackhq/kaldb/pull/567
https://github.com/slackhq/kaldb/pull/570
