### PR TITLE
Add hostname to cache slot metadata

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
@@ -59,8 +59,9 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
 
   private final String dataDirectoryPrefix;
   private final String s3Bucket;
-  private final SearchContext searchContext;
+  protected final SearchContext searchContext;
   protected final String slotName;
+  private final String slotId;
   private final CacheSlotMetadataStore cacheSlotMetadataStore;
   private final ReplicaMetadataStore replicaMetadataStore;
   private final SnapshotMetadataStore snapshotMetadataStore;
@@ -91,13 +92,13 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
       SearchMetadataStore searchMetadataStore,
       ExecutorService executorService)
       throws Exception {
-    String slotId = UUID.randomUUID().toString();
     this.meterRegistry = meterRegistry;
     this.blobFs = blobFs;
     this.s3Bucket = s3Bucket;
     this.dataDirectoryPrefix = dataDirectoryPrefix;
     this.executorService = executorService;
     this.searchContext = searchContext;
+    this.slotId = UUID.randomUUID().toString();
     this.slotName = String.format("%s-%s", searchContext.hostname, slotId);
 
     this.cacheSlotMetadataStore = cacheSlotMetadataStore;
@@ -111,7 +112,8 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
             Metadata.CacheSlotMetadata.CacheSlotState.FREE,
             "",
             Instant.now().toEpochMilli(),
-            List.of(Metadata.IndexType.LOGS_LUCENE9));
+            List.of(Metadata.IndexType.LOGS_LUCENE9),
+            searchContext.hostname);
     cacheSlotMetadataStore.createSync(cacheSlotMetadata);
 
     CacheSlotMetadataStore cacheSlotListenerMetadataStore =

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadata.java
@@ -12,6 +12,7 @@ import java.util.List;
  * Make transitions more controlled via a state machine like API.
  */
 public class CacheSlotMetadata extends KaldbMetadata {
+  public final String hostname;
   public final Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState;
   public final String replicaId;
   public final long updatedTimeEpochMs;
@@ -22,8 +23,10 @@ public class CacheSlotMetadata extends KaldbMetadata {
       Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState,
       String replicaId,
       long updatedTimeEpochMs,
-      List<Metadata.IndexType> supportedIndexTypes) {
+      List<Metadata.IndexType> supportedIndexTypes,
+      String hostname) {
     super(name);
+    checkArgument(hostname != null && !hostname.isEmpty(), "Hostname cannot be null or empty");
     checkArgument(cacheSlotState != null, "Cache slot state cannot be null");
     checkArgument(updatedTimeEpochMs > 0, "Updated time must be greater than 0");
     checkArgument(
@@ -39,6 +42,7 @@ public class CacheSlotMetadata extends KaldbMetadata {
           "If cache slot is not free, replicaId must not be empty");
     }
 
+    this.hostname = hostname;
     this.cacheSlotState = cacheSlotState;
     this.replicaId = replicaId;
     this.updatedTimeEpochMs = updatedTimeEpochMs;
@@ -48,12 +52,11 @@ public class CacheSlotMetadata extends KaldbMetadata {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof CacheSlotMetadata)) return false;
+    if (!(o instanceof CacheSlotMetadata that)) return false;
     if (!super.equals(o)) return false;
 
-    CacheSlotMetadata that = (CacheSlotMetadata) o;
-
     if (updatedTimeEpochMs != that.updatedTimeEpochMs) return false;
+    if (!hostname.equals(that.hostname)) return false;
     if (cacheSlotState != that.cacheSlotState) return false;
     if (!replicaId.equals(that.replicaId)) return false;
     return supportedIndexTypes.equals(that.supportedIndexTypes);
@@ -62,6 +65,7 @@ public class CacheSlotMetadata extends KaldbMetadata {
   @Override
   public int hashCode() {
     int result = super.hashCode();
+    result = 31 * result + hostname.hashCode();
     result = 31 * result + cacheSlotState.hashCode();
     result = 31 * result + replicaId.hashCode();
     result = 31 * result + (int) (updatedTimeEpochMs ^ (updatedTimeEpochMs >>> 32));
@@ -72,7 +76,10 @@ public class CacheSlotMetadata extends KaldbMetadata {
   @Override
   public String toString() {
     return "CacheSlotMetadata{"
-        + "cacheSlotState="
+        + "hostname='"
+        + hostname
+        + '\''
+        + ", cacheSlotState="
         + cacheSlotState
         + ", replicaId='"
         + replicaId

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializer.java
@@ -14,7 +14,8 @@ public class CacheSlotMetadataSerializer implements MetadataSerializer<CacheSlot
             cacheSlotMetadataProto.getCacheSlotState().name()),
         cacheSlotMetadataProto.getReplicaId(),
         cacheSlotMetadataProto.getUpdatedTimeEpochMs(),
-        cacheSlotMetadataProto.getSupportedIndexTypesList());
+        cacheSlotMetadataProto.getSupportedIndexTypesList(),
+        cacheSlotMetadataProto.getHostname());
   }
 
   private static Metadata.CacheSlotMetadata toCacheSlotMetadataProto(CacheSlotMetadata metadata) {
@@ -24,6 +25,7 @@ public class CacheSlotMetadataSerializer implements MetadataSerializer<CacheSlot
         .setCacheSlotState(metadata.cacheSlotState)
         .setUpdatedTimeEpochMs(metadata.updatedTimeEpochMs)
         .addAllSupportedIndexTypes(metadata.supportedIndexTypes)
+        .setHostname(metadata.hostname)
         .build();
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStore.java
@@ -74,7 +74,8 @@ public class CacheSlotMetadataStore extends KaldbMetadataStore<CacheSlotMetadata
             newState,
             replicaId,
             Instant.now().toEpochMilli(),
-            cacheSlotMetadata.supportedIndexTypes);
+            cacheSlotMetadata.supportedIndexTypes,
+            cacheSlotMetadata.hostname);
     // todo - consider refactoring this to return a completable future instead
     return JdkFutureAdapters.listenInPoolThread(
         updateAsync(updatedChunkMetadata).toCompletableFuture());

