### PR TITLE
Remove use of deprecated listSyncUncached

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/IndexingChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/IndexingChunkManager.java
@@ -318,8 +318,8 @@ public class IndexingChunkManager<T> extends ChunkManagerBase<T> {
   protected void startUp() throws Exception {
     LOG.info("Starting indexing chunk manager");
 
-    searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, false);
+    searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
+    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
 
     stopIngestion = false;
   }

--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/IndexingChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/IndexingChunkManager.java
@@ -85,9 +85,9 @@ public class IndexingChunkManager<T> extends ChunkManagerBase<T> {
   private boolean stopIngestion;
 
   /** Declare all the data stores used by Chunk manager here. */
-  private SnapshotMetadataStore snapshotMetadataStore;
+  protected SnapshotMetadataStore snapshotMetadataStore;
 
-  private SearchMetadataStore searchMetadataStore;
+  protected SearchMetadataStore searchMetadataStore;
 
   /**
    * For capacity planning, we want to control how many roll overs are in progress at the same time.

--- a/kaldb/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
@@ -91,10 +91,9 @@ public class KaldbIndexer extends AbstractExecutionThreadService {
    */
   private long indexerPreStart() throws Exception {
     LOG.info("Starting Kaldb indexer pre start.");
-    SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, false);
+    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
     RecoveryTaskMetadataStore recoveryTaskMetadataStore =
-        new RecoveryTaskMetadataStore(curatorFramework, false);
+        new RecoveryTaskMetadataStore(curatorFramework, true);
 
     String partitionId = kafkaConfig.getKafkaTopicPartition();
     long maxOffsetDelay = indexerConfig.getMaxOffsetDelayMessages();

--- a/kaldb/src/main/java/com/slack/kaldb/server/ManagerApiGrpc.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ManagerApiGrpc.java
@@ -125,7 +125,7 @@ public class ManagerApiGrpc extends ManagerApiServiceGrpc.ManagerApiServiceImplB
       responseObserver.onNext(
           ManagerApi.ListDatasetMetadataResponse.newBuilder()
               .addAllDatasetMetadata(
-                  datasetMetadataStore.listSyncUncached().stream()
+                  datasetMetadataStore.listSync().stream()
                       .map(DatasetMetadataSerializer::toDatasetMetadataProto)
                       .collect(Collectors.toList()))
               .build());

--- a/kaldb/src/main/java/com/slack/kaldb/server/RecoveryTaskCreator.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/RecoveryTaskCreator.java
@@ -150,7 +150,7 @@ public class RecoveryTaskCreator {
       LOG.warn("PartitionId can't be null.");
     }
 
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
+    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSync();
     List<SnapshotMetadata> snapshotsForPartition =
         snapshots.stream()
             .filter(
@@ -164,16 +164,14 @@ public class RecoveryTaskCreator {
                       && snapshotMetadata.partitionId != null
                       && snapshotMetadata.partitionId.equals(partitionId);
                 })
-            .collect(Collectors.toUnmodifiableList());
+            .toList();
     List<SnapshotMetadata> deletedSnapshots = deleteStaleLiveSnapshots(snapshotsForPartition);
 
     List<SnapshotMetadata> nonLiveSnapshotsForPartition =
-        snapshotsForPartition.stream()
-            .filter(s -> !deletedSnapshots.contains(s))
-            .collect(Collectors.toUnmodifiableList());
+        snapshotsForPartition.stream().filter(s -> !deletedSnapshots.contains(s)).toList();
 
     // Get the highest offset that is indexed in durable store.
-    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskMetadataStore.listSyncUncached();
+    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskMetadataStore.listSync();
     long highestDurableOffsetForPartition =
         getHighestDurableOffsetForPartition(
             nonLiveSnapshotsForPartition, recoveryTasks, partitionId);
@@ -287,7 +285,7 @@ public class RecoveryTaskCreator {
                       MoreExecutors.directExecutor());
                   return future;
                 })
-            .collect(Collectors.toUnmodifiableList());
+            .toList();
 
     //noinspection UnstableApiUsage
     ListenableFuture<?> futureList = Futures.successfulAsList(deletionFutures);

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -108,12 +108,11 @@ public class ReadOnlyChunkImplTest {
             .build();
 
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework, false);
-    SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, false);
+    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework, true);
+    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
     SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
     CacheSlotMetadataStore cacheSlotMetadataStore =
-        new CacheSlotMetadataStore(curatorFramework, false);
+        new CacheSlotMetadataStore(curatorFramework, true);
 
     String replicaId = "foo";
     String snapshotId = "bar";
@@ -147,7 +146,7 @@ public class ReadOnlyChunkImplTest {
     assignReplicaToChunk(cacheSlotMetadataStore, replicaId, readOnlyChunk);
 
     // ensure that the chunk was marked LIVE
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> searchMetadataStore.listSync().size() == 1);
     assertThat(readOnlyChunk.getChunkMetadataState())
         .isEqualTo(Metadata.CacheSlotMetadata.CacheSlotState.LIVE);
 
@@ -238,12 +237,11 @@ public class ReadOnlyChunkImplTest {
             .build();
 
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework, false);
-    SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, false);
+    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework, true);
+    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
     SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
     CacheSlotMetadataStore cacheSlotMetadataStore =
-        new CacheSlotMetadataStore(curatorFramework, false);
+        new CacheSlotMetadataStore(curatorFramework, true);
 
     String replicaId = "foo";
     String snapshotId = "bar";
@@ -306,12 +304,11 @@ public class ReadOnlyChunkImplTest {
             .build();
 
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework, false);
-    SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, false);
+    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework, true);
+    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
     SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
     CacheSlotMetadataStore cacheSlotMetadataStore =
-        new CacheSlotMetadataStore(curatorFramework, false);
+        new CacheSlotMetadataStore(curatorFramework, true);
 
     String replicaId = "foo";
     String snapshotId = "bar";
@@ -374,12 +371,11 @@ public class ReadOnlyChunkImplTest {
             .build();
 
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework, false);
-    SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, false);
+    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework, true);
+    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
     SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
     CacheSlotMetadataStore cacheSlotMetadataStore =
-        new CacheSlotMetadataStore(curatorFramework, false);
+        new CacheSlotMetadataStore(curatorFramework, true);
 
     String replicaId = "foo";
     String snapshotId = "bar";
