### PR TITLE
Add ZK partitioning store

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
@@ -128,9 +128,8 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
     LOG.info("Created a new read only chunk - zkSlotId: {}", slotId);
   }
 
-  private KaldbMetadataStoreChangeListener cacheNodeListener() {
-    return () -> {
-      CacheSlotMetadata cacheSlotMetadata = cacheSlotMetadataStore.getSync(slotName);
+  private KaldbMetadataStoreChangeListener<CacheSlotMetadata> cacheNodeListener() {
+    return (cacheSlotMetadata) -> {
       Metadata.CacheSlotMetadata.CacheSlotState newSlotState = cacheSlotMetadata.cacheSlotState;
 
       if (newSlotState.equals(Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED)) {

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ClusterMonitorService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ClusterMonitorService.java
@@ -27,17 +27,13 @@ public class ClusterMonitorService extends AbstractIdleService {
       MeterRegistry meterRegistry) {
 
     meterRegistry.gauge(
-        "cached_replica_nodes_size", replicaMetadataStore, store -> store.getCachedSync().size());
+        "cached_replica_nodes_size", replicaMetadataStore, store -> store.listSync().size());
     meterRegistry.gauge(
-        "cached_snapshots_size", snapshotMetadataStore, store -> store.getCachedSync().size());
+        "cached_snapshots_size", snapshotMetadataStore, store -> store.listSync().size());
     meterRegistry.gauge(
-        "cached_recovery_tasks_size",
-        recoveryTaskMetadataStore,
-        store -> store.getCachedSync().size());
+        "cached_recovery_tasks_size", recoveryTaskMetadataStore, store -> store.listSync().size());
     meterRegistry.gauge(
-        "cached_recovery_nodes_size",
-        recoveryNodeMetadataStore,
-        store -> store.getCachedSync().size());
+        "cached_recovery_nodes_size", recoveryNodeMetadataStore, store -> store.listSync().size());
 
     for (Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState :
         Metadata.CacheSlotMetadata.CacheSlotState.values()) {
@@ -46,16 +42,16 @@ public class ClusterMonitorService extends AbstractIdleService {
           List.of(Tag.of("cacheSlotState", cacheSlotState.toString())),
           cacheSlotMetadataStore,
           store ->
-              store.getCachedSync().stream()
+              store.listSync().stream()
                   .filter(
                       cacheSlotMetadata -> cacheSlotMetadata.cacheSlotState.equals(cacheSlotState))
                   .count());
     }
 
     meterRegistry.gauge(
-        "cached_cache_slots_size", cacheSlotMetadataStore, store -> store.getCachedSync().size());
+        "cached_cache_slots_size", cacheSlotMetadataStore, store -> store.listSync().size());
     meterRegistry.gauge(
-        "cached_service_nodes_size", datasetMetadataStore, store -> store.getCachedSync().size());
+        "cached_service_nodes_size", datasetMetadataStore, store -> store.listSync().size());
   }
 
   @Override

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentService.java
@@ -12,6 +12,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.JdkFutureAdapters;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.slack.kaldb.metadata.core.KaldbMetadataStoreChangeListener;
 import com.slack.kaldb.metadata.recovery.RecoveryNodeMetadata;
 import com.slack.kaldb.metadata.recovery.RecoveryNodeMetadataStore;
 import com.slack.kaldb.metadata.recovery.RecoveryTaskMetadata;
