### PR TITLE
Refactor IndexingChunkManager tests

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/IndexingChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/IndexingChunkManager.java
@@ -85,9 +85,9 @@ public class IndexingChunkManager<T> extends ChunkManagerBase<T> {
   private boolean stopIngestion;
 
   /** Declare all the data stores used by Chunk manager here. */
-  private SnapshotMetadataStore snapshotMetadataStore;
+  protected SnapshotMetadataStore snapshotMetadataStore;
 
-  private SearchMetadataStore searchMetadataStore;
+  protected SearchMetadataStore searchMetadataStore;
 
   /**
    * For capacity planning, we want to control how many roll overs are in progress at the same time.


### PR DESCRIPTION
###  Summary

This PR primarily addresses a persistently flaky test (see 1, 2, 3). Additionally, this updates invocations for better adaption into the ZK partitioning metadata store by using the listSync invocation and using await() where needed.

Spun out of #553 