@@ -478,8 +474,7 @@ public class ReadOnlyChunkImplTest {
 
   private void initializeZkSnapshot(AsyncCuratorFramework curatorFramework, String snapshotId)
       throws Exception {
-    SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, false);
+    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
     snapshotMetadataStore.createSync(
         new SnapshotMetadata(
             snapshotId,
@@ -494,7 +489,7 @@ public class ReadOnlyChunkImplTest {
   private void initializeZkReplica(
       AsyncCuratorFramework curatorFramework, String replicaId, String snapshotId)
       throws Exception {
-    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework, false);
+    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework, true);
     replicaMetadataStore.createSync(
         new ReplicaMetadata(
             replicaId,

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -142,6 +142,7 @@ public class ReadOnlyChunkImplTest {
             () ->
                 readOnlyChunk.getChunkMetadataState()
                     == Metadata.CacheSlotMetadata.CacheSlotState.FREE);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 1);
 
     assignReplicaToChunk(cacheSlotMetadataStore, replicaId, readOnlyChunk);
 
@@ -270,6 +271,7 @@ public class ReadOnlyChunkImplTest {
             () ->
                 readOnlyChunk.getChunkMetadataState()
                     == Metadata.CacheSlotMetadata.CacheSlotState.FREE);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 1);
 
     assignReplicaToChunk(cacheSlotMetadataStore, replicaId, readOnlyChunk);
 

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -339,6 +339,7 @@ public class ReadOnlyChunkImplTest {
             () ->
                 readOnlyChunk.getChunkMetadataState()
                     == Metadata.CacheSlotMetadata.CacheSlotState.FREE);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 1);
 
     assignReplicaToChunk(cacheSlotMetadataStore, replicaId, readOnlyChunk);
 
@@ -407,6 +408,7 @@ public class ReadOnlyChunkImplTest {
             () ->
                 readOnlyChunk.getChunkMetadataState()
                     == Metadata.CacheSlotMetadata.CacheSlotState.FREE);
+    await().until(() -> cacheSlotMetadataStore.listSync().size() == 1);
 
     assignReplicaToChunk(cacheSlotMetadataStore, replicaId, readOnlyChunk);
 

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
@@ -93,7 +93,7 @@ public class RecoveryChunkImplTest {
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
       snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
-      searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
+      searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
 
       final LuceneIndexStoreImpl logStore =
           LuceneIndexStoreImpl.makeLogStore(
@@ -448,7 +448,7 @@ public class RecoveryChunkImplTest {
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
       snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
-      searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
+      searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
 
       final LuceneIndexStoreImpl logStore =
           LuceneIndexStoreImpl.makeLogStore(

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/ChunkCleanerServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/ChunkCleanerServiceTest.java
@@ -72,7 +72,7 @@ public class ChunkCleanerServiceTest {
             KaldbConfigUtil.makeIndexerConfig());
     chunkManagerUtil.chunkManager.startAsync();
     chunkManagerUtil.chunkManager.awaitRunning(DEFAULT_START_STOP_DURATION);
-    searchMetadataStore = new SearchMetadataStore(chunkManagerUtil.getCuratorFramework(), false);
+    searchMetadataStore = new SearchMetadataStore(chunkManagerUtil.getCuratorFramework(), true);
     snapshotMetadataStore = new SnapshotMetadataStore(chunkManagerUtil.getCuratorFramework(), true);
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
@@ -75,6 +75,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.curator.test.TestingServer;
 import org.apache.curator.x.async.AsyncCuratorFramework;
@@ -111,8 +112,6 @@ public class IndexingChunkManagerTest {
   private S3BlobFs s3BlobFs;
   private TestingServer localZkServer;
   private AsyncCuratorFramework curatorFramework;
-  private SnapshotMetadataStore snapshotMetadataStore;
-  private SearchMetadataStore searchMetadataStore;
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -136,8 +135,6 @@ public class IndexingChunkManagerTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(metricsRegistry, zkConfig);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, false);
-    searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
   }
 
   @AfterEach
@@ -246,8 +243,8 @@ public class IndexingChunkManagerTest {
     assertThat(getValue(LIVE_BYTES_INDEXED, metricsRegistry)).isEqualTo(actualChunkSize);
 
     // Check metadata registration.
-    assertThat(snapshotMetadataStore.listSyncUncached().size()).isEqualTo(1);
-    assertThat(searchMetadataStore.listSyncUncached().size()).isEqualTo(1);
+    await().until(() -> chunkManager.snapshotMetadataStore.listSync().size() == 1);
+    await().until(() -> chunkManager.searchMetadataStore.listSync().size() == 1);
 
     SearchQuery searchQuery =
         new SearchQuery(
@@ -274,24 +271,34 @@ public class IndexingChunkManagerTest {
     assertThat(chunkInfo.getDataEndTimeEpochMs())
         .isEqualTo(messages.get(99).getTimestamp().toEpochMilli());
 
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
-    assertThat(snapshots.size()).isEqualTo(1);
-    List<SnapshotMetadata> liveSnapshots = fetchLiveSnapshot(snapshots);
+    AtomicReference<List<SnapshotMetadata>> snapshots = new AtomicReference<>();
+    await()
+        .until(
+            () -> {
+              snapshots.set(chunkManager.snapshotMetadataStore.listSync());
+              return snapshots.get().size() == 1;
+            });
+    List<SnapshotMetadata> liveSnapshots = fetchLiveSnapshot(snapshots.get());
     assertThat(liveSnapshots.size()).isEqualTo(1);
-    assertThat(fetchNonLiveSnapshot(snapshots)).isEmpty();
-    assertThat(snapshots.get(0).snapshotPath).startsWith(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
-    assertThat(snapshots.get(0).maxOffset).isEqualTo(0);
-    assertThat(snapshots.get(0).partitionId).isEqualTo(TEST_KAFKA_PARTITION_ID);
-    assertThat(snapshots.get(0).snapshotId).startsWith(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
-    assertThat(snapshots.get(0).startTimeEpochMs)
+    assertThat(fetchNonLiveSnapshot(snapshots.get())).isEmpty();
+    assertThat(snapshots.get().get(0).snapshotPath).startsWith(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
+    assertThat(snapshots.get().get(0).maxOffset).isEqualTo(0);
+    assertThat(snapshots.get().get(0).partitionId).isEqualTo(TEST_KAFKA_PARTITION_ID);
+    assertThat(snapshots.get().get(0).snapshotId).startsWith(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
+    assertThat(snapshots.get().get(0).startTimeEpochMs)
         .isCloseTo(creationTime.toEpochMilli(), Offset.offset(5000L));
-    assertThat(snapshots.get(0).endTimeEpochMs).isEqualTo(MAX_FUTURE_TIME);
+    assertThat(snapshots.get().get(0).endTimeEpochMs).isEqualTo(MAX_FUTURE_TIME);
 
-    List<SearchMetadata> searchNodes = searchMetadataStore.listSyncUncached();
-    assertThat(searchNodes.size()).isEqualTo(1);
-    assertThat(searchNodes.get(0).url).contains(TEST_HOST);
-    assertThat(searchNodes.get(0).url).contains(String.valueOf(TEST_PORT));
-    assertThat(searchNodes.get(0).snapshotName).contains(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
+    AtomicReference<List<SearchMetadata>> searchNodes = new AtomicReference<>();
+    await()
+        .until(
+            () -> {
+              searchNodes.set(chunkManager.searchMetadataStore.listSync());
+              return searchNodes.get().size() == 1;
+            });
+    assertThat(searchNodes.get().get(0).url).contains(TEST_HOST);
+    assertThat(searchNodes.get().get(0).url).contains(String.valueOf(TEST_PORT));
+    assertThat(searchNodes.get().get(0).snapshotName).contains(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
 
     // Add a message with a very high offset.
     final int veryHighOffset = 1000;
@@ -602,17 +609,28 @@ public class IndexingChunkManagerTest {
       int expectedNonLiveSnapshotSize,
       int expectedSearchNodeSize,
       int expectedInfinitySnapshotsCount) {
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
-    assertThat(snapshots.size()).isEqualTo(expectedSnapshotSize);
-    List<SnapshotMetadata> liveSnapshots = fetchLiveSnapshot(snapshots);
+    AtomicReference<List<SnapshotMetadata>> snapshots = new AtomicReference<>();
+    await()
+        .until(
+            () -> {
+              snapshots.set(chunkManager.snapshotMetadataStore.listSync());
+              return snapshots.get().size() == expectedSnapshotSize;
+            });
+    List<SnapshotMetadata> liveSnapshots = fetchLiveSnapshot(snapshots.get());
     assertThat(liveSnapshots.size()).isEqualTo(expectedLiveSnapshotSize);
-    assertThat(fetchNonLiveSnapshot(snapshots).size()).isEqualTo(expectedNonLiveSnapshotSize);
-    List<SearchMetadata> searchNodes = searchMetadataStore.listSyncUncached();
-    assertThat(searchNodes.size()).isEqualTo(expectedSearchNodeSize);
+    assertThat(fetchNonLiveSnapshot(snapshots.get()).size()).isEqualTo(expectedNonLiveSnapshotSize);
+    AtomicReference<List<SearchMetadata>> searchNodes = new AtomicReference<>();
+    await()
+        .until(
+            () -> {
+              searchNodes.set(chunkManager.searchMetadataStore.listSync());
+              return searchNodes.get();
+            },
+            (nodes) -> nodes.size() == expectedSearchNodeSize);
     assertThat(liveSnapshots.stream().map(s -> s.snapshotId).collect(Collectors.toList()))
         .containsExactlyInAnyOrderElementsOf(
-            searchNodes.stream().map(s -> s.snapshotName).collect(Collectors.toList()));
-    assertThat(snapshots.stream().filter(s -> s.endTimeEpochMs == MAX_FUTURE_TIME).count())
+            searchNodes.get().stream().map(s -> s.snapshotName).collect(Collectors.toList()));
+    assertThat(snapshots.get().stream().filter(s -> s.endTimeEpochMs == MAX_FUTURE_TIME).count())
         .isEqualTo(expectedInfinitySnapshotsCount);
   }
 
@@ -1037,10 +1055,8 @@ public class IndexingChunkManagerTest {
     initChunkManager(
         chunkRollOverStrategy, S3_TEST_BUCKET, IndexingChunkManager.makeDefaultRollOverExecutor());
 
-    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
-    assertThat(fetchLiveSnapshot(snapshotMetadataStore.listSyncUncached())).isEmpty();
-    assertThat(fetchNonLiveSnapshot(snapshotMetadataStore.listSyncUncached())).isEmpty();
-    assertThat(searchMetadataStore.listSyncUncached()).isEmpty();
+    await().until(() -> chunkManager.snapshotMetadataStore.listSync().isEmpty());
+    await().until(() -> chunkManager.searchMetadataStore.listSync().isEmpty());
 
     // Adding a messages very quickly when running a rollover in background would result in an
     // exception.
@@ -1054,17 +1070,29 @@ public class IndexingChunkManagerTest {
             })
         .isInstanceOf(ChunkRollOverException.class);
 
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
-    assertThat(snapshots.size()).isEqualTo(2);
-    List<SnapshotMetadata> liveSnapshots = fetchLiveSnapshot(snapshots);
+    AtomicReference<List<SnapshotMetadata>> snapshots = new AtomicReference<>();
+    await()
+        .until(
+            () -> {
+              snapshots.set(chunkManager.snapshotMetadataStore.listSync());
+              return snapshots.get();
+            },
+            (s) -> s.size() == 2);
+    List<SnapshotMetadata> liveSnapshots = fetchLiveSnapshot(snapshots.get());
     assertThat(liveSnapshots.size()).isGreaterThanOrEqualTo(2);
-    assertThat(fetchNonLiveSnapshot(snapshots).size()).isEqualTo(0);
-    List<SearchMetadata> searchNodes = searchMetadataStore.listSyncUncached();
-    assertThat(searchNodes.size()).isEqualTo(2);
+    assertThat(fetchNonLiveSnapshot(snapshots.get()).size()).isEqualTo(0);
+
+    AtomicReference<List<SearchMetadata>> searchNodes = new AtomicReference<>();
+    await()
+        .until(
+            () -> {
+              searchNodes.set(chunkManager.searchMetadataStore.listSync());
+              return searchNodes.get().size() == 2;
+            });
     assertThat(liveSnapshots.stream().map(s -> s.snapshotId).collect(Collectors.toList()))
         .containsExactlyInAnyOrderElementsOf(
-            searchNodes.stream().map(s -> s.snapshotName).collect(Collectors.toList()));
-    assertThat(snapshots.stream().filter(s -> s.endTimeEpochMs == MAX_FUTURE_TIME).count())
+            searchNodes.get().stream().map(s -> s.snapshotName).collect(Collectors.toList()));
+    assertThat(snapshots.get().stream().filter(s -> s.endTimeEpochMs == MAX_FUTURE_TIME).count())
         .isEqualTo(2);
   }
 
@@ -1080,6 +1108,9 @@ public class IndexingChunkManagerTest {
     initChunkManager(
         chunkRollOverStrategy, S3_TEST_BUCKET, IndexingChunkManager.makeDefaultRollOverExecutor());
 
+    await().until(() -> chunkManager.snapshotMetadataStore.listSync().isEmpty());
+    await().until(() -> chunkManager.searchMetadataStore.listSync().isEmpty());
+
     // Adding a message and close the chunkManager right away should still finish the failed
     // rollover.
     int offset = 1;
@@ -1090,10 +1121,9 @@ public class IndexingChunkManagerTest {
     ListenableFuture<?> rollOverFuture = chunkManager.getRolloverFuture();
 
     await().until(() -> getCount(RollOverChunkTask.ROLLOVERS_COMPLETED, metricsRegistry) == 1);
-    checkMetadata(2, 1, 1, 1, 0);
+    checkMetadata(2, 1, 1, 1, 0); // two snapshots, as expected
     chunkManager.stopAsync();
     chunkManager.awaitTerminated(DEFAULT_START_STOP_DURATION);
-    chunkManager = null;
 
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, metricsRegistry)).isEqualTo(10);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, metricsRegistry)).isEqualTo(0);
@@ -1101,20 +1131,27 @@ public class IndexingChunkManagerTest {
     assertThat(getCount(ROLLOVERS_FAILED, metricsRegistry)).isEqualTo(0);
     assertThat(rollOverFuture.isDone()).isTrue();
 
-    // The stores are closed so temporarily re-create them so we can query the data in ZK.
-    SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
-    SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, false);
-    assertThat(searchMetadataStore.listSyncUncached()).isEmpty();
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
-    assertThat(snapshots.size()).isEqualTo(1);
-    assertThat(fetchNonLiveSnapshot(snapshots).size()).isEqualTo(1);
-    assertThat(fetchLiveSnapshot(snapshots)).isEmpty();
-    assertThat(snapshots.get(0).maxOffset).isEqualTo(offset - 1);
-    assertThat(snapshots.get(0).endTimeEpochMs).isLessThan(MAX_FUTURE_TIME);
-    assertThat(snapshots.get(0).snapshotId).doesNotContain(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
-    searchMetadataStore.close();
-    snapshotMetadataStore.close();
+    await().until(chunkManager.searchMetadataStore::listSync, (List::isEmpty));
+    AtomicReference<List<SnapshotMetadata>> snapshots = new AtomicReference<>();
+
+    try (SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, true)) {
+      await()
+          .until(
+              () -> {
+                snapshots.set(snapshotMetadataStore.listSync());
+                return snapshots.get();
+              },
+              (snapshotList) -> snapshotList.size() == 1);
+    }
+    assertThat(fetchNonLiveSnapshot(snapshots.get()).size()).isEqualTo(1);
+    assertThat(fetchLiveSnapshot(snapshots.get())).isEmpty();
+    assertThat(snapshots.get().get(0).maxOffset).isEqualTo(offset - 1);
+    assertThat(snapshots.get().get(0).endTimeEpochMs).isLessThan(MAX_FUTURE_TIME);
+    assertThat(snapshots.get().get(0).snapshotId)
+        .doesNotContain(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
+
+    chunkManager = null;
   }
 
   @Test
@@ -1138,12 +1175,12 @@ public class IndexingChunkManagerTest {
       chunkManager.addMessage(m, m.toString().length(), TEST_KAFKA_PARTITION_ID, offset);
       offset++;
     }
+    await().until(() -> !chunkManager.snapshotMetadataStore.listSync().isEmpty());
     await().until(() -> getCount(ROLLOVERS_FAILED, metricsRegistry) == 1);
     checkMetadata(1, 1, 0, 1, 1);
     ListenableFuture<?> rollOverFuture = chunkManager.getRolloverFuture();
     chunkManager.stopAsync();
     chunkManager.awaitTerminated(15, TimeUnit.SECONDS);
-    chunkManager = null;
 
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, metricsRegistry)).isEqualTo(10);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, metricsRegistry)).isEqualTo(0);
@@ -1152,16 +1189,20 @@ public class IndexingChunkManagerTest {
     assertThat(getCount(ROLLOVERS_COMPLETED, metricsRegistry)).isEqualTo(0);
     assertThat(rollOverFuture.isDone()).isTrue();
 
-    // The stores are closed so temporarily re-create them so we can query the data in ZK.
     // All ephemeral data is ZK is deleted and no data or metadata is persisted.
-    SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
-    SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, false);
-    assertThat(searchMetadataStore.listSyncUncached()).isEmpty();
-    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
-    searchMetadataStore.close();
-    snapshotMetadataStore.close();
+    try (SearchMetadataStore searchMetadataStore =
+        new SearchMetadataStore(curatorFramework, true)) {
+      await().until(() -> searchMetadataStore.listSync().isEmpty());
+    }
+
+    try (SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, true)) {
+      await().until(() -> snapshotMetadataStore.listSync().isEmpty());
+    }
+
     // Data is lost and the indexer, we use recovery indexer to re-index this data.
+
+    chunkManager = null;
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
@@ -105,7 +105,7 @@ public class RecoveryChunkManagerTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(metricsRegistry, zkConfig);
-    searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
+    searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
     snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
@@ -96,7 +96,7 @@ public class DiskOrMessageCountBasedRolloverStrategyTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(metricsRegistry, zkConfig);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, false);
+    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
     searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
@@ -116,8 +116,8 @@ public class KaldbDistributedQueryServiceTest {
     Instant chunk1EndTime = Instant.ofEpochMilli(200);
     String chunk1Name =
         createIndexerZKMetadata(chunk1CreationTime, chunk1EndTime, "1", indexer1SearchContext);
-    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 2);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 2);
+    await().until(() -> searchMetadataStore.listSync().size() == 1);
 
     // we don't have any dataset metadata entry, so we shouldn't be able to find any snapshot
     Map<String, List<String>> searchNodes =
@@ -134,7 +134,7 @@ public class KaldbDistributedQueryServiceTest {
     DatasetMetadata datasetMetadata =
         new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
     // now we can find the snapshot
     searchNodes =
@@ -167,8 +167,8 @@ public class KaldbDistributedQueryServiceTest {
     Instant chunk2EndTime = Instant.ofEpochMilli(300);
     String chunk2Name =
         createIndexerZKMetadata(chunk2CreationTime, chunk2EndTime, "1", indexer1SearchContext);
-    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 4);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 2);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 4);
+    await().until(() -> searchMetadataStore.listSync().size() == 2);
     searchNodes =
         getSearchNodesToQuery(
             snapshotMetadataStore, searchMetadataStore, datasetMetadataStore, 0, 300, indexName);
@@ -202,11 +202,11 @@ public class KaldbDistributedQueryServiceTest {
 
     // re-add dataset metadata with a different time window that doesn't match any snapshot
     datasetMetadataStore.deleteAsync(datasetMetadata.name);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 0);
+    await().until(() -> datasetMetadataStore.listSync().size() == 0);
     partition = new DatasetPartitionMetadata(1, 99, List.of("1"));
     datasetMetadata = new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
     // we can't find snapshot since the time window doesn't match any dataset metadata
     searchNodes =
@@ -231,14 +231,14 @@ public class KaldbDistributedQueryServiceTest {
     DatasetMetadata datasetMetadata =
         new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
     Instant chunk1CreationTime = Instant.ofEpochMilli(100);
     Instant chunk1EndTime = Instant.ofEpochMilli(200);
     String snapshot1Name =
         createIndexerZKMetadata(chunk1CreationTime, chunk1EndTime, "1", indexer1SearchContext);
-    assertThat(snapshotMetadataStore.listSyncUncached().size()).isEqualTo(2);
-    assertThat(searchMetadataStore.listSyncUncached().size()).isEqualTo(1);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 2);
+    await().until(() -> searchMetadataStore.listSync().size() == 1);
 
     AtomicReference<Map<String, List<String>>> searchNodes = new AtomicReference<>();
     await()
@@ -267,7 +267,7 @@ public class KaldbDistributedQueryServiceTest {
     SearchMetadata cacheNodeSearchMetada =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache1SearchContext, snapshot1Name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 2);
+    await().until(() -> searchMetadataStore.listSync().size() == 2);
 
     searchNodes.set(
         getSearchNodesToQuery(
@@ -289,7 +289,7 @@ public class KaldbDistributedQueryServiceTest {
     SearchMetadata snapshot1Cache2SearchMetadata =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache2SearchContext, snapshot1Name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 3);
+    await().until(() -> searchMetadataStore.listSync().size() == 3);
 
     searchNodes.set(
         getSearchNodesToQuery(
@@ -318,13 +318,13 @@ public class KaldbDistributedQueryServiceTest {
     await()
         .until(
             () ->
-                snapshotMetadataStore.listSyncUncached().size()
+                snapshotMetadataStore.listSync().size()
                     == 3); // snapshot1(live + non_live) + snapshot2
 
     SearchMetadata snapshot2Cache2SearchMetadata =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache2SearchContext, snapshot2Metadata.name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 4);
+    await().until(() -> searchMetadataStore.listSync().size() == 4);
 
     Instant snapshot3CreationTime = Instant.ofEpochMilli(151);
     Instant snapshot3EndTime = Instant.ofEpochMilli(250);
@@ -333,13 +333,13 @@ public class KaldbDistributedQueryServiceTest {
     await()
         .until(
             () ->
-                snapshotMetadataStore.listSyncUncached().size()
+                snapshotMetadataStore.listSync().size()
                     == 4); // snapshot1(live + non_live) + snapshot2 + snapshot3
 
     SearchMetadata snapshot3Cache1SearchMetadata =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache1SearchContext, snapshot3Metadata.name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 5);
+    await().until(() -> searchMetadataStore.listSync().size() == 5);
 
     searchNodes.set(
         getSearchNodesToQuery(
@@ -396,14 +396,14 @@ public class KaldbDistributedQueryServiceTest {
     DatasetMetadata datasetMetadata =
         new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
     Instant chunk1CreationTime = Instant.ofEpochMilli(100);
     Instant chunk1EndTime = Instant.ofEpochMilli(200);
     String snapshot1Name =
         createIndexerZKMetadata(chunk1CreationTime, chunk1EndTime, "1", indexer1SearchContext);
-    assertThat(snapshotMetadataStore.listSyncUncached().size()).isEqualTo(2);
-    assertThat(searchMetadataStore.listSyncUncached().size()).isEqualTo(1);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 2);
+    await().until(() -> searchMetadataStore.listSync().size() == 1);
 
     Map<String, List<String>> searchNodes =
         getSearchNodesToQuery(
@@ -424,8 +424,8 @@ public class KaldbDistributedQueryServiceTest {
     Instant chunk2EndTime = Instant.ofEpochMilli(300);
     String snapshot2Name =
         createIndexerZKMetadata(chunk2CreationTime, chunk2EndTime, "1", indexer1SearchContext);
-    assertThat(snapshotMetadataStore.listSyncUncached().size()).isEqualTo(4);
-    assertThat(searchMetadataStore.listSyncUncached().size()).isEqualTo(2);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 4);
+    await().until(() -> searchMetadataStore.listSync().size() == 2);
 
     searchNodes =
         getSearchNodesToQuery(
@@ -471,7 +471,7 @@ public class KaldbDistributedQueryServiceTest {
     SearchMetadata cacheNodeSearchMetada =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache1SearchContext, snapshot1Name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 3);
+    await().until(() -> searchMetadataStore.listSync().size() == 3);
 
     searchNodes =
         getSearchNodesToQuery(
@@ -490,11 +490,11 @@ public class KaldbDistributedQueryServiceTest {
 
     // re-add dataset metadata with a different time window that doesn't match any snapshot
     datasetMetadataStore.deleteAsync(datasetMetadata.name);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 0);
+    await().until(() -> datasetMetadataStore.listSync().size() == 0);
     partition = new DatasetPartitionMetadata(1, 99, List.of("1"));
     datasetMetadata = new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
     // we can't find snapshot since the time window doesn't match any dataset metadata
     searchNodes =
@@ -518,19 +518,19 @@ public class KaldbDistributedQueryServiceTest {
     Instant chunkCreationTime = Instant.ofEpochMilli(100);
     Instant chunkEndTime = Instant.ofEpochMilli(200);
     SnapshotMetadata snapshotMetadata = createSnapshot(chunkCreationTime, chunkEndTime, false, "1");
-    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 1);
 
     // create first search metadata hosted by cache1
     SearchMetadata cache1NodeSearchMetada =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache1SearchContext, snapshotMetadata.name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> searchMetadataStore.listSync().size() == 1);
 
     DatasetPartitionMetadata partition = new DatasetPartitionMetadata(1, 500, List.of("1"));
     DatasetMetadata datasetMetadata =
         new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
     // assert search will always find cache1
     Map<String, List<String>> searchNodes =
@@ -552,7 +552,7 @@ public class KaldbDistributedQueryServiceTest {
     SearchMetadata cache2NodeSearchMetada =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache2SearchContext, snapshotMetadata.name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 2);
+    await().until(() -> searchMetadataStore.listSync().size() == 2);
 
     // assert search will always find cache1 or cache2
     searchNodes =
@@ -583,13 +583,12 @@ public class KaldbDistributedQueryServiceTest {
     Instant snapshot2EndTime = Instant.ofEpochMilli(150);
     SnapshotMetadata snapshot2Metadata =
         createSnapshot(snapshot2CreationTime, snapshot2EndTime, false, "1");
-    await()
-        .until(() -> snapshotMetadataStore.listSyncUncached().size() == 2); // snapshot1 + snapshot2
+    await().until(() -> snapshotMetadataStore.listSync().size() == 2); // snapshot1 + snapshot2
 
     SearchMetadata snapshot2Cache2SearchMetadata =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache2SearchContext, snapshot2Metadata.name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 3);
+    await().until(() -> searchMetadataStore.listSync().size() == 3);
 
     // now add snapshot3 to cache1
     Instant snapshot3CreationTime = Instant.ofEpochMilli(151);
@@ -599,13 +598,12 @@ public class KaldbDistributedQueryServiceTest {
     await()
         .until(
             () ->
-                snapshotMetadataStore.listSyncUncached().size()
-                    == 3); // snapshot1 + snapshot2 + snapshot3
+                snapshotMetadataStore.listSync().size() == 3); // snapshot1 + snapshot2 + snapshot3
 
     SearchMetadata snapshot3Cache1SearchMetadata =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache1SearchContext, snapshot3Metadata.name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 4);
+    await().until(() -> searchMetadataStore.listSync().size() == 4);
 
     // assert search will always find cache1 AND cache2
     searchNodes =
@@ -660,17 +658,17 @@ public class KaldbDistributedQueryServiceTest {
     // dataset1 snapshots/search-metadata/partitions
     SnapshotMetadata snapshotMetadata =
         createSnapshot(Instant.ofEpochMilli(100), Instant.ofEpochMilli(200), false, "1");
-    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 1);
     ReadOnlyChunkImpl.registerSearchMetadata(
         searchMetadataStore, cache1SearchContext, snapshotMetadata.name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> searchMetadataStore.listSync().size() == 1);
 
     snapshotMetadata =
         createSnapshot(Instant.ofEpochMilli(201), Instant.ofEpochMilli(300), false, "2");
-    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 2);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 2);
     ReadOnlyChunkImpl.registerSearchMetadata(
         searchMetadataStore, cache2SearchContext, snapshotMetadata.name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 2);
+    await().until(() -> searchMetadataStore.listSync().size() == 2);
 
     final String name = "testDataset";
     final String owner = "DatasetOwner";
@@ -684,22 +682,22 @@ public class KaldbDistributedQueryServiceTest {
         new DatasetMetadata(name, owner, throughputBytes, List.of(partition11, partition12), name);
 
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
     // dataset2 snapshots/search-metadata/partitions
     snapshotMetadata =
         createSnapshot(Instant.ofEpochMilli(100), Instant.ofEpochMilli(200), false, "2");
-    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 3);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 3);
     ReadOnlyChunkImpl.registerSearchMetadata(
         searchMetadataStore, cache3SearchContext, snapshotMetadata.name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 3);
+    await().until(() -> searchMetadataStore.listSync().size() == 3);
 
     snapshotMetadata =
         createSnapshot(Instant.ofEpochMilli(201), Instant.ofEpochMilli(300), false, "1");
-    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 4);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 4);
     ReadOnlyChunkImpl.registerSearchMetadata(
         searchMetadataStore, cache4SearchContext, snapshotMetadata.name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 4);
+    await().until(() -> searchMetadataStore.listSync().size() == 4);
 
     final String name1 = "testDataset1";
     final String owner1 = "DatasetOwner1";
@@ -713,7 +711,7 @@ public class KaldbDistributedQueryServiceTest {
         new DatasetMetadata(
             name1, owner1, throughputBytes1, List.of(partition21, partition22), name1);
     datasetMetadataStore.createSync(datasetMetadata1);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 2);
+    await().until(() -> datasetMetadataStore.listSync().size() == 2);
 
     // find search nodes that will be queries for the first dataset
     Map<String, List<String>> searchNodes =
@@ -763,14 +761,14 @@ public class KaldbDistributedQueryServiceTest {
     Instant chunkCreationTime = Instant.ofEpochMilli(100);
     Instant chunkEndTime = Instant.ofEpochMilli(200);
     createIndexerZKMetadata(chunkCreationTime, chunkEndTime, "1", indexer1SearchContext);
-    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 2);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 2);
+    await().until(() -> searchMetadataStore.listSync().size() == 1);
 
     DatasetPartitionMetadata partition = new DatasetPartitionMetadata(1, 200, List.of("1"));
     DatasetMetadata datasetMetadata =
         new DatasetMetadata(indexName1, "testOwner1", 1, List.of(partition), indexName1);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> datasetMetadataStore.listSync().size() == 1);
 
     Map<String, List<String>> searchNodes =
         getSearchNodesToQuery(
@@ -785,14 +783,14 @@ public class KaldbDistributedQueryServiceTest {
 
     // search for partition "2" only
     createIndexerZKMetadata(chunkCreationTime, chunkEndTime, "2", indexer2SearchContext);
-    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 4);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 2);
+    await().until(() -> snapshotMetadataStore.listSync().size() == 4);
+    await().until(() -> searchMetadataStore.listSync().size() == 2);
 
     partition = new DatasetPartitionMetadata(1, 101, List.of("2"));
     datasetMetadata =
         new DatasetMetadata(indexName2, "testOwner2", 1, List.of(partition), indexName2);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 2);