--- a/kaldb/src/main/proto/metadata.proto
+++ b/kaldb/src/main/proto/metadata.proto
@@ -33,6 +33,9 @@ message CacheSlotMetadata {
 
   // Index types supported by cache slot.
   repeated IndexType supported_index_types = 5;
+
+  // Unique string identifying the host
+  string hostname = 6;
 }
 
 message ReplicaMetadata {

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -473,7 +473,8 @@ public class ReadOnlyChunkImplTest {
             Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
             replicaId,
             Instant.now().toEpochMilli(),
-            List.of(LOGS_LUCENE9));
+            List.of(LOGS_LUCENE9),
+            readOnlyChunk.searchContext.hostname);
     cacheSlotMetadataStore.updateAsync(updatedCacheSlotMetadata);
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Test;
 public class ReplicaAssignmentServiceTest {
 
   private static final List<Metadata.IndexType> SUPPORTED_INDEX_TYPES = List.of(LOGS_LUCENE9);
+  public static final String HOSTNAME = "hostname";
 
   private TestingServer testingServer;
   private MeterRegistry meterRegistry;
@@ -240,7 +241,8 @@ public class ReplicaAssignmentServiceTest {
               Metadata.CacheSlotMetadata.CacheSlotState.FREE,
               "",
               Instant.now().toEpochMilli(),
-              SUPPORTED_INDEX_TYPES);
+              SUPPORTED_INDEX_TYPES,
+              HOSTNAME);
       cacheSlotMetadataList.add(cacheSlotMetadata);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
@@ -308,7 +310,8 @@ public class ReplicaAssignmentServiceTest {
               Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
               replicaMetadataList.get(i).name,
               Instant.now().toEpochMilli(),
-              SUPPORTED_INDEX_TYPES);
+              SUPPORTED_INDEX_TYPES,
+              HOSTNAME);
       cacheSlotMetadataList.add(cacheSlotMetadata);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
@@ -320,7 +323,8 @@ public class ReplicaAssignmentServiceTest {
               Metadata.CacheSlotMetadata.CacheSlotState.FREE,
               "",
               Instant.now().toEpochMilli(),
-              SUPPORTED_INDEX_TYPES);
+              SUPPORTED_INDEX_TYPES,
+              HOSTNAME);
       cacheSlotMetadataList.add(cacheSlotMetadata);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