@@ -67,6 +68,11 @@ public class RecoveryTaskAssignmentService extends AbstractScheduledService {
       Executors.newSingleThreadScheduledExecutor();
   private ScheduledFuture<?> pendingTask;
 
+  private final KaldbMetadataStoreChangeListener<RecoveryTaskMetadata> recoveryTaskListener =
+      (recoveryTaskMetadata) -> runOneIteration();
+  private final KaldbMetadataStoreChangeListener<RecoveryNodeMetadata> recoveryNodeListener =
+      (recoveryNodeMetadata) -> runOneIteration();
+
   public RecoveryTaskAssignmentService(
       RecoveryTaskMetadataStore recoveryTaskMetadataStore,
       RecoveryNodeMetadataStore recoveryNodeMetadataStore,
@@ -104,12 +110,14 @@ public class RecoveryTaskAssignmentService extends AbstractScheduledService {
   @Override
   protected void startUp() throws Exception {
     LOG.info("Starting recovery task assignment service");
-    recoveryTaskMetadataStore.addListener(this::runOneIteration);
-    recoveryNodeMetadataStore.addListener(this::runOneIteration);
+    recoveryTaskMetadataStore.addListener(recoveryTaskListener);
+    recoveryNodeMetadataStore.addListener(recoveryNodeListener);
   }
 
   @Override
   protected void shutDown() throws Exception {
+    recoveryTaskMetadataStore.addListener(recoveryTaskListener);
+    recoveryNodeMetadataStore.addListener(recoveryNodeListener);
     executorService.shutdown();
     LOG.info("Closed recovery task assignment service");
   }
@@ -137,13 +145,13 @@ public class RecoveryTaskAssignmentService extends AbstractScheduledService {
     Timer.Sample assignmentTimer = Timer.start(meterRegistry);
 
     Set<String> recoveryTasksAlreadyAssigned =
-        recoveryNodeMetadataStore.getCachedSync().stream()
+        recoveryNodeMetadataStore.listSync().stream()
             .map((recoveryNodeMetadata -> recoveryNodeMetadata.recoveryTaskName))
             .filter((recoveryTaskName) -> !recoveryTaskName.isEmpty())
             .collect(Collectors.toUnmodifiableSet());
 
     List<RecoveryTaskMetadata> recoveryTasksThatNeedAssignment =
-        recoveryTaskMetadataStore.getCachedSync().stream()
+        recoveryTaskMetadataStore.listSync().stream()
             .filter(recoveryTask -> !recoveryTasksAlreadyAssigned.contains(recoveryTask.name))
             // We are currently starting with the oldest tasks first in an effort to reduce the
             // possibility of data loss, but this is likely opposite of what most users will
@@ -154,7 +162,7 @@ public class RecoveryTaskAssignmentService extends AbstractScheduledService {
             .collect(Collectors.toUnmodifiableList());
 
     List<RecoveryNodeMetadata> availableRecoveryNodes =
-        recoveryNodeMetadataStore.getCachedSync().stream()
+        recoveryNodeMetadataStore.listSync().stream()
             .filter(
                 (recoveryNodeMetadata ->
                     recoveryNodeMetadata.recoveryNodeState.equals(

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaDeletionService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaDeletionService.java
@@ -99,13 +99,13 @@ public class ReplicaDeletionService extends AbstractScheduledService {
     Timer.Sample deleteTimer = Timer.start(meterRegistry);
 
     Set<String> replicaIdsWithAssignments =
-        cacheSlotMetadataStore.getCachedSync().stream()
+        cacheSlotMetadataStore.listSync().stream()
             .map(cacheSlotMetadata -> cacheSlotMetadata.replicaId)
             .collect(Collectors.toUnmodifiableSet());
 
     AtomicInteger successCounter = new AtomicInteger(0);
     List<ListenableFuture<?>> replicaDeletions =
-        replicaMetadataStore.getCachedSync().stream()
+        replicaMetadataStore.listSync().stream()
             .filter(
                 replicaMetadata ->
                     replicaMetadata.expireAfterEpochMs < deleteOlderThan.toEpochMilli()

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaEvictionService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaEvictionService.java
@@ -104,12 +104,12 @@ public class ReplicaEvictionService extends AbstractScheduledService {
     Timer.Sample evictionTimer = Timer.start(meterRegistry);
 
     Map<String, ReplicaMetadata> replicaMetadataByReplicaId =
-        replicaMetadataStore.getCachedSync().stream()
+        replicaMetadataStore.listSync().stream()
             .collect(Collectors.toUnmodifiableMap(ReplicaMetadata::getName, Function.identity()));
 
     AtomicInteger successCounter = new AtomicInteger(0);
     List<ListenableFuture<?>> replicaEvictions =
-        cacheSlotMetadataStore.getCachedSync().stream()
+        cacheSlotMetadataStore.listSync().stream()
             .filter(
                 cacheSlotMetadata ->
                     shouldEvictReplica(

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaRestoreService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaRestoreService.java
@@ -132,7 +132,7 @@ public class ReplicaRestoreService extends AbstractScheduledService {
     List<SnapshotMetadata> snapshotsToRestore = new ArrayList<>();
     Set<String> createdReplicas = new HashSet<>();
 
-    for (ReplicaMetadata replicaMetadata : replicaMetadataStore.getCachedSync()) {
+    for (ReplicaMetadata replicaMetadata : replicaMetadataStore.listSync()) {
       createdReplicas.add(replicaMetadata.snapshotId);
     }
 

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/SnapshotDeletionService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/SnapshotDeletionService.java
@@ -149,7 +149,7 @@ public class SnapshotDeletionService extends AbstractScheduledService {
     Timer.Sample deletionTimer = Timer.start(meterRegistry);
 
     Set<String> snapshotIdsWithReplicas =
-        replicaMetadataStore.getCachedSync().stream()
+        replicaMetadataStore.listSync().stream()
             .map(replicaMetadata -> replicaMetadata.snapshotId)
             .filter(snapshotId -> snapshotId != null && !snapshotId.isEmpty())
             .collect(Collectors.toUnmodifiableSet());
@@ -163,7 +163,7 @@ public class SnapshotDeletionService extends AbstractScheduledService {
             .toEpochMilli();
     AtomicInteger successCounter = new AtomicInteger(0);
     List<ListenableFuture<?>> deletedSnapshotList =
-        snapshotMetadataStore.getCachedSync().stream()
+        snapshotMetadataStore.listSync().stream()
             // only snapshots that only contain data prior to our cutoff, and have no replicas
             .filter(
                 snapshotMetadata ->

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreChangeListener.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreChangeListener.java
@@ -1,5 +1,5 @@
 package com.slack.kaldb.metadata.core;
 
-public interface KaldbMetadataStoreChangeListener {
-  void onMetadataStoreChanged();
+public interface KaldbMetadataStoreChangeListener<T> {
+  void onMetadataStoreChanged(T model);
 }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbPartitionedMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbPartitionedMetadata.java
@@ -1,0 +1,9 @@
+package com.slack.kaldb.metadata.core;
+
+public abstract class KaldbPartitionedMetadata extends KaldbMetadata {
+  public KaldbPartitionedMetadata(String name) {
+    super(name);
+  }
+
+  public abstract String getPartition();
+}

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbPartitioningMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbPartitioningMetadataStore.java
@@ -1,0 +1,243 @@
+package com.slack.kaldb.metadata.core;
+
+import static com.slack.kaldb.server.KaldbConfig.DEFAULT_ZK_TIMEOUT_SECS;
+
+import com.google.common.collect.Sets;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import org.apache.curator.x.async.AsyncCuratorFramework;
+import org.apache.curator.x.async.modeled.ModelSerializer;
+import org.apache.zookeeper.AddWatchMode;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KaldbPartitioningMetadataStore<T extends KaldbPartitionedMetadata>
+    implements Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(KaldbPartitioningMetadataStore.class);
+
+  private final Map<String, KaldbMetadataStore<T>> metadataStoreMap = new ConcurrentHashMap<>();
+
+  private final List<KaldbMetadataStoreChangeListener<T>> listeners = new CopyOnWriteArrayList<>();
+
+  private final AsyncCuratorFramework curator;
+
+  private final String storeFolder;
+
+  private final CreateMode createMode;
+  private final ModelSerializer<T> modelSerializer;
+
+  private final Watcher watcher;
+
+  public KaldbPartitioningMetadataStore(
+      AsyncCuratorFramework curator,
+      CreateMode createMode,
+      ModelSerializer<T> modelSerializer,
+      String storeFolder) {
+    this.curator = curator;
+    this.storeFolder = storeFolder;
+    this.createMode = createMode;
+    this.modelSerializer = modelSerializer;
+    this.watcher = buildWatcher();
+
+    curator
+        .addWatch()
+        .withMode(AddWatchMode.PERSISTENT) // NOT recursive
+        .usingWatcher(watcher)
+        .forPath(storeFolder);
+
+    // init stores for each existing path
+    curator
+        .getChildren()
+        .forPath(storeFolder)
+        .exceptionallyCompose(
+            (throwable) -> {
+              if (throwable instanceof KeeperException.NoNodeException) {
+                // this isn't a problem, as the node will be created once the first one is attempted
+                return CompletableFuture.completedFuture(List.of());
+              } else {
+                return CompletableFuture.failedFuture(throwable);
+              }
+            })
+        .thenAccept((children) -> children.forEach(this::getOrCreateMetadataStore))
+        .toCompletableFuture()
+        .join();
+  }
+
+  private Watcher buildWatcher() {
+    return event -> {
+      if (event.getType().equals(Watcher.Event.EventType.NodeChildrenChanged)) {
+        curator
+            .getChildren()
+            .forPath(storeFolder)
+            .thenAcceptAsync(
+                (partitions) -> {
+                  // create internal stores foreach partition that do not already exist
+                  partitions.forEach(this::getOrCreateMetadataStore);
+
+                  // remove metadata stores that exist in memory but no longer exist on ZK
+                  Set<String> partitionsToRemove =
+                      Sets.difference(metadataStoreMap.keySet(), Sets.newHashSet(partitions));
+                  partitionsToRemove.forEach(
+                      partition -> {
+                        LOG.info("Closing unused store for partition - {}", partition);
+                        KaldbMetadataStore<T> store = metadataStoreMap.remove(partition);
+                        store.close();
+                      });
+                });
+      }
+    };
+  }
+
+  public CompletionStage<String> createAsync(T metadataNode) {
+    return getOrCreateMetadataStore(metadataNode.getPartition()).createAsync(metadataNode);
+  }
+
+  public void createSync(T metadataNode) {
+    try {
+      createAsync(metadataNode)
+          .toCompletableFuture()
+          .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error creating node " + metadataNode, e);
+    }
+  }
+
+  public CompletionStage<T> getAsync(String partition, String path) {
+    return getOrCreateMetadataStore(partition).getAsync(path);
+  }
+
+  public T getSync(String partition, String path) {
+    try {
+      return getAsync(partition, path)
+          .toCompletableFuture()
+          .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error fetching node at path " + path, e);
+    }
+  }
+
+  @Deprecated
+  public CompletionStage<T> findAsync(String path) {
+    return getOrCreateMetadataStore(findPartition(path)).getAsync(path);
+  }
+
+  @Deprecated
+  public T findSync(String path) {
+    try {
+      return findAsync(path).toCompletableFuture().get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error fetching node at path " + path, e);
+    }
+  }
+
+  public CompletionStage<Stat> updateAsync(T metadataNode) {
+    return getOrCreateMetadataStore(metadataNode.getPartition()).updateAsync(metadataNode);
+  }
+
+  public void updateSync(T metadataNode) {
+    try {
+      updateAsync(metadataNode)
+          .toCompletableFuture()
+          .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error updating node: " + metadataNode, e);
+    }
+  }
+
+  public CompletionStage<Void> deleteAsync(T metadataNode) {
+    return getOrCreateMetadataStore(metadataNode.getPartition()).deleteAsync(metadataNode);
+  }
+
+  public void deleteSync(T metadataNode) {
+    try {
+      deleteAsync(metadataNode)
+          .toCompletableFuture()
+          .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+    } catch (ExecutionException | InterruptedException | TimeoutException e) {
+      throw new InternalMetadataStoreException(
+          "Error deleting node under at path: " + metadataNode.name, e);
+    }
+  }
+
+  public CompletableFuture<List<T>> listAsync() {
+    List<CompletableFuture<List<T>>> completionStages = new ArrayList<>();
+    for (Map.Entry<String, KaldbMetadataStore<T>> metadataStoreEntry :
+        metadataStoreMap.entrySet()) {
+      completionStages.add(metadataStoreEntry.getValue().listAsync().toCompletableFuture());
+    }
+
+    return CompletableFuture.allOf(completionStages.toArray(new CompletableFuture[0]))
+        .thenApply(
+            (unused) ->
+                completionStages.stream()
+                    .map(f -> f.toCompletableFuture().join())
+                    .flatMap(List::stream)
+                    .collect(Collectors.toList()));
+  }
+
+  public List<T> listSync() {
+    try {
+      return listAsync().toCompletableFuture().get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+    } catch (ExecutionException | InterruptedException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error listing nodes", e);
+    }
+  }
+
+  private KaldbMetadataStore<T> getOrCreateMetadataStore(String partition) {
+    return metadataStoreMap.computeIfAbsent(
+        partition,
+        (p1) -> {
+          String path = String.format("%s/%s", storeFolder, p1);
+          LOG.info("Creating new metadata store for partition - {}, at path - {}", partition, path);
+
+          KaldbMetadataStore<T> newStore =
+              new KaldbMetadataStore<>(curator, createMode, modelSerializer, path);
+          listeners.forEach(newStore::addListener);
+
+          return newStore;
+        });
+  }
+
+  private String findPartition(String path) {
+    for (Map.Entry<String, KaldbMetadataStore<T>> metadataStoreEntry :
+        metadataStoreMap.entrySet()) {
+      if (metadataStoreEntry.getValue().hasSync(path)) {
+        return metadataStoreEntry.getKey();
+      }
+    }
+    throw new IllegalArgumentException();
+  }
+
+  public void addListener(KaldbMetadataStoreChangeListener<T> watcher) {
+    listeners.add(watcher);
+    metadataStoreMap.forEach((partition, store) -> listeners.forEach(store::addListener));
+  }
+
+  public void removeListener(KaldbMetadataStoreChangeListener<T> watcher) {
+    listeners.remove(watcher);
+    metadataStoreMap.forEach((partition, store) -> store.removeListener(watcher));
+  }
+
+  @Override
+  public void close() throws IOException {
+    // only remove the watcher we created, since this curator instance is a singleton
+    curator.removeWatches().removing(watcher);
+    metadataStoreMap.forEach((partition, store) -> store.close());
+  }
+}

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/core/MetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/core/MetadataSerializer.java
@@ -23,6 +23,10 @@ public interface MetadataSerializer<T extends KaldbMetadata> {
     return new ModelSerializer<>() {
       @Override
       public byte[] serialize(T model) {
+        if (model == null) {
+          return null;
+        }
+
         try {
           return toJsonStr(model).getBytes();
         } catch (Exception e) {
@@ -32,6 +36,10 @@ public interface MetadataSerializer<T extends KaldbMetadata> {
 
       @Override
       public T deserialize(byte[] bytes) {
+        if (bytes == null || bytes.length == 0) {
+          return null;
+        }
+
         try {
           return fromJsonStr(new String(bytes));
         } catch (Exception e) {

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetPartitionMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetPartitionMetadata.java
@@ -100,7 +100,7 @@ public class DatasetPartitionMetadata {
       long endTimeEpochMs,
       String dataset) {
     boolean skipDatasetFilter = (dataset.equals("*") || dataset.equals(MATCH_ALL_DATASET));
-    return datasetMetadataStore.getCachedSync().stream()
+    return datasetMetadataStore.listSync().stream()
         .filter(serviceMetadata -> skipDatasetFilter || serviceMetadata.name.equals(dataset))
         .flatMap(
             serviceMetadata -> serviceMetadata.partitionConfigs.stream()) // will always return one

--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/PreprocessorService.java
@@ -5,6 +5,7 @@ import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static com.slack.kaldb.writer.kafka.KaldbKafkaConsumer.maybeOverride;
 
 import com.google.common.util.concurrent.AbstractService;
+import com.slack.kaldb.metadata.core.KaldbMetadataStoreChangeListener;
 import com.slack.kaldb.metadata.dataset.DatasetMetadata;
 import com.slack.kaldb.metadata.dataset.DatasetMetadataStore;
 import com.slack.kaldb.metadata.dataset.DatasetPartitionMetadata;
@@ -68,6 +69,9 @@ public class PreprocessorService extends AbstractService {
   private final Timer configReloadTimer;
   public static final String CONFIG_RELOAD_TIMER = "preprocessor_config_reload_timer";
 
+  private final KaldbMetadataStoreChangeListener<DatasetMetadata> datasetMetadataListener =
+      (datasetMetadata) -> load();
+
   public PreprocessorService(
       DatasetMetadataStore datasetMetadataStore,
       KaldbConfigs.PreprocessorConfig preprocessorConfig,
@@ -112,7 +116,7 @@ public class PreprocessorService extends AbstractService {
   private void startUp() {
     LOG.info("Starting preprocessor service");
     load();
-    datasetMetadataStore.addListener(this::load);
+    datasetMetadataStore.addListener(datasetMetadataListener);
     LOG.info("Preprocessor service started");
   }
 
@@ -124,7 +128,7 @@ public class PreprocessorService extends AbstractService {
     if (kafkaStreamsMetrics != null) {
       kafkaStreamsMetrics.close();
     }
-    datasetMetadataStore.removeListener(this::load);
+    datasetMetadataStore.removeListener(datasetMetadataListener);
     LOG.info("Preprocessor service closed");
   }
 
@@ -148,7 +152,7 @@ public class PreprocessorService extends AbstractService {
 
       // only attempt to register stream processing on valid dataset configurations
       List<DatasetMetadata> datasetMetadataToProcesses =
-          filterValidDatasetMetadata(datasetMetadataStore.getCachedSync());
+          filterValidDatasetMetadata(datasetMetadataStore.listSync());
 
       if (datasetMetadataToProcesses.size() > 0) {
         Topology topology =

--- a/kaldb/src/main/java/com/slack/kaldb/server/ManagerApiGrpc.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ManagerApiGrpc.java
@@ -125,7 +125,7 @@ public class ManagerApiGrpc extends ManagerApiServiceGrpc.ManagerApiServiceImplB
       responseObserver.onNext(
           ManagerApi.ListDatasetMetadataResponse.newBuilder()
               .addAllDatasetMetadata(
-                  datasetMetadataStore.listSync().stream()
+                  datasetMetadataStore.listSyncUncached().stream()
                       .map(DatasetMetadataSerializer::toDatasetMetadataProto)
                       .collect(Collectors.toList()))
               .build());
@@ -199,7 +199,7 @@ public class ManagerApiGrpc extends ManagerApiServiceGrpc.ManagerApiServiceImplB
 
       List<SnapshotMetadata> snapshotsToRestore =
           calculateRequiredSnapshots(
-              snapshotMetadataStore.getCachedSync(),
+              snapshotMetadataStore.listSync(),
               datasetMetadataStore,
               request.getStartTimeEpochMs(),
               request.getEndTimeEpochMs(),
@@ -229,7 +229,7 @@ public class ManagerApiGrpc extends ManagerApiServiceGrpc.ManagerApiServiceImplB
     try {
       List<SnapshotMetadata> snapshotsToRestore =
           calculateRequiredSnapshots(
-              request.getIdsToRestoreList(), snapshotMetadataStore.getCachedSync());
+              request.getIdsToRestoreList(), snapshotMetadataStore.listSync());
 
       replicaRestoreService.queueSnapshotsForRestoration(snapshotsToRestore);
 

--- a/kaldb/src/main/java/com/slack/kaldb/server/RecoveryTaskCreator.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/RecoveryTaskCreator.java
@@ -150,7 +150,7 @@ public class RecoveryTaskCreator {
       LOG.warn("PartitionId can't be null.");
     }
 
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSync();
+    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
     List<SnapshotMetadata> snapshotsForPartition =
         snapshots.stream()
             .filter(
@@ -173,7 +173,7 @@ public class RecoveryTaskCreator {
             .collect(Collectors.toUnmodifiableList());
 
     // Get the highest offset that is indexed in durable store.
-    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskMetadataStore.listSync();
+    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskMetadataStore.listSyncUncached();
     long highestDurableOffsetForPartition =
         getHighestDurableOffsetForPartition(
             nonLiveSnapshotsForPartition, recoveryTasks, partitionId);

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
@@ -73,9 +73,9 @@ public class IndexingChunkImplTest {
       SnapshotMetadataStore snapshotMetadataStore,
       SearchMetadataStore searchMetadataStore,
       ReadWriteChunk<LogMessage> chunk) {
-    assertThat(snapshotMetadataStore.listSync())
+    assertThat(snapshotMetadataStore.listSyncUncached())
         .containsOnly(ChunkInfo.toSnapshotMetadata(chunk.info(), LIVE_SNAPSHOT_PREFIX));
-    final List<SearchMetadata> beforeSearchNodes = searchMetadataStore.listSync();
+    final List<SearchMetadata> beforeSearchNodes = searchMetadataStore.listSyncUncached();
     assertThat(beforeSearchNodes.size()).isEqualTo(1);
     assertThat(beforeSearchNodes.get(0).url).contains(TEST_HOST);
     assertThat(beforeSearchNodes.get(0).url).contains(String.valueOf(TEST_PORT));
@@ -565,9 +565,9 @@ public class IndexingChunkImplTest {
               TEST_KAFKA_PARTITION_ID);
       chunk.postCreate();
       closeChunk = true;
-      List<SnapshotMetadata> snapshotNodes = snapshotMetadataStore.listSync();
+      List<SnapshotMetadata> snapshotNodes = snapshotMetadataStore.listSyncUncached();
       assertThat(snapshotNodes.size()).isEqualTo(1);
-      List<SearchMetadata> searchNodes = searchMetadataStore.listSync();
+      List<SearchMetadata> searchNodes = searchMetadataStore.listSyncUncached();
       assertThat(searchNodes.size()).isEqualTo(1);
     }
 
@@ -626,13 +626,13 @@ public class IndexingChunkImplTest {
       assertThat(chunk.info().getSnapshotPath()).isEqualTo(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
 
       // Metadata checks
-      List<SnapshotMetadata> afterSnapshots = snapshotMetadataStore.listSync();
+      List<SnapshotMetadata> afterSnapshots = snapshotMetadataStore.listSyncUncached();
       assertThat(afterSnapshots.size()).isEqualTo(1);
       assertThat(afterSnapshots.get(0).partitionId).isEqualTo(TEST_KAFKA_PARTITION_ID);
       assertThat(afterSnapshots.get(0).maxOffset).isEqualTo(0);
       assertThat(afterSnapshots.get(0).snapshotPath).isEqualTo(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
 
-      List<SearchMetadata> afterSearchNodes = searchMetadataStore.listSync();
+      List<SearchMetadata> afterSearchNodes = searchMetadataStore.listSyncUncached();
       assertThat(afterSearchNodes.size()).isEqualTo(1);
       assertThat(afterSearchNodes.get(0).url).contains(TEST_HOST);
       assertThat(afterSearchNodes.get(0).url).contains(String.valueOf(TEST_PORT));
@@ -703,7 +703,7 @@ public class IndexingChunkImplTest {
       chunk.postSnapshot();
 
       // Metadata checks
-      List<SnapshotMetadata> afterSnapshots = snapshotMetadataStore.listSync();
+      List<SnapshotMetadata> afterSnapshots = snapshotMetadataStore.listSyncUncached();
       assertThat(afterSnapshots.size()).isEqualTo(2);
       assertThat(afterSnapshots).contains(ChunkInfo.toSnapshotMetadata(chunk.info(), ""));
       SnapshotMetadata liveSnapshot =
@@ -715,7 +715,7 @@ public class IndexingChunkImplTest {
       assertThat(liveSnapshot.maxOffset).isEqualTo(offset - 1);
       assertThat(liveSnapshot.snapshotPath).isEqualTo(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
 
-      List<SearchMetadata> afterSearchNodes = searchMetadataStore.listSync();
+      List<SearchMetadata> afterSearchNodes = searchMetadataStore.listSyncUncached();
       assertThat(afterSearchNodes.size()).isEqualTo(1);
       assertThat(afterSearchNodes.get(0).url).contains(TEST_HOST);
       assertThat(afterSearchNodes.get(0).url).contains(String.valueOf(TEST_PORT));

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -147,7 +147,7 @@ public class ReadOnlyChunkImplTest {
     assignReplicaToChunk(cacheSlotMetadataStore, replicaId, readOnlyChunk);
 
     // ensure that the chunk was marked LIVE
-    await().until(() -> searchMetadataStore.listSync().size() == 1);
+    await().until(() -> searchMetadataStore.listSyncUncached().size() == 1);
     assertThat(readOnlyChunk.getChunkMetadataState())
         .isEqualTo(Metadata.CacheSlotMetadata.CacheSlotState.LIVE);
 
@@ -177,11 +177,10 @@ public class ReadOnlyChunkImplTest {
         .isEqualTo(0);
 
     // ensure we registered a search node for this cache slot
-    await().until(() -> searchMetadataStore.getCachedSync().size() == 1);
-    assertThat(searchMetadataStore.getCachedSync().get(0).snapshotName).isEqualTo(snapshotId);
-    assertThat(searchMetadataStore.getCachedSync().get(0).url)
-        .isEqualTo("gproto+http://localhost:8080");
-    assertThat(searchMetadataStore.getCachedSync().get(0).name)
+    await().until(() -> searchMetadataStore.listSync().size() == 1);
+    assertThat(searchMetadataStore.listSync().get(0).snapshotName).isEqualTo(snapshotId);
+    assertThat(searchMetadataStore.listSync().get(0).url).isEqualTo("gproto+http://localhost:8080");
+    assertThat(searchMetadataStore.listSync().get(0).name)
         .isEqualTo(SearchMetadata.generateSearchContextSnapshotId(snapshotId, "localhost"));
 
     // mark the chunk for eviction
@@ -198,7 +197,7 @@ public class ReadOnlyChunkImplTest {
                     == Metadata.CacheSlotMetadata.CacheSlotState.FREE);
 
     // ensure the search metadata node was unregistered
-    await().until(() -> searchMetadataStore.getCachedSync().size() == 0);
+    await().until(() -> searchMetadataStore.listSync().size() == 0);
 
     SearchResult<LogMessage> logMessageEmptySearchResult =
         readOnlyChunk.query(
@@ -284,7 +283,7 @@ public class ReadOnlyChunkImplTest {
                     == Metadata.CacheSlotMetadata.CacheSlotState.FREE);
 
     // ensure we did not register a search node
-    assertThat(searchMetadataStore.getCachedSync().size()).isEqualTo(0);
+    assertThat(searchMetadataStore.listSync().size()).isEqualTo(0);
 
     assertThat(meterRegistry.get(CHUNK_ASSIGNMENT_TIMER).tag("successful", "true").timer().count())
         .isEqualTo(0);
@@ -352,7 +351,7 @@ public class ReadOnlyChunkImplTest {
                     == Metadata.CacheSlotMetadata.CacheSlotState.FREE);
 
     // ensure we did not register a search node
-    assertThat(searchMetadataStore.getCachedSync().size()).isEqualTo(0);
+    assertThat(searchMetadataStore.listSync().size()).isEqualTo(0);
 
     assertThat(meterRegistry.get(CHUNK_ASSIGNMENT_TIMER).tag("successful", "true").timer().count())
         .isEqualTo(0);
@@ -436,11 +435,10 @@ public class ReadOnlyChunkImplTest {
         .isEqualTo(1);
 
     // ensure we registered a search node for this cache slot
-    await().until(() -> searchMetadataStore.getCachedSync().size() == 1);
-    assertThat(searchMetadataStore.getCachedSync().get(0).snapshotName).isEqualTo(snapshotId);
-    assertThat(searchMetadataStore.getCachedSync().get(0).url)
-        .isEqualTo("gproto+http://localhost:8080");
-    assertThat(searchMetadataStore.getCachedSync().get(0).name)
+    await().until(() -> searchMetadataStore.listSync().size() == 1);
+    assertThat(searchMetadataStore.listSync().get(0).snapshotName).isEqualTo(snapshotId);
+    assertThat(searchMetadataStore.listSync().get(0).url).isEqualTo("gproto+http://localhost:8080");
+    assertThat(searchMetadataStore.listSync().get(0).name)
         .isEqualTo(SearchMetadata.generateSearchContextSnapshotId(snapshotId, "localhost"));
 
     // verify we have files on disk

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
@@ -113,8 +113,8 @@ public class RecoveryChunkImplTest {
               TEST_KAFKA_PARTITION_ID);
 
       chunk.postCreate();
-      assertThat(snapshotMetadataStore.listSync()).isEmpty();
-      assertThat(searchMetadataStore.listSync()).isEmpty();
+      assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+      assertThat(searchMetadataStore.listSyncUncached()).isEmpty();
     }
 
     @AfterEach
@@ -131,8 +131,8 @@ public class RecoveryChunkImplTest {
     @Test
     public void testAddAndSearchChunk() {
       // test no metadata stores are created post create.
-      assertThat(searchMetadataStore.listSync()).isEmpty();
-      assertThat(snapshotMetadataStore.listSync()).isEmpty();
+      assertThat(searchMetadataStore.listSyncUncached()).isEmpty();
+      assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
 
       List<LogMessage> messages = MessageUtil.makeMessagesWithTimeDifference(1, 100);
       int offset = 1;
@@ -184,8 +184,8 @@ public class RecoveryChunkImplTest {
       assertThat(getTimerCount(REFRESHES_TIMER, registry)).isEqualTo(1);
       assertThat(getTimerCount(COMMITS_TIMER, registry)).isEqualTo(1);
 
-      assertThat(searchMetadataStore.listSync()).isEmpty();
-      assertThat(snapshotMetadataStore.listSync()).isEmpty();
+      assertThat(searchMetadataStore.listSyncUncached()).isEmpty();
+      assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
     }
 
     @Test
@@ -467,8 +467,8 @@ public class RecoveryChunkImplTest {
               TEST_KAFKA_PARTITION_ID);
 
       chunk.postCreate();
-      assertThat(snapshotMetadataStore.listSync()).isEmpty();
-      assertThat(searchMetadataStore.listSync()).isEmpty();
+      assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+      assertThat(searchMetadataStore.listSyncUncached()).isEmpty();
     }
 
     @AfterEach
@@ -553,8 +553,8 @@ public class RecoveryChunkImplTest {
               new SearchContext(TEST_HOST, TEST_PORT),
               TEST_KAFKA_PARTITION_ID);
       chunk.postCreate();
-      assertThat(snapshotMetadataStore.listSync()).isEmpty();
-      assertThat(searchMetadataStore.listSync()).isEmpty();
+      assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+      assertThat(searchMetadataStore.listSyncUncached()).isEmpty();
     }
 
     @AfterEach
@@ -613,8 +613,8 @@ public class RecoveryChunkImplTest {
       assertThat(chunk.info().getSnapshotPath()).isEqualTo(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
 
       // No live snapshot or search metadata is published since the S3 snapshot failed.
-      assertThat(snapshotMetadataStore.listSync()).isEmpty();
-      assertThat(searchMetadataStore.listSync()).isEmpty();
+      assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+      assertThat(searchMetadataStore.listSyncUncached()).isEmpty();
     }
 
     // TODO: Add a test to check that the data is deleted from the file system on cleanup.
@@ -671,14 +671,14 @@ public class RecoveryChunkImplTest {
       chunk.postSnapshot();
 
       // Metadata checks
-      List<SnapshotMetadata> afterSnapshots = snapshotMetadataStore.listSync();
+      List<SnapshotMetadata> afterSnapshots = snapshotMetadataStore.listSyncUncached();
       assertThat(afterSnapshots.size()).isEqualTo(1);
       assertThat(afterSnapshots).contains(ChunkInfo.toSnapshotMetadata(chunk.info(), ""));
       assertThat(s3BlobFs.exists(URI.create(afterSnapshots.get(0).snapshotPath))).isTrue();
       // Only non-live snapshots. No live snapshots.
       assertThat(afterSnapshots.stream().filter(SnapshotMetadata::isLive).count()).isZero();
       // No search nodes are added for recovery chunk.
-      assertThat(searchMetadataStore.listSync()).isEmpty();
+      assertThat(searchMetadataStore.listSyncUncached()).isEmpty();
 
       chunk.close();
       chunk = null;

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/ChunkCleanerServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/ChunkCleanerServiceTest.java
@@ -124,7 +124,7 @@ public class ChunkCleanerServiceTest {
     assertThat(getCount(RollOverChunkTask.ROLLOVERS_INITIATED, metricsRegistry)).isEqualTo(1);
     assertThat(getCount(RollOverChunkTask.ROLLOVERS_FAILED, metricsRegistry)).isEqualTo(0);
 
-    List<SnapshotMetadata> afterSnapshots = snapshotMetadataStore.listSync();
+    List<SnapshotMetadata> afterSnapshots = snapshotMetadataStore.listSyncUncached();
     assertThat(afterSnapshots.size()).isEqualTo(2);
     assertThat(afterSnapshots).contains(ChunkInfo.toSnapshotMetadata(chunk.info(), ""));
     SnapshotMetadata liveSnapshot = fetchLiveSnapshot(afterSnapshots).get(0);
@@ -145,7 +145,7 @@ public class ChunkCleanerServiceTest {
     assertThat(nonLiveSnapshot.startTimeEpochMs).isEqualTo(startTime.toEpochMilli());
     assertThat(nonLiveSnapshot.endTimeEpochMs).isEqualTo(startTime.plusSeconds(8).toEpochMilli());
 
-    List<SearchMetadata> afterSearchNodes = searchMetadataStore.listSync();
+    List<SearchMetadata> afterSearchNodes = searchMetadataStore.listSyncUncached();
     assertThat(afterSearchNodes.size()).isEqualTo(1);
     assertThat(afterSearchNodes.get(0).url).contains(TEST_HOST);
     assertThat(afterSearchNodes.get(0).url).contains(String.valueOf(TEST_PORT));
@@ -174,7 +174,7 @@ public class ChunkCleanerServiceTest {
     assertThat(chunkManager.getChunkList().size()).isZero();
 
     // Check metadata after chunk is deleted.
-    List<SnapshotMetadata> chunkDeletedSnapshots = snapshotMetadataStore.listSync();
+    List<SnapshotMetadata> chunkDeletedSnapshots = snapshotMetadataStore.listSyncUncached();
     assertThat(chunkDeletedSnapshots.size()).isEqualTo(1);
     SnapshotMetadata nonLiveSnapshotAfterChunkDelete =
         fetchNonLiveSnapshot(chunkDeletedSnapshots).get(0);
@@ -191,11 +191,11 @@ public class ChunkCleanerServiceTest {
         .isEqualTo(startTime.toEpochMilli());
     assertThat(nonLiveSnapshotAfterChunkDelete.endTimeEpochMs)
         .isEqualTo(startTime.plusSeconds(8).toEpochMilli());
-    assertThat(searchMetadataStore.listSync()).isEmpty();
+    assertThat(searchMetadataStore.listSyncUncached()).isEmpty();
   }
 
   private void testBasicSnapshotMetadata(Instant creationTime) {
-    final List<SnapshotMetadata> snapshotNodes = snapshotMetadataStore.listSync();
+    final List<SnapshotMetadata> snapshotNodes = snapshotMetadataStore.listSyncUncached();
     assertThat(snapshotNodes.size()).isEqualTo(1);
     assertThat(snapshotNodes.get(0).snapshotPath).startsWith(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
     assertThat(snapshotNodes.get(0).maxOffset).isEqualTo(0);
@@ -204,7 +204,7 @@ public class ChunkCleanerServiceTest {
     assertThat(snapshotNodes.get(0).startTimeEpochMs)
         .isCloseTo(creationTime.toEpochMilli(), Offset.offset(2500L));
     assertThat(snapshotNodes.get(0).endTimeEpochMs).isEqualTo(MAX_FUTURE_TIME);
-    final List<SearchMetadata> searchNodes = searchMetadataStore.listSync();
+    final List<SearchMetadata> searchNodes = searchMetadataStore.listSyncUncached();
     assertThat(searchNodes.size()).isEqualTo(1);
     assertThat(searchNodes.get(0).url).contains(TEST_HOST);
     assertThat(searchNodes.get(0).url).contains(String.valueOf(TEST_PORT));
@@ -270,7 +270,7 @@ public class ChunkCleanerServiceTest {
 
     checkMetadata(4, 2, 2, 2, 0);
     assertThat(
-            snapshotMetadataStore.listSync().stream()
+            snapshotMetadataStore.listSyncUncached().stream()
                 .map(s -> s.maxOffset)
                 .sorted()
                 .collect(Collectors.toList()))
@@ -305,7 +305,7 @@ public class ChunkCleanerServiceTest {
 
     checkMetadata(3, 1, 2, 1, 0);
     assertThat(
-            snapshotMetadataStore.listSync().stream()
+            snapshotMetadataStore.listSyncUncached().stream()
                 .map(s -> s.maxOffset)
                 .sorted()
                 .collect(Collectors.toList()))
@@ -320,7 +320,7 @@ public class ChunkCleanerServiceTest {
 
     checkMetadata(2, 0, 2, 0, 0);
     assertThat(
-            snapshotMetadataStore.listSync().stream()
+            snapshotMetadataStore.listSyncUncached().stream()
                 .map(s -> s.maxOffset)
                 .sorted()
                 .collect(Collectors.toList()))
@@ -333,12 +333,12 @@ public class ChunkCleanerServiceTest {
       int expectedNonLiveSnapshotSize,
       int expectedSearchNodeSize,
       int expectedInfinitySnapshotSize) {
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSync();
+    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
     assertThat(snapshots.size()).isEqualTo(expectedSnapshotSize);
     List<SnapshotMetadata> liveSnapshots = fetchLiveSnapshot(snapshots);
     assertThat(liveSnapshots.size()).isEqualTo(expectedLiveSnapshotSize);
     assertThat(fetchNonLiveSnapshot(snapshots).size()).isEqualTo(expectedNonLiveSnapshotSize);
-    List<SearchMetadata> searchNodes = searchMetadataStore.listSync();
+    List<SearchMetadata> searchNodes = searchMetadataStore.listSyncUncached();
     assertThat(searchNodes.size()).isEqualTo(expectedSearchNodeSize);
     assertThat(liveSnapshots.stream().map(s -> s.snapshotId).collect(Collectors.toList()))
         .containsExactlyInAnyOrderElementsOf(

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
@@ -246,8 +246,8 @@ public class IndexingChunkManagerTest {
     assertThat(getValue(LIVE_BYTES_INDEXED, metricsRegistry)).isEqualTo(actualChunkSize);
 
     // Check metadata registration.
-    assertThat(snapshotMetadataStore.listSync().size()).isEqualTo(1);
-    assertThat(searchMetadataStore.listSync().size()).isEqualTo(1);
+    assertThat(snapshotMetadataStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(searchMetadataStore.listSyncUncached().size()).isEqualTo(1);
 
     SearchQuery searchQuery =
         new SearchQuery(
@@ -274,7 +274,7 @@ public class IndexingChunkManagerTest {
     assertThat(chunkInfo.getDataEndTimeEpochMs())
         .isEqualTo(messages.get(99).getTimestamp().toEpochMilli());
 
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSync();
+    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
     assertThat(snapshots.size()).isEqualTo(1);
     List<SnapshotMetadata> liveSnapshots = fetchLiveSnapshot(snapshots);
     assertThat(liveSnapshots.size()).isEqualTo(1);
@@ -287,7 +287,7 @@ public class IndexingChunkManagerTest {
         .isCloseTo(creationTime.toEpochMilli(), Offset.offset(5000L));
     assertThat(snapshots.get(0).endTimeEpochMs).isEqualTo(MAX_FUTURE_TIME);
 
-    List<SearchMetadata> searchNodes = searchMetadataStore.listSync();
+    List<SearchMetadata> searchNodes = searchMetadataStore.listSyncUncached();
     assertThat(searchNodes.size()).isEqualTo(1);
     assertThat(searchNodes.get(0).url).contains(TEST_HOST);
     assertThat(searchNodes.get(0).url).contains(String.valueOf(TEST_PORT));
@@ -602,12 +602,12 @@ public class IndexingChunkManagerTest {
       int expectedNonLiveSnapshotSize,
       int expectedSearchNodeSize,
       int expectedInfinitySnapshotsCount) {
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSync();
+    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
     assertThat(snapshots.size()).isEqualTo(expectedSnapshotSize);
     List<SnapshotMetadata> liveSnapshots = fetchLiveSnapshot(snapshots);
     assertThat(liveSnapshots.size()).isEqualTo(expectedLiveSnapshotSize);
     assertThat(fetchNonLiveSnapshot(snapshots).size()).isEqualTo(expectedNonLiveSnapshotSize);
-    List<SearchMetadata> searchNodes = searchMetadataStore.listSync();
+    List<SearchMetadata> searchNodes = searchMetadataStore.listSyncUncached();
     assertThat(searchNodes.size()).isEqualTo(expectedSearchNodeSize);
     assertThat(liveSnapshots.stream().map(s -> s.snapshotId).collect(Collectors.toList()))
         .containsExactlyInAnyOrderElementsOf(
@@ -1037,10 +1037,10 @@ public class IndexingChunkManagerTest {
     initChunkManager(
         chunkRollOverStrategy, S3_TEST_BUCKET, IndexingChunkManager.makeDefaultRollOverExecutor());
 
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-    assertThat(fetchLiveSnapshot(snapshotMetadataStore.listSync())).isEmpty();
-    assertThat(fetchNonLiveSnapshot(snapshotMetadataStore.listSync())).isEmpty();
-    assertThat(searchMetadataStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(fetchLiveSnapshot(snapshotMetadataStore.listSyncUncached())).isEmpty();
+    assertThat(fetchNonLiveSnapshot(snapshotMetadataStore.listSyncUncached())).isEmpty();
+    assertThat(searchMetadataStore.listSyncUncached()).isEmpty();
 
     // Adding a messages very quickly when running a rollover in background would result in an
     // exception.
@@ -1054,12 +1054,12 @@ public class IndexingChunkManagerTest {
             })
         .isInstanceOf(ChunkRollOverException.class);
 
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSync();
+    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
     assertThat(snapshots.size()).isEqualTo(2);
     List<SnapshotMetadata> liveSnapshots = fetchLiveSnapshot(snapshots);
     assertThat(liveSnapshots.size()).isGreaterThanOrEqualTo(2);
     assertThat(fetchNonLiveSnapshot(snapshots).size()).isEqualTo(0);
-    List<SearchMetadata> searchNodes = searchMetadataStore.listSync();
+    List<SearchMetadata> searchNodes = searchMetadataStore.listSyncUncached();
     assertThat(searchNodes.size()).isEqualTo(2);
     assertThat(liveSnapshots.stream().map(s -> s.snapshotId).collect(Collectors.toList()))
         .containsExactlyInAnyOrderElementsOf(
@@ -1105,8 +1105,8 @@ public class IndexingChunkManagerTest {
     SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
     SnapshotMetadataStore snapshotMetadataStore =
         new SnapshotMetadataStore(curatorFramework, false);
-    assertThat(searchMetadataStore.listSync()).isEmpty();
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSync();
+    assertThat(searchMetadataStore.listSyncUncached()).isEmpty();
+    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
     assertThat(snapshots.size()).isEqualTo(1);
     assertThat(fetchNonLiveSnapshot(snapshots).size()).isEqualTo(1);
     assertThat(fetchLiveSnapshot(snapshots)).isEmpty();
@@ -1157,8 +1157,8 @@ public class IndexingChunkManagerTest {
     SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
     SnapshotMetadataStore snapshotMetadataStore =
         new SnapshotMetadataStore(curatorFramework, false);
-    assertThat(searchMetadataStore.listSync()).isEmpty();
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
+    assertThat(searchMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
     searchMetadataStore.close();
     snapshotMetadataStore.close();
     // Data is lost and the indexer, we use recovery indexer to re-index this data.

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
@@ -175,8 +175,8 @@ public class RecoveryChunkManagerTest {
     assertThat(getValue(LIVE_BYTES_INDEXED, metricsRegistry)).isEqualTo(actualChunkSize);
 
     // Check metadata registration. No metadata registration until rollover.
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-    assertThat(searchMetadataStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(searchMetadataStore.listSyncUncached()).isEmpty();
 
     // Search query
     SearchQuery searchQuery =
@@ -279,8 +279,8 @@ public class RecoveryChunkManagerTest {
     assertThat(getCount(ROLLOVERS_INITIATED, metricsRegistry)).isEqualTo(1);
     assertThat(getCount(ROLLOVERS_COMPLETED, metricsRegistry)).isEqualTo(1);
     assertThat(getCount(ROLLOVERS_FAILED, metricsRegistry)).isEqualTo(0);
-    assertThat(searchMetadataStore.listSync()).isEmpty();
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSync();
+    assertThat(searchMetadataStore.listSyncUncached()).isEmpty();
+    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
     assertThat(snapshots.size()).isEqualTo(1);
     assertThat(snapshots.get(0).startTimeEpochMs)
         .isEqualTo(messages.get(0).getTimestamp().toEpochMilli());
@@ -350,12 +350,12 @@ public class RecoveryChunkManagerTest {
     testChunkManagerSearch(chunkManager, "Message100", 1);
 
     // Check metadata.
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSync();
+    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
     assertThat(snapshots.size()).isEqualTo(0);
     List<SnapshotMetadata> liveSnapshots = fetchLiveSnapshot(snapshots);
     assertThat(liveSnapshots.size()).isZero();
     assertThat(fetchNonLiveSnapshot(snapshots).size()).isEqualTo(0);
-    List<SearchMetadata> searchNodes = searchMetadataStore.listSync();
+    List<SearchMetadata> searchNodes = searchMetadataStore.listSyncUncached();
     assertThat(searchNodes).isEmpty();
     assertThat(liveSnapshots.stream().map(s -> s.snapshotId).collect(Collectors.toList()))
         .isEmpty();
@@ -395,12 +395,12 @@ public class RecoveryChunkManagerTest {
                     MessageUtil.makeMessage(1000), 100, TEST_KAFKA_PARTITION_ID, 1000));
 
     // Check metadata.
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSync();
+    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
     assertThat(snapshots.size()).isEqualTo(0);
     List<SnapshotMetadata> liveSnapshots = fetchLiveSnapshot(snapshots);
     assertThat(liveSnapshots.size()).isZero();
     assertThat(fetchNonLiveSnapshot(snapshots).size()).isEqualTo(0);
-    List<SearchMetadata> searchNodes = searchMetadataStore.listSync();
+    List<SearchMetadata> searchNodes = searchMetadataStore.listSyncUncached();
     assertThat(searchNodes).isEmpty();
     assertThat(liveSnapshots.stream().map(s -> s.snapshotId).collect(Collectors.toList()))
         .isEmpty();

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentServiceTest.java
@@ -149,8 +149,8 @@ public class RecoveryTaskAssignmentServiceTest {
     int assignments = recoveryTaskAssignmentService.assignRecoveryTasksToNodes();
 
     assertThat(assignments).isEqualTo(0);
-    assertThat(recoveryTaskMetadataStore.listSync().isEmpty()).isTrue();
-    assertThat(recoveryNodeMetadataStore.listSync().isEmpty()).isTrue();
+    assertThat(recoveryTaskMetadataStore.listSyncUncached().isEmpty()).isTrue();
+    assertThat(recoveryNodeMetadataStore.listSyncUncached().isEmpty()).isTrue();
 
     assertThat(
             MetricsUtil.getCount(
@@ -195,13 +195,13 @@ public class RecoveryTaskAssignmentServiceTest {
               UUID.randomUUID().toString(), "1", 0, 1, Instant.now().toEpochMilli()));
     }
 
-    await().until(() -> recoveryTaskMetadataStore.getCachedSync().size() == 3);
+    await().until(() -> recoveryTaskMetadataStore.listSync().size() == 3);
 
     int assignments = recoveryTaskAssignmentService.assignRecoveryTasksToNodes();
 
     assertThat(assignments).isEqualTo(0);
-    assertThat(recoveryTaskMetadataStore.listSync().size()).isEqualTo(3);
-    assertThat(recoveryNodeMetadataStore.listSync().isEmpty()).isTrue();
+    assertThat(recoveryTaskMetadataStore.listSyncUncached().size()).isEqualTo(3);
+    assertThat(recoveryNodeMetadataStore.listSyncUncached().isEmpty()).isTrue();
 
     assertThat(
             MetricsUtil.getCount(
@@ -272,17 +272,18 @@ public class RecoveryTaskAssignmentServiceTest {
     ineligibleRecoveryNodes.add(ineligibleRecovering);
     recoveryNodeMetadataStore.createAsync(ineligibleRecovering);
 
-    await().until(() -> recoveryNodeMetadataStore.getCachedSync().size() == 3);
-    await().until(() -> recoveryTaskMetadataStore.getCachedSync().size() == 3);
+    await().until(() -> recoveryNodeMetadataStore.listSync().size() == 3);
+    await().until(() -> recoveryTaskMetadataStore.listSync().size() == 3);
 
     int assignments = recoveryTaskAssignmentService.assignRecoveryTasksToNodes();
 
     assertThat(assignments).isEqualTo(1);
-    assertThat(recoveryTaskMetadataStore.listSync().size()).isEqualTo(3);
-    assertThat(recoveryNodeMetadataStore.listSync().size()).isEqualTo(3);
-    assertThat(recoveryNodeMetadataStore.listSync().containsAll(ineligibleRecoveryNodes)).isTrue();
+    assertThat(recoveryTaskMetadataStore.listSyncUncached().size()).isEqualTo(3);
+    assertThat(recoveryNodeMetadataStore.listSyncUncached().size()).isEqualTo(3);
+    assertThat(recoveryNodeMetadataStore.listSyncUncached().containsAll(ineligibleRecoveryNodes))
+        .isTrue();
     assertThat(
-            recoveryNodeMetadataStore.listSync().stream()
+            recoveryNodeMetadataStore.listSyncUncached().stream()
                 .filter(
                     recoveryNodeMetadata ->
                         recoveryNodeMetadata.recoveryNodeState.equals(
@@ -336,13 +337,13 @@ public class RecoveryTaskAssignmentServiceTest {
               Instant.now().toEpochMilli()));
     }
 
-    await().until(() -> recoveryNodeMetadataStore.getCachedSync().size() == 3);
+    await().until(() -> recoveryNodeMetadataStore.listSync().size() == 3);
 
     int assignments = recoveryTaskAssignmentService.assignRecoveryTasksToNodes();
 
     assertThat(assignments).isEqualTo(0);
-    assertThat(recoveryTaskMetadataStore.listSync().isEmpty()).isTrue();
-    assertThat(recoveryNodeMetadataStore.listSync().size()).isEqualTo(3);
+    assertThat(recoveryTaskMetadataStore.listSyncUncached().isEmpty()).isTrue();
+    assertThat(recoveryNodeMetadataStore.listSyncUncached().size()).isEqualTo(3);
 
     assertThat(
             MetricsUtil.getCount(
@@ -402,17 +403,17 @@ public class RecoveryTaskAssignmentServiceTest {
             "",
             Instant.now().toEpochMilli()));
 
-    await().until(() -> recoveryNodeMetadataStore.getCachedSync().size() == 1);
-    await().until(() -> recoveryTaskMetadataStore.getCachedSync().size() == 2);
+    await().until(() -> recoveryNodeMetadataStore.listSync().size() == 1);
+    await().until(() -> recoveryTaskMetadataStore.listSync().size() == 2);
 
     int assignments = recoveryTaskAssignmentService.assignRecoveryTasksToNodes();
 
     assertThat(assignments).isEqualTo(1);
-    assertThat(recoveryTaskMetadataStore.listSync().size()).isEqualTo(2);
-    assertThat(recoveryNodeMetadataStore.listSync().size()).isEqualTo(1);
-    assertThat(recoveryNodeMetadataStore.listSync().get(0).recoveryTaskName)
+    assertThat(recoveryTaskMetadataStore.listSyncUncached().size()).isEqualTo(2);
+    assertThat(recoveryNodeMetadataStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(recoveryNodeMetadataStore.listSyncUncached().get(0).recoveryTaskName)
         .isEqualTo(oldTask.name);
-    assertThat(recoveryNodeMetadataStore.listSync().get(0).recoveryNodeState)
+    assertThat(recoveryNodeMetadataStore.listSyncUncached().get(0).recoveryNodeState)
         .isEqualTo(Metadata.RecoveryNodeMetadata.RecoveryNodeState.ASSIGNED);
 
     assertThat(
@@ -467,8 +468,8 @@ public class RecoveryTaskAssignmentServiceTest {
               UUID.randomUUID().toString(), "1", 0, 1, Instant.now().toEpochMilli()));
     }
 
-    await().until(() -> recoveryTaskMetadataStore.getCachedSync().size() == 3);
-    await().until(() -> recoveryNodeMetadataStore.getCachedSync().size() == 3);
+    await().until(() -> recoveryTaskMetadataStore.listSync().size() == 3);
+    await().until(() -> recoveryNodeMetadataStore.listSync().size() == 3);
 
     AsyncStage asyncStage = mock(AsyncStage.class);
     when(asyncStage.toCompletableFuture())
@@ -494,7 +495,7 @@ public class RecoveryTaskAssignmentServiceTest {
     await()
         .until(
             () ->
-                recoveryNodeMetadataStore.getCachedSync().stream()
+                recoveryNodeMetadataStore.listSync().stream()
                         .filter(
                             recoveryNodeMetadata ->
                                 recoveryNodeMetadata.recoveryNodeState.equals(
@@ -510,7 +511,7 @@ public class RecoveryTaskAssignmentServiceTest {
     await()
         .until(
             () ->
-                recoveryNodeMetadataStore.getCachedSync().stream()
+                recoveryNodeMetadataStore.listSync().stream()
                         .filter(
                             recoveryNodeMetadata ->
                                 recoveryNodeMetadata.recoveryNodeState.equals(
@@ -588,8 +589,8 @@ public class RecoveryTaskAssignmentServiceTest {
 
     doCallRealMethod().doReturn(asyncStage).when(recoveryNodeMetadataStore).updateAsync(any());
 
-    await().until(() -> recoveryNodeMetadataStore.getCachedSync().size() == 2);
-    await().until(() -> recoveryTaskMetadataStore.getCachedSync().size() == 2);
+    await().until(() -> recoveryNodeMetadataStore.listSync().size() == 2);
+    await().until(() -> recoveryTaskMetadataStore.listSync().size() == 2);
 
     int assignments = recoveryTaskAssignmentService.assignRecoveryTasksToNodes();
 
@@ -612,7 +613,7 @@ public class RecoveryTaskAssignmentServiceTest {
         .isEqualTo(1);
 
     assertThat(
-            recoveryNodeMetadataStore.listSync().stream()
+            recoveryNodeMetadataStore.listSyncUncached().stream()
                 .filter(
                     recoveryNodeMetadata ->
                         recoveryNodeMetadata.recoveryNodeState.equals(
@@ -620,7 +621,7 @@ public class RecoveryTaskAssignmentServiceTest {
                 .count())
         .isEqualTo(1);
     assertThat(
-            recoveryNodeMetadataStore.listSync().stream()
+            recoveryNodeMetadataStore.listSyncUncached().stream()
                 .filter(
                     recoveryNodeMetadata ->
                         recoveryNodeMetadata.recoveryNodeState.equals(
@@ -672,8 +673,8 @@ public class RecoveryTaskAssignmentServiceTest {
 
     doCallRealMethod().doReturn(asyncStage).when(recoveryNodeMetadataStore).updateAsync(any());
 
-    await().until(() -> recoveryNodeMetadataStore.getCachedSync().size() == 2);
-    await().until(() -> recoveryTaskMetadataStore.getCachedSync().size() == 2);
+    await().until(() -> recoveryNodeMetadataStore.listSync().size() == 2);
+    await().until(() -> recoveryTaskMetadataStore.listSync().size() == 2);
 
     int assignments = recoveryTaskAssignmentService.assignRecoveryTasksToNodes();
 
@@ -696,7 +697,7 @@ public class RecoveryTaskAssignmentServiceTest {
         .isEqualTo(1);
 
     assertThat(
-            recoveryNodeMetadataStore.listSync().stream()
+            recoveryNodeMetadataStore.listSyncUncached().stream()
                 .filter(
                     recoveryNodeMetadata ->
                         recoveryNodeMetadata.recoveryNodeState.equals(
@@ -704,7 +705,7 @@ public class RecoveryTaskAssignmentServiceTest {
                 .count())
         .isEqualTo(1);
     assertThat(
-            recoveryNodeMetadataStore.listSync().stream()
+            recoveryNodeMetadataStore.listSyncUncached().stream()
                 .filter(
                     recoveryNodeMetadata ->
                         recoveryNodeMetadata.recoveryNodeState.equals(
@@ -743,12 +744,12 @@ public class RecoveryTaskAssignmentServiceTest {
               Instant.now().toEpochMilli()));
     }
 
-    await().until(() -> recoveryNodeMetadataStore.getCachedSync().size() == 3);
+    await().until(() -> recoveryNodeMetadataStore.listSync().size() == 3);
     // all nodes should be FREE, and have no assignment
     await()
         .until(
             () ->
-                recoveryNodeMetadataStore.getCachedSync().stream()
+                recoveryNodeMetadataStore.listSync().stream()
                     .allMatch(
                         (recoveryNodeMetadata) ->
                             recoveryNodeMetadata.recoveryNodeState.equals(
@@ -761,12 +762,12 @@ public class RecoveryTaskAssignmentServiceTest {
               UUID.randomUUID().toString(), "1", 0, 1, Instant.now().toEpochMilli()));
     }
 
-    await().until(() -> recoveryTaskMetadataStore.getCachedSync().size() == 10);
+    await().until(() -> recoveryTaskMetadataStore.listSync().size() == 10);
     // all nodes should be ASSIGNED, and have an assignment
     await()
         .until(
             () ->
-                recoveryNodeMetadataStore.getCachedSync().stream()
+                recoveryNodeMetadataStore.listSync().stream()
                     .allMatch(
                         (recoveryNodeMetadata) ->
                             recoveryNodeMetadata.recoveryNodeState.equals(
@@ -775,7 +776,7 @@ public class RecoveryTaskAssignmentServiceTest {
 
     // mark all as recovering
     recoveryNodeMetadataStore
-        .getCachedSync()
+        .listSync()
         .forEach(
             recoveryNodeMetadata -> {
               RecoveryNodeMetadata updatedRecoveryNode =
@@ -791,7 +792,7 @@ public class RecoveryTaskAssignmentServiceTest {
     await()
         .until(
             () ->
-                recoveryNodeMetadataStore.getCachedSync().stream()
+                recoveryNodeMetadataStore.listSync().stream()
                     .allMatch(
                         (recoveryNodeMetadata) ->
                             recoveryNodeMetadata.recoveryNodeState.equals(
@@ -801,7 +802,7 @@ public class RecoveryTaskAssignmentServiceTest {
     Instant before = Instant.now();
     // next delete the task, and mark the node as free
     recoveryNodeMetadataStore
-        .getCachedSync()
+        .listSync()
         .forEach(
             recoveryNodeMetadata -> {
               // delete the task
@@ -820,13 +821,13 @@ public class RecoveryTaskAssignmentServiceTest {
     await()
         .until(
             () ->
-                recoveryNodeMetadataStore.getCachedSync().stream()
+                recoveryNodeMetadataStore.listSync().stream()
                     .allMatch(
                         (recoveryNodeMetadata ->
                             recoveryNodeMetadata.updatedTimeEpochMs > before.toEpochMilli()
                                 && recoveryNodeMetadata.recoveryNodeState.equals(
                                     Metadata.RecoveryNodeMetadata.RecoveryNodeState.ASSIGNED))));
-    assertThat(recoveryTaskMetadataStore.getCachedSync().size()).isEqualTo(7);
+    assertThat(recoveryTaskMetadataStore.listSync().size()).isEqualTo(7);
 
     recoveryTaskAssignmentService.stopAsync();
     recoveryTaskAssignmentService.awaitTerminated(DEFAULT_START_STOP_DURATION);
@@ -859,7 +860,7 @@ public class RecoveryTaskAssignmentServiceTest {
           new RecoveryTaskMetadata(
               UUID.randomUUID().toString(), "1", 0, 1, Instant.now().toEpochMilli()));
     }
-    await().until(() -> recoveryTaskMetadataStore.getCachedSync().size() == 10);
+    await().until(() -> recoveryTaskMetadataStore.listSync().size() == 10);
 
     for (int i = 0; i < 3; i++) {
       recoveryNodeMetadataStore.createAsync(
@@ -869,13 +870,13 @@ public class RecoveryTaskAssignmentServiceTest {
               "",
               Instant.now().toEpochMilli()));
     }
-    await().until(() -> recoveryNodeMetadataStore.getCachedSync().size() == 3);
+    await().until(() -> recoveryNodeMetadataStore.listSync().size() == 3);
 
     // all nodes should immediately pickup tasks and have an assignment
     await()
         .until(
             () ->
-                recoveryNodeMetadataStore.getCachedSync().stream()
+                recoveryNodeMetadataStore.listSync().stream()
                     .allMatch(
                         (recoveryNodeMetadata) ->
                             recoveryNodeMetadata.recoveryNodeState.equals(
@@ -884,7 +885,7 @@ public class RecoveryTaskAssignmentServiceTest {
 
     // mark all as recovering
     recoveryNodeMetadataStore
-        .getCachedSync()
+        .listSync()
         .forEach(
             recoveryNodeMetadata -> {
               RecoveryNodeMetadata updatedRecoveryNode =
@@ -900,7 +901,7 @@ public class RecoveryTaskAssignmentServiceTest {
     await()
         .until(
             () ->
-                recoveryNodeMetadataStore.getCachedSync().stream()
+                recoveryNodeMetadataStore.listSync().stream()
                     .allMatch(
                         (recoveryNodeMetadata) ->
                             recoveryNodeMetadata.recoveryNodeState.equals(
@@ -910,7 +911,7 @@ public class RecoveryTaskAssignmentServiceTest {
     Instant before = Instant.now();
     // next delete the task, and mark the node as free
     recoveryNodeMetadataStore
-        .getCachedSync()
+        .listSync()
         .forEach(
             recoveryNodeMetadata -> {
               // delete the task
@@ -929,13 +930,13 @@ public class RecoveryTaskAssignmentServiceTest {
     await()
         .until(
             () ->
-                recoveryNodeMetadataStore.getCachedSync().stream()
+                recoveryNodeMetadataStore.listSync().stream()
                     .allMatch(
                         (recoveryNodeMetadata ->
                             recoveryNodeMetadata.updatedTimeEpochMs > before.toEpochMilli()
                                 && recoveryNodeMetadata.recoveryNodeState.equals(
                                     Metadata.RecoveryNodeMetadata.RecoveryNodeState.ASSIGNED))));
-    assertThat(recoveryTaskMetadataStore.getCachedSync().size()).isEqualTo(7);
+    assertThat(recoveryTaskMetadataStore.listSync().size()).isEqualTo(7);
 
     recoveryTaskAssignmentService.stopAsync();
     recoveryTaskAssignmentService.awaitTerminated(DEFAULT_START_STOP_DURATION);

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
@@ -138,14 +138,14 @@ public class ReplicaAssignmentServiceTest {
         new ReplicaAssignmentService(
             cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
 
-    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(0);
-    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(0);
+    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(0);
+    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(0);
 
     int assignments = replicaAssignmentService.assignReplicasToCacheSlots();
     assertThat(assignments).isEqualTo(0);
 
-    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(0);
-    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(0);
+    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(0);
+    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(0);
     assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
     assertThat(
@@ -191,16 +191,16 @@ public class ReplicaAssignmentServiceTest {
       replicaMetadataStore.createAsync(replicaMetadata);
     }
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 3);
-    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(0);
+    await().until(() -> replicaMetadataStore.listSync().size() == 3);
+    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(0);
 
     int assignments = replicaAssignmentService.assignReplicasToCacheSlots();
     assertThat(assignments).isEqualTo(0);
 
-    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(0);
-    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(3);
+    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(0);
+    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(3);
 
-    assertThat(replicaMetadataList.containsAll(replicaMetadataStore.listSync())).isTrue();
+    assertThat(replicaMetadataList.containsAll(replicaMetadataStore.listSyncUncached())).isTrue();
     assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
     assertThat(
@@ -245,16 +245,17 @@ public class ReplicaAssignmentServiceTest {
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 3);
-    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(0);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 3);
+    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(0);
 
     int assignments = replicaAssignmentService.assignReplicasToCacheSlots();
     assertThat(assignments).isEqualTo(0);
 
-    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(0);
-    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(3);
+    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(0);
+    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(3);
 
-    assertThat(cacheSlotMetadataList.containsAll(cacheSlotMetadataStore.listSync())).isTrue();
+    assertThat(cacheSlotMetadataList.containsAll(cacheSlotMetadataStore.listSyncUncached()))
+        .isTrue();
     assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
     assertThat(
@@ -325,17 +326,18 @@ public class ReplicaAssignmentServiceTest {
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 5);
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 3);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 5);
+    await().until(() -> replicaMetadataStore.listSync().size() == 3);
 
     int assignments = replicaAssignmentService.assignReplicasToCacheSlots();
     assertThat(assignments).isEqualTo(0);
 
-    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(3);
-    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(5);
+    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(3);
+    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(5);
 
-    assertThat(cacheSlotMetadataList.containsAll(cacheSlotMetadataStore.listSync())).isTrue();
-    assertThat(replicaMetadataList.containsAll(replicaMetadataStore.listSync())).isTrue();
+    assertThat(cacheSlotMetadataList.containsAll(cacheSlotMetadataStore.listSyncUncached()))
+        .isTrue();
+    assertThat(replicaMetadataList.containsAll(replicaMetadataStore.listSyncUncached())).isTrue();
     assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
     assertThat(
@@ -421,25 +423,25 @@ public class ReplicaAssignmentServiceTest {
             SUPPORTED_INDEX_TYPES);
     cacheSlotMetadataStore.createAsync(cacheSlotFree);
 
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 4);
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 4);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 4);
+    await().until(() -> replicaMetadataStore.listSync().size() == 4);
 
     int assignments = replicaAssignmentService.assignReplicasToCacheSlots();
     assertThat(assignments).isEqualTo(1);
 
-    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(4);
-    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(4);
-    assertThat(cacheSlotMetadataStore.getCachedSync().containsAll(unmutatedSlots)).isTrue();
+    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(4);
+    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(4);
+    assertThat(cacheSlotMetadataStore.listSync().containsAll(unmutatedSlots)).isTrue();
 
     List<CacheSlotMetadata> mutatedCacheSlots =
-        cacheSlotMetadataStore.getCachedSync().stream()
+        cacheSlotMetadataStore.listSync().stream()
             .filter(cacheSlotMetadata -> !unmutatedSlots.contains(cacheSlotMetadata))
             .collect(Collectors.toList());
     assertThat(mutatedCacheSlots.size()).isEqualTo(1);
     assertThat(mutatedCacheSlots.get(0).name).isEqualTo(cacheSlotFree.name);
     assertThat(mutatedCacheSlots.get(0).replicaId).isEqualTo(replicaMetadataList.get(3).name);
 
-    assertThat(replicaMetadataList.containsAll(replicaMetadataStore.listSync())).isTrue();
+    assertThat(replicaMetadataList.containsAll(replicaMetadataStore.listSyncUncached())).isTrue();
 
     assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
@@ -499,17 +501,18 @@ public class ReplicaAssignmentServiceTest {
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 3);
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 5);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 3);
+    await().until(() -> replicaMetadataStore.listSync().size() == 5);
 
     int assignments = replicaAssignmentService.assignReplicasToCacheSlots();
     assertThat(assignments).isEqualTo(0);
 
-    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(5);
-    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(3);
+    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(5);
+    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(3);
 
-    assertThat(cacheSlotMetadataList.containsAll(cacheSlotMetadataStore.listSync())).isTrue();
-    assertThat(replicaMetadataList.containsAll(replicaMetadataStore.listSync())).isTrue();
+    assertThat(cacheSlotMetadataList.containsAll(cacheSlotMetadataStore.listSyncUncached()))
+        .isTrue();
+    assertThat(replicaMetadataList.containsAll(replicaMetadataStore.listSyncUncached())).isTrue();
     assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
     assertThat(
@@ -590,17 +593,17 @@ public class ReplicaAssignmentServiceTest {
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 4);
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 6);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 4);
+    await().until(() -> replicaMetadataStore.listSync().size() == 6);
 
     int assignments = replicaAssignmentService.assignReplicasToCacheSlots();
     assertThat(assignments).isEqualTo(3);
 
-    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(6);
-    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(4);
+    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(6);
+    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(4);
 
     assertThat(
-            cacheSlotMetadataStore.listSync().stream()
+            cacheSlotMetadataStore.listSyncUncached().stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -608,7 +611,7 @@ public class ReplicaAssignmentServiceTest {
                 .count())
         .isEqualTo(1);
     assertThat(
-            cacheSlotMetadataStore.listSync().stream()
+            cacheSlotMetadataStore.listSyncUncached().stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -617,7 +620,7 @@ public class ReplicaAssignmentServiceTest {
         .isEqualTo(3);
     assertThat(
             replicaMetadataExpiredList.containsAll(
-                replicaMetadataStore.listSync().stream()
+                replicaMetadataStore.listSyncUncached().stream()
                     .filter(
                         replicaMetadata ->
                             replicaMetadata.createdTimeEpochMs
@@ -679,8 +682,8 @@ public class ReplicaAssignmentServiceTest {
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 3);
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 2);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 3);
+    await().until(() -> replicaMetadataStore.listSync().size() == 2);
 
     AsyncStage asyncStage = mock(AsyncStage.class);
     when(asyncStage.toCompletableFuture())
@@ -691,10 +694,10 @@ public class ReplicaAssignmentServiceTest {
     int firstAssignment = replicaAssignmentService.assignReplicasToCacheSlots();
     assertThat(firstAssignment).isEqualTo(1);
 
-    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(2);
-    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(3);
+    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(2);
+    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(3);
     assertThat(
-            cacheSlotMetadataStore.listSync().stream()
+            cacheSlotMetadataStore.listSyncUncached().stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -702,7 +705,7 @@ public class ReplicaAssignmentServiceTest {
                 .count())
         .isEqualTo(2);
     assertThat(
-            cacheSlotMetadataStore.listSync().stream()
+            cacheSlotMetadataStore.listSyncUncached().stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -724,10 +727,10 @@ public class ReplicaAssignmentServiceTest {
     int secondAssignment = replicaAssignmentService.assignReplicasToCacheSlots();
     assertThat(secondAssignment).isEqualTo(1);
 
-    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(2);
-    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(3);
+    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(2);
+    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(3);
     assertThat(
-            cacheSlotMetadataStore.listSync().stream()
+            cacheSlotMetadataStore.listSyncUncached().stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -735,7 +738,7 @@ public class ReplicaAssignmentServiceTest {
                 .count())
         .isEqualTo(2);
     assertThat(
-            cacheSlotMetadataStore.listSync().stream()
+            cacheSlotMetadataStore.listSyncUncached().stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -797,8 +800,8 @@ public class ReplicaAssignmentServiceTest {
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 3);
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 2);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 3);
+    await().until(() -> replicaMetadataStore.listSync().size() == 2);
 
     replicaAssignmentService.futuresListTimeoutSecs = 2;
     ExecutorService timeoutServiceExecutor = Executors.newSingleThreadExecutor();
@@ -820,10 +823,10 @@ public class ReplicaAssignmentServiceTest {
     int firstAssignment = replicaAssignmentService.assignReplicasToCacheSlots();
     assertThat(firstAssignment).isEqualTo(1);
 
-    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(2);
-    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(3);
+    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(2);
+    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(3);
     assertThat(
-            cacheSlotMetadataStore.listSync().stream()
+            cacheSlotMetadataStore.listSyncUncached().stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -831,7 +834,7 @@ public class ReplicaAssignmentServiceTest {
                 .count())
         .isEqualTo(2);
     assertThat(
-            cacheSlotMetadataStore.listSync().stream()
+            cacheSlotMetadataStore.listSyncUncached().stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -895,8 +898,8 @@ public class ReplicaAssignmentServiceTest {
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 3);
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 2);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 3);
+    await().until(() -> replicaMetadataStore.listSync().size() == 2);
 
     AsyncStage asyncStage = mock(AsyncStage.class);
     when(asyncStage.toCompletableFuture())
@@ -907,10 +910,10 @@ public class ReplicaAssignmentServiceTest {
     int firstAssignment = replicaAssignmentService.assignReplicasToCacheSlots();
     assertThat(firstAssignment).isEqualTo(1);
 
-    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(2);
-    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(3);
+    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(2);
+    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(3);
     assertThat(
-            cacheSlotMetadataStore.listSync().stream()
+            cacheSlotMetadataStore.listSyncUncached().stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -918,7 +921,7 @@ public class ReplicaAssignmentServiceTest {
                 .count())
         .isEqualTo(2);
     assertThat(
-            cacheSlotMetadataStore.listSync().stream()
+            cacheSlotMetadataStore.listSyncUncached().stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -968,10 +971,10 @@ public class ReplicaAssignmentServiceTest {
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 3);
-    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(0);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 3);
+    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(0);
     assertThat(
-            cacheSlotMetadataStore.listSync().stream()
+            cacheSlotMetadataStore.listSyncUncached().stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -994,11 +997,11 @@ public class ReplicaAssignmentServiceTest {
       replicaMetadataStore.createAsync(replicaMetadata);
     }
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 2);
+    await().until(() -> replicaMetadataStore.listSync().size() == 2);
     await()
         .until(
             () ->
-                cacheSlotMetadataStore.getCachedSync().stream()
+                cacheSlotMetadataStore.listSync().stream()
                         .filter(
                             cacheSlotMetadata ->
                                 cacheSlotMetadata.cacheSlotState.equals(
@@ -1008,7 +1011,7 @@ public class ReplicaAssignmentServiceTest {
     await()
         .until(
             () ->
-                cacheSlotMetadataStore.getCachedSync().stream()
+                cacheSlotMetadataStore.listSync().stream()
                         .filter(
                             cacheSlotMetadata ->
                                 cacheSlotMetadata.cacheSlotState.equals(
@@ -1064,7 +1067,7 @@ public class ReplicaAssignmentServiceTest {
       replicaMetadataStore.createAsync(replicaMetadata);
     }
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 3);
+    await().until(() -> replicaMetadataStore.listSync().size() == 3);
 
     replicaAssignmentService.startAsync();
     replicaAssignmentService.awaitRunning(DEFAULT_START_STOP_DURATION);
@@ -1080,18 +1083,18 @@ public class ReplicaAssignmentServiceTest {
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 2);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 2);
     await()
         .until(
             () ->
-                cacheSlotMetadataStore.getCachedSync().stream()
+                cacheSlotMetadataStore.listSync().stream()
                         .filter(
                             cacheSlotMetadata ->
                                 cacheSlotMetadata.cacheSlotState.equals(
                                     Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED))
                         .count()
                     == 2);
-    assertThat(replicaMetadataList.containsAll(replicaMetadataStore.listSync())).isTrue();
+    assertThat(replicaMetadataList.containsAll(replicaMetadataStore.listSyncUncached())).isTrue();
 
     assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
@@ -1148,7 +1151,7 @@ public class ReplicaAssignmentServiceTest {
             LOGS_LUCENE9);
     replicaMetadataStore.createAsync(newerReplicaMetadata);
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 2);
+    await().until(() -> replicaMetadataStore.listSync().size() == 2);
 
     replicaAssignmentService.startAsync();
     replicaAssignmentService.awaitRunning(DEFAULT_START_STOP_DURATION);
@@ -1165,14 +1168,13 @@ public class ReplicaAssignmentServiceTest {
     await()
         .until(
             () -> {
-              List<CacheSlotMetadata> cacheSlotMetadataList =
-                  cacheSlotMetadataStore.getCachedSync();
+              List<CacheSlotMetadata> cacheSlotMetadataList = cacheSlotMetadataStore.listSync();
               return cacheSlotMetadataList.size() == 1
                   && cacheSlotMetadataList.get(0).cacheSlotState
                       == Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED;
             });
 
-    List<CacheSlotMetadata> assignedCacheSlot = cacheSlotMetadataStore.listSync();
+    List<CacheSlotMetadata> assignedCacheSlot = cacheSlotMetadataStore.listSyncUncached();
     assertThat(assignedCacheSlot.get(0).replicaId).isEqualTo(newerReplicaMetadata.name);
     assertThat(assignedCacheSlot.get(0).supportedIndexTypes).containsAll(SUPPORTED_INDEX_TYPES);
   }
@@ -1215,7 +1217,7 @@ public class ReplicaAssignmentServiceTest {
             LOGS_LUCENE9);
     replicaMetadataStore.createAsync(newerReplicaMetadata);
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 2);
+    await().until(() -> replicaMetadataStore.listSync().size() == 2);
 
     replicaAssignmentService.startAsync();
     replicaAssignmentService.awaitRunning(DEFAULT_START_STOP_DURATION);
@@ -1233,14 +1235,13 @@ public class ReplicaAssignmentServiceTest {
     await()
         .until(
             () -> {
-              List<CacheSlotMetadata> cacheSlotMetadataList =
-                  cacheSlotMetadataStore.getCachedSync();
+              List<CacheSlotMetadata> cacheSlotMetadataList = cacheSlotMetadataStore.listSync();
               return cacheSlotMetadataList.size() == 1
                   && cacheSlotMetadataList.get(0).cacheSlotState
                       == Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED;
             });
 
-    List<CacheSlotMetadata> assignedCacheSlot = cacheSlotMetadataStore.listSync();
+    List<CacheSlotMetadata> assignedCacheSlot = cacheSlotMetadataStore.listSyncUncached();
     assertThat(assignedCacheSlot.get(0).replicaId).isEqualTo(newerReplicaMetadata.name);
     assertThat(assignedCacheSlot.get(0).supportedIndexTypes)
         .containsExactlyInAnyOrderElementsOf(suppportedIndexTypes);

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaDeletionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaDeletionServiceTest.java
@@ -160,8 +160,8 @@ public class ReplicaDeletionServiceTest {
             SUPPORTED_INDEX_TYPES);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 1);
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> replicaMetadataStore.listSync().size() == 1);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 1);
 
     ReplicaDeletionService replicaDeletionService =
         new ReplicaDeletionService(
@@ -170,8 +170,8 @@ public class ReplicaDeletionServiceTest {
     int replicasDeleted = replicaDeletionService.deleteExpiredUnassignedReplicas(Instant.now());
     assertThat(replicasDeleted).isEqualTo(1);
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 0);
-    assertThat(cacheSlotMetadataStore.getCachedSync()).containsExactlyInAnyOrder(cacheSlotMetadata);
+    await().until(() -> replicaMetadataStore.listSync().size() == 0);
+    assertThat(cacheSlotMetadataStore.listSync()).containsExactlyInAnyOrder(cacheSlotMetadata);
 
     assertThat(MetricsUtil.getCount(ReplicaDeletionService.REPLICA_DELETE_SUCCESS, meterRegistry))
         .isEqualTo(1);
@@ -236,8 +236,8 @@ public class ReplicaDeletionServiceTest {
             SUPPORTED_INDEX_TYPES);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadataEvicting);
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 3);
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 3);
+    await().until(() -> replicaMetadataStore.listSync().size() == 3);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 3);
 
     ReplicaDeletionService replicaDeletionService =
         new ReplicaDeletionService(
@@ -246,9 +246,9 @@ public class ReplicaDeletionServiceTest {
     int replicasDeleted = replicaDeletionService.deleteExpiredUnassignedReplicas(Instant.now());
     assertThat(replicasDeleted).isEqualTo(0);
 
-    assertThat(replicaMetadataStore.getCachedSync())
+    assertThat(replicaMetadataStore.listSync())
         .containsExactlyInAnyOrderElementsOf(replicaMetadataList);
-    assertThat(cacheSlotMetadataStore.getCachedSync())
+    assertThat(cacheSlotMetadataStore.listSync())
         .containsExactlyInAnyOrder(
             cacheSlotMetadataAssigned, cacheSlotMetadataEvict, cacheSlotMetadataEvicting);
 
@@ -293,8 +293,8 @@ public class ReplicaDeletionServiceTest {
             SUPPORTED_INDEX_TYPES);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 1);
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> replicaMetadataStore.listSync().size() == 1);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 1);
 
     ReplicaDeletionService replicaDeletionService =
         new ReplicaDeletionService(
@@ -303,8 +303,8 @@ public class ReplicaDeletionServiceTest {
     int replicasDeleted = replicaDeletionService.deleteExpiredUnassignedReplicas(Instant.now());
     assertThat(replicasDeleted).isEqualTo(0);
 
-    assertThat(replicaMetadataStore.getCachedSync()).containsExactlyInAnyOrder(replicaMetadata);
-    assertThat(cacheSlotMetadataStore.getCachedSync()).containsExactlyInAnyOrder(cacheSlotMetadata);
+    assertThat(replicaMetadataStore.listSync()).containsExactlyInAnyOrder(replicaMetadata);
+    assertThat(cacheSlotMetadataStore.listSync()).containsExactlyInAnyOrder(cacheSlotMetadata);
 
     assertThat(MetricsUtil.getCount(ReplicaDeletionService.REPLICA_DELETE_SUCCESS, meterRegistry))
         .isEqualTo(0);
@@ -347,8 +347,8 @@ public class ReplicaDeletionServiceTest {
             SUPPORTED_INDEX_TYPES);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 1);
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> replicaMetadataStore.listSync().size() == 1);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 1);
 
     ReplicaDeletionService replicaDeletionService =
         new ReplicaDeletionService(
@@ -363,8 +363,8 @@ public class ReplicaDeletionServiceTest {
     int replicasDeleted = replicaDeletionService.deleteExpiredUnassignedReplicas(Instant.now());
     assertThat(replicasDeleted).isEqualTo(0);
 
-    assertThat(replicaMetadataStore.getCachedSync()).containsExactlyInAnyOrder(replicaMetadata);
-    assertThat(cacheSlotMetadataStore.getCachedSync()).containsExactlyInAnyOrder(cacheSlotMetadata);
+    assertThat(replicaMetadataStore.listSync()).containsExactlyInAnyOrder(replicaMetadata);
+    assertThat(cacheSlotMetadataStore.listSync()).containsExactlyInAnyOrder(cacheSlotMetadata);
 
     assertThat(MetricsUtil.getCount(ReplicaDeletionService.REPLICA_DELETE_SUCCESS, meterRegistry))
         .isEqualTo(0);
@@ -380,8 +380,8 @@ public class ReplicaDeletionServiceTest {
         replicaDeletionService.deleteExpiredUnassignedReplicas(Instant.now());
     assertThat(replicasDeletedRetry).isEqualTo(1);
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 0);
-    assertThat(cacheSlotMetadataStore.getCachedSync()).containsExactlyInAnyOrder(cacheSlotMetadata);
+    await().until(() -> replicaMetadataStore.listSync().size() == 0);
+    assertThat(cacheSlotMetadataStore.listSync()).containsExactlyInAnyOrder(cacheSlotMetadata);
 
     assertThat(MetricsUtil.getCount(ReplicaDeletionService.REPLICA_DELETE_SUCCESS, meterRegistry))
         .isEqualTo(1);
@@ -430,8 +430,8 @@ public class ReplicaDeletionServiceTest {
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 2);
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 2);
+    await().until(() -> replicaMetadataStore.listSync().size() == 2);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 2);
 
     ReplicaDeletionService replicaDeletionService =
         new ReplicaDeletionService(
@@ -459,8 +459,8 @@ public class ReplicaDeletionServiceTest {
     int replicasDeleted = replicaDeletionService.deleteExpiredUnassignedReplicas(Instant.now());
     assertThat(replicasDeleted).isEqualTo(1);
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 1);
-    assertThat(cacheSlotMetadataStore.getCachedSync())
+    await().until(() -> replicaMetadataStore.listSync().size() == 1);
+    assertThat(cacheSlotMetadataStore.listSync())
         .containsExactlyInAnyOrderElementsOf(cacheSlotMetadataList);
 
     assertThat(MetricsUtil.getCount(ReplicaDeletionService.REPLICA_DELETE_SUCCESS, meterRegistry))
@@ -477,8 +477,8 @@ public class ReplicaDeletionServiceTest {
         replicaDeletionService.deleteExpiredUnassignedReplicas(Instant.now());
     assertThat(replicasDeletedRetry).isEqualTo(1);
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 0);
-    assertThat(cacheSlotMetadataStore.getCachedSync())
+    await().until(() -> replicaMetadataStore.listSync().size() == 0);
+    assertThat(cacheSlotMetadataStore.listSync())
         .containsExactlyInAnyOrderElementsOf(cacheSlotMetadataList);
 
     assertThat(MetricsUtil.getCount(ReplicaDeletionService.REPLICA_DELETE_SUCCESS, meterRegistry))
@@ -543,8 +543,8 @@ public class ReplicaDeletionServiceTest {
             SUPPORTED_INDEX_TYPES);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadataAssigned);
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 2);
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 2);
+    await().until(() -> replicaMetadataStore.listSync().size() == 2);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 2);
 
     ReplicaDeletionService replicaDeletionService =
         new ReplicaDeletionService(
@@ -553,10 +553,9 @@ public class ReplicaDeletionServiceTest {
     replicaDeletionService.startAsync();
     replicaDeletionService.awaitRunning(DEFAULT_START_STOP_DURATION);
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 1);
-    assertThat(replicaMetadataStore.getCachedSync())
-        .containsExactlyInAnyOrder(replicaMetadataAssigned);
-    assertThat(cacheSlotMetadataStore.getCachedSync())
+    await().until(() -> replicaMetadataStore.listSync().size() == 1);
+    assertThat(replicaMetadataStore.listSync()).containsExactlyInAnyOrder(replicaMetadataAssigned);
+    assertThat(cacheSlotMetadataStore.listSync())
         .containsExactlyInAnyOrder(cacheSlotMetadataUnassigned, cacheSlotMetadataAssigned);
 
     assertThat(MetricsUtil.getCount(ReplicaDeletionService.REPLICA_DELETE_SUCCESS, meterRegistry))

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
@@ -198,15 +198,14 @@ public class ReplicaEvictionServiceTest {
     cacheSlots.add(cacheSlotLoading);
     cacheSlotMetadataStore.createAsync(cacheSlotLoading);
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 5);
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 3);
+    await().until(() -> replicaMetadataStore.listSync().size() == 5);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 3);
 
     int replicasMarked = replicaEvictionService.markReplicasForEviction(Instant.now());
     assertThat(replicasMarked).isEqualTo(0);
 
-    assertThat(replicaMetadataStore.getCachedSync()).containsExactlyInAnyOrderElementsOf(replicas);
-    assertThat(cacheSlotMetadataStore.getCachedSync())
-        .containsExactlyInAnyOrderElementsOf(cacheSlots);
+    assertThat(replicaMetadataStore.listSync()).containsExactlyInAnyOrderElementsOf(replicas);
+    assertThat(cacheSlotMetadataStore.listSync()).containsExactlyInAnyOrderElementsOf(cacheSlots);
 
     assertThat(
             MetricsUtil.getCount(
@@ -261,23 +260,23 @@ public class ReplicaEvictionServiceTest {
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     assertThat(cacheSlotMetadata.supportedIndexTypes.size()).isEqualTo(2);
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 1);
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> replicaMetadataStore.listSync().size() == 1);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 1);
 
     int replicasMarked = replicaEvictionService.markReplicasForEviction(Instant.now());
     assertThat(replicasMarked).isEqualTo(1);
 
-    assertThat(replicaMetadataStore.getCachedSync()).containsExactly(replicaMetadata);
+    assertThat(replicaMetadataStore.listSync()).containsExactly(replicaMetadata);
     await()
         .until(
             () ->
-                cacheSlotMetadataStore.getCachedSync().stream()
+                cacheSlotMetadataStore.listSync().stream()
                     .allMatch(
                         cacheSlot ->
                             cacheSlot.cacheSlotState.equals(
                                 Metadata.CacheSlotMetadata.CacheSlotState.EVICT)));
 
-    CacheSlotMetadata updatedCacheSlot = cacheSlotMetadataStore.getCachedSync().get(0);
+    CacheSlotMetadata updatedCacheSlot = cacheSlotMetadataStore.listSync().get(0);
     assertThat(updatedCacheSlot.updatedTimeEpochMs)
         .isGreaterThan(cacheSlotMetadata.updatedTimeEpochMs);
     assertThat(updatedCacheSlot.cacheSlotState)
@@ -337,23 +336,23 @@ public class ReplicaEvictionServiceTest {
             SUPPORTED_INDEX_TYPES);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 1);
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> replicaMetadataStore.listSync().size() == 1);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 1);
 
     int replicasMarked = replicaEvictionService.markReplicasForEviction(Instant.now());
     assertThat(replicasMarked).isEqualTo(1);
 
-    assertThat(replicaMetadataStore.getCachedSync()).containsExactly(replicaMetadata);
+    assertThat(replicaMetadataStore.listSync()).containsExactly(replicaMetadata);
     await()
         .until(
             () ->
-                cacheSlotMetadataStore.getCachedSync().stream()
+                cacheSlotMetadataStore.listSync().stream()
                     .allMatch(
                         cacheSlot ->
                             cacheSlot.cacheSlotState.equals(
                                 Metadata.CacheSlotMetadata.CacheSlotState.EVICT)));
 
-    CacheSlotMetadata updatedCacheSlot = cacheSlotMetadataStore.getCachedSync().get(0);
+    CacheSlotMetadata updatedCacheSlot = cacheSlotMetadataStore.listSync().get(0);
     assertThat(updatedCacheSlot.updatedTimeEpochMs)
         .isGreaterThan(cacheSlotMetadata.updatedTimeEpochMs);
     assertThat(updatedCacheSlot.cacheSlotState)
@@ -411,14 +410,14 @@ public class ReplicaEvictionServiceTest {
             SUPPORTED_INDEX_TYPES);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 1);
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> replicaMetadataStore.listSync().size() == 1);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 1);
 
     int replicasMarked = replicaEvictionService.markReplicasForEviction(Instant.now());
     assertThat(replicasMarked).isEqualTo(0);
 
-    assertThat(replicaMetadataStore.getCachedSync()).containsExactly(replicaMetadata);
-    assertThat(cacheSlotMetadataStore.getCachedSync()).containsExactly(cacheSlotMetadata);
+    assertThat(replicaMetadataStore.listSync()).containsExactly(replicaMetadata);
+    assertThat(cacheSlotMetadataStore.listSync()).containsExactly(cacheSlotMetadata);
 
     assertThat(
             MetricsUtil.getCount(
@@ -470,14 +469,14 @@ public class ReplicaEvictionServiceTest {
             SUPPORTED_INDEX_TYPES);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 1);
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> replicaMetadataStore.listSync().size() == 1);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 1);
 
     int replicasMarked = replicaEvictionService.markReplicasForEviction(Instant.now());
     assertThat(replicasMarked).isEqualTo(0);
 
-    assertThat(replicaMetadataStore.getCachedSync()).containsExactly(replicaMetadata);
-    assertThat(cacheSlotMetadataStore.getCachedSync()).containsExactly(cacheSlotMetadata);
+    assertThat(replicaMetadataStore.listSync()).containsExactly(replicaMetadata);
+    assertThat(cacheSlotMetadataStore.listSync()).containsExactly(cacheSlotMetadata);
 
     assertThat(
             MetricsUtil.getCount(
@@ -529,8 +528,8 @@ public class ReplicaEvictionServiceTest {
             SUPPORTED_INDEX_TYPES);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 1);
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> replicaMetadataStore.listSync().size() == 1);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 1);
 
     AsyncStage asyncStage = mock(AsyncStage.class);
     when(asyncStage.toCompletableFuture())
@@ -541,8 +540,8 @@ public class ReplicaEvictionServiceTest {
     int replicasMarkedFirstAttempt = replicaEvictionService.markReplicasForEviction(Instant.now());
     assertThat(replicasMarkedFirstAttempt).isEqualTo(0);
 
-    assertThat(replicaMetadataStore.getCachedSync()).containsExactly(replicaMetadata);
-    assertThat(cacheSlotMetadataStore.getCachedSync()).containsExactly(cacheSlotMetadata);
+    assertThat(replicaMetadataStore.listSync()).containsExactly(replicaMetadata);
+    assertThat(cacheSlotMetadataStore.listSync()).containsExactly(cacheSlotMetadata);
 
     assertThat(
             MetricsUtil.getCount(
@@ -561,18 +560,18 @@ public class ReplicaEvictionServiceTest {
     int replicasMarkedSecondAttempt = replicaEvictionService.markReplicasForEviction(Instant.now());
     assertThat(replicasMarkedSecondAttempt).isEqualTo(1);
 
-    assertThat(replicaMetadataStore.getCachedSync()).containsExactly(replicaMetadata);
+    assertThat(replicaMetadataStore.listSync()).containsExactly(replicaMetadata);
 
     await()
         .until(
             () ->
-                cacheSlotMetadataStore.getCachedSync().stream()
+                cacheSlotMetadataStore.listSync().stream()
                     .allMatch(
                         cacheSlot ->
                             cacheSlot.cacheSlotState.equals(
                                 Metadata.CacheSlotMetadata.CacheSlotState.EVICT)));
 
-    CacheSlotMetadata updatedCacheSlot = cacheSlotMetadataStore.getCachedSync().get(0);
+    CacheSlotMetadata updatedCacheSlot = cacheSlotMetadataStore.listSync().get(0);
     assertThat(updatedCacheSlot.updatedTimeEpochMs)
         .isGreaterThan(cacheSlotMetadata.updatedTimeEpochMs);
     assertThat(updatedCacheSlot.cacheSlotState)
@@ -637,8 +636,8 @@ public class ReplicaEvictionServiceTest {
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 2);
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 2);
+    await().until(() -> replicaMetadataStore.listSync().size() == 2);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 2);
 
     ExecutorService timeoutServiceExecutor = Executors.newSingleThreadExecutor();
     AsyncStage asyncStage = mock(AsyncStage.class);
@@ -659,11 +658,11 @@ public class ReplicaEvictionServiceTest {
     int replicasMarkedFirstAttempt = replicaEvictionService.markReplicasForEviction(Instant.now());
     assertThat(replicasMarkedFirstAttempt).isEqualTo(1);
 
-    assertThat(replicaMetadataStore.getCachedSync()).containsExactlyInAnyOrderElementsOf(replicas);
+    assertThat(replicaMetadataStore.listSync()).containsExactlyInAnyOrderElementsOf(replicas);
     await()
         .until(
             () ->
-                cacheSlotMetadataStore.getCachedSync().stream()
+                cacheSlotMetadataStore.listSync().stream()
                         .filter(
                             cacheSlotMetadata ->
                                 cacheSlotMetadata.cacheSlotState.equals(
@@ -673,14 +672,14 @@ public class ReplicaEvictionServiceTest {
     await()
         .until(
             () ->
-                cacheSlotMetadataStore.getCachedSync().stream()
+                cacheSlotMetadataStore.listSync().stream()
                         .filter(
                             cacheSlotMetadata ->
                                 cacheSlotMetadata.cacheSlotState.equals(
                                     Metadata.CacheSlotMetadata.CacheSlotState.EVICT))
                         .count()
                     == 1);
-    assertThat(cacheSlotMetadataStore.getCachedSync().size()).isEqualTo(2);
+    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(2);
 
     assertThat(
             MetricsUtil.getCount(
@@ -699,18 +698,18 @@ public class ReplicaEvictionServiceTest {
     int replicasMarkedSecondAttempt = replicaEvictionService.markReplicasForEviction(Instant.now());
     assertThat(replicasMarkedSecondAttempt).isEqualTo(1);
 
-    assertThat(replicaMetadataStore.getCachedSync()).containsExactlyInAnyOrderElementsOf(replicas);
+    assertThat(replicaMetadataStore.listSync()).containsExactlyInAnyOrderElementsOf(replicas);
     await()
         .until(
             () ->
-                cacheSlotMetadataStore.getCachedSync().stream()
+                cacheSlotMetadataStore.listSync().stream()
                         .filter(
                             cacheSlotMetadata ->
                                 cacheSlotMetadata.cacheSlotState.equals(
                                     Metadata.CacheSlotMetadata.CacheSlotState.EVICT))
                         .count()
                     == 2);
-    assertThat(cacheSlotMetadataStore.getCachedSync().size()).isEqualTo(2);
+    assertThat(cacheSlotMetadataStore.listSync().size()).isEqualTo(2);
 
     assertThat(
             MetricsUtil.getCount(
@@ -813,8 +812,8 @@ public class ReplicaEvictionServiceTest {
             SUPPORTED_INDEX_TYPES);
     cacheSlotMetadataStore.createAsync(cacheSlotFree);
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 4);
-    await().until(() -> cacheSlotMetadataStore.getCachedSync().size() == 4);
+    await().until(() -> replicaMetadataStore.listSync().size() == 4);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 4);
 
     ReplicaEvictionService replicaEvictionService =
         new ReplicaEvictionService(
@@ -831,7 +830,7 @@ public class ReplicaEvictionServiceTest {
     await()
         .until(
             () ->
-                cacheSlotMetadataStore.getCachedSync().stream()
+                cacheSlotMetadataStore.listSync().stream()
                         .filter(
                             cacheSlotMetadata ->
                                 cacheSlotMetadata.cacheSlotState.equals(
@@ -839,19 +838,19 @@ public class ReplicaEvictionServiceTest {
                         .count()
                     == 2);
 
-    assertThat(replicaMetadataStore.getCachedSync())
+    assertThat(replicaMetadataStore.listSync())
         .containsExactlyInAnyOrder(
             replicaMetadataExpiredOne,
             replicaMetadataExpiredTwo,
             replicaMetadataUnexpiredOne,
             replicaMetadataUnexpiredTwo);
-    assertThat(cacheSlotMetadataStore.getCachedSync())
+    assertThat(cacheSlotMetadataStore.listSync())
         .contains(cacheSlotReplicaExpireTwo, cacheSlotReplicaUnexpiredOne, cacheSlotFree);
-    assertThat(cacheSlotMetadataStore.getCachedSync()).doesNotContain(cacheSlotReplicaExpiredOne);
+    assertThat(cacheSlotMetadataStore.listSync()).doesNotContain(cacheSlotReplicaExpiredOne);
 
     @SuppressWarnings("OptionalGetWithoutIsPresent")
     CacheSlotMetadata updatedCacheSlot =
-        cacheSlotMetadataStore.getCachedSync().stream()
+        cacheSlotMetadataStore.listSync().stream()
             .filter(
                 cacheSlotMetadata ->
                     Objects.equals(cacheSlotMetadata.name, cacheSlotReplicaExpiredOne.name))

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaRestoreServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaRestoreServiceTest.java
@@ -100,11 +100,11 @@ public class ReplicaRestoreServiceTest {
       Thread.sleep(300);
     }
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 7);
+    await().until(() -> replicaMetadataStore.listSync().size() == 7);
     assertThat(meterRegistry.timer(ReplicaRestoreService.REPLICAS_RESTORE_TIMER).count())
         .isEqualTo(1);
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 10);
+    await().until(() -> replicaMetadataStore.listSync().size() == 10);
     assertThat(meterRegistry.timer(ReplicaRestoreService.REPLICAS_RESTORE_TIMER).count())
         .isEqualTo(2);
   }
@@ -141,11 +141,11 @@ public class ReplicaRestoreServiceTest {
           });
     }
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 14);
+    await().until(() -> replicaMetadataStore.listSync().size() == 14);
     assertThat(meterRegistry.timer(ReplicaRestoreService.REPLICAS_RESTORE_TIMER).count())
         .isEqualTo(1);
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 20);
+    await().until(() -> replicaMetadataStore.listSync().size() == 20);
     assertThat(meterRegistry.timer(ReplicaRestoreService.REPLICAS_RESTORE_TIMER).count())
         .isEqualTo(2);
 
@@ -178,7 +178,7 @@ public class ReplicaRestoreServiceTest {
 
     replicaRestoreService.queueSnapshotsForRestoration(duplicateSnapshots);
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> replicaMetadataStore.listSync().size() == 1);
     assertThat(meterRegistry.counter(ReplicaRestoreService.REPLICAS_SKIPPED).count()).isEqualTo(9);
     assertThat(meterRegistry.counter(ReplicaRestoreService.REPLICAS_CREATED).count()).isEqualTo(1);
 
@@ -192,10 +192,10 @@ public class ReplicaRestoreServiceTest {
     replicaRestoreService.queueSnapshotsForRestoration(snapshots);
     replicaRestoreService.queueSnapshotsForRestoration(duplicateSnapshots);
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 4);
+    await().until(() -> replicaMetadataStore.listSync().size() == 4);
     assertThat(meterRegistry.counter(ReplicaRestoreService.REPLICAS_SKIPPED).count()).isEqualTo(19);
     assertThat(meterRegistry.counter(ReplicaRestoreService.REPLICAS_CREATED).count()).isEqualTo(4);
-    assertThat(replicaMetadataStore.getCachedSync().stream().filter(r -> r.isRestored).count())
+    assertThat(replicaMetadataStore.listSync().stream().filter(r -> r.isRestored).count())
         .isEqualTo(4);
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/SnapshotDeletionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/SnapshotDeletionServiceTest.java
@@ -170,7 +170,7 @@ public class SnapshotDeletionServiceTest {
             "1",
             LOGS_LUCENE9);
     snapshotMetadataStore.createAsync(snapshotMetadata);
-    await().until(() -> snapshotMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 1);
 
     SnapshotDeletionService snapshotDeletionService =
         new SnapshotDeletionService(
@@ -179,7 +179,7 @@ public class SnapshotDeletionServiceTest {
     int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
     assertThat(deletes).isEqualTo(1);
 
-    await().until(() -> snapshotMetadataStore.getCachedSync().size() == 0);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 0);
     verify(s3BlobFs, times(1)).delete(eq(path), eq(true));
 
     assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry))
@@ -237,8 +237,8 @@ public class SnapshotDeletionServiceTest {
             LOGS_LUCENE9);
     replicaMetadataStore.createAsync(replicaMetadata);
 
-    await().until(() -> snapshotMetadataStore.getCachedSync().size() == 1);
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 1);
+    await().until(() -> replicaMetadataStore.listSync().size() == 1);
 
     SnapshotDeletionService snapshotDeletionService =
         new SnapshotDeletionService(
@@ -249,8 +249,8 @@ public class SnapshotDeletionServiceTest {
     int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
     assertThat(deletes).isEqualTo(0);
 
-    assertThat(snapshotMetadataStore.getCachedSync()).containsExactlyInAnyOrder(snapshotMetadata);
-    assertThat(replicaMetadataStore.getCachedSync()).containsExactlyInAnyOrder(replicaMetadata);
+    assertThat(snapshotMetadataStore.listSync()).containsExactlyInAnyOrder(snapshotMetadata);
+    assertThat(replicaMetadataStore.listSync()).containsExactlyInAnyOrder(replicaMetadata);
     verify(s3BlobFs, times(0)).delete(any(), anyBoolean());
     assertThat(s3BlobFs.listFiles(directoryPath, true)).isEqualTo(s3BlobFsFiles);
 
@@ -290,8 +290,8 @@ public class SnapshotDeletionServiceTest {
     int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
     assertThat(deletes).isEqualTo(0);
 
-    assertThat(snapshotMetadataStore.getCachedSync().size()).isEqualTo(0);
-    assertThat(replicaMetadataStore.getCachedSync().size()).isEqualTo(0);
+    assertThat(snapshotMetadataStore.listSync().size()).isEqualTo(0);
+    assertThat(replicaMetadataStore.listSync().size()).isEqualTo(0);
     verify(s3BlobFs, times(0)).delete(any(), anyBoolean());
 
     assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry))
@@ -338,7 +338,7 @@ public class SnapshotDeletionServiceTest {
             "1",
             LOGS_LUCENE9);
     snapshotMetadataStore.createAsync(snapshotMetadata);
-    await().until(() -> snapshotMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 1);
     String[] s3BlobFsFiles = s3BlobFs.listFiles(directoryPath, true);
     assertThat(s3BlobFsFiles.length).isNotEqualTo(0);
 
@@ -349,7 +349,7 @@ public class SnapshotDeletionServiceTest {
     int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
     assertThat(deletes).isEqualTo(0);
 
-    assertThat(snapshotMetadataStore.getCachedSync()).containsExactlyInAnyOrder(snapshotMetadata);
+    assertThat(snapshotMetadataStore.listSync()).containsExactlyInAnyOrder(snapshotMetadata);
     verify(s3BlobFs, times(0)).delete(any(), anyBoolean());
     assertThat(s3BlobFs.listFiles(directoryPath, true)).isEqualTo(s3BlobFsFiles);
 
@@ -410,8 +410,8 @@ public class SnapshotDeletionServiceTest {
             LOGS_LUCENE9);
     replicaMetadataStore.createAsync(replicaMetadata);
 
-    await().until(() -> snapshotMetadataStore.getCachedSync().size() == 1);
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 1);
+    await().until(() -> replicaMetadataStore.listSync().size() == 1);
     String[] s3BlobFsFiles = s3BlobFs.listFiles(directoryPath, true);
     assertThat(s3BlobFsFiles.length).isNotEqualTo(0);
 
@@ -422,8 +422,8 @@ public class SnapshotDeletionServiceTest {
     int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
     assertThat(deletes).isEqualTo(0);
 
-    assertThat(snapshotMetadataStore.getCachedSync()).containsExactlyInAnyOrder(snapshotMetadata);
-    assertThat(replicaMetadataStore.getCachedSync()).containsExactlyInAnyOrder(replicaMetadata);
+    assertThat(snapshotMetadataStore.listSync()).containsExactlyInAnyOrder(snapshotMetadata);
+    assertThat(replicaMetadataStore.listSync()).containsExactlyInAnyOrder(replicaMetadata);
     verify(s3BlobFs, times(0)).delete(any(), anyBoolean());
     assertThat(s3BlobFs.listFiles(directoryPath, true)).isEqualTo(s3BlobFsFiles);
 
@@ -473,7 +473,7 @@ public class SnapshotDeletionServiceTest {
             LOGS_LUCENE9);
     snapshotMetadataStore.createAsync(snapshotMetadata);
 
-    await().until(() -> snapshotMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 1);
 
     SnapshotDeletionService snapshotDeletionService =
         new SnapshotDeletionService(
@@ -483,7 +483,7 @@ public class SnapshotDeletionServiceTest {
     int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
     assertThat(deletes).isEqualTo(0);
 
-    assertThat(snapshotMetadataStore.getCachedSync().size()).isEqualTo(1);
+    assertThat(snapshotMetadataStore.listSync().size()).isEqualTo(1);
 
     assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry))
         .isEqualTo(0);
@@ -530,7 +530,7 @@ public class SnapshotDeletionServiceTest {
             "1",
             LOGS_LUCENE9);
     snapshotMetadataStore.createAsync(snapshotMetadata);
-    await().until(() -> snapshotMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 1);
 
     SnapshotDeletionService snapshotDeletionService =
         new SnapshotDeletionService(
@@ -545,7 +545,7 @@ public class SnapshotDeletionServiceTest {
     int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
     assertThat(deletes).isEqualTo(0);
 
-    assertThat(snapshotMetadataStore.getCachedSync()).containsExactlyInAnyOrder(snapshotMetadata);
+    assertThat(snapshotMetadataStore.listSync()).containsExactlyInAnyOrder(snapshotMetadata);
     verify(s3BlobFs, times(1)).delete(any(), anyBoolean());
     assertThat(s3BlobFs.listFiles(directoryPath, true)).isEmpty();
 
@@ -594,7 +594,7 @@ public class SnapshotDeletionServiceTest {
             "1",
             LOGS_LUCENE9);
     snapshotMetadataStore.createAsync(snapshotMetadata);
-    await().until(() -> snapshotMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 1);
 
     SnapshotDeletionService snapshotDeletionService =
         new SnapshotDeletionService(
@@ -604,7 +604,7 @@ public class SnapshotDeletionServiceTest {
     int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
     assertThat(deletes).isEqualTo(0);
 
-    assertThat(snapshotMetadataStore.getCachedSync().size()).isEqualTo(1);
+    assertThat(snapshotMetadataStore.listSync().size()).isEqualTo(1);
 
     assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry))
         .isEqualTo(0);
@@ -651,7 +651,7 @@ public class SnapshotDeletionServiceTest {
             "1",
             LOGS_LUCENE9);
     snapshotMetadataStore.createAsync(snapshotMetadata);
-    await().until(() -> snapshotMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 1);
 
     SnapshotDeletionService snapshotDeletionService =
         new SnapshotDeletionService(
@@ -679,7 +679,7 @@ public class SnapshotDeletionServiceTest {
     int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
     assertThat(deletes).isEqualTo(0);
 
-    assertThat(snapshotMetadataStore.getCachedSync()).containsExactlyInAnyOrder(snapshotMetadata);
+    assertThat(snapshotMetadataStore.listSync()).containsExactlyInAnyOrder(snapshotMetadata);
     verify(s3BlobFs, times(1)).delete(any(), anyBoolean());
     assertThat(s3BlobFs.listFiles(directoryPath, true)).isEmpty();
 
@@ -696,7 +696,7 @@ public class SnapshotDeletionServiceTest {
     int deletesRetry = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
     assertThat(deletesRetry).isEqualTo(1);
 
-    await().until(() -> snapshotMetadataStore.getCachedSync().size() == 0);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 0);
     // delete was called once before - should still be only once
     verify(s3BlobFs, times(1)).delete(any(), anyBoolean());
     assertThat(s3BlobFs.listFiles(directoryPath, true)).isEmpty();
@@ -749,7 +749,7 @@ public class SnapshotDeletionServiceTest {
             LOGS_LUCENE9);
     snapshotMetadataStore.createAsync(snapshotMetadata);
 
-    await().until(() -> snapshotMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 1);
 
     SnapshotDeletionService snapshotDeletionService =
         new SnapshotDeletionService(
@@ -759,7 +759,7 @@ public class SnapshotDeletionServiceTest {
     int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
     assertThat(deletes).isEqualTo(0);
 
-    assertThat(snapshotMetadataStore.getCachedSync().size()).isEqualTo(1);
+    assertThat(snapshotMetadataStore.listSync().size()).isEqualTo(1);
     verify(s3BlobFs, times(1)).delete(any(), anyBoolean());
 
     assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry))
@@ -774,7 +774,7 @@ public class SnapshotDeletionServiceTest {
     int deleteRetry = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
     assertThat(deleteRetry).isEqualTo(1);
 
-    await().until(() -> snapshotMetadataStore.getCachedSync().size() == 0);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 0);
     verify(s3BlobFs, times(2)).delete(any(), anyBoolean());
 
     assertThat(MetricsUtil.getCount(SnapshotDeletionService.SNAPSHOT_DELETE_SUCCESS, meterRegistry))
@@ -821,7 +821,7 @@ public class SnapshotDeletionServiceTest {
             "1",
             LOGS_LUCENE9);
     snapshotMetadataStore.createAsync(snapshotMetadata);
-    await().until(() -> snapshotMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 1);
 
     SnapshotDeletionService snapshotDeletionService =
         new SnapshotDeletionService(
@@ -829,7 +829,7 @@ public class SnapshotDeletionServiceTest {
     snapshotDeletionService.startAsync();
     snapshotDeletionService.awaitRunning(DEFAULT_START_STOP_DURATION);
 
-    await().until(() -> snapshotMetadataStore.getCachedSync().size() == 0);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 0);
     verify(s3BlobFs, times(1)).delete(eq(directoryPath), eq(true));
 
     await()

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
@@ -116,8 +116,8 @@ public class KaldbDistributedQueryServiceTest {
     Instant chunk1EndTime = Instant.ofEpochMilli(200);
     String chunk1Name =
         createIndexerZKMetadata(chunk1CreationTime, chunk1EndTime, "1", indexer1SearchContext);
-    await().until(() -> snapshotMetadataStore.listSync().size() == 2);
-    await().until(() -> searchMetadataStore.listSync().size() == 1);
+    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 2);
+    await().until(() -> searchMetadataStore.listSyncUncached().size() == 1);
 
     // we don't have any dataset metadata entry, so we shouldn't be able to find any snapshot
     Map<String, List<String>> searchNodes =
@@ -134,7 +134,7 @@ public class KaldbDistributedQueryServiceTest {
     DatasetMetadata datasetMetadata =
         new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSync().size() == 1);
+    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
 
     // now we can find the snapshot
     searchNodes =
@@ -167,8 +167,8 @@ public class KaldbDistributedQueryServiceTest {
     Instant chunk2EndTime = Instant.ofEpochMilli(300);
     String chunk2Name =
         createIndexerZKMetadata(chunk2CreationTime, chunk2EndTime, "1", indexer1SearchContext);
-    await().until(() -> snapshotMetadataStore.listSync().size() == 4);
-    await().until(() -> searchMetadataStore.listSync().size() == 2);
+    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 4);
+    await().until(() -> searchMetadataStore.listSyncUncached().size() == 2);
     searchNodes =
         getSearchNodesToQuery(
             snapshotMetadataStore, searchMetadataStore, datasetMetadataStore, 0, 300, indexName);
@@ -202,11 +202,11 @@ public class KaldbDistributedQueryServiceTest {
 
     // re-add dataset metadata with a different time window that doesn't match any snapshot
     datasetMetadataStore.deleteAsync(datasetMetadata.name);
-    await().until(() -> datasetMetadataStore.listSync().size() == 0);
+    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 0);
     partition = new DatasetPartitionMetadata(1, 99, List.of("1"));
     datasetMetadata = new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSync().size() == 1);
+    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
 
     // we can't find snapshot since the time window doesn't match any dataset metadata
     searchNodes =
@@ -231,14 +231,14 @@ public class KaldbDistributedQueryServiceTest {
     DatasetMetadata datasetMetadata =
         new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSync().size() == 1);
+    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
 
     Instant chunk1CreationTime = Instant.ofEpochMilli(100);
     Instant chunk1EndTime = Instant.ofEpochMilli(200);
     String snapshot1Name =
         createIndexerZKMetadata(chunk1CreationTime, chunk1EndTime, "1", indexer1SearchContext);
-    assertThat(snapshotMetadataStore.listSync().size()).isEqualTo(2);
-    assertThat(searchMetadataStore.listSync().size()).isEqualTo(1);
+    assertThat(snapshotMetadataStore.listSyncUncached().size()).isEqualTo(2);
+    assertThat(searchMetadataStore.listSyncUncached().size()).isEqualTo(1);
 
     AtomicReference<Map<String, List<String>>> searchNodes = new AtomicReference<>();
     await()
@@ -267,7 +267,7 @@ public class KaldbDistributedQueryServiceTest {
     SearchMetadata cacheNodeSearchMetada =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache1SearchContext, snapshot1Name);
-    await().until(() -> searchMetadataStore.listSync().size() == 2);
+    await().until(() -> searchMetadataStore.listSyncUncached().size() == 2);
 
     searchNodes.set(
         getSearchNodesToQuery(
@@ -289,7 +289,7 @@ public class KaldbDistributedQueryServiceTest {
     SearchMetadata snapshot1Cache2SearchMetadata =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache2SearchContext, snapshot1Name);
-    await().until(() -> searchMetadataStore.listSync().size() == 3);
+    await().until(() -> searchMetadataStore.listSyncUncached().size() == 3);
 
     searchNodes.set(
         getSearchNodesToQuery(
@@ -318,13 +318,13 @@ public class KaldbDistributedQueryServiceTest {
     await()
         .until(
             () ->
-                snapshotMetadataStore.listSync().size()
+                snapshotMetadataStore.listSyncUncached().size()
                     == 3); // snapshot1(live + non_live) + snapshot2
 
     SearchMetadata snapshot2Cache2SearchMetadata =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache2SearchContext, snapshot2Metadata.name);
-    await().until(() -> searchMetadataStore.listSync().size() == 4);
+    await().until(() -> searchMetadataStore.listSyncUncached().size() == 4);
 
     Instant snapshot3CreationTime = Instant.ofEpochMilli(151);
     Instant snapshot3EndTime = Instant.ofEpochMilli(250);
@@ -333,13 +333,13 @@ public class KaldbDistributedQueryServiceTest {
     await()
         .until(
             () ->
-                snapshotMetadataStore.listSync().size()
+                snapshotMetadataStore.listSyncUncached().size()
                     == 4); // snapshot1(live + non_live) + snapshot2 + snapshot3
 
     SearchMetadata snapshot3Cache1SearchMetadata =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache1SearchContext, snapshot3Metadata.name);
-    await().until(() -> searchMetadataStore.listSync().size() == 5);
+    await().until(() -> searchMetadataStore.listSyncUncached().size() == 5);
 
     searchNodes.set(
         getSearchNodesToQuery(
@@ -396,14 +396,14 @@ public class KaldbDistributedQueryServiceTest {
     DatasetMetadata datasetMetadata =
         new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSync().size() == 1);
+    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
 
     Instant chunk1CreationTime = Instant.ofEpochMilli(100);
     Instant chunk1EndTime = Instant.ofEpochMilli(200);
     String snapshot1Name =
         createIndexerZKMetadata(chunk1CreationTime, chunk1EndTime, "1", indexer1SearchContext);
-    assertThat(snapshotMetadataStore.listSync().size()).isEqualTo(2);
-    assertThat(searchMetadataStore.listSync().size()).isEqualTo(1);
+    assertThat(snapshotMetadataStore.listSyncUncached().size()).isEqualTo(2);
+    assertThat(searchMetadataStore.listSyncUncached().size()).isEqualTo(1);
 
     Map<String, List<String>> searchNodes =
         getSearchNodesToQuery(
@@ -424,8 +424,8 @@ public class KaldbDistributedQueryServiceTest {
     Instant chunk2EndTime = Instant.ofEpochMilli(300);
     String snapshot2Name =
         createIndexerZKMetadata(chunk2CreationTime, chunk2EndTime, "1", indexer1SearchContext);
-    assertThat(snapshotMetadataStore.listSync().size()).isEqualTo(4);
-    assertThat(searchMetadataStore.listSync().size()).isEqualTo(2);
+    assertThat(snapshotMetadataStore.listSyncUncached().size()).isEqualTo(4);
+    assertThat(searchMetadataStore.listSyncUncached().size()).isEqualTo(2);
 
     searchNodes =
         getSearchNodesToQuery(
@@ -471,7 +471,7 @@ public class KaldbDistributedQueryServiceTest {
     SearchMetadata cacheNodeSearchMetada =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache1SearchContext, snapshot1Name);
-    await().until(() -> searchMetadataStore.listSync().size() == 3);
+    await().until(() -> searchMetadataStore.listSyncUncached().size() == 3);
 
     searchNodes =
         getSearchNodesToQuery(
@@ -490,11 +490,11 @@ public class KaldbDistributedQueryServiceTest {
 
     // re-add dataset metadata with a different time window that doesn't match any snapshot
     datasetMetadataStore.deleteAsync(datasetMetadata.name);
-    await().until(() -> datasetMetadataStore.listSync().size() == 0);
+    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 0);
     partition = new DatasetPartitionMetadata(1, 99, List.of("1"));
     datasetMetadata = new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSync().size() == 1);
+    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
 
     // we can't find snapshot since the time window doesn't match any dataset metadata
     searchNodes =
@@ -518,19 +518,19 @@ public class KaldbDistributedQueryServiceTest {
     Instant chunkCreationTime = Instant.ofEpochMilli(100);
     Instant chunkEndTime = Instant.ofEpochMilli(200);
     SnapshotMetadata snapshotMetadata = createSnapshot(chunkCreationTime, chunkEndTime, false, "1");
-    await().until(() -> snapshotMetadataStore.listSync().size() == 1);
+    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 1);
 
     // create first search metadata hosted by cache1
     SearchMetadata cache1NodeSearchMetada =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache1SearchContext, snapshotMetadata.name);
-    await().until(() -> searchMetadataStore.listSync().size() == 1);
+    await().until(() -> searchMetadataStore.listSyncUncached().size() == 1);
 
     DatasetPartitionMetadata partition = new DatasetPartitionMetadata(1, 500, List.of("1"));
     DatasetMetadata datasetMetadata =
         new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSync().size() == 1);
+    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
 
     // assert search will always find cache1
     Map<String, List<String>> searchNodes =
@@ -552,7 +552,7 @@ public class KaldbDistributedQueryServiceTest {
     SearchMetadata cache2NodeSearchMetada =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache2SearchContext, snapshotMetadata.name);
-    await().until(() -> searchMetadataStore.listSync().size() == 2);
+    await().until(() -> searchMetadataStore.listSyncUncached().size() == 2);
 
     // assert search will always find cache1 or cache2
     searchNodes =
@@ -583,12 +583,13 @@ public class KaldbDistributedQueryServiceTest {
     Instant snapshot2EndTime = Instant.ofEpochMilli(150);
     SnapshotMetadata snapshot2Metadata =
         createSnapshot(snapshot2CreationTime, snapshot2EndTime, false, "1");
-    await().until(() -> snapshotMetadataStore.listSync().size() == 2); // snapshot1 + snapshot2
+    await()
+        .until(() -> snapshotMetadataStore.listSyncUncached().size() == 2); // snapshot1 + snapshot2
 
     SearchMetadata snapshot2Cache2SearchMetadata =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache2SearchContext, snapshot2Metadata.name);
-    await().until(() -> searchMetadataStore.listSync().size() == 3);
+    await().until(() -> searchMetadataStore.listSyncUncached().size() == 3);
 
     // now add snapshot3 to cache1
     Instant snapshot3CreationTime = Instant.ofEpochMilli(151);
@@ -598,12 +599,13 @@ public class KaldbDistributedQueryServiceTest {
     await()
         .until(
             () ->
-                snapshotMetadataStore.listSync().size() == 3); // snapshot1 + snapshot2 + snapshot3
+                snapshotMetadataStore.listSyncUncached().size()
+                    == 3); // snapshot1 + snapshot2 + snapshot3
 
     SearchMetadata snapshot3Cache1SearchMetadata =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache1SearchContext, snapshot3Metadata.name);
-    await().until(() -> searchMetadataStore.listSync().size() == 4);
+    await().until(() -> searchMetadataStore.listSyncUncached().size() == 4);
 
     // assert search will always find cache1 AND cache2
     searchNodes =
@@ -658,17 +660,17 @@ public class KaldbDistributedQueryServiceTest {
     // dataset1 snapshots/search-metadata/partitions
     SnapshotMetadata snapshotMetadata =
         createSnapshot(Instant.ofEpochMilli(100), Instant.ofEpochMilli(200), false, "1");
-    await().until(() -> snapshotMetadataStore.listSync().size() == 1);
+    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 1);
     ReadOnlyChunkImpl.registerSearchMetadata(
         searchMetadataStore, cache1SearchContext, snapshotMetadata.name);
-    await().until(() -> searchMetadataStore.listSync().size() == 1);
+    await().until(() -> searchMetadataStore.listSyncUncached().size() == 1);
 
     snapshotMetadata =
         createSnapshot(Instant.ofEpochMilli(201), Instant.ofEpochMilli(300), false, "2");
-    await().until(() -> snapshotMetadataStore.listSync().size() == 2);
+    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 2);
     ReadOnlyChunkImpl.registerSearchMetadata(
         searchMetadataStore, cache2SearchContext, snapshotMetadata.name);
-    await().until(() -> searchMetadataStore.listSync().size() == 2);
+    await().until(() -> searchMetadataStore.listSyncUncached().size() == 2);
 
     final String name = "testDataset";
     final String owner = "DatasetOwner";
@@ -682,22 +684,22 @@ public class KaldbDistributedQueryServiceTest {
         new DatasetMetadata(name, owner, throughputBytes, List.of(partition11, partition12), name);
 
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSync().size() == 1);
+    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
 
     // dataset2 snapshots/search-metadata/partitions
     snapshotMetadata =
         createSnapshot(Instant.ofEpochMilli(100), Instant.ofEpochMilli(200), false, "2");
-    await().until(() -> snapshotMetadataStore.listSync().size() == 3);
+    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 3);
     ReadOnlyChunkImpl.registerSearchMetadata(
         searchMetadataStore, cache3SearchContext, snapshotMetadata.name);
-    await().until(() -> searchMetadataStore.listSync().size() == 3);
+    await().until(() -> searchMetadataStore.listSyncUncached().size() == 3);
 
     snapshotMetadata =
         createSnapshot(Instant.ofEpochMilli(201), Instant.ofEpochMilli(300), false, "1");
-    await().until(() -> snapshotMetadataStore.listSync().size() == 4);
+    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 4);
     ReadOnlyChunkImpl.registerSearchMetadata(
         searchMetadataStore, cache4SearchContext, snapshotMetadata.name);
-    await().until(() -> searchMetadataStore.listSync().size() == 4);
+    await().until(() -> searchMetadataStore.listSyncUncached().size() == 4);
 
     final String name1 = "testDataset1";
     final String owner1 = "DatasetOwner1";
@@ -711,7 +713,7 @@ public class KaldbDistributedQueryServiceTest {
         new DatasetMetadata(
             name1, owner1, throughputBytes1, List.of(partition21, partition22), name1);
     datasetMetadataStore.createSync(datasetMetadata1);
-    await().until(() -> datasetMetadataStore.listSync().size() == 2);
+    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 2);
 
     // find search nodes that will be queries for the first dataset
     Map<String, List<String>> searchNodes =
@@ -761,14 +763,14 @@ public class KaldbDistributedQueryServiceTest {
     Instant chunkCreationTime = Instant.ofEpochMilli(100);
     Instant chunkEndTime = Instant.ofEpochMilli(200);
     createIndexerZKMetadata(chunkCreationTime, chunkEndTime, "1", indexer1SearchContext);
-    await().until(() -> snapshotMetadataStore.listSync().size() == 2);
-    await().until(() -> searchMetadataStore.listSync().size() == 1);
+    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 2);
+    await().until(() -> searchMetadataStore.listSyncUncached().size() == 1);
 
     DatasetPartitionMetadata partition = new DatasetPartitionMetadata(1, 200, List.of("1"));
     DatasetMetadata datasetMetadata =
         new DatasetMetadata(indexName1, "testOwner1", 1, List.of(partition), indexName1);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSync().size() == 1);
+    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
 
     Map<String, List<String>> searchNodes =
         getSearchNodesToQuery(
@@ -783,14 +785,14 @@ public class KaldbDistributedQueryServiceTest {
 
     // search for partition "2" only
     createIndexerZKMetadata(chunkCreationTime, chunkEndTime, "2", indexer2SearchContext);
-    await().until(() -> snapshotMetadataStore.listSync().size() == 4);
-    await().until(() -> searchMetadataStore.listSync().size() == 2);
+    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 4);
+    await().until(() -> searchMetadataStore.listSyncUncached().size() == 2);
 
     partition = new DatasetPartitionMetadata(1, 101, List.of("2"));
     datasetMetadata =
         new DatasetMetadata(indexName2, "testOwner2", 1, List.of(partition), indexName2);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSync().size() == 2);
+    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 2);
 
     searchNodes =
         getSearchNodesToQuery(
@@ -822,10 +824,10 @@ public class KaldbDistributedQueryServiceTest {
 
     // mock the zookeeper responses, as we don't want to test ZK behavior here
     SearchMetadataStore searchMetadataStoreMock = mock(SearchMetadataStore.class);
-    when(searchMetadataStoreMock.getCachedSync())
+    when(searchMetadataStoreMock.listSync())
         .thenReturn(List.of(new SearchMetadata("foo", "snapshot1", "http://127.0.0.1")));
     SnapshotMetadataStore snapshotMetadataStoreMock = mock(SnapshotMetadataStore.class);
-    when(snapshotMetadataStoreMock.getCachedSync())
+    when(snapshotMetadataStoreMock.listSync())
         .thenReturn(
             List.of(
                 new SnapshotMetadata(
@@ -837,7 +839,7 @@ public class KaldbDistributedQueryServiceTest {
                     "1",
                     Metadata.IndexType.LOGS_LUCENE9)));
     DatasetMetadataStore datasetMetadataStoreMock = mock(DatasetMetadataStore.class);
-    when(datasetMetadataStoreMock.getCachedSync())
+    when(datasetMetadataStoreMock.listSync())
         .thenReturn(
             List.of(
                 new DatasetMetadata(

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStoreTest.java
@@ -72,12 +72,12 @@ public class CacheSlotMetadataStoreTest {
     assertThat(cacheSlotMetadata.supportedIndexTypes).isEqualTo(SUPPORTED_INDEX_TYPES);
 
     uncachedStore.createSync(cacheSlotMetadata);
-    assertThat(uncachedStore.listSync().size()).isEqualTo(1);
+    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
 
     uncachedStore
         .getAndUpdateNonFreeCacheSlotState(name, CacheSlotState.LIVE)
         .get(1, TimeUnit.SECONDS);
-    assertThat(uncachedStore.listSync().size()).isEqualTo(1);
+    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
     final CacheSlotMetadata liveNode = uncachedStore.getSync(name);
     assertThat(liveNode.name).isEqualTo(name);
     assertThat(liveNode.cacheSlotState).isEqualTo(CacheSlotState.LIVE);
@@ -88,7 +88,7 @@ public class CacheSlotMetadataStoreTest {
     uncachedStore
         .getAndUpdateNonFreeCacheSlotState(name, CacheSlotState.EVICT)
         .get(1, TimeUnit.SECONDS);
-    assertThat(uncachedStore.listSync().size()).isEqualTo(1);
+    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
     final CacheSlotMetadata evictNode = uncachedStore.getSync(name);
     assertThat(evictNode.name).isEqualTo(name);
     assertThat(evictNode.cacheSlotState).isEqualTo(CacheSlotState.EVICT);
@@ -99,7 +99,7 @@ public class CacheSlotMetadataStoreTest {
     uncachedStore
         .getAndUpdateNonFreeCacheSlotState(name, CacheSlotState.FREE)
         .get(1, TimeUnit.SECONDS);
-    assertThat(uncachedStore.listSync().size()).isEqualTo(1);
+    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
     final CacheSlotMetadata freeNode = uncachedStore.getSync(name);
     assertThat(freeNode.name).isEqualTo(name);
     assertThat(freeNode.cacheSlotState).isEqualTo(CacheSlotState.FREE);
@@ -133,12 +133,12 @@ public class CacheSlotMetadataStoreTest {
     assertThat(cacheSlotMetadata.supportedIndexTypes).isEqualTo(SUPPORTED_INDEX_TYPES);
 
     uncachedStore.createSync(cacheSlotMetadata);
-    assertThat(uncachedStore.listSync().size()).isEqualTo(1);
+    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
 
     uncachedStore
         .updateNonFreeCacheSlotState(cacheSlotMetadata, CacheSlotState.LIVE)
         .get(1, TimeUnit.SECONDS);
-    assertThat(uncachedStore.listSync().size()).isEqualTo(1);
+    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
     final CacheSlotMetadata liveNode = uncachedStore.getSync(name);
     assertThat(liveNode.name).isEqualTo(name);
     assertThat(liveNode.cacheSlotState).isEqualTo(CacheSlotState.LIVE);
@@ -149,7 +149,7 @@ public class CacheSlotMetadataStoreTest {
     uncachedStore
         .updateNonFreeCacheSlotState(liveNode, CacheSlotState.EVICT)
         .get(1, TimeUnit.SECONDS);
-    assertThat(uncachedStore.listSync().size()).isEqualTo(1);
+    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
     final CacheSlotMetadata evictNode = uncachedStore.getSync(name);
     assertThat(evictNode.name).isEqualTo(name);
     assertThat(evictNode.cacheSlotState).isEqualTo(CacheSlotState.EVICT);
@@ -160,7 +160,7 @@ public class CacheSlotMetadataStoreTest {
     uncachedStore
         .updateNonFreeCacheSlotState(evictNode, CacheSlotState.FREE)
         .get(1, TimeUnit.SECONDS);
-    assertThat(uncachedStore.listSync().size()).isEqualTo(1);
+    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
     final CacheSlotMetadata freeNode = uncachedStore.getSync(name);
     assertThat(freeNode.name).isEqualTo(name);
     assertThat(freeNode.cacheSlotState).isEqualTo(CacheSlotState.FREE);
@@ -195,12 +195,12 @@ public class CacheSlotMetadataStoreTest {
     assertThat(cacheSlotMetadata.supportedIndexTypes).isEqualTo(SUPPORTED_INDEX_TYPES);
 
     uncachedStore.createSync(cacheSlotMetadata);
-    assertThat(uncachedStore.listSync().size()).isEqualTo(1);
+    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
 
     uncachedStore
         .updateCacheSlotStateStateWithReplicaId(cacheSlotMetadata, cacheSlotState, "")
         .get(1, TimeUnit.SECONDS);
-    assertThat(uncachedStore.listSync().size()).isEqualTo(1);
+    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
     final CacheSlotMetadata freeNode = uncachedStore.getSync(name);
     assertThat(freeNode.name).isEqualTo(name);
     assertThat(freeNode.cacheSlotState).isEqualTo(cacheSlotState);
@@ -213,7 +213,7 @@ public class CacheSlotMetadataStoreTest {
         .updateCacheSlotStateStateWithReplicaId(
             cacheSlotMetadata, Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED, replicaId)
         .get(1, TimeUnit.SECONDS);
-    assertThat(uncachedStore.listSync().size()).isEqualTo(1);
+    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
     CacheSlotMetadata assignedNode = uncachedStore.getSync(name);
     assertThat(assignedNode.name).isEqualTo(name);
     assertThat(assignedNode.cacheSlotState)
@@ -226,7 +226,7 @@ public class CacheSlotMetadataStoreTest {
         .updateCacheSlotStateStateWithReplicaId(
             cacheSlotMetadata, Metadata.CacheSlotMetadata.CacheSlotState.EVICT, replicaId)
         .get(1, TimeUnit.SECONDS);
-    assertThat(uncachedStore.listSync().size()).isEqualTo(1);
+    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
     CacheSlotMetadata evictedNode = uncachedStore.getSync(name);
     assertThat(evictedNode.name).isEqualTo(name);
     assertThat(evictedNode.cacheSlotState)

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbPartitioningMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbPartitioningMetadataStoreTest.java
@@ -1,0 +1,362 @@
+package com.slack.kaldb.metadata.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.slack.kaldb.metadata.snapshot.SnapshotMetadata;
+import com.slack.kaldb.metadata.snapshot.SnapshotMetadataSerializer;
+import com.slack.kaldb.proto.config.KaldbConfigs;
+import com.slack.kaldb.proto.metadata.Metadata;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.curator.test.TestingServer;
+import org.apache.curator.x.async.AsyncCuratorFramework;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.server.EphemeralType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class KaldbPartitioningMetadataStoreTest {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(KaldbPartitioningMetadataStoreTest.class);
+
+  private SimpleMeterRegistry meterRegistry;
+  private TestingServer testingServer;
+  private AsyncCuratorFramework curatorFramework;
+
+  private static final String ZNODE_CONTAINER_CHECK_INTERVAL_MS = "znode.container.checkIntervalMs";
+  private final Integer checkInterval = Integer.getInteger(ZNODE_CONTAINER_CHECK_INTERVAL_MS);
+
+  private static class ExampleMetadata extends KaldbPartitionedMetadata {
+
+    private String extraField = "";
+
+    public ExampleMetadata(String name) {
+      super(name);
+    }
+
+    @JsonCreator
+    public ExampleMetadata(
+        @JsonProperty("name") String name, @JsonProperty("extraField") String extraField) {
+      super(name);
+      this.extraField = extraField;
+    }
+
+    public String getExtraField() {
+      return extraField;
+    }
+
+    public void setExtraField(String extraField) {
+      this.extraField = extraField;
+    }
+
+    @Override
+    @JsonIgnore
+    public String getPartition() {
+      return String.valueOf(Math.abs(name.hashCode() % 10));
+    }
+  }
+
+  private static class ExampleMetadataSerializer implements MetadataSerializer<ExampleMetadata> {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String toJsonStr(ExampleMetadata metadata) {
+      try {
+        return objectMapper.writeValueAsString(metadata);
+      } catch (JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    public ExampleMetadata fromJsonStr(String data) {
+      try {
+        return objectMapper.readValue(data, ExampleMetadata.class);
+      } catch (JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    System.setProperty(ZNODE_CONTAINER_CHECK_INTERVAL_MS, "100");
+
+    meterRegistry = new SimpleMeterRegistry();
+    testingServer = new TestingServer();
+
+    KaldbConfigs.ZookeeperConfig zookeeperConfig =
+        KaldbConfigs.ZookeeperConfig.newBuilder()
+            // .setZkConnectString("127.0.0.1:2181")
+            .setZkConnectString(testingServer.getConnectString())
+            .setZkPathPrefix("Test")
+            .setZkSessionTimeoutMs(1000)
+            .setZkConnectionTimeoutMs(1000)
+            .setSleepBetweenRetriesMs(500)
+            .build();
+    this.curatorFramework = CuratorBuilder.build(meterRegistry, zookeeperConfig);
+  }
+
+  @AfterEach
+  public void tearDown() throws IOException {
+    curatorFramework.unwrap().close();
+    testingServer.close();
+    meterRegistry.close();
+
+    System.setProperty(ZNODE_CONTAINER_CHECK_INTERVAL_MS, String.valueOf(checkInterval));
+  }
+
+  @Test
+  @Disabled("For local benchmarking purposes only")
+  void legacy() {
+    KaldbMetadataStore<SnapshotMetadata> unpartitionedMetdataStore =
+        new KaldbMetadataStore<>(
+            curatorFramework,
+            CreateMode.PERSISTENT,
+            new SnapshotMetadataSerializer().toModelSerializer(),
+            "/unpartitioned_snapshot");
+
+    int size = 50_000;
+
+    for (int i = 1; i <= (size / 1000); i++) {
+      for (int j = 0; j < 1000; j++) {
+        Instant randomizedStart =
+            Instant.now().minus(Duration.of(Math.round(Math.random() * 24), ChronoUnit.HOURS));
+
+        unpartitionedMetdataStore.createAsync(
+            new SnapshotMetadata(
+                "id" + i + "_" + j,
+                "foo",
+                randomizedStart.toEpochMilli(),
+                randomizedStart.toEpochMilli(),
+                10,
+                "foo",
+                Metadata.IndexType.LOGS_LUCENE9));
+      }
+
+      int finalI = i;
+      await().until(() -> unpartitionedMetdataStore.listSyncUncached().size() == (finalI * 1000));
+
+      LOG.info("current batch iterator {}", i);
+    }
+
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .until(
+            () -> {
+              int cacheSize = unpartitionedMetdataStore.listSyncUncached().size();
+              LOG.info("current cache size {}", cacheSize);
+              return cacheSize == size;
+            });
+  }
+
+  @Test
+  void partitioned() throws IOException {
+    try (KaldbPartitioningMetadataStore<ExampleMetadata> partitionedMetdataStore =
+        new KaldbPartitioningMetadataStore<>(
+            curatorFramework,
+            CreateMode.PERSISTENT,
+            new ExampleMetadataSerializer().toModelSerializer(),
+            "/partitioned_snapshot")) {
+
+      int size = 50_000;
+
+      for (int i = 1; i <= (size / 1000); i++) {
+        for (int j = 0; j < 1000; j++) {
+          partitionedMetdataStore.createAsync(new ExampleMetadata("id" + i + "_" + j));
+        }
+
+        int finalI = i;
+        await().until(() -> partitionedMetdataStore.listSync().size() == (finalI * 1000));
+
+        LOG.info("current batch iterator {}", i);
+      }
+
+      await()
+          .atMost(Duration.ofSeconds(30))
+          .until(
+              () -> {
+                int cacheSize = partitionedMetdataStore.listSync().size();
+                LOG.info("current cache size {}", cacheSize);
+                return cacheSize == size;
+              });
+    }
+  }
+
+  @Test
+  void create() throws IOException {
+    try (KaldbPartitioningMetadataStore<ExampleMetadata> partitionedMetdataStore =
+        new KaldbPartitioningMetadataStore<>(
+            curatorFramework,
+            CreateMode.PERSISTENT,
+            new ExampleMetadataSerializer().toModelSerializer(),
+            "/partitioned_snapshot_2")) {
+
+      ExampleMetadata exampleMetadata = new ExampleMetadata("id");
+      partitionedMetdataStore.createSync(exampleMetadata);
+
+      await().until(() -> partitionedMetdataStore.listSync().size() == 1);
+      await()
+          .until(
+              () -> {
+                List<ExampleMetadata> snapshotMetadataList = partitionedMetdataStore.listSync();
+                return snapshotMetadataList.contains(exampleMetadata)
+                    && snapshotMetadataList.size() == 1;
+              });
+    }
+  }
+
+  @Test
+  void update() throws IOException {
+    try (KaldbPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
+        new KaldbPartitioningMetadataStore<>(
+            curatorFramework,
+            CreateMode.PERSISTENT,
+            new ExampleMetadataSerializer().toModelSerializer(),
+            "/partitioned_snapshot_update")) {
+
+      ExampleMetadata exampleMetadata = new ExampleMetadata("id");
+      partitionedMetadataStore.createAsync(exampleMetadata);
+
+      AtomicReference<List<ExampleMetadata>> exampleMetadataList = new AtomicReference<>();
+      await()
+          .until(
+              () -> {
+                exampleMetadataList.set(partitionedMetadataStore.listSync());
+                return exampleMetadataList.get().size() == 1;
+              });
+      assertThat(exampleMetadataList.get()).containsExactly(exampleMetadata);
+
+      exampleMetadata.setExtraField("foo");
+      partitionedMetadataStore.updateSync(exampleMetadata);
+
+      await()
+          .until(
+              () -> Objects.equals(partitionedMetadataStore.listSync().get(0).extraField, "foo"));
+    }
+  }
+
+  @Test
+  void listeners() throws ExecutionException, InterruptedException, IOException {
+    try (KaldbPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
+        new KaldbPartitioningMetadataStore<>(
+            curatorFramework,
+            CreateMode.PERSISTENT,
+            new ExampleMetadataSerializer().toModelSerializer(),
+            "/partitioned_snapshot_listeners")) {
+
+      AtomicInteger counter = new AtomicInteger(0);
+      partitionedMetadataStore.addListener((metadata) -> counter.incrementAndGet());
+
+      int size = 100;
+      Queue<ExampleMetadata> addedMetadata = new ArrayBlockingQueue<>(size);
+      for (int i = 1; i <= size; i++) {
+        Instant randomizedStart =
+            Instant.now().minus(Duration.of(Math.round(Math.random() * 10), ChronoUnit.HOURS));
+
+        ExampleMetadata exampleMetadata = new ExampleMetadata("id" + i);
+        partitionedMetadataStore.createAsync(exampleMetadata);
+        addedMetadata.add(exampleMetadata);
+      }
+
+      await()
+          .until(
+              () -> {
+                int currentSize = partitionedMetadataStore.listSync().size();
+                LOG.info("Current size - {}", currentSize);
+                return currentSize == size;
+              });
+      assertThat(counter.get()).isGreaterThanOrEqualTo(size);
+
+      List<String> partitions =
+          curatorFramework
+              .getChildren()
+              .forPath("/partitioned_snapshot_listeners")
+              .toCompletableFuture()
+              .get();
+
+      partitions.forEach(
+          partition -> {
+            curatorFramework
+                .checkExists()
+                .forPath("/partitioned_snapshot_listeners/" + partition)
+                .thenAccept(
+                    stat -> {
+                      EphemeralType ephemeralType = EphemeralType.get(stat.getEphemeralOwner());
+                      // todo - this is not clear why this is reported as a VOID type when
+                      // inspecting
+                      //  the nodes created. The persisted type is correct, but upon fetching later
+                      //  it appears unset. This behavior is consistent directly using ZK or via
+                      //  Curator, so we cannot do asserts on the node type here.
+                      LOG.info("Curator checked ephemeralType - {}", ephemeralType.toString());
+                    });
+          });
+
+      LOG.info("Deleting nodes");
+      for (int i = 0; i < 50; i++) {
+        ExampleMetadata toRemove = addedMetadata.remove();
+        partitionedMetadataStore.deleteAsync(toRemove);
+      }
+
+      await().until(() -> partitionedMetadataStore.listSync().size() == 50);
+      assertThat(counter.get())
+          // todo - why can this be larger than 150? Extra bucket event again?
+          .isGreaterThanOrEqualTo(150);
+
+      for (int i = 0; i < 50; i++) {
+        ExampleMetadata toRemove = addedMetadata.remove();
+        partitionedMetadataStore.deleteAsync(toRemove);
+      }
+
+      await().until(() -> partitionedMetadataStore.listSync().size() == 0);
+      // todo - explain why 211 (200 + 11 bucket events)?
+      // todo - should we be including bucket events?
+      await().until(counter::get, (value) -> value >= 200);
+
+      await()
+          .until(
+              () -> {
+                if (curatorFramework
+                        .checkExists()
+                        .forPath("/partitioned_snapshot_listeners")
+                        .toCompletableFuture()
+                        .get()
+                    == null) {
+                  LOG.info("Parent node no longer exists");
+                  return true;
+                }
+
+                int childrenSize =
+                    curatorFramework
+                        .getChildren()
+                        .forPath("/partitioned_snapshot_listeners")
+                        .toCompletableFuture()
+                        .get()
+                        .size();
+                LOG.info("Children size - {}", childrenSize);
+                return childrenSize == 0;
+              });
+    }
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetPartitionMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetPartitionMetadataTest.java
@@ -135,7 +135,7 @@ public class DatasetPartitionMetadataTest {
               "testDataset1", "datasetOwner1", throughputBytes, List.of(partition), "testDataset1");
 
       datasetMetadataStore.createSync(datasetMetadata);
-      await().until(() -> datasetMetadataStore.getCachedSync().size() == 1);
+      await().until(() -> datasetMetadataStore.listSync().size() == 1);
     }
 
     {
@@ -144,7 +144,7 @@ public class DatasetPartitionMetadataTest {
           new DatasetMetadata(
               "testDataset2", "datasetOwner2", throughputBytes, List.of(partition), "testDataset2");
       datasetMetadataStore.createSync(datasetMetadata);
-      await().until(() -> datasetMetadataStore.getCachedSync().size() == 2);
+      await().until(() -> datasetMetadataStore.listSync().size() == 2);
     }
 
     // Start and end time within query window
@@ -187,7 +187,7 @@ public class DatasetPartitionMetadataTest {
         new DatasetMetadata(name, owner, throughputBytes, List.of(partition), name);
 
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
     // Start and end time within query window
     List<DatasetPartitionMetadata> partitionMetadata =
@@ -230,7 +230,7 @@ public class DatasetPartitionMetadataTest {
         new DatasetMetadata(name, owner, throughputBytes, List.of(partition1, partition2), name);
 
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
     // Fetch first partition between time 101 and 199
     List<DatasetPartitionMetadata> partitionMetadata =
@@ -271,7 +271,7 @@ public class DatasetPartitionMetadataTest {
         new DatasetMetadata(name, owner, throughputBytes, List.of(partition), name);
 
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
     final String name1 = "testDataset1";
     final String owner1 = "datasetOwner1";
@@ -283,7 +283,7 @@ public class DatasetPartitionMetadataTest {
         new DatasetMetadata(name1, owner1, throughputBytes1, List.of(partition1), name1);
 
     datasetMetadataStore.createSync(datasetMetadata1);
-    await().until(() -> datasetMetadataStore.getCachedSync().size() == 2);
+    await().until(() -> datasetMetadataStore.listSync().size() == 2);
 
     List<DatasetPartitionMetadata> partitionMetadata =
         findPartitionsToQuery(datasetMetadataStore, 101, 199, name);

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
@@ -94,7 +94,7 @@ public class PreprocessorServiceIntegrationTest {
     datasetMetadataStore.createSync(new DatasetMetadata("name", "owner", 0, List.of(), "name"));
 
     // wait for the cache to be updated
-    await().until(() -> datasetMetadataStore.listSync().size() == 1);
+    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
     assertThat(MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry))
         .isEqualTo(2);
 
@@ -172,7 +172,7 @@ public class PreprocessorServiceIntegrationTest {
     datasetMetadataStore.createSync(datasetMetadata);
 
     // wait for the cache to be updated
-    await().until(() -> datasetMetadataStore.listSync().size() == 1);
+    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
     await()
         .until(
             () ->
@@ -197,8 +197,8 @@ public class PreprocessorServiceIntegrationTest {
             () ->
                 MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry)
                     == 3);
-    assertThat(datasetMetadataStore.listSync().size()).isEqualTo(1);
-    assertThat(datasetMetadataStore.listSync().get(0).getThroughputBytes())
+    assertThat(datasetMetadataStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(datasetMetadataStore.listSyncUncached().get(0).getThroughputBytes())
         .isEqualTo(Long.MAX_VALUE);
 
     // produce messages to upstream

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
@@ -499,7 +499,7 @@ public class PreprocessorServiceUnitTest {
   @Test
   public void shouldHandleEmptyDatasetMetadata() throws TimeoutException {
     DatasetMetadataStore datasetMetadataStore = mock(DatasetMetadataStore.class);
-    when(datasetMetadataStore.listSync()).thenReturn(List.of());
+    when(datasetMetadataStore.listSyncUncached()).thenReturn(List.of());
 
     KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
         KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()

--- a/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
@@ -164,12 +164,12 @@ public class RecoveryServiceTest {
 
     SnapshotMetadataStore snapshotMetadataStore =
         new SnapshotMetadataStore(curatorFramework, false);
-    assertThat(snapshotMetadataStore.listSync().size()).isZero();
+    assertThat(snapshotMetadataStore.listSyncUncached().size()).isZero();
     // Start recovery
     RecoveryTaskMetadata recoveryTask =
         new RecoveryTaskMetadata("testRecoveryTask", "0", 30, 60, Instant.now().toEpochMilli());
     assertThat(recoveryService.handleRecoveryTask(recoveryTask)).isTrue();
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSync();
+    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
     assertThat(snapshots.size()).isEqualTo(1);
     assertThat(blobFs.listFiles(BlobFsUtils.createURI(TEST_S3_BUCKET, "/", ""), true)).isNotEmpty();
     assertThat(blobFs.exists(URI.create(snapshots.get(0).snapshotPath))).isTrue();
@@ -237,7 +237,7 @@ public class RecoveryServiceTest {
 
     SnapshotMetadataStore snapshotMetadataStore =
         new SnapshotMetadataStore(curatorFramework, false);
-    assertThat(snapshotMetadataStore.listSync().size()).isZero();
+    assertThat(snapshotMetadataStore.listSyncUncached().size()).isZero();
 
     // Start recovery service
     recoveryService =
@@ -257,7 +257,7 @@ public class RecoveryServiceTest {
     assertThat(getCount(RECORDS_NO_LONGER_AVAILABLE, components.meterRegistry))
         .isEqualTo(endOffset - startOffset + 1);
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, components.meterRegistry)).isEqualTo(0);
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSync();
+    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
     assertThat(snapshots.size()).isEqualTo(0);
     assertThat(blobFs.listFiles(BlobFsUtils.createURI(TEST_S3_BUCKET, "/", ""), true)).isEmpty();
     assertThat(getCount(MESSAGES_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
@@ -320,7 +320,7 @@ public class RecoveryServiceTest {
 
     SnapshotMetadataStore snapshotMetadataStore =
         new SnapshotMetadataStore(curatorFramework, false);
-    assertThat(snapshotMetadataStore.listSync().size()).isZero();
+    assertThat(snapshotMetadataStore.listSyncUncached().size()).isZero();
 
     // Start recovery service
     recoveryService =
@@ -341,7 +341,7 @@ public class RecoveryServiceTest {
     assertThat(recoveryService.handleRecoveryTask(recoveryTask)).isTrue();
     assertThat(getCount(RECORDS_NO_LONGER_AVAILABLE, components.meterRegistry)).isEqualTo(50);
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, components.meterRegistry)).isEqualTo(51);
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSync();
+    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
     assertThat(snapshots.size()).isEqualTo(1);
     assertThat(blobFs.listFiles(BlobFsUtils.createURI(TEST_S3_BUCKET, "/", ""), true)).isNotEmpty();
     assertThat(blobFs.exists(URI.create(snapshots.get(0).snapshotPath))).isTrue();
@@ -374,7 +374,7 @@ public class RecoveryServiceTest {
     assertThat(s3Client.listBuckets().buckets().get(0).name()).isNotEqualTo(fakeS3Bucket);
     SnapshotMetadataStore snapshotMetadataStore =
         new SnapshotMetadataStore(curatorFramework, false);
-    assertThat(snapshotMetadataStore.listSync().size()).isZero();
+    assertThat(snapshotMetadataStore.listSyncUncached().size()).isZero();
 
     // Start recovery
     RecoveryTaskMetadata recoveryTask =
@@ -411,23 +411,23 @@ public class RecoveryServiceTest {
     assertThat(s3Client.listBuckets().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
     SnapshotMetadataStore snapshotMetadataStore =
         new SnapshotMetadataStore(curatorFramework, false);
-    assertThat(snapshotMetadataStore.listSync().size()).isZero();
+    assertThat(snapshotMetadataStore.listSyncUncached().size()).isZero();
 
-    assertThat(snapshotMetadataStore.listSync().size()).isZero();
+    assertThat(snapshotMetadataStore.listSyncUncached().size()).isZero();
     // Create a recovery task
     RecoveryTaskMetadataStore recoveryTaskMetadataStore =
         new RecoveryTaskMetadataStore(curatorFramework, false);
-    assertThat(recoveryTaskMetadataStore.listSync().size()).isZero();
+    assertThat(recoveryTaskMetadataStore.listSyncUncached().size()).isZero();
     RecoveryTaskMetadata recoveryTask =
         new RecoveryTaskMetadata("testRecoveryTask", "0", 30, 60, Instant.now().toEpochMilli());
     recoveryTaskMetadataStore.createSync(recoveryTask);
-    assertThat(recoveryTaskMetadataStore.listSync().size()).isEqualTo(1);
-    assertThat(recoveryTaskMetadataStore.listSync().get(0)).isEqualTo(recoveryTask);
+    assertThat(recoveryTaskMetadataStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(recoveryTaskMetadataStore.listSyncUncached().get(0)).isEqualTo(recoveryTask);
 
     // Assign the recovery task to node.
     RecoveryNodeMetadataStore recoveryNodeMetadataStore =
         new RecoveryNodeMetadataStore(curatorFramework, false);
-    List<RecoveryNodeMetadata> recoveryNodes = recoveryNodeMetadataStore.listSync();
+    List<RecoveryNodeMetadata> recoveryNodes = recoveryNodeMetadataStore.listSyncUncached();
     assertThat(recoveryNodes.size()).isEqualTo(1);
     RecoveryNodeMetadata recoveryNodeMetadata = recoveryNodes.get(0);
     assertThat(recoveryNodeMetadata.recoveryNodeState)
@@ -438,7 +438,7 @@ public class RecoveryServiceTest {
             Metadata.RecoveryNodeMetadata.RecoveryNodeState.ASSIGNED,
             recoveryTask.getName(),
             Instant.now().toEpochMilli()));
-    assertThat(recoveryTaskMetadataStore.listSync().size()).isEqualTo(1);
+    assertThat(recoveryTaskMetadataStore.listSyncUncached().size()).isEqualTo(1);
 
     await().until(() -> getCount(RECOVERY_NODE_ASSIGNMENT_SUCCESS, meterRegistry) == 1);
     assertThat(getCount(RECOVERY_NODE_ASSIGNMENT_RECEIVED, meterRegistry)).isEqualTo(1);
@@ -449,13 +449,13 @@ public class RecoveryServiceTest {
     assertThat(s3Client.listBuckets().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
 
     // Post recovery checks
-    assertThat(recoveryNodeMetadataStore.listSync().size()).isEqualTo(1);
-    assertThat(recoveryNodeMetadataStore.listSync().get(0).recoveryNodeState)
+    assertThat(recoveryNodeMetadataStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(recoveryNodeMetadataStore.listSyncUncached().get(0).recoveryNodeState)
         .isEqualTo(Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE);
 
     // 1 snapshot is published
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSync();
-    assertThat(snapshotMetadataStore.listSync().size()).isEqualTo(1);
+    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
+    assertThat(snapshotMetadataStore.listSyncUncached().size()).isEqualTo(1);
     assertThat(blobFs.exists(URI.create(snapshots.get(0).snapshotPath))).isTrue();
     assertThat(blobFs.listFiles(URI.create(snapshots.get(0).snapshotPath), false).length)
         .isGreaterThan(1);
@@ -488,23 +488,23 @@ public class RecoveryServiceTest {
     assertThat(s3Client.listBuckets().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
     SnapshotMetadataStore snapshotMetadataStore =
         new SnapshotMetadataStore(curatorFramework, false);
-    assertThat(snapshotMetadataStore.listSync().size()).isZero();
+    assertThat(snapshotMetadataStore.listSyncUncached().size()).isZero();
 
-    assertThat(snapshotMetadataStore.listSync().size()).isZero();
+    assertThat(snapshotMetadataStore.listSyncUncached().size()).isZero();
     // Create a recovery task
     RecoveryTaskMetadataStore recoveryTaskMetadataStore =
         new RecoveryTaskMetadataStore(curatorFramework, false);
-    assertThat(recoveryTaskMetadataStore.listSync().size()).isZero();
+    assertThat(recoveryTaskMetadataStore.listSyncUncached().size()).isZero();
     RecoveryTaskMetadata recoveryTask =
         new RecoveryTaskMetadata("testRecoveryTask", "0", 30, 60, Instant.now().toEpochMilli());
     recoveryTaskMetadataStore.createSync(recoveryTask);
-    assertThat(recoveryTaskMetadataStore.listSync().size()).isEqualTo(1);
-    assertThat(recoveryTaskMetadataStore.listSync().get(0)).isEqualTo(recoveryTask);
+    assertThat(recoveryTaskMetadataStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(recoveryTaskMetadataStore.listSyncUncached().get(0)).isEqualTo(recoveryTask);
 
     // Assign the recovery task to node.
     RecoveryNodeMetadataStore recoveryNodeMetadataStore =
         new RecoveryNodeMetadataStore(curatorFramework, false);
-    List<RecoveryNodeMetadata> recoveryNodes = recoveryNodeMetadataStore.listSync();
+    List<RecoveryNodeMetadata> recoveryNodes = recoveryNodeMetadataStore.listSyncUncached();
     assertThat(recoveryNodes.size()).isEqualTo(1);
     RecoveryNodeMetadata recoveryNodeMetadata = recoveryNodes.get(0);
     assertThat(recoveryNodeMetadata.recoveryNodeState)
@@ -515,7 +515,7 @@ public class RecoveryServiceTest {
             Metadata.RecoveryNodeMetadata.RecoveryNodeState.ASSIGNED,
             recoveryTask.getName(),
             Instant.now().toEpochMilli()));
-    assertThat(recoveryTaskMetadataStore.listSync().size()).isEqualTo(1);
+    assertThat(recoveryTaskMetadataStore.listSyncUncached().size()).isEqualTo(1);
 
     await().until(() -> getCount(RECOVERY_NODE_ASSIGNMENT_FAILED, meterRegistry) == 1);
     assertThat(getCount(RECOVERY_NODE_ASSIGNMENT_RECEIVED, meterRegistry)).isEqualTo(1);
@@ -526,16 +526,16 @@ public class RecoveryServiceTest {
     assertThat(s3Client.listBuckets().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
 
     // Post recovery checks
-    assertThat(recoveryNodeMetadataStore.listSync().size()).isEqualTo(1);
-    assertThat(recoveryNodeMetadataStore.listSync().get(0).recoveryNodeState)
+    assertThat(recoveryNodeMetadataStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(recoveryNodeMetadataStore.listSyncUncached().get(0).recoveryNodeState)
         .isEqualTo(Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE);
 
     // Recovery task still exists for re-assignment.
-    assertThat(recoveryTaskMetadataStore.listSync().size()).isEqualTo(1);
-    assertThat(recoveryTaskMetadataStore.listSync().get(0)).isEqualTo(recoveryTask);
+    assertThat(recoveryTaskMetadataStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(recoveryTaskMetadataStore.listSyncUncached().get(0)).isEqualTo(recoveryTask);
 
     // No snapshots are published on failure.
-    assertThat(snapshotMetadataStore.listSync().size()).isZero();
+    assertThat(snapshotMetadataStore.listSyncUncached().size()).isZero();
 
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, meterRegistry)).isEqualTo(31);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, meterRegistry)).isEqualTo(0);

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -163,8 +163,8 @@ public class KaldbIndexerTest {
   public void testIndexFreshConsumerKafkaSearchViaGrpcSearchApi() throws Exception {
     // Start kafka, produce messages to it and start a search server.
     startKafkaServer();
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
 
     // Empty consumer offset since there is no prior consumer.
     kaldbIndexer =
@@ -180,17 +180,17 @@ public class KaldbIndexerTest {
     await().until(() -> kafkaServer.getConnectedConsumerGroups() == 1);
 
     consumeMessagesAndSearchMessagesTest(100, 1);
-    assertThat(snapshotMetadataStore.listSync().size()).isEqualTo(2);
-    assertThat(searchMetadataStore.listSync().size()).isEqualTo(1);
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached().size()).isEqualTo(2);
+    assertThat(searchMetadataStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
   }
 
   @Test
   public void testDeleteStaleSnapshotAndStartConsumerKafkaSearchViaGrpcSearchApi()
       throws Exception {
     startKafkaServer();
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
 
     // Create a live partition for this partiton
     final String name = "testSnapshotId";
@@ -207,7 +207,7 @@ public class KaldbIndexerTest {
             "0",
             LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition1);
-    assertThat(snapshotMetadataStore.listSync()).containsOnly(livePartition1);
+    assertThat(snapshotMetadataStore.listSyncUncached()).containsOnly(livePartition1);
 
     // Empty consumer offset since there is no prior consumer.
     kaldbIndexer =
@@ -224,17 +224,17 @@ public class KaldbIndexerTest {
     consumeMessagesAndSearchMessagesTest(100, 1);
 
     // Live snapshot is deleted.
-    assertThat(snapshotMetadataStore.listSync().size()).isEqualTo(2);
-    assertThat(snapshotMetadataStore.listSync()).doesNotContain(livePartition1);
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
-    assertThat(searchMetadataStore.listSync().size()).isEqualTo(1);
+    assertThat(snapshotMetadataStore.listSyncUncached().size()).isEqualTo(2);
+    assertThat(snapshotMetadataStore.listSyncUncached()).doesNotContain(livePartition1);
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(searchMetadataStore.listSyncUncached().size()).isEqualTo(1);
   }
 
   @Test
   public void testExceptionOnIndexerStartup() throws Exception {
     startKafkaServer();
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
 
     // Create a live partition for this partiton
     final String name = "testSnapshotId";
@@ -262,7 +262,8 @@ public class KaldbIndexerTest {
             "1",
             LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition1);
-    assertThat(snapshotMetadataStore.listSync()).containsOnly(livePartition1, livePartition0);
+    assertThat(snapshotMetadataStore.listSyncUncached())
+        .containsOnly(livePartition1, livePartition0);
 
     // Throw exception on initialization
     doThrow(new RuntimeException()).when(curatorFramework).with(any(), any(), any(), any());
@@ -284,8 +285,8 @@ public class KaldbIndexerTest {
   @Test
   public void testWithMultipleLiveSnapshotsOnIndexerStart() throws Exception {
     startKafkaServer();
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
 
     // Create a live partition for this partiton
     final String name = "testSnapshotId";
@@ -313,7 +314,8 @@ public class KaldbIndexerTest {
             "1",
             LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition1);
-    assertThat(snapshotMetadataStore.listSync()).containsOnly(livePartition1, livePartition0);
+    assertThat(snapshotMetadataStore.listSyncUncached())
+        .containsOnly(livePartition1, livePartition0);
 
     // Empty consumer offset since there is no prior consumer.
     kaldbIndexer =
@@ -330,17 +332,17 @@ public class KaldbIndexerTest {
     consumeMessagesAndSearchMessagesTest(100, 1);
 
     // Live snapshot is deleted.
-    assertThat(snapshotMetadataStore.listSync()).contains(livePartition1);
-    assertThat(snapshotMetadataStore.listSync().size()).isEqualTo(3);
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
-    assertThat(searchMetadataStore.listSync().size()).isEqualTo(1);
+    assertThat(snapshotMetadataStore.listSyncUncached()).contains(livePartition1);
+    assertThat(snapshotMetadataStore.listSyncUncached().size()).isEqualTo(3);
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(searchMetadataStore.listSyncUncached().size()).isEqualTo(1);
   }
 
   @Test
   public void testIndexerStartsWithPreviousOffset() throws Exception {
     startKafkaServer();
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
 
     // Create a live partition for this partiton
     final String name = "testSnapshotId";
@@ -374,7 +376,7 @@ public class KaldbIndexerTest {
         new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition0);
 
-    assertThat(snapshotMetadataStore.listSync())
+    assertThat(snapshotMetadataStore.listSyncUncached())
         .containsOnly(livePartition1, livePartition0, partition0);
 
     // Empty consumer offset since there is no prior consumer.
@@ -392,19 +394,19 @@ public class KaldbIndexerTest {
     consumeMessagesAndSearchMessagesTest(49, 0);
 
     // Live snapshot is deleted.
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSync();
+    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
     assertThat(snapshots).contains(livePartition1, partition0);
     assertThat(snapshots).doesNotContain(livePartition0);
     assertThat(snapshots.size()).isEqualTo(3);
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
-    assertThat(searchMetadataStore.listSync().size()).isEqualTo(1);
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(searchMetadataStore.listSyncUncached().size()).isEqualTo(1);
   }
 
   @Test
   public void testIndexerCreatesRecoveryTask() throws Exception {
     startKafkaServer();
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
 
     // Create a live partition for this partiton
     final String name = "testSnapshotId";
@@ -438,7 +440,7 @@ public class KaldbIndexerTest {
         new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition0);
 
-    assertThat(snapshotMetadataStore.listSync())
+    assertThat(snapshotMetadataStore.listSyncUncached())
         .containsOnly(livePartition1, livePartition0, partition0);
 
     // Empty consumer offset since there is no prior consumer.
@@ -459,13 +461,13 @@ public class KaldbIndexerTest {
     consumeMessagesAndSearchMessagesTest(100, 1);
 
     // Live snapshot is deleted, recovery task is created.
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSync();
+    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
     assertThat(snapshots).contains(livePartition1, partition0);
     assertThat(snapshots).doesNotContain(livePartition0);
     assertThat(snapshots.size()).isEqualTo(4);
-    assertThat(searchMetadataStore.listSync().size()).isEqualTo(1);
-    assertThat(recoveryTaskStore.listSync().size()).isEqualTo(1);
-    RecoveryTaskMetadata recoveryTask1 = recoveryTaskStore.listSync().get(0);
+    assertThat(searchMetadataStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(recoveryTaskStore.listSyncUncached().size()).isEqualTo(1);
+    RecoveryTaskMetadata recoveryTask1 = recoveryTaskStore.listSyncUncached().get(0);
     assertThat(recoveryTask1.startOffset).isEqualTo(31);
     assertThat(recoveryTask1.endOffset).isEqualTo(99);
     assertThat(recoveryTask1.partitionId).isEqualTo("0");
@@ -474,8 +476,8 @@ public class KaldbIndexerTest {
   @Test
   public void testIndexerShutdownTwice() throws Exception {
     startKafkaServer();
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
 
     // Create a live partition for this partiton
     final String name = "testSnapshotId";
@@ -509,7 +511,7 @@ public class KaldbIndexerTest {
         new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition0);
 
-    assertThat(snapshotMetadataStore.listSync())
+    assertThat(snapshotMetadataStore.listSyncUncached())
         .containsOnly(livePartition1, livePartition0, partition0);
 
     // Empty consumer offset since there is no prior consumer.
@@ -530,11 +532,11 @@ public class KaldbIndexerTest {
     consumeMessagesAndSearchMessagesTest(100, 1);
 
     // Live snapshot is deleted, recovery task is created.
-    assertThat(snapshotMetadataStore.listSync()).contains(livePartition1, partition0);
-    assertThat(snapshotMetadataStore.listSync().size()).isEqualTo(4);
-    assertThat(recoveryTaskStore.listSync().size()).isEqualTo(1);
-    assertThat(searchMetadataStore.listSync().size()).isEqualTo(1);
-    RecoveryTaskMetadata recoveryTask1 = recoveryTaskStore.listSync().get(0);
+    assertThat(snapshotMetadataStore.listSyncUncached()).contains(livePartition1, partition0);
+    assertThat(snapshotMetadataStore.listSyncUncached().size()).isEqualTo(4);
+    assertThat(recoveryTaskStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(searchMetadataStore.listSyncUncached().size()).isEqualTo(1);
+    RecoveryTaskMetadata recoveryTask1 = recoveryTaskStore.listSyncUncached().get(0);
     assertThat(recoveryTask1.startOffset).isEqualTo(31);
     assertThat(recoveryTask1.endOffset).isEqualTo(99);
     assertThat(recoveryTask1.partitionId).isEqualTo("0");
@@ -548,9 +550,9 @@ public class KaldbIndexerTest {
   @Test
   public void testIndexerRestart() throws Exception {
     startKafkaServer();
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
-    assertThat(searchMetadataStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(searchMetadataStore.listSyncUncached()).isEmpty();
 
     // Create a live partition for this partiton
     final String name = "testSnapshotId";
@@ -584,7 +586,7 @@ public class KaldbIndexerTest {
         new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition0);
 
-    assertThat(snapshotMetadataStore.listSync())
+    assertThat(snapshotMetadataStore.listSyncUncached())
         .containsOnly(livePartition1, livePartition0, partition0);
 
     // Empty consumer offset since there is no prior consumer.
@@ -603,11 +605,11 @@ public class KaldbIndexerTest {
     consumeMessagesAndSearchMessagesTest(69, 0);
 
     // Live snapshot is deleted, no recovery task is created.
-    assertThat(snapshotMetadataStore.listSync()).contains(livePartition1, partition0);
-    assertThat(snapshotMetadataStore.listSync()).doesNotContain(livePartition0);
-    assertThat(snapshotMetadataStore.listSync().size()).isEqualTo(3);
-    assertThat(recoveryTaskStore.listSync().size()).isZero();
-    assertThat(searchMetadataStore.listSync().size()).isEqualTo(1);
+    assertThat(snapshotMetadataStore.listSyncUncached()).contains(livePartition1, partition0);
+    assertThat(snapshotMetadataStore.listSyncUncached()).doesNotContain(livePartition0);
+    assertThat(snapshotMetadataStore.listSyncUncached().size()).isEqualTo(3);
+    assertThat(recoveryTaskStore.listSyncUncached().size()).isZero();
+    assertThat(searchMetadataStore.listSyncUncached().size()).isEqualTo(1);
 
     // Shutting down is idempotent. So, doing it twice shouldn't throw an error.
     kaldbIndexer.stopAsync();
@@ -616,11 +618,11 @@ public class KaldbIndexerTest {
     chunkManagerUtil.chunkManager.awaitTerminated(DEFAULT_START_STOP_DURATION);
 
     // await().until(() -> kafkaServer.getConnectedConsumerGroups() == 0);
-    assertThat(snapshotMetadataStore.listSync()).contains(livePartition1, partition0);
-    assertThat(snapshotMetadataStore.listSync()).doesNotContain(livePartition0);
-    assertThat(snapshotMetadataStore.listSync().size()).isEqualTo(2);
-    assertThat(recoveryTaskStore.listSync().size()).isZero();
-    assertThat(searchMetadataStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).contains(livePartition1, partition0);
+    assertThat(snapshotMetadataStore.listSyncUncached()).doesNotContain(livePartition0);
+    assertThat(snapshotMetadataStore.listSyncUncached().size()).isEqualTo(2);
+    assertThat(recoveryTaskStore.listSyncUncached().size()).isZero();
+    assertThat(searchMetadataStore.listSyncUncached()).isEmpty();
 
     // start indexer again. The indexer should index the same data again.
     LOG.info("Starting the indexer again");
@@ -652,10 +654,10 @@ public class KaldbIndexerTest {
     consumeMessagesAndSearchMessagesTest(138, 0);
 
     // Live snapshot is deleted, recovery task is created.
-    assertThat(snapshotMetadataStore.listSync()).contains(livePartition1, partition0);
-    assertThat(snapshotMetadataStore.listSync()).doesNotContain(livePartition0);
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
-    assertThat(searchMetadataStore.listSync().size()).isEqualTo(1);
+    assertThat(snapshotMetadataStore.listSyncUncached()).contains(livePartition1, partition0);
+    assertThat(snapshotMetadataStore.listSyncUncached()).doesNotContain(livePartition0);
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(searchMetadataStore.listSyncUncached().size()).isEqualTo(1);
   }
 
   private void startKafkaServer() throws Exception {

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
@@ -135,7 +135,7 @@ public class KaldbTest {
             partitionConfigs,
             MessageUtil.TEST_DATASET_NAME);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSync().size() == 1);
+    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
   }
 
   @AfterEach

--- a/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
@@ -218,7 +218,7 @@ public class ManagerApiGrpcTest {
                             .build()));
     assertThat(throwable3.getStatus().getCode()).isEqualTo(Status.UNKNOWN.getCode());
 
-    assertThat(datasetMetadataStore.listSync().size()).isEqualTo(0);
+    assertThat(datasetMetadataStore.listSyncUncached().size()).isEqualTo(0);
   }
 
   @Test
@@ -237,7 +237,7 @@ public class ManagerApiGrpcTest {
     assertThat(throwable.getStatus().getCode()).isEqualTo(Status.UNKNOWN.getCode());
     assertThat(throwable.getStatus().getDescription()).isEqualTo("owner must not be null or blank");
 
-    assertThat(datasetMetadataStore.listSync().size()).isEqualTo(0);
+    assertThat(datasetMetadataStore.listSyncUncached().size()).isEqualTo(0);
   }
 
   @Test
@@ -326,7 +326,7 @@ public class ManagerApiGrpcTest {
     Status status = throwable.getStatus();
     assertThat(status.getCode()).isEqualTo(Status.UNKNOWN.getCode());
 
-    assertThat(datasetMetadataStore.listSync().size()).isEqualTo(0);
+    assertThat(datasetMetadataStore.listSyncUncached().size()).isEqualTo(0);
   }
 
   @Test
@@ -467,7 +467,7 @@ public class ManagerApiGrpcTest {
                             .build()));
     assertThat(throwable1.getStatus().getCode()).isEqualTo(Status.UNKNOWN.getCode());
 
-    assertThat(datasetMetadataStore.listSync().size()).isEqualTo(0);
+    assertThat(datasetMetadataStore.listSyncUncached().size()).isEqualTo(0);
   }
 
   @Test
@@ -510,10 +510,10 @@ public class ManagerApiGrpcTest {
                         .setThroughputBytes(0)
                         .build())));
 
-    assertThat(datasetMetadataStore.listSync().size()).isEqualTo(2);
+    assertThat(datasetMetadataStore.listSyncUncached().size()).isEqualTo(2);
     assertThat(
         datasetMetadataStore
-            .listSync()
+            .listSyncUncached()
             .containsAll(
                 List.of(
                     new DatasetMetadata(
@@ -569,7 +569,7 @@ public class ManagerApiGrpcTest {
     assertThat(throwableUpdate.getStatus().getCode()).isEqualTo(Status.UNKNOWN.getCode());
     assertThat(throwableUpdate.getStatus().getDescription()).contains(datasetName);
 
-    assertThat(datasetMetadataStore.listSync().size()).isEqualTo(0);
+    assertThat(datasetMetadataStore.listSyncUncached().size()).isEqualTo(0);
   }
 
   @Test
@@ -623,7 +623,7 @@ public class ManagerApiGrpcTest {
 
     datasetMetadataStore.createSync(datasetWithDataInPartitionA);
 
-    await().until(() -> datasetMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
     List<SnapshotMetadata> snapshotsWithData =
         ManagerApiGrpc.calculateRequiredSnapshots(
@@ -680,8 +680,8 @@ public class ManagerApiGrpcTest {
 
     datasetMetadataStore.createSync(serviceWithDataInPartitionA);
 
-    await().until(() -> datasetMetadataStore.getCachedSync().size() == 1);
-    await().until(() -> snapshotMetadataStore.getCachedSync().size() == 2);
+    await().until(() -> datasetMetadataStore.listSync().size() == 1);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 2);
 
     managerApiStub.restoreReplica(
         ManagerApi.RestoreReplicaRequest.newBuilder()
@@ -690,7 +690,7 @@ public class ManagerApiGrpcTest {
             .setEndTimeEpochMs(end)
             .build());
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 1);
+    await().until(() -> replicaMetadataStore.listSync().size() == 1);
     await()
         .until(
             () -> MetricsUtil.getCount(ReplicaRestoreService.REPLICAS_CREATED, meterRegistry) == 1);
@@ -728,8 +728,8 @@ public class ManagerApiGrpcTest {
 
     datasetMetadataStore.createSync(serviceWithDataInPartitionA);
 
-    await().until(() -> datasetMetadataStore.getCachedSync().size() == 1);
-    await().until(() -> snapshotMetadataStore.getCachedSync().size() == 3);
+    await().until(() -> datasetMetadataStore.listSync().size() == 1);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 3);
 
     replicaRestoreService.startAsync();
     replicaRestoreService.awaitRunning();
@@ -741,7 +741,7 @@ public class ManagerApiGrpcTest {
             .setEndTimeEpochMs(end)
             .build());
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 2);
+    await().until(() -> replicaMetadataStore.listSync().size() == 2);
     assertThat(MetricsUtil.getCount(ReplicaRestoreService.REPLICAS_CREATED, meterRegistry))
         .isEqualTo(2);
     assertThat(MetricsUtil.getCount(ReplicaRestoreService.REPLICAS_FAILED, meterRegistry))
@@ -767,7 +767,7 @@ public class ManagerApiGrpcTest {
     snapshotMetadataStore.createSync(snapshotFoo);
     snapshotMetadataStore.createSync(snapshotBar);
     snapshotMetadataStore.createSync(snapshotBaz);
-    await().until(() -> snapshotMetadataStore.getCachedSync().size() == 3);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 3);
 
     replicaRestoreService.startAsync();
     replicaRestoreService.awaitRunning();
@@ -777,7 +777,7 @@ public class ManagerApiGrpcTest {
             .addAllIdsToRestore(List.of("foo", "bar", "baz"))
             .build());
 
-    await().until(() -> replicaMetadataStore.getCachedSync().size() == 3);
+    await().until(() -> replicaMetadataStore.listSync().size() == 3);
     assertThat(MetricsUtil.getCount(ReplicaRestoreService.REPLICAS_CREATED, meterRegistry))
         .isEqualTo(3);
     assertThat(MetricsUtil.getCount(ReplicaRestoreService.REPLICAS_FAILED, meterRegistry))

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -213,7 +213,7 @@ public class RecoveryTaskCreatorTest {
       int deletedSnapshotSize,
       List<SnapshotMetadata> expectedSnapshots) {
     actualSnapshots.forEach(snapshot -> snapshotMetadataStore.createSync(snapshot));
-    assertThat(snapshotMetadataStore.listSync())
+    assertThat(snapshotMetadataStore.listSyncUncached())
         .containsExactlyInAnyOrderElementsOf(actualSnapshots);
 
     RecoveryTaskCreator recoveryTaskCreator =
@@ -226,7 +226,7 @@ public class RecoveryTaskCreatorTest {
             meterRegistry);
     assertThat(recoveryTaskCreator.deleteStaleLiveSnapshots(actualSnapshots).size())
         .isEqualTo(deletedSnapshotSize);
-    assertThat(snapshotMetadataStore.listSync())
+    assertThat(snapshotMetadataStore.listSyncUncached())
         .containsExactlyInAnyOrderElementsOf(expectedSnapshots);
     // Clear state
     expectedSnapshots.forEach(snapshot -> snapshotMetadataStore.deleteSync(snapshot));
@@ -290,7 +290,7 @@ public class RecoveryTaskCreatorTest {
       boolean hasException) {
 
     actualSnapshots.forEach(snapshot -> snapshotMetadataStore.createSync(snapshot));
-    assertThat(snapshotMetadataStore.listSync())
+    assertThat(snapshotMetadataStore.listSyncUncached())
         .containsExactlyInAnyOrderElementsOf(actualSnapshots);
 
     RecoveryTaskCreator recoveryTaskCreator =
@@ -316,7 +316,7 @@ public class RecoveryTaskCreatorTest {
       assertThat(recoveryTaskCreator.deleteStaleLiveSnapshots(actualSnapshots)).isEmpty();
     }
 
-    assertThat(snapshotMetadataStore.listSync())
+    assertThat(snapshotMetadataStore.listSyncUncached())
         .containsExactlyInAnyOrderElementsOf(expectedSnapshots);
 
     // Clear state but reset the overloaded method.
@@ -362,7 +362,8 @@ public class RecoveryTaskCreatorTest {
         List.of(partition1, livePartition1, livePartition11, partition2, livePartition2);
 
     snapshots.forEach(snapshot -> snapshotMetadataStore.createSync(snapshot));
-    assertThat(snapshotMetadataStore.listSync()).containsExactlyInAnyOrderElementsOf(snapshots);
+    assertThat(snapshotMetadataStore.listSyncUncached())
+        .containsExactlyInAnyOrderElementsOf(snapshots);
 
     RecoveryTaskCreator recoveryTaskCreator =
         new RecoveryTaskCreator(
@@ -407,7 +408,7 @@ public class RecoveryTaskCreatorTest {
         .isThrownBy(() -> recoveryTaskCreator.deleteStaleLiveSnapshots(snapshots));
 
     // Either liveSnapshot1 or liveSnapshot11 remain but not both.
-    List<SnapshotMetadata> actualSnapshots = snapshotMetadataStore.listSync();
+    List<SnapshotMetadata> actualSnapshots = snapshotMetadataStore.listSyncUncached();
     assertThat(actualSnapshots.size()).isEqualTo(4);
     assertThat(actualSnapshots).contains(partition1, partition2, livePartition2);
     assertThat(
@@ -682,8 +683,8 @@ public class RecoveryTaskCreatorTest {
             TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
 
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
@@ -699,14 +700,14 @@ public class RecoveryTaskCreatorTest {
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(name, path, startTime, endTime, maxOffset, "2", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
-    assertThat(snapshotMetadataStore.listSync()).contains(partition1);
+    assertThat(snapshotMetadataStore.listSyncUncached()).contains(partition1);
     assertThat(recoveryTaskCreator.determineStartingOffset(0)).isNegative();
 
     final SnapshotMetadata partition11 =
         new SnapshotMetadata(
             name + "1", path, endTime + 1, endTime * 2, maxOffset * 2, "2", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition11);
-    assertThat(snapshotMetadataStore.listSync()).contains(partition1, partition11);
+    assertThat(snapshotMetadataStore.listSyncUncached()).contains(partition1, partition11);
     assertThat(recoveryTaskCreator.determineStartingOffset(0)).isNegative();
 
     final String recoveryTaskName = "recoveryTask";
@@ -721,7 +722,7 @@ public class RecoveryTaskCreatorTest {
             recoveryStartOffset * 2,
             createdTimeUtc);
     recoveryTaskStore.createSync(recoveryTask1);
-    assertThat(recoveryTaskStore.listSync()).contains(recoveryTask1);
+    assertThat(recoveryTaskStore.listSyncUncached()).contains(recoveryTask1);
     assertThat(recoveryTaskCreator.determineStartingOffset(0)).isNegative();
   }
 
@@ -736,8 +737,8 @@ public class RecoveryTaskCreatorTest {
             TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
 
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
@@ -753,7 +754,7 @@ public class RecoveryTaskCreatorTest {
             recoveryStartOffset * 2,
             createdTimeUtc);
     recoveryTaskStore.createSync(recoveryTask1);
-    assertThat(recoveryTaskStore.listSync()).contains(recoveryTask1);
+    assertThat(recoveryTaskStore.listSyncUncached()).contains(recoveryTask1);
     assertThat(recoveryTaskCreator.determineStartingOffset(850))
         .isEqualTo((recoveryStartOffset * 2) + 1);
     assertThatIllegalStateException()
@@ -767,15 +768,15 @@ public class RecoveryTaskCreatorTest {
             recoveryStartOffset * 3,
             createdTimeUtc);
     recoveryTaskStore.createSync(recoveryTask11);
-    assertThat(recoveryTaskStore.listSync()).contains(recoveryTask1, recoveryTask11);
+    assertThat(recoveryTaskStore.listSyncUncached()).contains(recoveryTask1, recoveryTask11);
     assertThat(recoveryTaskCreator.determineStartingOffset(1201))
         .isEqualTo((recoveryStartOffset * 3) + 1);
     assertThat(recoveryTaskCreator.determineStartingOffset(1200))
         .isEqualTo((recoveryStartOffset * 3) + 1);
     assertThatIllegalStateException()
         .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(1150));
-    assertThat(recoveryTaskStore.listSync()).contains(recoveryTask1, recoveryTask11);
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).contains(recoveryTask1, recoveryTask11);
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
   }
 
   @Test
@@ -789,8 +790,8 @@ public class RecoveryTaskCreatorTest {
             TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
 
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
@@ -806,11 +807,11 @@ public class RecoveryTaskCreatorTest {
             recoveryStartOffset * 2,
             createdTimeUtc);
     recoveryTaskStore.createSync(recoveryTask1);
-    assertThat(recoveryTaskStore.listSync()).contains(recoveryTask1);
+    assertThat(recoveryTaskStore.listSyncUncached()).contains(recoveryTask1);
     final long currentHeadOffset = 4000;
     assertThat(recoveryTaskCreator.determineStartingOffset(currentHeadOffset))
         .isEqualTo(currentHeadOffset);
-    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSync();
+    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSyncUncached();
     assertThat(recoveryTasks.size()).isEqualTo(2);
     assertThat(recoveryTasks).contains(recoveryTask1);
     Optional<RecoveryTaskMetadata> newRecoveryTask =
@@ -819,7 +820,7 @@ public class RecoveryTaskCreatorTest {
     RecoveryTaskMetadata recoveryTask = newRecoveryTask.get();
     assertThat(recoveryTask.startOffset).isEqualTo(recoveryStartOffset * 2 + 1);
     assertThat(recoveryTask.endOffset).isEqualTo(currentHeadOffset - 1);
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
   }
 
   @Test
@@ -833,8 +834,8 @@ public class RecoveryTaskCreatorTest {
             TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
 
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
@@ -858,12 +859,12 @@ public class RecoveryTaskCreatorTest {
             recoveryStartOffset * 3,
             createdTimeUtc);
     recoveryTaskStore.createSync(recoveryTask11);
-    assertThat(recoveryTaskStore.listSync()).contains(recoveryTask1, recoveryTask11);
+    assertThat(recoveryTaskStore.listSyncUncached()).contains(recoveryTask1, recoveryTask11);
 
     final long currentHeadOffset = 4000;
     assertThat(recoveryTaskCreator.determineStartingOffset(currentHeadOffset))
         .isEqualTo(currentHeadOffset);
-    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSync();
+    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSyncUncached();
     assertThat(recoveryTasks.size()).isEqualTo(3);
     assertThat(recoveryTasks).contains(recoveryTask1, recoveryTask11);
     Optional<RecoveryTaskMetadata> newRecoveryTask =
@@ -872,7 +873,7 @@ public class RecoveryTaskCreatorTest {
     RecoveryTaskMetadata recoveryTask = newRecoveryTask.get();
     assertThat(recoveryTask.startOffset).isEqualTo(recoveryStartOffset * 3 + 1);
     assertThat(recoveryTask.endOffset).isEqualTo(currentHeadOffset - 1);
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
   }
 
   @Test
@@ -886,8 +887,8 @@ public class RecoveryTaskCreatorTest {
             TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
 
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
@@ -923,13 +924,13 @@ public class RecoveryTaskCreatorTest {
         new RecoveryTaskMetadata(
             recoveryTaskName + "21", "2", recoveryStartOffset * 4 + 1, 50000, createdTimeUtc);
     recoveryTaskStore.createSync(recoveryTask21);
-    assertThat(recoveryTaskStore.listSync())
+    assertThat(recoveryTaskStore.listSyncUncached())
         .contains(recoveryTask1, recoveryTask11, recoveryTask2, recoveryTask21);
 
     final long currentHeadOffset = 4000;
     assertThat(recoveryTaskCreator.determineStartingOffset(currentHeadOffset))
         .isEqualTo(currentHeadOffset);
-    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSync();
+    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSyncUncached();
     assertThat(recoveryTasks.size()).isEqualTo(5);
     assertThat(recoveryTasks)
         .contains(recoveryTask1, recoveryTask11, recoveryTask2, recoveryTask21);
@@ -939,7 +940,7 @@ public class RecoveryTaskCreatorTest {
     RecoveryTaskMetadata recoveryTask = newRecoveryTask.get();
     assertThat(recoveryTask.startOffset).isEqualTo((recoveryStartOffset * 3) + 1);
     assertThat(recoveryTask.endOffset).isEqualTo(currentHeadOffset - 1);
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
   }
 
   @Test
@@ -953,8 +954,8 @@ public class RecoveryTaskCreatorTest {
             TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
 
@@ -967,13 +968,13 @@ public class RecoveryTaskCreatorTest {
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
-    assertThat(snapshotMetadataStore.listSync()).contains(partition1);
+    assertThat(snapshotMetadataStore.listSyncUncached()).contains(partition1);
     assertThat(
             getHighestDurableOffsetForPartition(
-                snapshotMetadataStore.listSync(), Collections.emptyList(), partitionId))
+                snapshotMetadataStore.listSyncUncached(), Collections.emptyList(), partitionId))
         .isEqualTo(100);
     assertThat(recoveryTaskCreator.determineStartingOffset(150)).isEqualTo(101);
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
     assertThatIllegalStateException()
         .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(50));
 
@@ -982,12 +983,13 @@ public class RecoveryTaskCreatorTest {
             name + "11", path, endTime + 1, endTime * 2, maxOffset * 2, partitionId, LOGS_LUCENE9);
 
     snapshotMetadataStore.createSync(partition11);
-    assertThat(snapshotMetadataStore.listSync()).containsExactlyInAnyOrder(partition1, partition11);
+    assertThat(snapshotMetadataStore.listSyncUncached())
+        .containsExactlyInAnyOrder(partition1, partition11);
     assertThat(recoveryTaskCreator.determineStartingOffset(250)).isEqualTo(201);
     assertThat(recoveryTaskCreator.determineStartingOffset(201)).isEqualTo(201);
     assertThatIllegalStateException()
         .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(150));
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
     assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(0);
     assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(0);
 
@@ -1002,10 +1004,12 @@ public class RecoveryTaskCreatorTest {
             partitionId,
             LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition1);
-    assertThat(snapshotMetadataStore.listSync()).contains(partition1, partition11, livePartition1);
+    assertThat(snapshotMetadataStore.listSyncUncached())
+        .contains(partition1, partition11, livePartition1);
     assertThat(recoveryTaskCreator.determineStartingOffset(250)).isEqualTo(201);
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
-    assertThat(snapshotMetadataStore.listSync()).containsExactlyInAnyOrder(partition1, partition11);
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached())
+        .containsExactlyInAnyOrder(partition1, partition11);
     assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(1);
     assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(0);
 
@@ -1021,11 +1025,12 @@ public class RecoveryTaskCreatorTest {
             partitionId,
             LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition11);
-    assertThat(snapshotMetadataStore.listSync())
+    assertThat(snapshotMetadataStore.listSyncUncached())
         .contains(partition1, partition11, livePartition1, livePartition11);
     assertThat(recoveryTaskCreator.determineStartingOffset(250)).isEqualTo(201);
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
-    assertThat(snapshotMetadataStore.listSync()).containsExactlyInAnyOrder(partition1, partition11);
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached())
+        .containsExactlyInAnyOrder(partition1, partition11);
     assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(3);
     assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(0);
 
@@ -1036,11 +1041,11 @@ public class RecoveryTaskCreatorTest {
         new SnapshotMetadata(
             name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset * 5, "2", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition2);
-    assertThat(snapshotMetadataStore.listSync())
+    assertThat(snapshotMetadataStore.listSyncUncached())
         .contains(partition1, partition11, livePartition1, livePartition2);
     assertThat(recoveryTaskCreator.determineStartingOffset(250)).isEqualTo(201);
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
-    assertThat(snapshotMetadataStore.listSync())
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached())
         .containsExactlyInAnyOrder(partition1, partition11, livePartition2);
     assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(5);
     assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(0);
@@ -1052,11 +1057,11 @@ public class RecoveryTaskCreatorTest {
         new SnapshotMetadata(
             name + "3", path, startTime, endTime, maxOffset * 3, "2", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition2);
-    assertThat(snapshotMetadataStore.listSync())
+    assertThat(snapshotMetadataStore.listSyncUncached())
         .contains(partition1, partition11, livePartition1, livePartition2, partition2);
     assertThat(recoveryTaskCreator.determineStartingOffset(250)).isEqualTo(201);
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
-    assertThat(snapshotMetadataStore.listSync())
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached())
         .containsExactlyInAnyOrder(partition1, partition11, livePartition2, partition2);
     assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(7);
     assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(0);
@@ -1074,8 +1079,8 @@ public class RecoveryTaskCreatorTest {
             TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
 
@@ -1088,13 +1093,13 @@ public class RecoveryTaskCreatorTest {
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
-    assertThat(snapshotMetadataStore.listSync()).contains(partition1);
+    assertThat(snapshotMetadataStore.listSyncUncached()).contains(partition1);
     assertThat(
             getHighestDurableOffsetForPartition(
-                snapshotMetadataStore.listSync(), Collections.emptyList(), partitionId))
+                snapshotMetadataStore.listSyncUncached(), Collections.emptyList(), partitionId))
         .isEqualTo(100);
     assertThat(recoveryTaskCreator.determineStartingOffset(1150)).isEqualTo(1150);
-    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSync();
+    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSyncUncached();
     assertThat(recoveryTasks1.size()).isEqualTo(1);
     assertThat(recoveryTasks1.get(0).startOffset).isEqualTo(101);
     assertThat(recoveryTasks1.get(0).endOffset).isEqualTo(1149);
@@ -1105,17 +1110,18 @@ public class RecoveryTaskCreatorTest {
     assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(1);
     // clean up recovery task.
     recoveryTaskStore.deleteSync(recoveryTasks1.get(0).name);
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
 
     final SnapshotMetadata partition11 =
         new SnapshotMetadata(
             name + "11", path, endTime + 1, endTime * 2, maxOffset * 2, partitionId, LOGS_LUCENE9);
 
     snapshotMetadataStore.createSync(partition11);
-    assertThat(snapshotMetadataStore.listSync()).containsExactlyInAnyOrder(partition1, partition11);
+    assertThat(snapshotMetadataStore.listSyncUncached())
+        .containsExactlyInAnyOrder(partition1, partition11);
     assertThat(recoveryTaskCreator.determineStartingOffset(1250)).isEqualTo(1250);
-    assertThat(recoveryTaskStore.listSync().size()).isEqualTo(1);
-    RecoveryTaskMetadata recoveryTask1 = recoveryTaskStore.listSync().get(0);
+    assertThat(recoveryTaskStore.listSyncUncached().size()).isEqualTo(1);
+    RecoveryTaskMetadata recoveryTask1 = recoveryTaskStore.listSyncUncached().get(0);
     assertThat(recoveryTask1.startOffset).isEqualTo(201);
     assertThat(recoveryTask1.endOffset).isEqualTo(1249);
     assertThat(recoveryTask1.partitionId).isEqualTo(partitionId);
@@ -1124,7 +1130,7 @@ public class RecoveryTaskCreatorTest {
     assertThat(recoveryTaskCreator.determineStartingOffset(1249)).isEqualTo(1250);
     assertThat(recoveryTaskCreator.determineStartingOffset(1250)).isEqualTo(1250);
     assertThat(recoveryTaskCreator.determineStartingOffset(1251)).isEqualTo(1250);
-    assertThat(recoveryTaskStore.listSync().size()).isEqualTo(1);
+    assertThat(recoveryTaskStore.listSyncUncached().size()).isEqualTo(1);
     assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(0);
     assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(2);
 
@@ -1139,20 +1145,22 @@ public class RecoveryTaskCreatorTest {
             partitionId,
             LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition1);
-    assertThat(recoveryTaskStore.listSync()).containsExactly(recoveryTask1);
-    assertThat(snapshotMetadataStore.listSync()).contains(partition1, partition11, livePartition1);
+    assertThat(recoveryTaskStore.listSyncUncached()).containsExactly(recoveryTask1);
+    assertThat(snapshotMetadataStore.listSyncUncached())
+        .contains(partition1, partition11, livePartition1);
     assertThatIllegalStateException()
         .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(250));
     assertThat(recoveryTaskCreator.determineStartingOffset(1450)).isEqualTo(1450);
-    assertThat(snapshotMetadataStore.listSync()).containsExactlyInAnyOrder(partition1, partition11);
-    List<RecoveryTaskMetadata> recoveryTasks2 = recoveryTaskStore.listSync();
+    assertThat(snapshotMetadataStore.listSyncUncached())
+        .containsExactlyInAnyOrder(partition1, partition11);
+    List<RecoveryTaskMetadata> recoveryTasks2 = recoveryTaskStore.listSyncUncached();
     assertThat(recoveryTasks2.size()).isEqualTo(2);
     RecoveryTaskMetadata recoveryTask2 =
         recoveryTasks2.stream().filter(r -> !recoveryTask1.equals(r)).findFirst().get();
     assertThat(recoveryTask2.startOffset).isEqualTo(1250);
     assertThat(recoveryTask2.endOffset).isEqualTo(1449);
     assertThat(recoveryTask2.partitionId).isEqualTo(partitionId);
-    assertThat(recoveryTaskStore.listSync())
+    assertThat(recoveryTaskStore.listSyncUncached())
         .containsExactlyInAnyOrder(recoveryTask1, recoveryTask2);
     assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(1);
     assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(3);
@@ -1169,24 +1177,26 @@ public class RecoveryTaskCreatorTest {
             partitionId,
             LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition11);
-    assertThat(snapshotMetadataStore.listSync())
+    assertThat(snapshotMetadataStore.listSyncUncached())
         .contains(partition1, partition11, livePartition1, livePartition11);
     assertThat(recoveryTaskCreator.determineStartingOffset(1500)).isEqualTo(1450);
-    assertThat(snapshotMetadataStore.listSync()).containsExactlyInAnyOrder(partition1, partition11);
-    assertThat(recoveryTaskStore.listSync()).contains(recoveryTask1, recoveryTask2);
+    assertThat(snapshotMetadataStore.listSyncUncached())
+        .containsExactlyInAnyOrder(partition1, partition11);
+    assertThat(recoveryTaskStore.listSyncUncached()).contains(recoveryTask1, recoveryTask2);
     assertThat(recoveryTaskCreator.determineStartingOffset(1650)).isEqualTo(1650);
-    assertThat(snapshotMetadataStore.listSync()).containsExactlyInAnyOrder(partition1, partition11);
-    List<RecoveryTaskMetadata> recoveryTasks3 = recoveryTaskStore.listSync();
+    assertThat(snapshotMetadataStore.listSyncUncached())
+        .containsExactlyInAnyOrder(partition1, partition11);
+    List<RecoveryTaskMetadata> recoveryTasks3 = recoveryTaskStore.listSyncUncached();
     assertThat(recoveryTasks3.size()).isEqualTo(3);
     RecoveryTaskMetadata recoveryTask3 =
-        recoveryTaskStore.listSync().stream()
+        recoveryTaskStore.listSyncUncached().stream()
             .filter(r -> !r.equals(recoveryTask1) && !r.equals(recoveryTask2))
             .findFirst()
             .get();
     assertThat(recoveryTask3.partitionId).isEqualTo(partitionId);
     assertThat(recoveryTask3.startOffset).isEqualTo(1450);
     assertThat(recoveryTask3.endOffset).isEqualTo(1649);
-    assertThat(recoveryTaskStore.listSync())
+    assertThat(recoveryTaskStore.listSyncUncached())
         .containsExactlyInAnyOrder(recoveryTask1, recoveryTask2, recoveryTask3);
     assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(3);
     assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(4);
@@ -1198,27 +1208,27 @@ public class RecoveryTaskCreatorTest {
         new SnapshotMetadata(
             name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset * 5, "2", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition2);
-    assertThat(snapshotMetadataStore.listSync())
+    assertThat(snapshotMetadataStore.listSyncUncached())
         .contains(partition1, partition11, livePartition1, livePartition2);
     assertThat(recoveryTaskCreator.determineStartingOffset(1660)).isEqualTo(1650);
-    assertThat(recoveryTaskStore.listSync())
+    assertThat(recoveryTaskStore.listSyncUncached())
         .containsExactlyInAnyOrder(recoveryTask1, recoveryTask2, recoveryTask3);
-    assertThat(snapshotMetadataStore.listSync())
+    assertThat(snapshotMetadataStore.listSyncUncached())
         .containsExactlyInAnyOrder(partition1, partition11, livePartition2);
     assertThat(recoveryTaskCreator.determineStartingOffset(1850)).isEqualTo(1850);
-    List<RecoveryTaskMetadata> recoveryTasks4 = recoveryTaskStore.listSync();
+    List<RecoveryTaskMetadata> recoveryTasks4 = recoveryTaskStore.listSyncUncached();
     assertThat(recoveryTasks4.size()).isEqualTo(4);
     RecoveryTaskMetadata recoveryTask4 =
-        recoveryTaskStore.listSync().stream()
+        recoveryTaskStore.listSyncUncached().stream()
             .filter(r -> !recoveryTasks3.contains(r))
             .findFirst()
             .get();
     assertThat(recoveryTask4.partitionId).isEqualTo(partitionId);
     assertThat(recoveryTask4.startOffset).isEqualTo(1650);
     assertThat(recoveryTask4.endOffset).isEqualTo(1849);
-    assertThat(snapshotMetadataStore.listSync())
+    assertThat(snapshotMetadataStore.listSyncUncached())
         .containsExactlyInAnyOrder(partition1, partition11, livePartition2);
-    assertThat(recoveryTaskStore.listSync())
+    assertThat(recoveryTaskStore.listSyncUncached())
         .containsExactlyInAnyOrder(recoveryTask1, recoveryTask2, recoveryTask3, recoveryTask4);
     assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(5);
     assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(5);
@@ -1230,7 +1240,7 @@ public class RecoveryTaskCreatorTest {
         new SnapshotMetadata(
             name + "3", path, startTime, endTime, maxOffset * 3, "2", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition2);
-    assertThat(snapshotMetadataStore.listSync())
+    assertThat(snapshotMetadataStore.listSyncUncached())
         .contains(partition1, partition11, livePartition1, livePartition2, partition2);
     final RecoveryTaskMetadata recoveryTaskPartition2 =
         new RecoveryTaskMetadata("basicRecovery" + "2", "2", 10000, 20000, 1000);
@@ -1238,22 +1248,22 @@ public class RecoveryTaskCreatorTest {
     assertThatIllegalStateException()
         .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(1650));
     assertThat(recoveryTaskCreator.determineStartingOffset(1900)).isEqualTo(1850);
-    assertThat(recoveryTaskStore.listSync())
+    assertThat(recoveryTaskStore.listSyncUncached())
         .containsExactlyInAnyOrder(
             recoveryTask1, recoveryTask2, recoveryTask3, recoveryTask4, recoveryTaskPartition2);
     assertThat(recoveryTaskCreator.determineStartingOffset(2050)).isEqualTo(2050);
-    assertThat(recoveryTaskStore.listSync().size()).isEqualTo(6);
+    assertThat(recoveryTaskStore.listSyncUncached().size()).isEqualTo(6);
     RecoveryTaskMetadata recoveryTask5 =
-        recoveryTaskStore.listSync().stream()
+        recoveryTaskStore.listSyncUncached().stream()
             .filter(r -> !recoveryTasks4.contains(r) && !r.equals(recoveryTaskPartition2))
             .findFirst()
             .get();
     assertThat(recoveryTask5.partitionId).isEqualTo(partitionId);
     assertThat(recoveryTask5.startOffset).isEqualTo(1850);
     assertThat(recoveryTask5.endOffset).isEqualTo(2049);
-    assertThat(snapshotMetadataStore.listSync())
+    assertThat(snapshotMetadataStore.listSyncUncached())
         .containsExactlyInAnyOrder(partition1, partition11, livePartition2, partition2);
-    assertThat(recoveryTaskStore.listSync())
+    assertThat(recoveryTaskStore.listSyncUncached())
         .containsExactlyInAnyOrder(
             recoveryTask1,
             recoveryTask2,
@@ -1276,8 +1286,8 @@ public class RecoveryTaskCreatorTest {
             TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
 
@@ -1290,13 +1300,13 @@ public class RecoveryTaskCreatorTest {
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
-    assertThat(snapshotMetadataStore.listSync()).contains(partition1);
+    assertThat(snapshotMetadataStore.listSyncUncached()).contains(partition1);
     assertThat(
             getHighestDurableOffsetForPartition(
-                snapshotMetadataStore.listSync(), Collections.emptyList(), partitionId))
+                snapshotMetadataStore.listSyncUncached(), Collections.emptyList(), partitionId))
         .isEqualTo(100);
     assertThat(recoveryTaskCreator.determineStartingOffset(1150)).isEqualTo(1150);
-    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSync();
+    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSyncUncached();
     assertThat(recoveryTasks1.size()).isEqualTo(1);
     assertThat(recoveryTasks1.get(0).startOffset).isEqualTo(101);
     assertThat(recoveryTasks1.get(0).endOffset).isEqualTo(1149);
@@ -1309,8 +1319,8 @@ public class RecoveryTaskCreatorTest {
 
     assertThatExceptionOfType(RuntimeException.class)
         .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(1350));
-    assertThat(recoveryTaskStore.listSync()).containsExactly(recoveryTasks1.get(0));
-    assertThat(snapshotMetadataStore.listSync()).contains(partition1);
+    assertThat(recoveryTaskStore.listSyncUncached()).containsExactly(recoveryTasks1.get(0));
+    assertThat(snapshotMetadataStore.listSyncUncached()).contains(partition1);
   }
 
   @Test
@@ -1324,8 +1334,8 @@ public class RecoveryTaskCreatorTest {
             TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
 
@@ -1338,13 +1348,13 @@ public class RecoveryTaskCreatorTest {
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
-    assertThat(snapshotMetadataStore.listSync()).contains(partition1);
+    assertThat(snapshotMetadataStore.listSyncUncached()).contains(partition1);
     assertThat(
             getHighestDurableOffsetForPartition(
-                snapshotMetadataStore.listSync(), Collections.emptyList(), partitionId))
+                snapshotMetadataStore.listSyncUncached(), Collections.emptyList(), partitionId))
         .isEqualTo(100);
     assertThat(recoveryTaskCreator.determineStartingOffset(1150)).isEqualTo(1150);
-    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSync();
+    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSyncUncached();
     assertThat(recoveryTasks1.size()).isEqualTo(1);
     assertThat(recoveryTasks1.get(0).startOffset).isEqualTo(101);
     assertThat(recoveryTasks1.get(0).endOffset).isEqualTo(1149);
@@ -1356,12 +1366,12 @@ public class RecoveryTaskCreatorTest {
     doThrow(new InternalMetadataStoreException(""))
         .doCallRealMethod()
         .when(snapshotMetadataStore)
-        .listSync();
+        .listSyncUncached();
 
     assertThatExceptionOfType(RuntimeException.class)
         .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(1350));
-    assertThat(recoveryTaskStore.listSync()).containsExactly(recoveryTasks1.get(0));
-    assertThat(snapshotMetadataStore.listSync()).containsExactly(partition1);
+    assertThat(recoveryTaskStore.listSyncUncached()).containsExactly(recoveryTasks1.get(0));
+    assertThat(snapshotMetadataStore.listSyncUncached()).containsExactly(partition1);
   }
 
   @Test
@@ -1375,8 +1385,8 @@ public class RecoveryTaskCreatorTest {
             TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
 
@@ -1389,13 +1399,13 @@ public class RecoveryTaskCreatorTest {
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
-    assertThat(snapshotMetadataStore.listSync()).contains(partition1);
+    assertThat(snapshotMetadataStore.listSyncUncached()).contains(partition1);
     assertThat(
             getHighestDurableOffsetForPartition(
-                snapshotMetadataStore.listSync(), Collections.emptyList(), partitionId))
+                snapshotMetadataStore.listSyncUncached(), Collections.emptyList(), partitionId))
         .isEqualTo(100);
     assertThat(recoveryTaskCreator.determineStartingOffset(1150)).isEqualTo(1150);
-    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSync();
+    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSyncUncached();
     assertThat(recoveryTasks1.size()).isEqualTo(1);
     assertThat(recoveryTasks1.get(0).startOffset).isEqualTo(101);
     assertThat(recoveryTasks1.get(0).endOffset).isEqualTo(1149);
@@ -1407,12 +1417,12 @@ public class RecoveryTaskCreatorTest {
     doThrow(new InternalMetadataStoreException(""))
         .doCallRealMethod()
         .when(recoveryTaskStore)
-        .listSync();
+        .listSyncUncached();
 
     assertThatExceptionOfType(RuntimeException.class)
         .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(1350));
-    assertThat(recoveryTaskStore.listSync()).containsExactly(recoveryTasks1.get(0));
-    assertThat(snapshotMetadataStore.listSync()).containsExactly(partition1);
+    assertThat(recoveryTaskStore.listSyncUncached()).containsExactly(recoveryTasks1.get(0));
+    assertThat(snapshotMetadataStore.listSyncUncached()).containsExactly(partition1);
   }
 
   @Test
@@ -1427,8 +1437,8 @@ public class RecoveryTaskCreatorTest {
             TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
 
@@ -1441,13 +1451,13 @@ public class RecoveryTaskCreatorTest {
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
-    assertThat(snapshotMetadataStore.listSync()).contains(partition1);
+    assertThat(snapshotMetadataStore.listSyncUncached()).contains(partition1);
     assertThat(
             getHighestDurableOffsetForPartition(
-                snapshotMetadataStore.listSync(), Collections.emptyList(), partitionId))
+                snapshotMetadataStore.listSyncUncached(), Collections.emptyList(), partitionId))
         .isEqualTo(100);
     assertThat(recoveryTaskCreator.determineStartingOffset(1150)).isEqualTo(1150);
-    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSync();
+    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSyncUncached();
     assertThat(recoveryTasks1.size()).isEqualTo(1);
     assertThat(recoveryTasks1.get(0).startOffset).isEqualTo(101);
     assertThat(recoveryTasks1.get(0).endOffset).isEqualTo(1149);
@@ -1466,7 +1476,7 @@ public class RecoveryTaskCreatorTest {
             partitionId,
             LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition1);
-    assertThat(snapshotMetadataStore.listSync())
+    assertThat(snapshotMetadataStore.listSyncUncached())
         .containsExactlyInAnyOrder(partition1, livePartition1);
     // Fail deletion on snapshot metadata store.
     doThrow(new IllegalStateException())
@@ -1476,8 +1486,8 @@ public class RecoveryTaskCreatorTest {
 
     assertThatIllegalStateException()
         .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(1350));
-    assertThat(recoveryTaskStore.listSync()).containsExactly(recoveryTasks1.get(0));
-    assertThat(snapshotMetadataStore.listSync())
+    assertThat(recoveryTaskStore.listSyncUncached()).containsExactly(recoveryTasks1.get(0));
+    assertThat(snapshotMetadataStore.listSyncUncached())
         .containsExactlyInAnyOrder(partition1, livePartition1);
   }
 
@@ -1494,9 +1504,9 @@ public class RecoveryTaskCreatorTest {
             meterRegistry);
 
     // Long range - 1 chunk
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
     recoveryTaskCreator.createRecoveryTasks("1", 10, 100, maxMessagesPerRecoveryTask);
-    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSync();
+    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSyncUncached();
     assertThat(recoveryTasks.size()).isEqualTo(1);
     assertThat(recoveryTasks.get(0).startOffset).isEqualTo(10);
     assertThat(recoveryTasks.get(0).endOffset).isEqualTo(100);
@@ -1517,9 +1527,9 @@ public class RecoveryTaskCreatorTest {
             maxMessagesPerRecoveryTask,
             meterRegistry);
 
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
     recoveryTaskCreator.createRecoveryTasks(testPartitionId, 100, 101, maxMessagesPerRecoveryTask);
-    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSync();
+    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSyncUncached();
     assertThat(recoveryTasks.size()).isEqualTo(1);
     assertThat(recoveryTasks.get(0).startOffset).isEqualTo(100);
     assertThat(recoveryTasks.get(0).endOffset).isEqualTo(101);
@@ -1534,9 +1544,9 @@ public class RecoveryTaskCreatorTest {
         new RecoveryTaskCreator(
             snapshotMetadataStore, recoveryTaskStore, testPartitionId, 100, 2, meterRegistry);
 
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
     recoveryTaskCreator.createRecoveryTasks(testPartitionId, 100, 105, 2);
-    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSync();
+    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSyncUncached();
     assertThat(recoveryTasks.size()).isEqualTo(3);
     assertThat(recoveryTasks.stream().mapToLong(r -> r.startOffset).sorted().toArray())
         .containsExactly(100, 102, 104);
@@ -1555,9 +1565,9 @@ public class RecoveryTaskCreatorTest {
         new RecoveryTaskCreator(
             snapshotMetadataStore, recoveryTaskStore, partitionId, 100, 2, meterRegistry);
 
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
     recoveryTaskCreator.createRecoveryTasks(partitionId, 100, 104, 2);
-    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSync();
+    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSyncUncached();
     assertThat(recoveryTasks.size()).isEqualTo(3);
     assertThat(recoveryTasks.stream().mapToLong(r -> r.startOffset).sorted().toArray())
         .containsExactly(100, 102, 104);
@@ -1583,11 +1593,11 @@ public class RecoveryTaskCreatorTest {
             maxMessagesPerRecoveryTask,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSync()).isEmpty();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
-    assertThat(recoveryTaskStore.listSync()).isEmpty();
+    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
 
     final String name = "testSnapshotId";
     final String path = "/testPath_" + name;
@@ -1598,13 +1608,13 @@ public class RecoveryTaskCreatorTest {
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
-    assertThat(snapshotMetadataStore.listSync()).contains(partition1);
+    assertThat(snapshotMetadataStore.listSyncUncached()).contains(partition1);
     assertThat(
             getHighestDurableOffsetForPartition(
-                snapshotMetadataStore.listSync(), Collections.emptyList(), partitionId))
+                snapshotMetadataStore.listSyncUncached(), Collections.emptyList(), partitionId))
         .isEqualTo(100);
     assertThat(recoveryTaskCreator.determineStartingOffset(1150)).isEqualTo(1150);
-    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSync();
+    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSyncUncached();
     assertThat(recoveryTasks1.size()).isEqualTo(3);
     assertThat(recoveryTasks1.stream().mapToLong(r -> r.startOffset).sorted().toArray())
         .containsExactly(101, 601, 1101);

--- a/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceTest.java
@@ -98,7 +98,7 @@ public class ZipkinServiceTest {
         new DatasetMetadata(
             TEST_DATASET_NAME, "serviceOwner", 1000, partitionConfigs, TEST_DATASET_NAME);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSync().size() == 1);
+    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
   }
 
   @AfterEach


### PR DESCRIPTION
###  Summary

Adds the ZK partitioning store, refactoring the underlying metadata store as needed. This doesn't introduce any classes using the new partitioning store yet, as those will follow in separate PRs. Also model into the metadata change listener, as exposed via ZK.

Note: This renames `getCachedAsync` to `listAsync`, and `listAsync` to `listAsyncUncached`, which better aligns with the partitioned store. We would like to completely remove all use of the `listAsyncUncached` method (which is now marked as deprecated), as this is an exceptionally expensive operation. Today most use is done in tests, with very little being done in code execution.

Spun off #553 