+    await().until(() -> datasetMetadataStore.listSync().size() == 2);
 
     searchNodes =
         getSearchNodesToQuery(

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStoreTest.java
@@ -138,7 +138,6 @@ public class CacheSlotMetadataStoreTest {
   public void testNonFreeCacheSlotState() throws Exception {
     final String hostname = "hostname";
     final String name = "slot1";
-    final String hostname = "hostname";
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState = CacheSlotState.ASSIGNED;
     final String replicaId = "3456";
     long updatedTimeEpochMs = Instant.now().toEpochMilli();
@@ -221,7 +220,6 @@ public class CacheSlotMetadataStoreTest {
   public void testCacheSlotStateWithReplica() throws Exception {
     String hostname = "hostname";
     String name = "slot1";
-    final String hostname = "hostname";
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState =
         Metadata.CacheSlotMetadata.CacheSlotState.FREE;
     String emptyReplicaId = "";

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
@@ -193,13 +193,6 @@ public class KaldbMetadataStoreTest {
       TestMetadata metadata1 = new TestMetadata("foo", "val1");
       store.createSync(metadata1);
 
-      await()
-          .until(
-              () -> {
-                List<TestMetadata> metadata = store.listSync();
-                return metadata.contains(metadata1) && metadata.size() == 1;
-              });
-
       // verify exceptions are thrown attempting to use cached methods
       assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(store::listSync);
       assertThatExceptionOfType(UnsupportedOperationException.class)
@@ -216,7 +209,7 @@ public class KaldbMetadataStoreTest {
         super(
             curatorFramework,
             CreateMode.PERSISTENT,
-            false,
+            true,
             new JacksonModelSerializer<>(TestMetadata.class),
             "/persistent");
       }
@@ -227,7 +220,7 @@ public class KaldbMetadataStoreTest {
         super(
             curatorFramework,
             CreateMode.EPHEMERAL,
-            false,
+            true,
             new JacksonModelSerializer<>(TestMetadata.class),
             "/ephemeral");
       }

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataStoreTest.java
@@ -1,0 +1,61 @@
+package com.slack.kaldb.metadata.snapshot;
+
+import static org.awaitility.Awaitility.await;
+
+import com.slack.kaldb.metadata.core.CuratorBuilder;
+import com.slack.kaldb.proto.config.KaldbConfigs;
+import com.slack.kaldb.proto.metadata.Metadata;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.time.Instant;
+import org.apache.curator.test.TestingServer;
+import org.apache.curator.x.async.AsyncCuratorFramework;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SnapshotMetadataStoreTest {
+  private SimpleMeterRegistry meterRegistry;
+  private TestingServer testingServer;
+  private AsyncCuratorFramework curatorFramework;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    meterRegistry = new SimpleMeterRegistry();
+    testingServer = new TestingServer();
+
+    KaldbConfigs.ZookeeperConfig zookeeperConfig =
+        KaldbConfigs.ZookeeperConfig.newBuilder()
+            .setZkConnectString(testingServer.getConnectString())
+            .setZkPathPrefix("Test")
+            .setZkSessionTimeoutMs(1000)
+            .setZkConnectionTimeoutMs(1000)
+            .setSleepBetweenRetriesMs(500)
+            .build();
+    this.curatorFramework = CuratorBuilder.build(meterRegistry, zookeeperConfig);
+  }
+
+  @AfterEach
+  public void tearDown() throws IOException {
+    curatorFramework.unwrap().close();
+    testingServer.close();
+    meterRegistry.close();
+  }
+
+  @Test
+  void createSync() throws Exception {
+    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
+
+    snapshotMetadataStore.createSync(
+        new SnapshotMetadata(
+            "id",
+            "path",
+            Instant.now().toEpochMilli(),
+            Instant.now().toEpochMilli(),
+            100,
+            "1",
+            Metadata.IndexType.LOGS_LUCENE9));
+
+    await().until(() -> snapshotMetadataStore.listSync().size() == 1);
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
@@ -94,7 +94,7 @@ public class PreprocessorServiceIntegrationTest {
     datasetMetadataStore.createSync(new DatasetMetadata("name", "owner", 0, List.of(), "name"));
 
     // wait for the cache to be updated
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> datasetMetadataStore.listSync().size() == 1);
     assertThat(MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry))
         .isEqualTo(2);
 
@@ -172,7 +172,7 @@ public class PreprocessorServiceIntegrationTest {
     datasetMetadataStore.createSync(datasetMetadata);
 
     // wait for the cache to be updated
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> datasetMetadataStore.listSync().size() == 1);
     await()
         .until(
             () ->
@@ -197,9 +197,13 @@ public class PreprocessorServiceIntegrationTest {
             () ->
                 MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry)
                     == 3);
-    assertThat(datasetMetadataStore.listSyncUncached().size()).isEqualTo(1);
-    assertThat(datasetMetadataStore.listSyncUncached().get(0).getThroughputBytes())
-        .isEqualTo(Long.MAX_VALUE);
+
+    await()
+        .until(
+            datasetMetadataStore::listSync,
+            (metadataList) ->
+                metadataList.size() == 1
+                    && metadataList.get(0).getThroughputBytes() == Long.MAX_VALUE);
 
     // produce messages to upstream
     final Instant startTime = Instant.now();

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
@@ -499,7 +499,7 @@ public class PreprocessorServiceUnitTest {
   @Test
   public void shouldHandleEmptyDatasetMetadata() throws TimeoutException {
     DatasetMetadataStore datasetMetadataStore = mock(DatasetMetadataStore.class);
-    when(datasetMetadataStore.listSyncUncached()).thenReturn(List.of());
+    when(datasetMetadataStore.listSync()).thenReturn(List.of());
 
     KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
         KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()

--- a/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
@@ -162,9 +162,8 @@ public class RecoveryServiceTest {
     final Instant startTime = Instant.now();
     produceMessagesToKafka(kafkaServer.getBroker(), startTime, TEST_KAFKA_TOPIC_1, 0);
 
-    SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, false);
-    assertThat(snapshotMetadataStore.listSyncUncached().size()).isZero();
+    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
+    assertThat(snapshotMetadataStore.listSync().size()).isZero();
     // Start recovery
     RecoveryTaskMetadata recoveryTask =
         new RecoveryTaskMetadata("testRecoveryTask", "0", 30, 60, Instant.now().toEpochMilli());
@@ -235,9 +234,8 @@ public class RecoveryServiceTest {
     await()
         .until(() -> localTestConsumer.getEndOffSetForPartition() == msgsToProduce + msgsToProduce);
 
-    SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, false);
-    assertThat(snapshotMetadataStore.listSyncUncached().size()).isZero();
+    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
+    assertThat(snapshotMetadataStore.listSync().size()).isZero();
 
     // Start recovery service
     recoveryService =
@@ -318,9 +316,8 @@ public class RecoveryServiceTest {
     await()
         .until(() -> localTestConsumer.getEndOffSetForPartition() == msgsToProduce + msgsToProduce);
 
-    SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, false);
-    assertThat(snapshotMetadataStore.listSyncUncached().size()).isZero();
+    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
+    assertThat(snapshotMetadataStore.listSync().size()).isZero();
 
     // Start recovery service
     recoveryService =
@@ -372,9 +369,8 @@ public class RecoveryServiceTest {
     assertThat(s3Client.listBuckets().buckets().size()).isEqualTo(1);
     assertThat(s3Client.listBuckets().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
     assertThat(s3Client.listBuckets().buckets().get(0).name()).isNotEqualTo(fakeS3Bucket);
-    SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, false);
-    assertThat(snapshotMetadataStore.listSyncUncached().size()).isZero();
+    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
+    assertThat(snapshotMetadataStore.listSync().size()).isZero();
 
     // Start recovery
     RecoveryTaskMetadata recoveryTask =
@@ -409,9 +405,8 @@ public class RecoveryServiceTest {
 
     assertThat(s3Client.listBuckets().buckets().size()).isEqualTo(1);
     assertThat(s3Client.listBuckets().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
-    SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, false);
-    assertThat(snapshotMetadataStore.listSyncUncached().size()).isZero();
+    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
+    assertThat(snapshotMetadataStore.listSync().size()).isZero();
 
     assertThat(snapshotMetadataStore.listSyncUncached().size()).isZero();
     // Create a recovery task
@@ -486,9 +481,8 @@ public class RecoveryServiceTest {
     // fakeS3Bucket is not present.
     assertThat(s3Client.listBuckets().buckets().size()).isEqualTo(1);
     assertThat(s3Client.listBuckets().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
-    SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, false);
-    assertThat(snapshotMetadataStore.listSyncUncached().size()).isZero();
+    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
+    assertThat(snapshotMetadataStore.listSync().size()).isZero();
 
     assertThat(snapshotMetadataStore.listSyncUncached().size()).isZero();
     // Create a recovery task

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -119,8 +119,8 @@ public class KaldbIndexerTest {
     chunkManagerUtil.chunkManager.startAsync();
     chunkManagerUtil.chunkManager.awaitRunning(DEFAULT_START_STOP_DURATION);
     snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
-    recoveryTaskStore = new RecoveryTaskMetadataStore(curatorFramework, false);
-    searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
+    recoveryTaskStore = new RecoveryTaskMetadataStore(curatorFramework, true);
+    searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
 
     kafkaServer = new TestKafkaServer();
   }

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
@@ -135,7 +135,7 @@ public class KaldbTest {
             partitionConfigs,
             MessageUtil.TEST_DATASET_NAME);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> datasetMetadataStore.listSync().size() == 1);
   }
 
   @AfterEach

--- a/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
@@ -218,7 +218,7 @@ public class ManagerApiGrpcTest {
                             .build()));
     assertThat(throwable3.getStatus().getCode()).isEqualTo(Status.UNKNOWN.getCode());
 
-    assertThat(datasetMetadataStore.listSyncUncached().size()).isEqualTo(0);
+    await().until(() -> datasetMetadataStore.listSync().isEmpty());
   }
 
   @Test
@@ -237,7 +237,7 @@ public class ManagerApiGrpcTest {
     assertThat(throwable.getStatus().getCode()).isEqualTo(Status.UNKNOWN.getCode());
     assertThat(throwable.getStatus().getDescription()).isEqualTo("owner must not be null or blank");
 
-    assertThat(datasetMetadataStore.listSyncUncached().size()).isEqualTo(0);
+    await().until(() -> datasetMetadataStore.listSync().isEmpty());
   }
 
   @Test
@@ -326,7 +326,7 @@ public class ManagerApiGrpcTest {
     Status status = throwable.getStatus();
     assertThat(status.getCode()).isEqualTo(Status.UNKNOWN.getCode());
 
-    assertThat(datasetMetadataStore.listSyncUncached().size()).isEqualTo(0);
+    await().until(() -> datasetMetadataStore.listSync().isEmpty());
   }
 
   @Test
@@ -467,7 +467,7 @@ public class ManagerApiGrpcTest {
                             .build()));
     assertThat(throwable1.getStatus().getCode()).isEqualTo(Status.UNKNOWN.getCode());
 
-    assertThat(datasetMetadataStore.listSyncUncached().size()).isEqualTo(0);
+    await().until(() -> datasetMetadataStore.listSync().isEmpty());
   }
 
   @Test
@@ -479,6 +479,7 @@ public class ManagerApiGrpcTest {
         ManagerApi.CreateDatasetMetadataRequest.newBuilder()
             .setName(datasetName1)
             .setOwner(datasetOwner1)
+            .setServiceNamePattern(datasetName1)
             .build());
 
     String datasetName2 = "testDataset2";
@@ -488,6 +489,7 @@ public class ManagerApiGrpcTest {
         ManagerApi.CreateDatasetMetadataRequest.newBuilder()
             .setName(datasetName2)
             .setOwner(datasetOwner2)
+            .setServiceNamePattern(datasetName2)
             .build());
 
     ManagerApi.ListDatasetMetadataResponse listDatasetMetadataResponse =
@@ -510,16 +512,25 @@ public class ManagerApiGrpcTest {
                         .setThroughputBytes(0)
                         .build())));
 
-    assertThat(datasetMetadataStore.listSyncUncached().size()).isEqualTo(2);
-    assertThat(
-        datasetMetadataStore
-            .listSyncUncached()
-            .containsAll(
-                List.of(
-                    new DatasetMetadata(
-                        datasetName1, datasetOwner1, 0, Collections.emptyList(), datasetName1),
-                    new DatasetMetadata(
-                        datasetName2, datasetOwner2, 0, Collections.emptyList(), datasetName2))));
+    await()
+        .until(
+            () -> datasetMetadataStore.listSync(),
+            (metadata) ->
+                metadata.size() == 2
+                    && metadata.containsAll(
+                        List.of(
+                            new DatasetMetadata(
+                                datasetName1,
+                                datasetOwner1,
+                                0,
+                                Collections.emptyList(),
+                                datasetName1),
+                            new DatasetMetadata(
+                                datasetName2,
+                                datasetOwner2,
+                                0,
+                                Collections.emptyList(),
+                                datasetName2))));
   }
 
   @Test
@@ -569,7 +580,7 @@ public class ManagerApiGrpcTest {
     assertThat(throwableUpdate.getStatus().getCode()).isEqualTo(Status.UNKNOWN.getCode());
     assertThat(throwableUpdate.getStatus().getDescription()).contains(datasetName);
 
-    assertThat(datasetMetadataStore.listSyncUncached().size()).isEqualTo(0);
+    await().until(() -> datasetMetadataStore.listSync().isEmpty());
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -69,8 +69,8 @@ public class RecoveryTaskCreatorTest {
             .setSleepBetweenRetriesMs(500)
             .build();
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, false));
-    recoveryTaskStore = spy(new RecoveryTaskMetadataStore(curatorFramework, false));
+    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, true));
+    recoveryTaskStore = spy(new RecoveryTaskMetadataStore(curatorFramework, true));
   }
 
   @AfterEach