@@ -388,7 +392,8 @@ public class ReplicaAssignmentServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
             replicaMetadataList.get(0).name,
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
     unmutatedSlots.add(cacheSlotWithAssignment);
     cacheSlotMetadataStore.createAsync(cacheSlotWithAssignment);
 
@@ -398,7 +403,8 @@ public class ReplicaAssignmentServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.LIVE,
             replicaMetadataList.get(1).name,
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
     unmutatedSlots.add(cacheSlotLive);
     cacheSlotMetadataStore.createAsync(cacheSlotLive);
 
@@ -408,7 +414,8 @@ public class ReplicaAssignmentServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
             replicaMetadataList.get(2).name,
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
     unmutatedSlots.add(cacheSlotEvicting);
     cacheSlotMetadataStore.createAsync(cacheSlotEvicting);
 
@@ -418,7 +425,8 @@ public class ReplicaAssignmentServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.FREE,
             "",
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
     cacheSlotMetadataStore.createAsync(cacheSlotFree);
 
     await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 4);
@@ -494,7 +502,8 @@ public class ReplicaAssignmentServiceTest {
               Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
               replicaMetadataList.get(i).name,
               Instant.now().toEpochMilli(),
-              SUPPORTED_INDEX_TYPES);
+              SUPPORTED_INDEX_TYPES,
+              HOSTNAME);
       cacheSlotMetadataList.add(cacheSlotMetadata);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
@@ -586,7 +595,8 @@ public class ReplicaAssignmentServiceTest {
               Metadata.CacheSlotMetadata.CacheSlotState.FREE,
               "",
               Instant.now().toEpochMilli(),
-              SUPPORTED_INDEX_TYPES);
+              SUPPORTED_INDEX_TYPES,
+              HOSTNAME);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
@@ -675,7 +685,8 @@ public class ReplicaAssignmentServiceTest {
               Metadata.CacheSlotMetadata.CacheSlotState.FREE,
               "",
               Instant.now().toEpochMilli(),
-              SUPPORTED_INDEX_TYPES);
+              SUPPORTED_INDEX_TYPES,
+              HOSTNAME);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
@@ -793,7 +804,8 @@ public class ReplicaAssignmentServiceTest {
               Metadata.CacheSlotMetadata.CacheSlotState.FREE,
               "",
               Instant.now().toEpochMilli(),
-              SUPPORTED_INDEX_TYPES);
+              SUPPORTED_INDEX_TYPES,
+              HOSTNAME);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
@@ -891,7 +903,8 @@ public class ReplicaAssignmentServiceTest {
               Metadata.CacheSlotMetadata.CacheSlotState.FREE,
               "",
               Instant.now().toEpochMilli(),
-              SUPPORTED_INDEX_TYPES);
+              SUPPORTED_INDEX_TYPES,
+              HOSTNAME);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
@@ -964,7 +977,8 @@ public class ReplicaAssignmentServiceTest {
               Metadata.CacheSlotMetadata.CacheSlotState.FREE,
               "",
               Instant.now().toEpochMilli(),
-              SUPPORTED_INDEX_TYPES);
+              SUPPORTED_INDEX_TYPES,
+              HOSTNAME);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
@@ -1076,7 +1090,8 @@ public class ReplicaAssignmentServiceTest {
               Metadata.CacheSlotMetadata.CacheSlotState.FREE,
               "",
               Instant.now().toEpochMilli(),
-              SUPPORTED_INDEX_TYPES);
+              SUPPORTED_INDEX_TYPES,
+              HOSTNAME);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
@@ -1159,7 +1174,8 @@ public class ReplicaAssignmentServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.FREE,
             "",
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
 
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     await()
@@ -1227,7 +1243,8 @@ public class ReplicaAssignmentServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.FREE,
             "",
             Instant.now().toEpochMilli(),
-            suppportedIndexTypes);
+            suppportedIndexTypes,
+            HOSTNAME);
 
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     await()

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaDeletionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaDeletionServiceTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Test;
 
 public class ReplicaDeletionServiceTest {
   public static final List<Metadata.IndexType> SUPPORTED_INDEX_TYPES = List.of(LOGS_LUCENE9);
+  public static final String HOSTNAME = "hostname";
   private TestingServer testingServer;
   private MeterRegistry meterRegistry;
 
@@ -157,7 +158,8 @@ public class ReplicaDeletionServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.FREE,
             "",
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
     await().until(() -> replicaMetadataStore.getCachedSync().size() == 1);
@@ -215,7 +217,8 @@ public class ReplicaDeletionServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
             replicaMetadataList.get(0).name,
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadataAssigned);
 
     CacheSlotMetadata cacheSlotMetadataEvict =
@@ -224,7 +227,8 @@ public class ReplicaDeletionServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.EVICT,
             replicaMetadataList.get(1).name,
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadataEvict);
 
     CacheSlotMetadata cacheSlotMetadataEvicting =
@@ -233,7 +237,8 @@ public class ReplicaDeletionServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.EVICTING,
             replicaMetadataList.get(2).name,
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadataEvicting);
 
     await().until(() -> replicaMetadataStore.getCachedSync().size() == 3);
@@ -290,7 +295,8 @@ public class ReplicaDeletionServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.FREE,
             "",
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
     await().until(() -> replicaMetadataStore.getCachedSync().size() == 1);
@@ -344,7 +350,8 @@ public class ReplicaDeletionServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.FREE,
             "",
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
     await().until(() -> replicaMetadataStore.getCachedSync().size() == 1);
@@ -425,7 +432,8 @@ public class ReplicaDeletionServiceTest {
               Metadata.CacheSlotMetadata.CacheSlotState.FREE,
               "",
               Instant.now().toEpochMilli(),
-              SUPPORTED_INDEX_TYPES);
+              SUPPORTED_INDEX_TYPES,
+              HOSTNAME);
       cacheSlotMetadataList.add(cacheSlotMetadata);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
@@ -531,7 +539,8 @@ public class ReplicaDeletionServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.FREE,
             "",
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadataUnassigned);
 
     CacheSlotMetadata cacheSlotMetadataAssigned =
@@ -540,7 +549,8 @@ public class ReplicaDeletionServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
             replicaMetadataAssigned.name,
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadataAssigned);
 
     await().until(() -> replicaMetadataStore.getCachedSync().size() == 2);

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Test;
 
 public class ReplicaEvictionServiceTest {
   private static final List<Metadata.IndexType> SUPPORTED_INDEX_TYPES = List.of(LOGS_LUCENE9);
+  public static final String HOSTNAME = "hostname";
   private TestingServer testingServer;
   private MeterRegistry meterRegistry;
 
@@ -174,7 +175,8 @@ public class ReplicaEvictionServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
             replicas.get(0).name,
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
     cacheSlots.add(cacheSlotAssigned);
     cacheSlotMetadataStore.createAsync(cacheSlotAssigned);
 
@@ -184,7 +186,8 @@ public class ReplicaEvictionServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.LIVE,
             replicas.get(1).name,
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
     cacheSlots.add(cacheSlotLive);
     cacheSlotMetadataStore.createAsync(cacheSlotLive);
 
@@ -194,7 +197,8 @@ public class ReplicaEvictionServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.LOADING,
             replicas.get(2).name,
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
     cacheSlots.add(cacheSlotLoading);
     cacheSlotMetadataStore.createAsync(cacheSlotLoading);
 
@@ -257,7 +261,8 @@ public class ReplicaEvictionServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.LIVE,
             replicaMetadata.name,
             Instant.now().toEpochMilli(),
-            supportedIndexTypes);
+            supportedIndexTypes,
+            HOSTNAME);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     assertThat(cacheSlotMetadata.supportedIndexTypes.size()).isEqualTo(2);
 
@@ -334,7 +339,8 @@ public class ReplicaEvictionServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.LIVE,
             replicaMetadata.name,
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
     await().until(() -> replicaMetadataStore.getCachedSync().size() == 1);
@@ -408,7 +414,8 @@ public class ReplicaEvictionServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.EVICT,
             replicaMetadata.name,
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
     await().until(() -> replicaMetadataStore.getCachedSync().size() == 1);