@@ -1366,7 +1366,7 @@ public class RecoveryTaskCreatorTest {
     doThrow(new InternalMetadataStoreException(""))
         .doCallRealMethod()
         .when(snapshotMetadataStore)
-        .listSyncUncached();
+        .listSync();
 
     assertThatExceptionOfType(RuntimeException.class)
         .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(1350));
@@ -1417,7 +1417,7 @@ public class RecoveryTaskCreatorTest {
     doThrow(new InternalMetadataStoreException(""))
         .doCallRealMethod()
         .when(recoveryTaskStore)
-        .listSyncUncached();
+        .listSync();
 
     assertThatExceptionOfType(RuntimeException.class)
         .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(1350));

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -71,7 +71,7 @@ public class RecoveryTaskCreatorTest {
             .build();
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
     snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, true));
-    recoveryTaskStore = spy(new RecoveryTaskMetadataStore(curatorFramework, false));
+    recoveryTaskStore = spy(new RecoveryTaskMetadataStore(curatorFramework, true));
   }
 
   @AfterEach

--- a/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceTest.java
@@ -98,7 +98,7 @@ public class ZipkinServiceTest {
         new DatasetMetadata(
             TEST_DATASET_NAME, "serviceOwner", 1000, partitionConfigs, TEST_DATASET_NAME);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> datasetMetadataStore.listSync().size() == 1);
   }
 
   @AfterEach


### PR DESCRIPTION
###  Summary

This removes the use of `listSyncUncached` throughout our codebase. In actual production code, this was only used in two places - the `ManagerApiGrpc.java` when listing dataset, and the `RecoveryTaskCreator.java` when determining offsets. 

todo: IndexingChunkManager > 

The former is fine to just use the ZK cache when listing this via the api. The recovery task creator should also be fine, but for a slightly different reason - we instantiate the store as cached, and then immediately consume the list. As long as the store hydrates the cache on init, this would never be meaningfully stale. Furthermore, we only care about the offset for this particular partition, which would have been last mutated by the previous instance of this indexer. 

Long term it seems a simpler way would be storing these offsets directly, such as a separate ZK path instead of having to read and calculate from the list of snapshots. This however is outside the scope of this effort.