@@ -467,7 +474,8 @@ public class ReplicaEvictionServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.EVICTING,
             replicaMetadata.name,
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
     await().until(() -> replicaMetadataStore.getCachedSync().size() == 1);
@@ -526,7 +534,8 @@ public class ReplicaEvictionServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.LIVE,
             replicaMetadata.name,
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
     await().until(() -> replicaMetadataStore.getCachedSync().size() == 1);
@@ -633,7 +642,8 @@ public class ReplicaEvictionServiceTest {
               Metadata.CacheSlotMetadata.CacheSlotState.LIVE,
               replicas.get(0).name,
               Instant.now().toEpochMilli(),
-              SUPPORTED_INDEX_TYPES);
+              SUPPORTED_INDEX_TYPES,
+              HOSTNAME);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
@@ -756,7 +766,8 @@ public class ReplicaEvictionServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.LIVE,
             replicaMetadataExpiredOne.name,
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
     cacheSlotMetadataStore.createAsync(cacheSlotReplicaExpiredOne);
 
     ReplicaMetadata replicaMetadataExpiredTwo =
@@ -774,7 +785,8 @@ public class ReplicaEvictionServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.EVICT,
             replicaMetadataExpiredTwo.name,
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
     cacheSlotMetadataStore.createAsync(cacheSlotReplicaExpireTwo);
 
     ReplicaMetadata replicaMetadataUnexpiredOne =
@@ -792,7 +804,8 @@ public class ReplicaEvictionServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.LIVE,
             replicaMetadataUnexpiredOne.name,
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
     cacheSlotMetadataStore.createAsync(cacheSlotReplicaUnexpiredOne);
 
     ReplicaMetadata replicaMetadataUnexpiredTwo =
@@ -810,7 +823,8 @@ public class ReplicaEvictionServiceTest {
             Metadata.CacheSlotMetadata.CacheSlotState.FREE,
             "",
             Instant.now().toEpochMilli(),
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            HOSTNAME);
     cacheSlotMetadataStore.createAsync(cacheSlotFree);
 
     await().until(() -> replicaMetadataStore.getCachedSync().size() == 4);

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializerTest.java
@@ -16,6 +16,7 @@ public class CacheSlotMetadataSerializerTest {
   @Test
   public void testCacheSlotMetadataSerializer() throws InvalidProtocolBufferException {
     String name = "name";
+    String hostname = "hostname";
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState =
         Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED;
     String replicaId = "123";
@@ -24,7 +25,7 @@ public class CacheSlotMetadataSerializerTest {
 
     CacheSlotMetadata cacheSlotMetadata =
         new CacheSlotMetadata(
-            name, cacheSlotState, replicaId, updatedTimeEpochMs, supportedIndexTypes);
+            name, cacheSlotState, replicaId, updatedTimeEpochMs, supportedIndexTypes, hostname);
 
     String serializedCacheSlotMetadata = serDe.toJsonStr(cacheSlotMetadata);
     assertThat(serializedCacheSlotMetadata).isNotEmpty();
@@ -34,6 +35,7 @@ public class CacheSlotMetadataSerializerTest {
     assertThat(deserializedCacheSlotMetadata).isEqualTo(cacheSlotMetadata);
 
     assertThat(deserializedCacheSlotMetadata.name).isEqualTo(name);
+    assertThat(deserializedCacheSlotMetadata.hostname).isEqualTo(hostname);
     assertThat(deserializedCacheSlotMetadata.cacheSlotState).isEqualTo(cacheSlotState);
     assertThat(deserializedCacheSlotMetadata.replicaId).isEqualTo(replicaId);
     assertThat(deserializedCacheSlotMetadata.updatedTimeEpochMs).isEqualTo(updatedTimeEpochMs);

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStoreTest.java
@@ -58,18 +58,20 @@ public class CacheSlotMetadataStoreTest {
   @Test
   public void testGetAndUpdateNonFreeCacheSlotStateSync() throws Exception {
     final String name = "slot1";
+    final String hostname = "hostname";
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState = CacheSlotState.ASSIGNED;
     final String replicaId = "3456";
     long updatedTimeEpochMs = Instant.now().toEpochMilli();
 
     final CacheSlotMetadata cacheSlotMetadata =
         new CacheSlotMetadata(
-            name, cacheSlotState, replicaId, updatedTimeEpochMs, SUPPORTED_INDEX_TYPES);
+            name, cacheSlotState, replicaId, updatedTimeEpochMs, SUPPORTED_INDEX_TYPES, hostname);
     assertThat(cacheSlotMetadata.name).isEqualTo(name);
     assertThat(cacheSlotMetadata.cacheSlotState).isEqualTo(cacheSlotState);
     assertThat(cacheSlotMetadata.replicaId).isEqualTo(replicaId);
     assertThat(cacheSlotMetadata.updatedTimeEpochMs).isEqualTo(updatedTimeEpochMs);
     assertThat(cacheSlotMetadata.supportedIndexTypes).isEqualTo(SUPPORTED_INDEX_TYPES);
+    assertThat(cacheSlotMetadata.hostname).isEqualTo(hostname);
 
     uncachedStore.createSync(cacheSlotMetadata);
     assertThat(uncachedStore.listSync().size()).isEqualTo(1);
@@ -119,18 +121,20 @@ public class CacheSlotMetadataStoreTest {
   @Test
   public void testNonFreeCacheSlotState() throws Exception {
     final String name = "slot1";
+    final String hostname = "hostname";
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState = CacheSlotState.ASSIGNED;
     final String replicaId = "3456";
     long updatedTimeEpochMs = Instant.now().toEpochMilli();
 
     final CacheSlotMetadata cacheSlotMetadata =
         new CacheSlotMetadata(
-            name, cacheSlotState, replicaId, updatedTimeEpochMs, SUPPORTED_INDEX_TYPES);
+            name, cacheSlotState, replicaId, updatedTimeEpochMs, SUPPORTED_INDEX_TYPES, hostname);
     assertThat(cacheSlotMetadata.name).isEqualTo(name);
     assertThat(cacheSlotMetadata.cacheSlotState).isEqualTo(cacheSlotState);
     assertThat(cacheSlotMetadata.replicaId).isEqualTo(replicaId);
     assertThat(cacheSlotMetadata.updatedTimeEpochMs).isEqualTo(updatedTimeEpochMs);
     assertThat(cacheSlotMetadata.supportedIndexTypes).isEqualTo(SUPPORTED_INDEX_TYPES);
+    assertThat(cacheSlotMetadata.hostname).isEqualTo(hostname);
 
     uncachedStore.createSync(cacheSlotMetadata);
     assertThat(uncachedStore.listSync().size()).isEqualTo(1);
@@ -180,6 +184,7 @@ public class CacheSlotMetadataStoreTest {
   @Test
   public void testCacheSlotStateWithReplica() throws Exception {
     String name = "slot1";
+    final String hostname = "hostname";
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState =
         Metadata.CacheSlotMetadata.CacheSlotState.FREE;
     String emptyReplicaId = "";
@@ -187,12 +192,18 @@ public class CacheSlotMetadataStoreTest {
 
     final CacheSlotMetadata cacheSlotMetadata =
         new CacheSlotMetadata(
-            name, cacheSlotState, emptyReplicaId, updatedTimeEpochMs, SUPPORTED_INDEX_TYPES);
+            name,
+            cacheSlotState,
+            emptyReplicaId,
+            updatedTimeEpochMs,
+            SUPPORTED_INDEX_TYPES,
+            hostname);
     assertThat(cacheSlotMetadata.name).isEqualTo(name);
     assertThat(cacheSlotMetadata.cacheSlotState).isEqualTo(cacheSlotState);
     assertThat(cacheSlotMetadata.replicaId).isEqualTo(emptyReplicaId);
     assertThat(cacheSlotMetadata.updatedTimeEpochMs).isEqualTo(updatedTimeEpochMs);
     assertThat(cacheSlotMetadata.supportedIndexTypes).isEqualTo(SUPPORTED_INDEX_TYPES);
+    assertThat(cacheSlotMetadata.hostname).isEqualTo(hostname);
 
     uncachedStore.createSync(cacheSlotMetadata);
     assertThat(uncachedStore.listSync().size()).isEqualTo(1);

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataTest.java
@@ -16,6 +16,7 @@ public class CacheSlotMetadataTest {
 
   @Test
   public void testCacheSlotMetadata() {
+    String hostname = "hostname";
     String name = "name";
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState =
         Metadata.CacheSlotMetadata.CacheSlotState.FREE;
@@ -24,8 +25,9 @@ public class CacheSlotMetadataTest {
 
     CacheSlotMetadata cacheSlotMetadata =
         new CacheSlotMetadata(
-            name, cacheSlotState, replicaId, updatedTimeEpochMs, SUPPORTED_INDEX_TYPES);
+            name, cacheSlotState, replicaId, updatedTimeEpochMs, SUPPORTED_INDEX_TYPES, hostname);
     assertThat(cacheSlotMetadata.name).isEqualTo(name);
+    assertThat(cacheSlotMetadata.hostname).isEqualTo(hostname);
     assertThat(cacheSlotMetadata.cacheSlotState).isEqualTo(cacheSlotState);
     assertThat(cacheSlotMetadata.replicaId).isEqualTo(replicaId);
     assertThat(cacheSlotMetadata.updatedTimeEpochMs).isEqualTo(updatedTimeEpochMs);
@@ -34,6 +36,7 @@ public class CacheSlotMetadataTest {
 
   @Test
   public void testCacheSlotEqualsHashcode() {
+    String hostname = "hostname";
     String name = "name";
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState =
         Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED;
@@ -42,30 +45,45 @@ public class CacheSlotMetadataTest {
 
     CacheSlotMetadata cacheSlot =
         new CacheSlotMetadata(
-            name, cacheSlotState, replicaId, updatedTimeEpochMs, SUPPORTED_INDEX_TYPES);
+            name, cacheSlotState, replicaId, updatedTimeEpochMs, SUPPORTED_INDEX_TYPES, hostname);
     CacheSlotMetadata cacheSlotDuplicate =
         new CacheSlotMetadata(
-            name, cacheSlotState, replicaId, updatedTimeEpochMs, SUPPORTED_INDEX_TYPES);
+            name, cacheSlotState, replicaId, updatedTimeEpochMs, SUPPORTED_INDEX_TYPES, hostname);
     CacheSlotMetadata cacheSlotDifferentState =
         new CacheSlotMetadata(
             name,
             Metadata.CacheSlotMetadata.CacheSlotState.EVICT,
             replicaId,
             updatedTimeEpochMs,
-            SUPPORTED_INDEX_TYPES);
+            SUPPORTED_INDEX_TYPES,
+            hostname);
     CacheSlotMetadata cacheSlotDifferentReplicaId =
         new CacheSlotMetadata(
-            name, cacheSlotState, "321", updatedTimeEpochMs, SUPPORTED_INDEX_TYPES);
+            name, cacheSlotState, "321", updatedTimeEpochMs, SUPPORTED_INDEX_TYPES, hostname);
     CacheSlotMetadata cacheSlotDifferentUpdatedTime =
         new CacheSlotMetadata(
-            name, cacheSlotState, replicaId, updatedTimeEpochMs + 1, SUPPORTED_INDEX_TYPES);
+            name,
+            cacheSlotState,
+            replicaId,
+            updatedTimeEpochMs + 1,
+            SUPPORTED_INDEX_TYPES,
+            hostname);
     CacheSlotMetadata cacheSlotDifferentSupportedIndexType =
         new CacheSlotMetadata(
             name,
             cacheSlotState,
             replicaId,
             updatedTimeEpochMs + 1,
-            List.of(LOGS_LUCENE9, LOGS_LUCENE9));
+            List.of(LOGS_LUCENE9, LOGS_LUCENE9),
+            hostname);
+    CacheSlotMetadata cacheSlotDifferentHostname =
+        new CacheSlotMetadata(
+            name,
+            cacheSlotState,
+            replicaId,
+            updatedTimeEpochMs,
+            SUPPORTED_INDEX_TYPES,
+            "hostname2");
 
     assertThat(cacheSlot.hashCode()).isEqualTo(cacheSlotDuplicate.hashCode());
     assertThat(cacheSlot).isEqualTo(cacheSlotDuplicate);
@@ -78,6 +96,8 @@ public class CacheSlotMetadataTest {
     assertThat(cacheSlot).isNotEqualTo(cacheSlotDifferentSupportedIndexType);
     assertThat(cacheSlot.hashCode()).isNotEqualTo(cacheSlotDifferentUpdatedTime.hashCode());
     assertThat(cacheSlot.hashCode()).isNotEqualTo(cacheSlotDifferentSupportedIndexType.hashCode());
+    assertThat(cacheSlot).isNotEqualTo(cacheSlotDifferentHostname);
+    assertThat(cacheSlot.hashCode()).isNotEqualTo(cacheSlotDifferentHostname.hashCode());
   }
 
   @Test
@@ -90,7 +110,8 @@ public class CacheSlotMetadataTest {
                     Metadata.CacheSlotMetadata.CacheSlotState.FREE,
                     "123",
                     Instant.now().toEpochMilli(),
-                    SUPPORTED_INDEX_TYPES));
+                    SUPPORTED_INDEX_TYPES,
+                    "hostname"));
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
@@ -99,7 +120,8 @@ public class CacheSlotMetadataTest {
                     Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED,
                     "",
                     Instant.now().toEpochMilli(),
-                    SUPPORTED_INDEX_TYPES));
+                    SUPPORTED_INDEX_TYPES,
+                    "hostname"));
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
@@ -108,7 +130,8 @@ public class CacheSlotMetadataTest {
                     Metadata.CacheSlotMetadata.CacheSlotState.EVICT,
                     "",
                     Instant.now().toEpochMilli(),
-                    SUPPORTED_INDEX_TYPES));
+                    SUPPORTED_INDEX_TYPES,
+                    "hostname"));
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
@@ -117,7 +140,8 @@ public class CacheSlotMetadataTest {
                     Metadata.CacheSlotMetadata.CacheSlotState.EVICTING,
                     "",
                     Instant.now().toEpochMilli(),
-                    SUPPORTED_INDEX_TYPES));
+                    SUPPORTED_INDEX_TYPES,
+                    "hostname"));
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
@@ -126,7 +150,8 @@ public class CacheSlotMetadataTest {
                     Metadata.CacheSlotMetadata.CacheSlotState.LOADING,
                     "",
                     Instant.now().toEpochMilli(),
-                    SUPPORTED_INDEX_TYPES));
+                    SUPPORTED_INDEX_TYPES,
+                    "hostname"));
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
@@ -135,7 +160,8 @@ public class CacheSlotMetadataTest {
                     Metadata.CacheSlotMetadata.CacheSlotState.LIVE,
                     "",
                     Instant.now().toEpochMilli(),
-                    SUPPORTED_INDEX_TYPES));
+                    SUPPORTED_INDEX_TYPES,
+                    "hostname"));
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
@@ -144,7 +170,8 @@ public class CacheSlotMetadataTest {
                     Metadata.CacheSlotMetadata.CacheSlotState.FREE,
                     "",
                     0,
-                    SUPPORTED_INDEX_TYPES));
+                    SUPPORTED_INDEX_TYPES,
+                    "hostname"));
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
@@ -153,8 +180,8 @@ public class CacheSlotMetadataTest {
                     Metadata.CacheSlotMetadata.CacheSlotState.FREE,
                     null,
                     Instant.now().toEpochMilli(),
-                    SUPPORTED_INDEX_TYPES));
-
+                    SUPPORTED_INDEX_TYPES,
+                    "hostname"));
     assertThatIllegalArgumentException()
         .isThrownBy(
             () -> {
@@ -163,7 +190,19 @@ public class CacheSlotMetadataTest {
                   Metadata.CacheSlotMetadata.CacheSlotState.FREE,
                   "123",
                   100000,
-                  Collections.emptyList());
+                  Collections.emptyList(),
+                  "hostname");
+            });
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () -> {
+              new CacheSlotMetadata(
+                  "name",
+                  Metadata.CacheSlotMetadata.CacheSlotState.FREE,
+                  "123",
+                  100000,
+                  SUPPORTED_INDEX_TYPES,
+                  "hostname");
             });
   }
 }


### PR DESCRIPTION
###  Summary

Adds hostname to the cache slot metadata. This will enable two future use cases, including zookeeper partitioning and better slot/replica assignments.