### PR TITLE
Deprecate remaining metadata listSyncUncached access from production

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
@@ -91,10 +91,9 @@ public class KaldbIndexer extends AbstractExecutionThreadService {
    */
   private long indexerPreStart() throws Exception {
     LOG.info("Starting Kaldb indexer pre start.");
-    SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, false);
+    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
     RecoveryTaskMetadataStore recoveryTaskMetadataStore =
-        new RecoveryTaskMetadataStore(curatorFramework, false);
+        new RecoveryTaskMetadataStore(curatorFramework, true);
 
     String partitionId = kafkaConfig.getKafkaTopicPartition();
     long maxOffsetDelay = indexerConfig.getMaxOffsetDelayMessages();

--- a/kaldb/src/main/java/com/slack/kaldb/server/ManagerApiGrpc.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ManagerApiGrpc.java
@@ -125,7 +125,7 @@ public class ManagerApiGrpc extends ManagerApiServiceGrpc.ManagerApiServiceImplB
       responseObserver.onNext(
           ManagerApi.ListDatasetMetadataResponse.newBuilder()
               .addAllDatasetMetadata(
-                  datasetMetadataStore.listSyncUncached().stream()
+                  datasetMetadataStore.listSync().stream()
                       .map(DatasetMetadataSerializer::toDatasetMetadataProto)
                       .collect(Collectors.toList()))
               .build());

--- a/kaldb/src/main/java/com/slack/kaldb/server/RecoveryTaskCreator.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/RecoveryTaskCreator.java
@@ -150,7 +150,7 @@ public class RecoveryTaskCreator {
       LOG.warn("PartitionId can't be null.");
     }
 
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
+    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSync();
     List<SnapshotMetadata> snapshotsForPartition =
         snapshots.stream()
             .filter(
@@ -173,7 +173,7 @@ public class RecoveryTaskCreator {
             .collect(Collectors.toUnmodifiableList());
 
     // Get the highest offset that is indexed in durable store.
-    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskMetadataStore.listSyncUncached();
+    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskMetadataStore.listSync();
     long highestDurableOffsetForPartition =
         getHighestDurableOffsetForPartition(
             nonLiveSnapshotsForPartition, recoveryTasks, partitionId);

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
@@ -26,6 +26,7 @@ import com.slack.kaldb.logstore.search.SearchQuery;
 import com.slack.kaldb.logstore.search.SearchResult;
 import com.slack.kaldb.logstore.search.aggregations.DateHistogramAggBuilder;
 import com.slack.kaldb.metadata.core.CuratorBuilder;
+import com.slack.kaldb.metadata.core.KaldbMetadataTestUtils;
 import com.slack.kaldb.metadata.search.SearchMetadata;
 import com.slack.kaldb.metadata.search.SearchMetadataStore;
 import com.slack.kaldb.metadata.snapshot.SnapshotMetadata;
@@ -73,9 +74,10 @@ public class IndexingChunkImplTest {
       SnapshotMetadataStore snapshotMetadataStore,
       SearchMetadataStore searchMetadataStore,
       ReadWriteChunk<LogMessage> chunk) {
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .containsOnly(ChunkInfo.toSnapshotMetadata(chunk.info(), LIVE_SNAPSHOT_PREFIX));
-    final List<SearchMetadata> beforeSearchNodes = searchMetadataStore.listSyncUncached();
+    final List<SearchMetadata> beforeSearchNodes =
+        KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore);
     assertThat(beforeSearchNodes.size()).isEqualTo(1);
     assertThat(beforeSearchNodes.get(0).url).contains(TEST_HOST);
     assertThat(beforeSearchNodes.get(0).url).contains(String.valueOf(TEST_PORT));
@@ -111,7 +113,7 @@ public class IndexingChunkImplTest {
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
       SnapshotMetadataStore snapshotMetadataStore =
-          new SnapshotMetadataStore(curatorFramework, false);
+          new SnapshotMetadataStore(curatorFramework, true);
       SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
 
       final LuceneIndexStoreImpl logStore =
@@ -458,7 +460,7 @@ public class IndexingChunkImplTest {
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
       SnapshotMetadataStore snapshotMetadataStore =
-          new SnapshotMetadataStore(curatorFramework, false);
+          new SnapshotMetadataStore(curatorFramework, true);
       SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
 
       final LuceneIndexStoreImpl logStore =
@@ -542,7 +544,7 @@ public class IndexingChunkImplTest {
 
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
-      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, false);
+      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
       searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
 
       final LuceneIndexStoreImpl logStore =
@@ -565,9 +567,11 @@ public class IndexingChunkImplTest {
               TEST_KAFKA_PARTITION_ID);
       chunk.postCreate();
       closeChunk = true;
-      List<SnapshotMetadata> snapshotNodes = snapshotMetadataStore.listSyncUncached();
+      List<SnapshotMetadata> snapshotNodes =
+          KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore);
       assertThat(snapshotNodes.size()).isEqualTo(1);
-      List<SearchMetadata> searchNodes = searchMetadataStore.listSyncUncached();
+      List<SearchMetadata> searchNodes =
+          KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore);
       assertThat(searchNodes.size()).isEqualTo(1);
     }
 
@@ -626,13 +630,15 @@ public class IndexingChunkImplTest {
       assertThat(chunk.info().getSnapshotPath()).isEqualTo(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
 
       // Metadata checks
-      List<SnapshotMetadata> afterSnapshots = snapshotMetadataStore.listSyncUncached();
+      List<SnapshotMetadata> afterSnapshots =
+          KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore);
       assertThat(afterSnapshots.size()).isEqualTo(1);
       assertThat(afterSnapshots.get(0).partitionId).isEqualTo(TEST_KAFKA_PARTITION_ID);
       assertThat(afterSnapshots.get(0).maxOffset).isEqualTo(0);
       assertThat(afterSnapshots.get(0).snapshotPath).isEqualTo(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
 
-      List<SearchMetadata> afterSearchNodes = searchMetadataStore.listSyncUncached();
+      List<SearchMetadata> afterSearchNodes =
+          KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore);
       assertThat(afterSearchNodes.size()).isEqualTo(1);
       assertThat(afterSearchNodes.get(0).url).contains(TEST_HOST);
       assertThat(afterSearchNodes.get(0).url).contains(String.valueOf(TEST_PORT));
@@ -703,7 +709,8 @@ public class IndexingChunkImplTest {
       chunk.postSnapshot();
 
       // Metadata checks
-      List<SnapshotMetadata> afterSnapshots = snapshotMetadataStore.listSyncUncached();
+      List<SnapshotMetadata> afterSnapshots =
+          KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore);
       assertThat(afterSnapshots.size()).isEqualTo(2);
       assertThat(afterSnapshots).contains(ChunkInfo.toSnapshotMetadata(chunk.info(), ""));
       SnapshotMetadata liveSnapshot =
@@ -715,7 +722,8 @@ public class IndexingChunkImplTest {
       assertThat(liveSnapshot.maxOffset).isEqualTo(offset - 1);
       assertThat(liveSnapshot.snapshotPath).isEqualTo(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
 
-      List<SearchMetadata> afterSearchNodes = searchMetadataStore.listSyncUncached();
+      List<SearchMetadata> afterSearchNodes =
+          KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore);
       assertThat(afterSearchNodes.size()).isEqualTo(1);
       assertThat(afterSearchNodes.get(0).url).contains(TEST_HOST);
       assertThat(afterSearchNodes.get(0).url).contains(String.valueOf(TEST_PORT));

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -29,6 +29,7 @@ import com.slack.kaldb.logstore.search.aggregations.DateHistogramAggBuilder;
 import com.slack.kaldb.metadata.cache.CacheSlotMetadata;
 import com.slack.kaldb.metadata.cache.CacheSlotMetadataStore;
 import com.slack.kaldb.metadata.core.CuratorBuilder;
+import com.slack.kaldb.metadata.core.KaldbMetadataTestUtils;
 import com.slack.kaldb.metadata.replica.ReplicaMetadata;
 import com.slack.kaldb.metadata.replica.ReplicaMetadataStore;
 import com.slack.kaldb.metadata.schema.ChunkSchema;
@@ -109,8 +110,7 @@ public class ReadOnlyChunkImplTest {
 
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
     ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework, false);
-    SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, false);
+    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
     SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
     CacheSlotMetadataStore cacheSlotMetadataStore =
         new CacheSlotMetadataStore(curatorFramework, false);
@@ -147,7 +147,7 @@ public class ReadOnlyChunkImplTest {
     assignReplicaToChunk(cacheSlotMetadataStore, replicaId, readOnlyChunk);
 
     // ensure that the chunk was marked LIVE
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore).size() == 1);
     assertThat(readOnlyChunk.getChunkMetadataState())
         .isEqualTo(Metadata.CacheSlotMetadata.CacheSlotState.LIVE);
 
@@ -239,8 +239,7 @@ public class ReadOnlyChunkImplTest {
 
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
     ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework, false);
-    SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, false);
+    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
     SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
     CacheSlotMetadataStore cacheSlotMetadataStore =
         new CacheSlotMetadataStore(curatorFramework, false);
@@ -307,8 +306,7 @@ public class ReadOnlyChunkImplTest {
 
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
     ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework, false);
-    SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, false);
+    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
     SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
     CacheSlotMetadataStore cacheSlotMetadataStore =
         new CacheSlotMetadataStore(curatorFramework, false);
@@ -375,8 +373,7 @@ public class ReadOnlyChunkImplTest {
 
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
     ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework, false);
-    SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, false);
+    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
     SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
     CacheSlotMetadataStore cacheSlotMetadataStore =
         new CacheSlotMetadataStore(curatorFramework, false);
@@ -478,8 +475,7 @@ public class ReadOnlyChunkImplTest {
 
   private void initializeZkSnapshot(AsyncCuratorFramework curatorFramework, String snapshotId)
       throws Exception {
-    SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, false);
+    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
     snapshotMetadataStore.createSync(
         new SnapshotMetadata(
             snapshotId,

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
@@ -30,6 +30,7 @@ import com.slack.kaldb.logstore.search.SearchQuery;
 import com.slack.kaldb.logstore.search.SearchResult;
 import com.slack.kaldb.logstore.search.aggregations.DateHistogramAggBuilder;
 import com.slack.kaldb.metadata.core.CuratorBuilder;
+import com.slack.kaldb.metadata.core.KaldbMetadataTestUtils;
 import com.slack.kaldb.metadata.search.SearchMetadata;
 import com.slack.kaldb.metadata.search.SearchMetadataStore;
 import com.slack.kaldb.metadata.snapshot.SnapshotMetadata;
@@ -104,7 +105,7 @@ public class RecoveryChunkManagerTest {
 
     curatorFramework = CuratorBuilder.build(metricsRegistry, zkConfig);
     searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, false);
+    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
   }
 
   @AfterEach
@@ -175,8 +176,8 @@ public class RecoveryChunkManagerTest {
     assertThat(getValue(LIVE_BYTES_INDEXED, metricsRegistry)).isEqualTo(actualChunkSize);
 
     // Check metadata registration. No metadata registration until rollover.
-    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
-    assertThat(searchMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore)).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore)).isEmpty();
 
     // Search query
     SearchQuery searchQuery =
@@ -279,8 +280,9 @@ public class RecoveryChunkManagerTest {
     assertThat(getCount(ROLLOVERS_INITIATED, metricsRegistry)).isEqualTo(1);
     assertThat(getCount(ROLLOVERS_COMPLETED, metricsRegistry)).isEqualTo(1);
     assertThat(getCount(ROLLOVERS_FAILED, metricsRegistry)).isEqualTo(0);
-    assertThat(searchMetadataStore.listSyncUncached()).isEmpty();
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore)).isEmpty();
+    List<SnapshotMetadata> snapshots =
+        KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore);
     assertThat(snapshots.size()).isEqualTo(1);
     assertThat(snapshots.get(0).startTimeEpochMs)
         .isEqualTo(messages.get(0).getTimestamp().toEpochMilli());
@@ -350,12 +352,13 @@ public class RecoveryChunkManagerTest {
     testChunkManagerSearch(chunkManager, "Message100", 1);
 
     // Check metadata.
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
+    List<SnapshotMetadata> snapshots =
+        KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore);
     assertThat(snapshots.size()).isEqualTo(0);
     List<SnapshotMetadata> liveSnapshots = fetchLiveSnapshot(snapshots);
     assertThat(liveSnapshots.size()).isZero();
     assertThat(fetchNonLiveSnapshot(snapshots).size()).isEqualTo(0);
-    List<SearchMetadata> searchNodes = searchMetadataStore.listSyncUncached();
+    List<SearchMetadata> searchNodes = KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore);
     assertThat(searchNodes).isEmpty();
     assertThat(liveSnapshots.stream().map(s -> s.snapshotId).collect(Collectors.toList()))
         .isEmpty();
@@ -395,12 +398,13 @@ public class RecoveryChunkManagerTest {
                     MessageUtil.makeMessage(1000), 100, TEST_KAFKA_PARTITION_ID, 1000));
 
     // Check metadata.
-    List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSyncUncached();
+    List<SnapshotMetadata> snapshots =
+        KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore);
     assertThat(snapshots.size()).isEqualTo(0);
     List<SnapshotMetadata> liveSnapshots = fetchLiveSnapshot(snapshots);
     assertThat(liveSnapshots.size()).isZero();
     assertThat(fetchNonLiveSnapshot(snapshots).size()).isEqualTo(0);
-    List<SearchMetadata> searchNodes = searchMetadataStore.listSyncUncached();
+    List<SearchMetadata> searchNodes = KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore);
     assertThat(searchNodes).isEmpty();
     assertThat(liveSnapshots.stream().map(s -> s.snapshotId).collect(Collectors.toList()))
         .isEmpty();

--- a/kaldb/src/test/java/com/slack/kaldb/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
@@ -96,7 +96,7 @@ public class DiskOrMessageCountBasedRolloverStrategyTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(metricsRegistry, zkConfig);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, false);
+    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, true);
     searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import brave.Tracing;
 import com.slack.kaldb.metadata.core.CuratorBuilder;
+import com.slack.kaldb.metadata.core.KaldbMetadataTestUtils;
 import com.slack.kaldb.metadata.recovery.RecoveryNodeMetadata;
 import com.slack.kaldb.metadata.recovery.RecoveryNodeMetadataStore;
 import com.slack.kaldb.metadata.recovery.RecoveryTaskMetadata;
@@ -149,8 +150,10 @@ public class RecoveryTaskAssignmentServiceTest {
     int assignments = recoveryTaskAssignmentService.assignRecoveryTasksToNodes();
 
     assertThat(assignments).isEqualTo(0);
-    assertThat(recoveryTaskMetadataStore.listSyncUncached().isEmpty()).isTrue();
-    assertThat(recoveryNodeMetadataStore.listSyncUncached().isEmpty()).isTrue();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskMetadataStore).isEmpty())
+        .isTrue();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore).isEmpty())
+        .isTrue();
 
     assertThat(
             MetricsUtil.getCount(
@@ -200,8 +203,10 @@ public class RecoveryTaskAssignmentServiceTest {
     int assignments = recoveryTaskAssignmentService.assignRecoveryTasksToNodes();
 
     assertThat(assignments).isEqualTo(0);
-    assertThat(recoveryTaskMetadataStore.listSyncUncached().size()).isEqualTo(3);
-    assertThat(recoveryNodeMetadataStore.listSyncUncached().isEmpty()).isTrue();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskMetadataStore).size())
+        .isEqualTo(3);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore).isEmpty())
+        .isTrue();
 
     assertThat(
             MetricsUtil.getCount(
@@ -278,12 +283,16 @@ public class RecoveryTaskAssignmentServiceTest {
     int assignments = recoveryTaskAssignmentService.assignRecoveryTasksToNodes();
 
     assertThat(assignments).isEqualTo(1);
-    assertThat(recoveryTaskMetadataStore.listSyncUncached().size()).isEqualTo(3);
-    assertThat(recoveryNodeMetadataStore.listSyncUncached().size()).isEqualTo(3);
-    assertThat(recoveryNodeMetadataStore.listSyncUncached().containsAll(ineligibleRecoveryNodes))
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskMetadataStore).size())
+        .isEqualTo(3);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore).size())
+        .isEqualTo(3);
+    assertThat(
+            KaldbMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore)
+                .containsAll(ineligibleRecoveryNodes))
         .isTrue();
     assertThat(
-            recoveryNodeMetadataStore.listSyncUncached().stream()
+            KaldbMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore).stream()
                 .filter(
                     recoveryNodeMetadata ->
                         recoveryNodeMetadata.recoveryNodeState.equals(
@@ -342,8 +351,10 @@ public class RecoveryTaskAssignmentServiceTest {
     int assignments = recoveryTaskAssignmentService.assignRecoveryTasksToNodes();
 
     assertThat(assignments).isEqualTo(0);
-    assertThat(recoveryTaskMetadataStore.listSyncUncached().isEmpty()).isTrue();
-    assertThat(recoveryNodeMetadataStore.listSyncUncached().size()).isEqualTo(3);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskMetadataStore).isEmpty())
+        .isTrue();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore).size())
+        .isEqualTo(3);
 
     assertThat(
             MetricsUtil.getCount(
@@ -409,11 +420,19 @@ public class RecoveryTaskAssignmentServiceTest {
     int assignments = recoveryTaskAssignmentService.assignRecoveryTasksToNodes();
 
     assertThat(assignments).isEqualTo(1);
-    assertThat(recoveryTaskMetadataStore.listSyncUncached().size()).isEqualTo(2);
-    assertThat(recoveryNodeMetadataStore.listSyncUncached().size()).isEqualTo(1);
-    assertThat(recoveryNodeMetadataStore.listSyncUncached().get(0).recoveryTaskName)
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskMetadataStore).size())
+        .isEqualTo(2);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore).size())
+        .isEqualTo(1);
+    assertThat(
+            KaldbMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore)
+                .get(0)
+                .recoveryTaskName)
         .isEqualTo(oldTask.name);
-    assertThat(recoveryNodeMetadataStore.listSyncUncached().get(0).recoveryNodeState)
+    assertThat(
+            KaldbMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore)
+                .get(0)
+                .recoveryNodeState)
         .isEqualTo(Metadata.RecoveryNodeMetadata.RecoveryNodeState.ASSIGNED);
 
     assertThat(
@@ -613,7 +632,7 @@ public class RecoveryTaskAssignmentServiceTest {
         .isEqualTo(1);
 
     assertThat(
-            recoveryNodeMetadataStore.listSyncUncached().stream()
+            KaldbMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore).stream()
                 .filter(
                     recoveryNodeMetadata ->
                         recoveryNodeMetadata.recoveryNodeState.equals(
@@ -621,7 +640,7 @@ public class RecoveryTaskAssignmentServiceTest {
                 .count())
         .isEqualTo(1);
     assertThat(
-            recoveryNodeMetadataStore.listSyncUncached().stream()
+            KaldbMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore).stream()
                 .filter(
                     recoveryNodeMetadata ->
                         recoveryNodeMetadata.recoveryNodeState.equals(
@@ -697,7 +716,7 @@ public class RecoveryTaskAssignmentServiceTest {
         .isEqualTo(1);
 
     assertThat(
-            recoveryNodeMetadataStore.listSyncUncached().stream()
+            KaldbMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore).stream()
                 .filter(
                     recoveryNodeMetadata ->
                         recoveryNodeMetadata.recoveryNodeState.equals(
@@ -705,7 +724,7 @@ public class RecoveryTaskAssignmentServiceTest {
                 .count())
         .isEqualTo(1);
     assertThat(
-            recoveryNodeMetadataStore.listSyncUncached().stream()
+            KaldbMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore).stream()
                 .filter(
                     recoveryNodeMetadata ->
                         recoveryNodeMetadata.recoveryNodeState.equals(

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
@@ -15,6 +15,7 @@ import brave.Tracing;
 import com.slack.kaldb.metadata.cache.CacheSlotMetadata;
 import com.slack.kaldb.metadata.cache.CacheSlotMetadataStore;
 import com.slack.kaldb.metadata.core.CuratorBuilder;
+import com.slack.kaldb.metadata.core.KaldbMetadataTestUtils;
 import com.slack.kaldb.metadata.replica.ReplicaMetadata;
 import com.slack.kaldb.metadata.replica.ReplicaMetadataStore;
 import com.slack.kaldb.proto.config.KaldbConfigs;
@@ -139,14 +140,14 @@ public class ReplicaAssignmentServiceTest {
         new ReplicaAssignmentService(
             cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
 
-    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(0);
-    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(0);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).size()).isEqualTo(0);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore).size()).isEqualTo(0);
 
     int assignments = replicaAssignmentService.assignReplicasToCacheSlots();
     assertThat(assignments).isEqualTo(0);
 
-    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(0);
-    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(0);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).size()).isEqualTo(0);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore).size()).isEqualTo(0);
     assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
     assertThat(
@@ -193,15 +194,18 @@ public class ReplicaAssignmentServiceTest {
     }
 
     await().until(() -> replicaMetadataStore.listSync().size() == 3);
-    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(0);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).size()).isEqualTo(0);
 
     int assignments = replicaAssignmentService.assignReplicasToCacheSlots();
     assertThat(assignments).isEqualTo(0);
 
-    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(0);
-    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(3);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).size()).isEqualTo(0);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore).size()).isEqualTo(3);
 
-    assertThat(replicaMetadataList.containsAll(replicaMetadataStore.listSyncUncached())).isTrue();
+    assertThat(
+            replicaMetadataList.containsAll(
+                KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore)))
+        .isTrue();
     assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
     assertThat(
@@ -248,15 +252,17 @@ public class ReplicaAssignmentServiceTest {
     }
 
     await().until(() -> cacheSlotMetadataStore.listSync().size() == 3);
-    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(0);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore).size()).isEqualTo(0);
 
     int assignments = replicaAssignmentService.assignReplicasToCacheSlots();
     assertThat(assignments).isEqualTo(0);
 
-    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(0);
-    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(3);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore).size()).isEqualTo(0);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).size()).isEqualTo(3);
 
-    assertThat(cacheSlotMetadataList.containsAll(cacheSlotMetadataStore.listSyncUncached()))
+    assertThat(
+            cacheSlotMetadataList.containsAll(
+                KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore)))
         .isTrue();
     assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
@@ -336,12 +342,17 @@ public class ReplicaAssignmentServiceTest {
     int assignments = replicaAssignmentService.assignReplicasToCacheSlots();
     assertThat(assignments).isEqualTo(0);
 
-    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(3);
-    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(5);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore).size()).isEqualTo(3);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).size()).isEqualTo(5);
 
-    assertThat(cacheSlotMetadataList.containsAll(cacheSlotMetadataStore.listSyncUncached()))
+    assertThat(
+            cacheSlotMetadataList.containsAll(
+                KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore)))
         .isTrue();
-    assertThat(replicaMetadataList.containsAll(replicaMetadataStore.listSyncUncached())).isTrue();
+    assertThat(
+            replicaMetadataList.containsAll(
+                KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore)))
+        .isTrue();
     assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
     assertThat(
@@ -437,19 +448,22 @@ public class ReplicaAssignmentServiceTest {
     int assignments = replicaAssignmentService.assignReplicasToCacheSlots();
     assertThat(assignments).isEqualTo(1);
 
-    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(4);
-    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(4);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore).size()).isEqualTo(4);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).size()).isEqualTo(4);
     assertThat(cacheSlotMetadataStore.listSync().containsAll(unmutatedSlots)).isTrue();
 
     List<CacheSlotMetadata> mutatedCacheSlots =
-        cacheSlotMetadataStore.listSyncUncached().stream()
+        KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).stream()
             .filter(cacheSlotMetadata -> !unmutatedSlots.contains(cacheSlotMetadata))
-            .collect(Collectors.toList());
+            .toList();
     assertThat(mutatedCacheSlots.size()).isEqualTo(1);
     assertThat(mutatedCacheSlots.get(0).name).isEqualTo(cacheSlotFree.name);
     assertThat(mutatedCacheSlots.get(0).replicaId).isEqualTo(replicaMetadataList.get(3).name);
 
-    assertThat(replicaMetadataList.containsAll(replicaMetadataStore.listSyncUncached())).isTrue();
+    assertThat(
+            replicaMetadataList.containsAll(
+                KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore)))
+        .isTrue();
 
     assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
@@ -516,12 +530,17 @@ public class ReplicaAssignmentServiceTest {
     int assignments = replicaAssignmentService.assignReplicasToCacheSlots();
     assertThat(assignments).isEqualTo(0);
 
-    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(5);
-    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(3);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore).size()).isEqualTo(5);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).size()).isEqualTo(3);
 
-    assertThat(cacheSlotMetadataList.containsAll(cacheSlotMetadataStore.listSyncUncached()))
+    assertThat(
+            cacheSlotMetadataList.containsAll(
+                KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore)))
         .isTrue();
-    assertThat(replicaMetadataList.containsAll(replicaMetadataStore.listSyncUncached())).isTrue();
+    assertThat(
+            replicaMetadataList.containsAll(
+                KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore)))
+        .isTrue();
     assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
     assertThat(
@@ -609,11 +628,11 @@ public class ReplicaAssignmentServiceTest {
     int assignments = replicaAssignmentService.assignReplicasToCacheSlots();
     assertThat(assignments).isEqualTo(3);
 
-    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(6);
-    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(4);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore).size()).isEqualTo(6);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).size()).isEqualTo(4);
 
     assertThat(
-            cacheSlotMetadataStore.listSyncUncached().stream()
+            KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -621,7 +640,7 @@ public class ReplicaAssignmentServiceTest {
                 .count())
         .isEqualTo(1);
     assertThat(
-            cacheSlotMetadataStore.listSyncUncached().stream()
+            KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -630,7 +649,7 @@ public class ReplicaAssignmentServiceTest {
         .isEqualTo(3);
     assertThat(
             replicaMetadataExpiredList.containsAll(
-                replicaMetadataStore.listSyncUncached().stream()
+                KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore).stream()
                     .filter(
                         replicaMetadata ->
                             replicaMetadata.createdTimeEpochMs
@@ -705,10 +724,10 @@ public class ReplicaAssignmentServiceTest {
     int firstAssignment = replicaAssignmentService.assignReplicasToCacheSlots();
     assertThat(firstAssignment).isEqualTo(1);
 
-    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(2);
-    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(3);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore).size()).isEqualTo(2);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).size()).isEqualTo(3);
     assertThat(
-            cacheSlotMetadataStore.listSyncUncached().stream()
+            KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -716,7 +735,7 @@ public class ReplicaAssignmentServiceTest {
                 .count())
         .isEqualTo(2);
     assertThat(
-            cacheSlotMetadataStore.listSyncUncached().stream()
+            KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -738,10 +757,10 @@ public class ReplicaAssignmentServiceTest {
     int secondAssignment = replicaAssignmentService.assignReplicasToCacheSlots();
     assertThat(secondAssignment).isEqualTo(1);
 
-    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(2);
-    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(3);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore).size()).isEqualTo(2);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).size()).isEqualTo(3);
     assertThat(
-            cacheSlotMetadataStore.listSyncUncached().stream()
+            KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -749,7 +768,7 @@ public class ReplicaAssignmentServiceTest {
                 .count())
         .isEqualTo(2);
     assertThat(
-            cacheSlotMetadataStore.listSyncUncached().stream()
+            KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -835,10 +854,10 @@ public class ReplicaAssignmentServiceTest {
     int firstAssignment = replicaAssignmentService.assignReplicasToCacheSlots();
     assertThat(firstAssignment).isEqualTo(1);
 
-    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(2);
-    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(3);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore).size()).isEqualTo(2);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).size()).isEqualTo(3);
     assertThat(
-            cacheSlotMetadataStore.listSyncUncached().stream()
+            KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -846,7 +865,7 @@ public class ReplicaAssignmentServiceTest {
                 .count())
         .isEqualTo(2);
     assertThat(
-            cacheSlotMetadataStore.listSyncUncached().stream()
+            KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -923,10 +942,10 @@ public class ReplicaAssignmentServiceTest {
     int firstAssignment = replicaAssignmentService.assignReplicasToCacheSlots();
     assertThat(firstAssignment).isEqualTo(1);
 
-    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(2);
-    assertThat(cacheSlotMetadataStore.listSyncUncached().size()).isEqualTo(3);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore).size()).isEqualTo(2);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).size()).isEqualTo(3);
     assertThat(
-            cacheSlotMetadataStore.listSyncUncached().stream()
+            KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -934,7 +953,7 @@ public class ReplicaAssignmentServiceTest {
                 .count())
         .isEqualTo(2);
     assertThat(
-            cacheSlotMetadataStore.listSyncUncached().stream()
+            KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -986,9 +1005,9 @@ public class ReplicaAssignmentServiceTest {
     }
 
     await().until(() -> cacheSlotMetadataStore.listSync().size() == 3);
-    assertThat(replicaMetadataStore.listSyncUncached().size()).isEqualTo(0);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore).size()).isEqualTo(0);
     assertThat(
-            cacheSlotMetadataStore.listSyncUncached().stream()
+            KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).stream()
                 .filter(
                     cacheSlotMetadata ->
                         cacheSlotMetadata.cacheSlotState.equals(
@@ -1109,7 +1128,10 @@ public class ReplicaAssignmentServiceTest {
                                     Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED))
                         .count()
                     == 2);
-    assertThat(replicaMetadataList.containsAll(replicaMetadataStore.listSyncUncached())).isTrue();
+    assertThat(
+            replicaMetadataList.containsAll(
+                KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore)))
+        .isTrue();
 
     assertThat(MetricsUtil.getCount(ReplicaAssignmentService.REPLICA_ASSIGN_FAILED, meterRegistry))
         .isEqualTo(0);
@@ -1190,7 +1212,8 @@ public class ReplicaAssignmentServiceTest {
                       == Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED;
             });
 
-    List<CacheSlotMetadata> assignedCacheSlot = cacheSlotMetadataStore.listSyncUncached();
+    List<CacheSlotMetadata> assignedCacheSlot =
+        KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore);
     assertThat(assignedCacheSlot.get(0).replicaId).isEqualTo(newerReplicaMetadata.name);
     assertThat(assignedCacheSlot.get(0).supportedIndexTypes).containsAll(SUPPORTED_INDEX_TYPES);
   }
@@ -1258,7 +1281,8 @@ public class ReplicaAssignmentServiceTest {
                       == Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED;
             });
 
-    List<CacheSlotMetadata> assignedCacheSlot = cacheSlotMetadataStore.listSyncUncached();
+    List<CacheSlotMetadata> assignedCacheSlot =
+        KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore);
     assertThat(assignedCacheSlot.get(0).replicaId).isEqualTo(newerReplicaMetadata.name);
     assertThat(assignedCacheSlot.get(0).supportedIndexTypes)
         .containsExactlyInAnyOrderElementsOf(suppportedIndexTypes);

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
@@ -528,14 +528,15 @@ public class LuceneIndexStoreImplTest {
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, testLogStore.metricsRegistry)).isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, testLogStore.metricsRegistry)).isEqualTo(0);
+
       await()
           .until(
               () -> getTimerCount(REFRESHES_TIMER, testLogStore.metricsRegistry),
-              (timer) -> timer >= 1 && timer <= 3);
+              (value) -> value >= 1 && value <= 3);
       await()
           .until(
               () -> getTimerCount(COMMITS_TIMER, testLogStore.metricsRegistry),
-              (timer) -> timer >= 1 && timer <= 3);
+              (value) -> value >= 1 && value <= 3);
     }
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
@@ -22,6 +22,7 @@ import com.slack.kaldb.chunk.ChunkInfo;
 import com.slack.kaldb.chunk.ReadOnlyChunkImpl;
 import com.slack.kaldb.chunk.SearchContext;
 import com.slack.kaldb.metadata.core.CuratorBuilder;
+import com.slack.kaldb.metadata.core.KaldbMetadataTestUtils;
 import com.slack.kaldb.metadata.dataset.DatasetMetadata;
 import com.slack.kaldb.metadata.dataset.DatasetMetadataStore;
 import com.slack.kaldb.metadata.dataset.DatasetPartitionMetadata;
@@ -116,8 +117,8 @@ public class KaldbDistributedQueryServiceTest {
     Instant chunk1EndTime = Instant.ofEpochMilli(200);
     String chunk1Name =
         createIndexerZKMetadata(chunk1CreationTime, chunk1EndTime, "1", indexer1SearchContext);
-    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 2);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size() == 2);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore).size() == 1);
 
     // we don't have any dataset metadata entry, so we shouldn't be able to find any snapshot
     Map<String, List<String>> searchNodes =
@@ -134,7 +135,7 @@ public class KaldbDistributedQueryServiceTest {
     DatasetMetadata datasetMetadata =
         new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore).size() == 1);
 
     // now we can find the snapshot
     searchNodes =
@@ -167,8 +168,8 @@ public class KaldbDistributedQueryServiceTest {
     Instant chunk2EndTime = Instant.ofEpochMilli(300);
     String chunk2Name =
         createIndexerZKMetadata(chunk2CreationTime, chunk2EndTime, "1", indexer1SearchContext);
-    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 4);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 2);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size() == 4);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore).size() == 2);
     searchNodes =
         getSearchNodesToQuery(
             snapshotMetadataStore, searchMetadataStore, datasetMetadataStore, 0, 300, indexName);
@@ -202,11 +203,11 @@ public class KaldbDistributedQueryServiceTest {
 
     // re-add dataset metadata with a different time window that doesn't match any snapshot
     datasetMetadataStore.deleteAsync(datasetMetadata.name);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 0);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore).size() == 0);
     partition = new DatasetPartitionMetadata(1, 99, List.of("1"));
     datasetMetadata = new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore).size() == 1);
 
     // we can't find snapshot since the time window doesn't match any dataset metadata
     searchNodes =
@@ -231,14 +232,14 @@ public class KaldbDistributedQueryServiceTest {
     DatasetMetadata datasetMetadata =
         new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore).size() == 1);
 
     Instant chunk1CreationTime = Instant.ofEpochMilli(100);
     Instant chunk1EndTime = Instant.ofEpochMilli(200);
     String snapshot1Name =
         createIndexerZKMetadata(chunk1CreationTime, chunk1EndTime, "1", indexer1SearchContext);
-    assertThat(snapshotMetadataStore.listSyncUncached().size()).isEqualTo(2);
-    assertThat(searchMetadataStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isEqualTo(2);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore).size()).isEqualTo(1);
 
     AtomicReference<Map<String, List<String>>> searchNodes = new AtomicReference<>();
     await()
@@ -267,7 +268,7 @@ public class KaldbDistributedQueryServiceTest {
     SearchMetadata cacheNodeSearchMetada =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache1SearchContext, snapshot1Name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 2);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore).size() == 2);
 
     searchNodes.set(
         getSearchNodesToQuery(
@@ -289,7 +290,7 @@ public class KaldbDistributedQueryServiceTest {
     SearchMetadata snapshot1Cache2SearchMetadata =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache2SearchContext, snapshot1Name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 3);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore).size() == 3);
 
     searchNodes.set(
         getSearchNodesToQuery(
@@ -318,13 +319,13 @@ public class KaldbDistributedQueryServiceTest {
     await()
         .until(
             () ->
-                snapshotMetadataStore.listSyncUncached().size()
+                KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()
                     == 3); // snapshot1(live + non_live) + snapshot2
 
     SearchMetadata snapshot2Cache2SearchMetadata =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache2SearchContext, snapshot2Metadata.name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 4);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore).size() == 4);
 
     Instant snapshot3CreationTime = Instant.ofEpochMilli(151);
     Instant snapshot3EndTime = Instant.ofEpochMilli(250);
@@ -333,13 +334,13 @@ public class KaldbDistributedQueryServiceTest {
     await()
         .until(
             () ->
-                snapshotMetadataStore.listSyncUncached().size()
+                KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()
                     == 4); // snapshot1(live + non_live) + snapshot2 + snapshot3
 
     SearchMetadata snapshot3Cache1SearchMetadata =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache1SearchContext, snapshot3Metadata.name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 5);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore).size() == 5);
 
     searchNodes.set(
         getSearchNodesToQuery(
@@ -396,14 +397,14 @@ public class KaldbDistributedQueryServiceTest {
     DatasetMetadata datasetMetadata =
         new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore).size() == 1);
 
     Instant chunk1CreationTime = Instant.ofEpochMilli(100);
     Instant chunk1EndTime = Instant.ofEpochMilli(200);
     String snapshot1Name =
         createIndexerZKMetadata(chunk1CreationTime, chunk1EndTime, "1", indexer1SearchContext);
-    assertThat(snapshotMetadataStore.listSyncUncached().size()).isEqualTo(2);
-    assertThat(searchMetadataStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isEqualTo(2);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore).size()).isEqualTo(1);
 
     Map<String, List<String>> searchNodes =
         getSearchNodesToQuery(
@@ -424,8 +425,8 @@ public class KaldbDistributedQueryServiceTest {
     Instant chunk2EndTime = Instant.ofEpochMilli(300);
     String snapshot2Name =
         createIndexerZKMetadata(chunk2CreationTime, chunk2EndTime, "1", indexer1SearchContext);
-    assertThat(snapshotMetadataStore.listSyncUncached().size()).isEqualTo(4);
-    assertThat(searchMetadataStore.listSyncUncached().size()).isEqualTo(2);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isEqualTo(4);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore).size()).isEqualTo(2);
 
     searchNodes =
         getSearchNodesToQuery(
@@ -471,7 +472,7 @@ public class KaldbDistributedQueryServiceTest {
     SearchMetadata cacheNodeSearchMetada =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache1SearchContext, snapshot1Name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 3);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore).size() == 3);
 
     searchNodes =
         getSearchNodesToQuery(
@@ -490,11 +491,11 @@ public class KaldbDistributedQueryServiceTest {
 
     // re-add dataset metadata with a different time window that doesn't match any snapshot
     datasetMetadataStore.deleteAsync(datasetMetadata.name);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 0);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore).size() == 0);
     partition = new DatasetPartitionMetadata(1, 99, List.of("1"));
     datasetMetadata = new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore).size() == 1);
 
     // we can't find snapshot since the time window doesn't match any dataset metadata
     searchNodes =
@@ -518,19 +519,19 @@ public class KaldbDistributedQueryServiceTest {
     Instant chunkCreationTime = Instant.ofEpochMilli(100);
     Instant chunkEndTime = Instant.ofEpochMilli(200);
     SnapshotMetadata snapshotMetadata = createSnapshot(chunkCreationTime, chunkEndTime, false, "1");
-    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size() == 1);
 
     // create first search metadata hosted by cache1
     SearchMetadata cache1NodeSearchMetada =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache1SearchContext, snapshotMetadata.name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore).size() == 1);
 
     DatasetPartitionMetadata partition = new DatasetPartitionMetadata(1, 500, List.of("1"));
     DatasetMetadata datasetMetadata =
         new DatasetMetadata(indexName, "testOwner", 1, List.of(partition), indexName);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore).size() == 1);
 
     // assert search will always find cache1
     Map<String, List<String>> searchNodes =
@@ -552,7 +553,7 @@ public class KaldbDistributedQueryServiceTest {
     SearchMetadata cache2NodeSearchMetada =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache2SearchContext, snapshotMetadata.name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 2);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore).size() == 2);
 
     // assert search will always find cache1 or cache2
     searchNodes =
@@ -584,12 +585,15 @@ public class KaldbDistributedQueryServiceTest {
     SnapshotMetadata snapshot2Metadata =
         createSnapshot(snapshot2CreationTime, snapshot2EndTime, false, "1");
     await()
-        .until(() -> snapshotMetadataStore.listSyncUncached().size() == 2); // snapshot1 + snapshot2
+        .until(
+            () ->
+                KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()
+                    == 2); // snapshot1 + snapshot2
 
     SearchMetadata snapshot2Cache2SearchMetadata =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache2SearchContext, snapshot2Metadata.name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 3);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore).size() == 3);
 
     // now add snapshot3 to cache1
     Instant snapshot3CreationTime = Instant.ofEpochMilli(151);
@@ -599,13 +603,13 @@ public class KaldbDistributedQueryServiceTest {
     await()
         .until(
             () ->
-                snapshotMetadataStore.listSyncUncached().size()
+                KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()
                     == 3); // snapshot1 + snapshot2 + snapshot3
 
     SearchMetadata snapshot3Cache1SearchMetadata =
         ReadOnlyChunkImpl.registerSearchMetadata(
             searchMetadataStore, cache1SearchContext, snapshot3Metadata.name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 4);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore).size() == 4);
 
     // assert search will always find cache1 AND cache2
     searchNodes =
@@ -660,17 +664,17 @@ public class KaldbDistributedQueryServiceTest {
     // dataset1 snapshots/search-metadata/partitions
     SnapshotMetadata snapshotMetadata =
         createSnapshot(Instant.ofEpochMilli(100), Instant.ofEpochMilli(200), false, "1");
-    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size() == 1);
     ReadOnlyChunkImpl.registerSearchMetadata(
         searchMetadataStore, cache1SearchContext, snapshotMetadata.name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore).size() == 1);
 
     snapshotMetadata =
         createSnapshot(Instant.ofEpochMilli(201), Instant.ofEpochMilli(300), false, "2");
-    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 2);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size() == 2);
     ReadOnlyChunkImpl.registerSearchMetadata(
         searchMetadataStore, cache2SearchContext, snapshotMetadata.name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 2);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore).size() == 2);
 
     final String name = "testDataset";
     final String owner = "DatasetOwner";
@@ -684,22 +688,22 @@ public class KaldbDistributedQueryServiceTest {
         new DatasetMetadata(name, owner, throughputBytes, List.of(partition11, partition12), name);
 
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore).size() == 1);
 
     // dataset2 snapshots/search-metadata/partitions
     snapshotMetadata =
         createSnapshot(Instant.ofEpochMilli(100), Instant.ofEpochMilli(200), false, "2");
-    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 3);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size() == 3);
     ReadOnlyChunkImpl.registerSearchMetadata(
         searchMetadataStore, cache3SearchContext, snapshotMetadata.name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 3);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore).size() == 3);
 
     snapshotMetadata =
         createSnapshot(Instant.ofEpochMilli(201), Instant.ofEpochMilli(300), false, "1");
-    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 4);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size() == 4);
     ReadOnlyChunkImpl.registerSearchMetadata(
         searchMetadataStore, cache4SearchContext, snapshotMetadata.name);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 4);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore).size() == 4);
 
     final String name1 = "testDataset1";
     final String owner1 = "DatasetOwner1";
@@ -713,7 +717,7 @@ public class KaldbDistributedQueryServiceTest {
         new DatasetMetadata(
             name1, owner1, throughputBytes1, List.of(partition21, partition22), name1);
     datasetMetadataStore.createSync(datasetMetadata1);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 2);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore).size() == 2);
 
     // find search nodes that will be queries for the first dataset
     Map<String, List<String>> searchNodes =
@@ -763,14 +767,14 @@ public class KaldbDistributedQueryServiceTest {
     Instant chunkCreationTime = Instant.ofEpochMilli(100);
     Instant chunkEndTime = Instant.ofEpochMilli(200);
     createIndexerZKMetadata(chunkCreationTime, chunkEndTime, "1", indexer1SearchContext);
-    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 2);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size() == 2);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore).size() == 1);
 
     DatasetPartitionMetadata partition = new DatasetPartitionMetadata(1, 200, List.of("1"));
     DatasetMetadata datasetMetadata =
         new DatasetMetadata(indexName1, "testOwner1", 1, List.of(partition), indexName1);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore).size() == 1);
 
     Map<String, List<String>> searchNodes =
         getSearchNodesToQuery(
@@ -785,14 +789,14 @@ public class KaldbDistributedQueryServiceTest {
 
     // search for partition "2" only
     createIndexerZKMetadata(chunkCreationTime, chunkEndTime, "2", indexer2SearchContext);
-    await().until(() -> snapshotMetadataStore.listSyncUncached().size() == 4);
-    await().until(() -> searchMetadataStore.listSyncUncached().size() == 2);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size() == 4);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore).size() == 2);
 
     partition = new DatasetPartitionMetadata(1, 101, List.of("2"));
     datasetMetadata =
         new DatasetMetadata(indexName2, "testOwner2", 1, List.of(partition), indexName2);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 2);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore).size() == 2);
 
     searchNodes =
         getSearchNodesToQuery(

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStoreTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import com.slack.kaldb.metadata.core.CuratorBuilder;
+import com.slack.kaldb.metadata.core.KaldbMetadataTestUtils;
 import com.slack.kaldb.proto.config.KaldbConfigs;
 import com.slack.kaldb.proto.metadata.Metadata;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -74,12 +75,12 @@ public class CacheSlotMetadataStoreTest {
     assertThat(cacheSlotMetadata.hostname).isEqualTo(hostname);
 
     uncachedStore.createSync(cacheSlotMetadata);
-    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(uncachedStore).size()).isEqualTo(1);
 
     uncachedStore
         .getAndUpdateNonFreeCacheSlotState(name, CacheSlotState.LIVE)
         .get(1, TimeUnit.SECONDS);
-    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(uncachedStore).size()).isEqualTo(1);
     final CacheSlotMetadata liveNode = uncachedStore.getSync(name);
     assertThat(liveNode.name).isEqualTo(name);
     assertThat(liveNode.cacheSlotState).isEqualTo(CacheSlotState.LIVE);
@@ -90,7 +91,7 @@ public class CacheSlotMetadataStoreTest {
     uncachedStore
         .getAndUpdateNonFreeCacheSlotState(name, CacheSlotState.EVICT)
         .get(1, TimeUnit.SECONDS);
-    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(uncachedStore).size()).isEqualTo(1);
     final CacheSlotMetadata evictNode = uncachedStore.getSync(name);
     assertThat(evictNode.name).isEqualTo(name);
     assertThat(evictNode.cacheSlotState).isEqualTo(CacheSlotState.EVICT);
@@ -101,7 +102,7 @@ public class CacheSlotMetadataStoreTest {
     uncachedStore
         .getAndUpdateNonFreeCacheSlotState(name, CacheSlotState.FREE)
         .get(1, TimeUnit.SECONDS);
-    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(uncachedStore).size()).isEqualTo(1);
     final CacheSlotMetadata freeNode = uncachedStore.getSync(name);
     assertThat(freeNode.name).isEqualTo(name);
     assertThat(freeNode.cacheSlotState).isEqualTo(CacheSlotState.FREE);
@@ -137,12 +138,12 @@ public class CacheSlotMetadataStoreTest {
     assertThat(cacheSlotMetadata.hostname).isEqualTo(hostname);
 
     uncachedStore.createSync(cacheSlotMetadata);
-    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(uncachedStore).size()).isEqualTo(1);
 
     uncachedStore
         .updateNonFreeCacheSlotState(cacheSlotMetadata, CacheSlotState.LIVE)
         .get(1, TimeUnit.SECONDS);
-    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(uncachedStore).size()).isEqualTo(1);
     final CacheSlotMetadata liveNode = uncachedStore.getSync(name);
     assertThat(liveNode.name).isEqualTo(name);
     assertThat(liveNode.cacheSlotState).isEqualTo(CacheSlotState.LIVE);
@@ -153,7 +154,7 @@ public class CacheSlotMetadataStoreTest {
     uncachedStore
         .updateNonFreeCacheSlotState(liveNode, CacheSlotState.EVICT)
         .get(1, TimeUnit.SECONDS);
-    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(uncachedStore).size()).isEqualTo(1);
     final CacheSlotMetadata evictNode = uncachedStore.getSync(name);
     assertThat(evictNode.name).isEqualTo(name);
     assertThat(evictNode.cacheSlotState).isEqualTo(CacheSlotState.EVICT);
@@ -164,7 +165,7 @@ public class CacheSlotMetadataStoreTest {
     uncachedStore
         .updateNonFreeCacheSlotState(evictNode, CacheSlotState.FREE)
         .get(1, TimeUnit.SECONDS);
-    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(uncachedStore).size()).isEqualTo(1);
     final CacheSlotMetadata freeNode = uncachedStore.getSync(name);
     assertThat(freeNode.name).isEqualTo(name);
     assertThat(freeNode.cacheSlotState).isEqualTo(CacheSlotState.FREE);
@@ -206,12 +207,12 @@ public class CacheSlotMetadataStoreTest {
     assertThat(cacheSlotMetadata.hostname).isEqualTo(hostname);
 
     uncachedStore.createSync(cacheSlotMetadata);
-    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(uncachedStore).size()).isEqualTo(1);
 
     uncachedStore
         .updateCacheSlotStateStateWithReplicaId(cacheSlotMetadata, cacheSlotState, "")
         .get(1, TimeUnit.SECONDS);
-    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(uncachedStore).size()).isEqualTo(1);
     final CacheSlotMetadata freeNode = uncachedStore.getSync(name);
     assertThat(freeNode.name).isEqualTo(name);
     assertThat(freeNode.cacheSlotState).isEqualTo(cacheSlotState);
@@ -224,7 +225,7 @@ public class CacheSlotMetadataStoreTest {
         .updateCacheSlotStateStateWithReplicaId(
             cacheSlotMetadata, Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED, replicaId)
         .get(1, TimeUnit.SECONDS);
-    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(uncachedStore).size()).isEqualTo(1);
     CacheSlotMetadata assignedNode = uncachedStore.getSync(name);
     assertThat(assignedNode.name).isEqualTo(name);
     assertThat(assignedNode.cacheSlotState)
@@ -237,7 +238,7 @@ public class CacheSlotMetadataStoreTest {
         .updateCacheSlotStateStateWithReplicaId(
             cacheSlotMetadata, Metadata.CacheSlotMetadata.CacheSlotState.EVICT, replicaId)
         .get(1, TimeUnit.SECONDS);
-    assertThat(uncachedStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(uncachedStore).size()).isEqualTo(1);
     CacheSlotMetadata evictedNode = uncachedStore.getSync(name);
     assertThat(evictedNode.name).isEqualTo(name);
     assertThat(evictedNode.cacheSlotState)

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
@@ -114,7 +114,7 @@ public class KaldbMetadataStoreTest {
       store.createSync(metadata2);
 
       // do a non-cached list to ensure both are persisted
-      List<TestMetadata> metadataListUncached = store.listSyncUncached();
+      List<TestMetadata> metadataListUncached = KaldbMetadataTestUtils.listSyncUncached(store);
       assertThat(metadataListUncached).containsExactlyInAnyOrder(metadata1, metadata2);
 
       // check to see if the cache contains the elements as well
@@ -140,12 +140,12 @@ public class KaldbMetadataStoreTest {
 
       // delete a node by object reference, and ensure that list and cache both reflect the change
       store.deleteSync(metadata2);
-      assertThat(store.listSyncUncached()).containsExactly(metadata1);
+      assertThat(KaldbMetadataTestUtils.listSyncUncached(store)).containsExactly(metadata1);
       assertThat(store.listSync()).containsExactly(metadata1);
 
       // delete a node by path reference, and ensure that list and cache both reflect the change
       store.deleteSync(metadata1.name);
-      assertThat(store.listSyncUncached()).isEmpty();
+      assertThat(KaldbMetadataTestUtils.listSyncUncached(store)).isEmpty();
       assertThat(store.listSync()).isEmpty();
     }
   }
@@ -189,8 +189,12 @@ public class KaldbMetadataStoreTest {
       TestMetadata metadata1 = new TestMetadata("foo", "val1");
       store.createSync(metadata1);
 
-      // do a non-cached list to ensure node has been persisted
-      assertThat(store.listSyncUncached()).containsExactly(metadata1);
+      await()
+          .until(
+              () -> {
+                List<TestMetadata> metadata = KaldbMetadataTestUtils.listSyncUncached(store);
+                return metadata.contains(metadata1) && metadata.size() == 1;
+              });
 
       // verify exceptions are thrown attempting to use cached methods
       assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(store::listSync);
@@ -231,7 +235,8 @@ public class KaldbMetadataStoreTest {
       persistentStore.createSync(metadata1);
 
       // do a non-cached list to ensure node has been persisted
-      assertThat(persistentStore.listSyncUncached()).containsExactly(metadata1);
+      assertThat(KaldbMetadataTestUtils.listSyncUncached(persistentStore))
+          .containsExactly(metadata1);
     }
 
     TestMetadata metadata2 = new TestMetadata("foo", "val1");
@@ -240,7 +245,8 @@ public class KaldbMetadataStoreTest {
       ephemeralStore.createSync(metadata2);
 
       // do a non-cached list to ensure node has been persisted
-      assertThat(ephemeralStore.listSyncUncached()).containsExactly(metadata2);
+      assertThat(KaldbMetadataTestUtils.listSyncUncached(ephemeralStore))
+          .containsExactly(metadata2);
     }
 
     // close curator, and then instantiate a new copy

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataTestUtils.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataTestUtils.java
@@ -1,0 +1,41 @@
+package com.slack.kaldb.metadata.core;
+
+import static com.slack.kaldb.server.KaldbConfig.DEFAULT_ZK_TIMEOUT_SECS;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import org.apache.curator.x.async.modeled.ZPath;
+
+/**
+ * This is a collection of helpful methods for writing Kaldb tests that use the KaldbMetadataStores
+ * that cannot or should not exist in the production client.
+ */
+public class KaldbMetadataTestUtils {
+
+  /**
+   * Listing an uncached directory is very expensive, and not recommended for production code. For a
+   * directory containing 100 znodes this would result in 100 additional zookeeper queries after the
+   * initial listing.
+   *
+   * <p>To prevent production access, all existing use of this method has been deprecated and
+   * removed. However, the ability to perform asserts without dealing with cache timing is useful
+   * for testing, so this method still has visibility for all test suites.
+   */
+  public static <T extends KaldbMetadata> List<T> listSyncUncached(KaldbMetadataStore<T> store) {
+    try {
+      return store
+          .modeledClient
+          .withPath(ZPath.parse(store.storeFolder))
+          .childrenAsZNodes()
+          .thenApply(
+              (zNodes) -> zNodes.stream().map(znode -> znode.model()).collect(Collectors.toList()))
+          .toCompletableFuture()
+          .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+    } catch (ExecutionException | InterruptedException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error listing node", e);
+    }
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import com.slack.kaldb.metadata.core.CuratorBuilder;
+import com.slack.kaldb.metadata.core.KaldbMetadataTestUtils;
 import com.slack.kaldb.metadata.dataset.DatasetMetadata;
 import com.slack.kaldb.metadata.dataset.DatasetMetadataStore;
 import com.slack.kaldb.metadata.dataset.DatasetPartitionMetadata;
@@ -94,7 +95,7 @@ public class PreprocessorServiceIntegrationTest {
     datasetMetadataStore.createSync(new DatasetMetadata("name", "owner", 0, List.of(), "name"));
 
     // wait for the cache to be updated
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore).size() == 1);
     assertThat(MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry))
         .isEqualTo(2);
 
@@ -172,7 +173,7 @@ public class PreprocessorServiceIntegrationTest {
     datasetMetadataStore.createSync(datasetMetadata);
 
     // wait for the cache to be updated
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore).size() == 1);
     await()
         .until(
             () ->
@@ -197,8 +198,11 @@ public class PreprocessorServiceIntegrationTest {
             () ->
                 MetricsUtil.getTimerCount(PreprocessorService.CONFIG_RELOAD_TIMER, meterRegistry)
                     == 3);
-    assertThat(datasetMetadataStore.listSyncUncached().size()).isEqualTo(1);
-    assertThat(datasetMetadataStore.listSyncUncached().get(0).getThroughputBytes())
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore).size()).isEqualTo(1);
+    assertThat(
+            KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore)
+                .get(0)
+                .getThroughputBytes())
         .isEqualTo(Long.MAX_VALUE);
 
     // produce messages to upstream

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceUnitTest.java
@@ -499,7 +499,7 @@ public class PreprocessorServiceUnitTest {
   @Test
   public void shouldHandleEmptyDatasetMetadata() throws TimeoutException {
     DatasetMetadataStore datasetMetadataStore = mock(DatasetMetadataStore.class);
-    when(datasetMetadataStore.listSyncUncached()).thenReturn(List.of());
+    when(datasetMetadataStore.listSync()).thenReturn(List.of());
 
     KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
         KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
@@ -16,6 +16,7 @@ import com.google.common.collect.ImmutableMap;
 import com.slack.kaldb.chunkManager.RollOverChunkTask;
 import com.slack.kaldb.logstore.schema.SchemaAwareLogDocumentBuilderImpl;
 import com.slack.kaldb.metadata.core.CuratorBuilder;
+import com.slack.kaldb.metadata.core.KaldbMetadataTestUtils;
 import com.slack.kaldb.metadata.dataset.DatasetMetadata;
 import com.slack.kaldb.metadata.dataset.DatasetMetadataStore;
 import com.slack.kaldb.metadata.dataset.DatasetPartitionMetadata;
@@ -135,7 +136,7 @@ public class KaldbTest {
             partitionConfigs,
             MessageUtil.TEST_DATASET_NAME);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore).size() == 1);
   }
 
   @AfterEach

--- a/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
@@ -13,6 +13,7 @@ import brave.Tracing;
 import com.slack.kaldb.clusterManager.ReplicaRestoreService;
 import com.slack.kaldb.metadata.core.CuratorBuilder;
 import com.slack.kaldb.metadata.core.InternalMetadataStoreException;
+import com.slack.kaldb.metadata.core.KaldbMetadataTestUtils;
 import com.slack.kaldb.metadata.dataset.DatasetMetadata;
 import com.slack.kaldb.metadata.dataset.DatasetMetadataStore;
 import com.slack.kaldb.metadata.dataset.DatasetPartitionMetadata;
@@ -218,7 +219,7 @@ public class ManagerApiGrpcTest {
                             .build()));
     assertThat(throwable3.getStatus().getCode()).isEqualTo(Status.UNKNOWN.getCode());
 
-    assertThat(datasetMetadataStore.listSyncUncached().size()).isEqualTo(0);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore).size()).isEqualTo(0);
   }
 
   @Test
@@ -237,7 +238,7 @@ public class ManagerApiGrpcTest {
     assertThat(throwable.getStatus().getCode()).isEqualTo(Status.UNKNOWN.getCode());
     assertThat(throwable.getStatus().getDescription()).isEqualTo("owner must not be null or blank");
 
-    assertThat(datasetMetadataStore.listSyncUncached().size()).isEqualTo(0);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore).size()).isEqualTo(0);
   }
 
   @Test
@@ -326,7 +327,7 @@ public class ManagerApiGrpcTest {
     Status status = throwable.getStatus();
     assertThat(status.getCode()).isEqualTo(Status.UNKNOWN.getCode());
 
-    assertThat(datasetMetadataStore.listSyncUncached().size()).isEqualTo(0);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore).size()).isEqualTo(0);
   }
 
   @Test
@@ -467,7 +468,7 @@ public class ManagerApiGrpcTest {
                             .build()));
     assertThat(throwable1.getStatus().getCode()).isEqualTo(Status.UNKNOWN.getCode());
 
-    assertThat(datasetMetadataStore.listSyncUncached().size()).isEqualTo(0);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore).size()).isEqualTo(0);
   }
 
   @Test
@@ -510,10 +511,9 @@ public class ManagerApiGrpcTest {
                         .setThroughputBytes(0)
                         .build())));
 
-    assertThat(datasetMetadataStore.listSyncUncached().size()).isEqualTo(2);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore).size()).isEqualTo(2);
     assertThat(
-        datasetMetadataStore
-            .listSyncUncached()
+        KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore)
             .containsAll(
                 List.of(
                     new DatasetMetadata(
@@ -569,7 +569,7 @@ public class ManagerApiGrpcTest {
     assertThat(throwableUpdate.getStatus().getCode()).isEqualTo(Status.UNKNOWN.getCode());
     assertThat(throwableUpdate.getStatus().getDescription()).contains(datasetName);
 
-    assertThat(datasetMetadataStore.listSyncUncached().size()).isEqualTo(0);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore).size()).isEqualTo(0);
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
@@ -22,6 +23,7 @@ import static org.mockito.Mockito.when;
 import brave.Tracing;
 import com.slack.kaldb.metadata.core.CuratorBuilder;
 import com.slack.kaldb.metadata.core.InternalMetadataStoreException;
+import com.slack.kaldb.metadata.core.KaldbMetadataTestUtils;
 import com.slack.kaldb.metadata.recovery.RecoveryTaskMetadata;
 import com.slack.kaldb.metadata.recovery.RecoveryTaskMetadataStore;
 import com.slack.kaldb.metadata.snapshot.SnapshotMetadata;
@@ -69,8 +71,8 @@ public class RecoveryTaskCreatorTest {
             .setSleepBetweenRetriesMs(500)
             .build();
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, false));
-    recoveryTaskStore = spy(new RecoveryTaskMetadataStore(curatorFramework, false));
+    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, true));
+    recoveryTaskStore = spy(new RecoveryTaskMetadataStore(curatorFramework, true));
   }
 
   @AfterEach
@@ -213,8 +215,7 @@ public class RecoveryTaskCreatorTest {
       int deletedSnapshotSize,
       List<SnapshotMetadata> expectedSnapshots) {
     actualSnapshots.forEach(snapshot -> snapshotMetadataStore.createSync(snapshot));
-    assertThat(snapshotMetadataStore.listSyncUncached())
-        .containsExactlyInAnyOrderElementsOf(actualSnapshots);
+    await().until(() -> snapshotMetadataStore.listSync().containsAll(actualSnapshots));
 
     RecoveryTaskCreator recoveryTaskCreator =
         new RecoveryTaskCreator(
@@ -226,7 +227,7 @@ public class RecoveryTaskCreatorTest {
             meterRegistry);
     assertThat(recoveryTaskCreator.deleteStaleLiveSnapshots(actualSnapshots).size())
         .isEqualTo(deletedSnapshotSize);
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .containsExactlyInAnyOrderElementsOf(expectedSnapshots);
     // Clear state
     expectedSnapshots.forEach(snapshot -> snapshotMetadataStore.deleteSync(snapshot));
@@ -290,8 +291,7 @@ public class RecoveryTaskCreatorTest {
       boolean hasException) {
 
     actualSnapshots.forEach(snapshot -> snapshotMetadataStore.createSync(snapshot));
-    assertThat(snapshotMetadataStore.listSyncUncached())
-        .containsExactlyInAnyOrderElementsOf(actualSnapshots);
+    await().until(() -> snapshotMetadataStore.listSync().containsAll(actualSnapshots));
 
     RecoveryTaskCreator recoveryTaskCreator =
         new RecoveryTaskCreator(
@@ -316,7 +316,7 @@ public class RecoveryTaskCreatorTest {
       assertThat(recoveryTaskCreator.deleteStaleLiveSnapshots(actualSnapshots)).isEmpty();
     }
 
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .containsExactlyInAnyOrderElementsOf(expectedSnapshots);
 
     // Clear state but reset the overloaded method.
@@ -362,8 +362,7 @@ public class RecoveryTaskCreatorTest {
         List.of(partition1, livePartition1, livePartition11, partition2, livePartition2);
 
     snapshots.forEach(snapshot -> snapshotMetadataStore.createSync(snapshot));
-    assertThat(snapshotMetadataStore.listSyncUncached())
-        .containsExactlyInAnyOrderElementsOf(snapshots);
+    await().until(() -> snapshotMetadataStore.listSync().containsAll(snapshots));
 
     RecoveryTaskCreator recoveryTaskCreator =
         new RecoveryTaskCreator(
@@ -408,7 +407,8 @@ public class RecoveryTaskCreatorTest {
         .isThrownBy(() -> recoveryTaskCreator.deleteStaleLiveSnapshots(snapshots));
 
     // Either liveSnapshot1 or liveSnapshot11 remain but not both.
-    List<SnapshotMetadata> actualSnapshots = snapshotMetadataStore.listSyncUncached();
+    List<SnapshotMetadata> actualSnapshots =
+        KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore);
     assertThat(actualSnapshots.size()).isEqualTo(4);
     assertThat(actualSnapshots).contains(partition1, partition2, livePartition2);
     assertThat(
@@ -683,8 +683,8 @@ public class RecoveryTaskCreatorTest {
             TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore)).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
 
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
@@ -700,14 +700,16 @@ public class RecoveryTaskCreatorTest {
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(name, path, startTime, endTime, maxOffset, "2", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
-    assertThat(snapshotMetadataStore.listSyncUncached()).contains(partition1);
+    await().until(() -> snapshotMetadataStore.listSync().contains(partition1));
     assertThat(recoveryTaskCreator.determineStartingOffset(0)).isNegative();
 
     final SnapshotMetadata partition11 =
         new SnapshotMetadata(
             name + "1", path, endTime + 1, endTime * 2, maxOffset * 2, "2", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition11);
-    assertThat(snapshotMetadataStore.listSyncUncached()).contains(partition1, partition11);
+    await().until(() -> snapshotMetadataStore.listSync().contains(partition11));
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
+        .contains(partition1, partition11);
     assertThat(recoveryTaskCreator.determineStartingOffset(0)).isNegative();
 
     final String recoveryTaskName = "recoveryTask";
@@ -722,7 +724,7 @@ public class RecoveryTaskCreatorTest {
             recoveryStartOffset * 2,
             createdTimeUtc);
     recoveryTaskStore.createSync(recoveryTask1);
-    assertThat(recoveryTaskStore.listSyncUncached()).contains(recoveryTask1);
+    await().until(() -> recoveryTaskStore.listSync().contains(recoveryTask1));
     assertThat(recoveryTaskCreator.determineStartingOffset(0)).isNegative();
   }
 
@@ -737,8 +739,8 @@ public class RecoveryTaskCreatorTest {
             TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore)).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
 
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
@@ -754,7 +756,7 @@ public class RecoveryTaskCreatorTest {
             recoveryStartOffset * 2,
             createdTimeUtc);
     recoveryTaskStore.createSync(recoveryTask1);
-    assertThat(recoveryTaskStore.listSyncUncached()).contains(recoveryTask1);
+    await().until(() -> recoveryTaskStore.listSync().contains(recoveryTask1));
     assertThat(recoveryTaskCreator.determineStartingOffset(850))
         .isEqualTo((recoveryStartOffset * 2) + 1);
     assertThatIllegalStateException()
@@ -768,15 +770,18 @@ public class RecoveryTaskCreatorTest {
             recoveryStartOffset * 3,
             createdTimeUtc);
     recoveryTaskStore.createSync(recoveryTask11);
-    assertThat(recoveryTaskStore.listSyncUncached()).contains(recoveryTask1, recoveryTask11);
+    await()
+        .until(
+            () -> recoveryTaskStore.listSync().containsAll(List.of(recoveryTask1, recoveryTask11)));
     assertThat(recoveryTaskCreator.determineStartingOffset(1201))
         .isEqualTo((recoveryStartOffset * 3) + 1);
     assertThat(recoveryTaskCreator.determineStartingOffset(1200))
         .isEqualTo((recoveryStartOffset * 3) + 1);
     assertThatIllegalStateException()
         .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(1150));
-    assertThat(recoveryTaskStore.listSyncUncached()).contains(recoveryTask1, recoveryTask11);
-    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore))
+        .contains(recoveryTask1, recoveryTask11);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore)).isEmpty();
   }
 
   @Test
@@ -790,8 +795,8 @@ public class RecoveryTaskCreatorTest {
             TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore)).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
 
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
@@ -807,11 +812,12 @@ public class RecoveryTaskCreatorTest {
             recoveryStartOffset * 2,
             createdTimeUtc);
     recoveryTaskStore.createSync(recoveryTask1);
-    assertThat(recoveryTaskStore.listSyncUncached()).contains(recoveryTask1);
+    await().until(() -> recoveryTaskStore.listSync().contains(recoveryTask1));
     final long currentHeadOffset = 4000;
     assertThat(recoveryTaskCreator.determineStartingOffset(currentHeadOffset))
         .isEqualTo(currentHeadOffset);
-    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSyncUncached();
+    List<RecoveryTaskMetadata> recoveryTasks =
+        KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore);
     assertThat(recoveryTasks.size()).isEqualTo(2);
     assertThat(recoveryTasks).contains(recoveryTask1);
     Optional<RecoveryTaskMetadata> newRecoveryTask =
@@ -820,7 +826,7 @@ public class RecoveryTaskCreatorTest {
     RecoveryTaskMetadata recoveryTask = newRecoveryTask.get();
     assertThat(recoveryTask.startOffset).isEqualTo(recoveryStartOffset * 2 + 1);
     assertThat(recoveryTask.endOffset).isEqualTo(currentHeadOffset - 1);
-    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore)).isEmpty();
   }
 
   @Test
@@ -834,8 +840,8 @@ public class RecoveryTaskCreatorTest {
             TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore)).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
 
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
@@ -859,12 +865,15 @@ public class RecoveryTaskCreatorTest {
             recoveryStartOffset * 3,
             createdTimeUtc);
     recoveryTaskStore.createSync(recoveryTask11);
-    assertThat(recoveryTaskStore.listSyncUncached()).contains(recoveryTask1, recoveryTask11);
+    await()
+        .until(
+            () -> recoveryTaskStore.listSync().containsAll(List.of(recoveryTask1, recoveryTask11)));
 
     final long currentHeadOffset = 4000;
     assertThat(recoveryTaskCreator.determineStartingOffset(currentHeadOffset))
         .isEqualTo(currentHeadOffset);
-    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSyncUncached();
+    List<RecoveryTaskMetadata> recoveryTasks =
+        KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore);
     assertThat(recoveryTasks.size()).isEqualTo(3);
     assertThat(recoveryTasks).contains(recoveryTask1, recoveryTask11);
     Optional<RecoveryTaskMetadata> newRecoveryTask =
@@ -873,7 +882,7 @@ public class RecoveryTaskCreatorTest {
     RecoveryTaskMetadata recoveryTask = newRecoveryTask.get();
     assertThat(recoveryTask.startOffset).isEqualTo(recoveryStartOffset * 3 + 1);
     assertThat(recoveryTask.endOffset).isEqualTo(currentHeadOffset - 1);
-    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore)).isEmpty();
   }
 
   @Test
@@ -887,8 +896,8 @@ public class RecoveryTaskCreatorTest {
             TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore)).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
 
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
@@ -924,13 +933,19 @@ public class RecoveryTaskCreatorTest {
         new RecoveryTaskMetadata(
             recoveryTaskName + "21", "2", recoveryStartOffset * 4 + 1, 50000, createdTimeUtc);
     recoveryTaskStore.createSync(recoveryTask21);
-    assertThat(recoveryTaskStore.listSyncUncached())
-        .contains(recoveryTask1, recoveryTask11, recoveryTask2, recoveryTask21);
+    await()
+        .until(
+            () ->
+                recoveryTaskStore
+                    .listSync()
+                    .containsAll(
+                        List.of(recoveryTask1, recoveryTask11, recoveryTask2, recoveryTask21)));
 
     final long currentHeadOffset = 4000;
     assertThat(recoveryTaskCreator.determineStartingOffset(currentHeadOffset))
         .isEqualTo(currentHeadOffset);
-    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSyncUncached();
+    List<RecoveryTaskMetadata> recoveryTasks =
+        KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore);
     assertThat(recoveryTasks.size()).isEqualTo(5);
     assertThat(recoveryTasks)
         .contains(recoveryTask1, recoveryTask11, recoveryTask2, recoveryTask21);
@@ -940,7 +955,7 @@ public class RecoveryTaskCreatorTest {
     RecoveryTaskMetadata recoveryTask = newRecoveryTask.get();
     assertThat(recoveryTask.startOffset).isEqualTo((recoveryStartOffset * 3) + 1);
     assertThat(recoveryTask.endOffset).isEqualTo(currentHeadOffset - 1);
-    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore)).isEmpty();
   }
 
   @Test
@@ -954,8 +969,8 @@ public class RecoveryTaskCreatorTest {
             TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore)).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
 
@@ -968,13 +983,15 @@ public class RecoveryTaskCreatorTest {
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
-    assertThat(snapshotMetadataStore.listSyncUncached()).contains(partition1);
+    await().until(() -> snapshotMetadataStore.listSync().contains(partition1));
     assertThat(
             getHighestDurableOffsetForPartition(
-                snapshotMetadataStore.listSyncUncached(), Collections.emptyList(), partitionId))
+                KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore),
+                Collections.emptyList(),
+                partitionId))
         .isEqualTo(100);
     assertThat(recoveryTaskCreator.determineStartingOffset(150)).isEqualTo(101);
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
     assertThatIllegalStateException()
         .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(50));
 
@@ -983,13 +1000,14 @@ public class RecoveryTaskCreatorTest {
             name + "11", path, endTime + 1, endTime * 2, maxOffset * 2, partitionId, LOGS_LUCENE9);
 
     snapshotMetadataStore.createSync(partition11);
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    await().until(() -> snapshotMetadataStore.listSync().contains(partition11));
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .containsExactlyInAnyOrder(partition1, partition11);
     assertThat(recoveryTaskCreator.determineStartingOffset(250)).isEqualTo(201);
     assertThat(recoveryTaskCreator.determineStartingOffset(201)).isEqualTo(201);
     assertThatIllegalStateException()
         .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(150));
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
     assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(0);
     assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(0);
 
@@ -1004,11 +1022,12 @@ public class RecoveryTaskCreatorTest {
             partitionId,
             LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition1);
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    await().until(() -> snapshotMetadataStore.listSync().contains(livePartition1));
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .contains(partition1, partition11, livePartition1);
     assertThat(recoveryTaskCreator.determineStartingOffset(250)).isEqualTo(201);
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .containsExactlyInAnyOrder(partition1, partition11);
     assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(1);
     assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(0);
@@ -1025,11 +1044,12 @@ public class RecoveryTaskCreatorTest {
             partitionId,
             LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition11);
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    await().until(() -> snapshotMetadataStore.listSync().contains(livePartition11));
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .contains(partition1, partition11, livePartition1, livePartition11);
     assertThat(recoveryTaskCreator.determineStartingOffset(250)).isEqualTo(201);
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .containsExactlyInAnyOrder(partition1, partition11);
     assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(3);
     assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(0);
@@ -1041,11 +1061,17 @@ public class RecoveryTaskCreatorTest {
         new SnapshotMetadata(
             name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset * 5, "2", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition2);
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    await()
+        .until(
+            () ->
+                snapshotMetadataStore
+                    .listSync()
+                    .containsAll(List.of(livePartition1, livePartition11, livePartition2)));
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .contains(partition1, partition11, livePartition1, livePartition2);
     assertThat(recoveryTaskCreator.determineStartingOffset(250)).isEqualTo(201);
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .containsExactlyInAnyOrder(partition1, partition11, livePartition2);
     assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(5);
     assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(0);
@@ -1057,11 +1083,17 @@ public class RecoveryTaskCreatorTest {
         new SnapshotMetadata(
             name + "3", path, startTime, endTime, maxOffset * 3, "2", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition2);
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    await()
+        .until(
+            () ->
+                snapshotMetadataStore
+                    .listSync()
+                    .containsAll(List.of(livePartition1, livePartition11, partition2)));
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .contains(partition1, partition11, livePartition1, livePartition2, partition2);
     assertThat(recoveryTaskCreator.determineStartingOffset(250)).isEqualTo(201);
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .containsExactlyInAnyOrder(partition1, partition11, livePartition2, partition2);
     assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(7);
     assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(0);
@@ -1079,8 +1111,8 @@ public class RecoveryTaskCreatorTest {
             TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore)).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
 
@@ -1093,13 +1125,16 @@ public class RecoveryTaskCreatorTest {
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
-    assertThat(snapshotMetadataStore.listSyncUncached()).contains(partition1);
+    await().until(() -> snapshotMetadataStore.listSync().contains(partition1));
     assertThat(
             getHighestDurableOffsetForPartition(
-                snapshotMetadataStore.listSyncUncached(), Collections.emptyList(), partitionId))
+                KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore),
+                Collections.emptyList(),
+                partitionId))
         .isEqualTo(100);
     assertThat(recoveryTaskCreator.determineStartingOffset(1150)).isEqualTo(1150);
-    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSyncUncached();
+    List<RecoveryTaskMetadata> recoveryTasks1 =
+        KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore);
     assertThat(recoveryTasks1.size()).isEqualTo(1);
     assertThat(recoveryTasks1.get(0).startOffset).isEqualTo(101);
     assertThat(recoveryTasks1.get(0).endOffset).isEqualTo(1149);
@@ -1110,18 +1145,18 @@ public class RecoveryTaskCreatorTest {
     assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(1);
     // clean up recovery task.
     recoveryTaskStore.deleteSync(recoveryTasks1.get(0).name);
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
 
     final SnapshotMetadata partition11 =
         new SnapshotMetadata(
             name + "11", path, endTime + 1, endTime * 2, maxOffset * 2, partitionId, LOGS_LUCENE9);
 
     snapshotMetadataStore.createSync(partition11);
-    assertThat(snapshotMetadataStore.listSyncUncached())
-        .containsExactlyInAnyOrder(partition1, partition11);
+    await().until(() -> snapshotMetadataStore.listSync().contains(partition11));
     assertThat(recoveryTaskCreator.determineStartingOffset(1250)).isEqualTo(1250);
-    assertThat(recoveryTaskStore.listSyncUncached().size()).isEqualTo(1);
-    RecoveryTaskMetadata recoveryTask1 = recoveryTaskStore.listSyncUncached().get(0);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore).size()).isEqualTo(1);
+    RecoveryTaskMetadata recoveryTask1 =
+        KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore).get(0);
     assertThat(recoveryTask1.startOffset).isEqualTo(201);
     assertThat(recoveryTask1.endOffset).isEqualTo(1249);
     assertThat(recoveryTask1.partitionId).isEqualTo(partitionId);
@@ -1130,7 +1165,7 @@ public class RecoveryTaskCreatorTest {
     assertThat(recoveryTaskCreator.determineStartingOffset(1249)).isEqualTo(1250);
     assertThat(recoveryTaskCreator.determineStartingOffset(1250)).isEqualTo(1250);
     assertThat(recoveryTaskCreator.determineStartingOffset(1251)).isEqualTo(1250);
-    assertThat(recoveryTaskStore.listSyncUncached().size()).isEqualTo(1);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore).size()).isEqualTo(1);
     assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(0);
     assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(2);
 
@@ -1145,22 +1180,25 @@ public class RecoveryTaskCreatorTest {
             partitionId,
             LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition1);
-    assertThat(recoveryTaskStore.listSyncUncached()).containsExactly(recoveryTask1);
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    await().until(() -> snapshotMetadataStore.listSync().contains(livePartition1));
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore))
+        .containsExactly(recoveryTask1);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .contains(partition1, partition11, livePartition1);
     assertThatIllegalStateException()
         .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(250));
     assertThat(recoveryTaskCreator.determineStartingOffset(1450)).isEqualTo(1450);
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .containsExactlyInAnyOrder(partition1, partition11);
-    List<RecoveryTaskMetadata> recoveryTasks2 = recoveryTaskStore.listSyncUncached();
+    List<RecoveryTaskMetadata> recoveryTasks2 =
+        KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore);
     assertThat(recoveryTasks2.size()).isEqualTo(2);
     RecoveryTaskMetadata recoveryTask2 =
         recoveryTasks2.stream().filter(r -> !recoveryTask1.equals(r)).findFirst().get();
     assertThat(recoveryTask2.startOffset).isEqualTo(1250);
     assertThat(recoveryTask2.endOffset).isEqualTo(1449);
     assertThat(recoveryTask2.partitionId).isEqualTo(partitionId);
-    assertThat(recoveryTaskStore.listSyncUncached())
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore))
         .containsExactlyInAnyOrder(recoveryTask1, recoveryTask2);
     assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(1);
     assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(3);
@@ -1177,26 +1215,34 @@ public class RecoveryTaskCreatorTest {
             partitionId,
             LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition11);
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    await()
+        .until(
+            () ->
+                snapshotMetadataStore
+                    .listSync()
+                    .containsAll(List.of(livePartition1, livePartition11)));
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .contains(partition1, partition11, livePartition1, livePartition11);
     assertThat(recoveryTaskCreator.determineStartingOffset(1500)).isEqualTo(1450);
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .containsExactlyInAnyOrder(partition1, partition11);
-    assertThat(recoveryTaskStore.listSyncUncached()).contains(recoveryTask1, recoveryTask2);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore))
+        .contains(recoveryTask1, recoveryTask2);
     assertThat(recoveryTaskCreator.determineStartingOffset(1650)).isEqualTo(1650);
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .containsExactlyInAnyOrder(partition1, partition11);
-    List<RecoveryTaskMetadata> recoveryTasks3 = recoveryTaskStore.listSyncUncached();
+    List<RecoveryTaskMetadata> recoveryTasks3 =
+        KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore);
     assertThat(recoveryTasks3.size()).isEqualTo(3);
     RecoveryTaskMetadata recoveryTask3 =
-        recoveryTaskStore.listSyncUncached().stream()
+        KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore).stream()
             .filter(r -> !r.equals(recoveryTask1) && !r.equals(recoveryTask2))
             .findFirst()
             .get();
     assertThat(recoveryTask3.partitionId).isEqualTo(partitionId);
     assertThat(recoveryTask3.startOffset).isEqualTo(1450);
     assertThat(recoveryTask3.endOffset).isEqualTo(1649);
-    assertThat(recoveryTaskStore.listSyncUncached())
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore))
         .containsExactlyInAnyOrder(recoveryTask1, recoveryTask2, recoveryTask3);
     assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(3);
     assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(4);
@@ -1208,27 +1254,34 @@ public class RecoveryTaskCreatorTest {
         new SnapshotMetadata(
             name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset * 5, "2", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition2);
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    await()
+        .until(
+            () ->
+                snapshotMetadataStore
+                    .listSync()
+                    .containsAll(List.of(livePartition1, livePartition11, livePartition2)));
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .contains(partition1, partition11, livePartition1, livePartition2);
     assertThat(recoveryTaskCreator.determineStartingOffset(1660)).isEqualTo(1650);
-    assertThat(recoveryTaskStore.listSyncUncached())
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore))
         .containsExactlyInAnyOrder(recoveryTask1, recoveryTask2, recoveryTask3);
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .containsExactlyInAnyOrder(partition1, partition11, livePartition2);
     assertThat(recoveryTaskCreator.determineStartingOffset(1850)).isEqualTo(1850);
-    List<RecoveryTaskMetadata> recoveryTasks4 = recoveryTaskStore.listSyncUncached();
+    List<RecoveryTaskMetadata> recoveryTasks4 =
+        KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore);
     assertThat(recoveryTasks4.size()).isEqualTo(4);
     RecoveryTaskMetadata recoveryTask4 =
-        recoveryTaskStore.listSyncUncached().stream()
+        KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore).stream()
             .filter(r -> !recoveryTasks3.contains(r))
             .findFirst()
             .get();
     assertThat(recoveryTask4.partitionId).isEqualTo(partitionId);
     assertThat(recoveryTask4.startOffset).isEqualTo(1650);
     assertThat(recoveryTask4.endOffset).isEqualTo(1849);
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .containsExactlyInAnyOrder(partition1, partition11, livePartition2);
-    assertThat(recoveryTaskStore.listSyncUncached())
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore))
         .containsExactlyInAnyOrder(recoveryTask1, recoveryTask2, recoveryTask3, recoveryTask4);
     assertThat(getCount(STALE_SNAPSHOT_DELETE_SUCCESS, meterRegistry)).isEqualTo(5);
     assertThat(getCount(RECOVERY_TASKS_CREATED, meterRegistry)).isEqualTo(5);
@@ -1240,7 +1293,13 @@ public class RecoveryTaskCreatorTest {
         new SnapshotMetadata(
             name + "3", path, startTime, endTime, maxOffset * 3, "2", LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition2);
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    await()
+        .until(
+            () ->
+                snapshotMetadataStore
+                    .listSync()
+                    .containsAll(List.of(livePartition1, livePartition11, livePartition2)));
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .contains(partition1, partition11, livePartition1, livePartition2, partition2);
     final RecoveryTaskMetadata recoveryTaskPartition2 =
         new RecoveryTaskMetadata("basicRecovery" + "2", "2", 10000, 20000, 1000);
@@ -1248,22 +1307,22 @@ public class RecoveryTaskCreatorTest {
     assertThatIllegalStateException()
         .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(1650));
     assertThat(recoveryTaskCreator.determineStartingOffset(1900)).isEqualTo(1850);
-    assertThat(recoveryTaskStore.listSyncUncached())
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore))
         .containsExactlyInAnyOrder(
             recoveryTask1, recoveryTask2, recoveryTask3, recoveryTask4, recoveryTaskPartition2);
     assertThat(recoveryTaskCreator.determineStartingOffset(2050)).isEqualTo(2050);
-    assertThat(recoveryTaskStore.listSyncUncached().size()).isEqualTo(6);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore).size()).isEqualTo(6);
     RecoveryTaskMetadata recoveryTask5 =
-        recoveryTaskStore.listSyncUncached().stream()
+        KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore).stream()
             .filter(r -> !recoveryTasks4.contains(r) && !r.equals(recoveryTaskPartition2))
             .findFirst()
             .get();
     assertThat(recoveryTask5.partitionId).isEqualTo(partitionId);
     assertThat(recoveryTask5.startOffset).isEqualTo(1850);
     assertThat(recoveryTask5.endOffset).isEqualTo(2049);
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .containsExactlyInAnyOrder(partition1, partition11, livePartition2, partition2);
-    assertThat(recoveryTaskStore.listSyncUncached())
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore))
         .containsExactlyInAnyOrder(
             recoveryTask1,
             recoveryTask2,
@@ -1286,8 +1345,8 @@ public class RecoveryTaskCreatorTest {
             TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore)).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
 
@@ -1300,13 +1359,16 @@ public class RecoveryTaskCreatorTest {
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
-    assertThat(snapshotMetadataStore.listSyncUncached()).contains(partition1);
+    await().until(() -> snapshotMetadataStore.listSync().contains(partition1));
     assertThat(
             getHighestDurableOffsetForPartition(
-                snapshotMetadataStore.listSyncUncached(), Collections.emptyList(), partitionId))
+                KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore),
+                Collections.emptyList(),
+                partitionId))
         .isEqualTo(100);
     assertThat(recoveryTaskCreator.determineStartingOffset(1150)).isEqualTo(1150);
-    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSyncUncached();
+    List<RecoveryTaskMetadata> recoveryTasks1 =
+        KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore);
     assertThat(recoveryTasks1.size()).isEqualTo(1);
     assertThat(recoveryTasks1.get(0).startOffset).isEqualTo(101);
     assertThat(recoveryTasks1.get(0).endOffset).isEqualTo(1149);
@@ -1319,8 +1381,9 @@ public class RecoveryTaskCreatorTest {
 
     assertThatExceptionOfType(RuntimeException.class)
         .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(1350));
-    assertThat(recoveryTaskStore.listSyncUncached()).containsExactly(recoveryTasks1.get(0));
-    assertThat(snapshotMetadataStore.listSyncUncached()).contains(partition1);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore))
+        .containsExactly(recoveryTasks1.get(0));
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore)).contains(partition1);
   }
 
   @Test
@@ -1334,8 +1397,8 @@ public class RecoveryTaskCreatorTest {
             TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore)).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
 
@@ -1348,13 +1411,16 @@ public class RecoveryTaskCreatorTest {
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
-    assertThat(snapshotMetadataStore.listSyncUncached()).contains(partition1);
+    await().until(() -> snapshotMetadataStore.listSync().contains(partition1));
     assertThat(
             getHighestDurableOffsetForPartition(
-                snapshotMetadataStore.listSyncUncached(), Collections.emptyList(), partitionId))
+                KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore),
+                Collections.emptyList(),
+                partitionId))
         .isEqualTo(100);
     assertThat(recoveryTaskCreator.determineStartingOffset(1150)).isEqualTo(1150);
-    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSyncUncached();
+    List<RecoveryTaskMetadata> recoveryTasks1 =
+        KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore);
     assertThat(recoveryTasks1.size()).isEqualTo(1);
     assertThat(recoveryTasks1.get(0).startOffset).isEqualTo(101);
     assertThat(recoveryTasks1.get(0).endOffset).isEqualTo(1149);
@@ -1366,12 +1432,14 @@ public class RecoveryTaskCreatorTest {
     doThrow(new InternalMetadataStoreException(""))
         .doCallRealMethod()
         .when(snapshotMetadataStore)
-        .listSyncUncached();
+        .listSync();
 
     assertThatExceptionOfType(RuntimeException.class)
         .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(1350));
-    assertThat(recoveryTaskStore.listSyncUncached()).containsExactly(recoveryTasks1.get(0));
-    assertThat(snapshotMetadataStore.listSyncUncached()).containsExactly(partition1);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore))
+        .containsExactly(recoveryTasks1.get(0));
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
+        .containsExactly(partition1);
   }
 
   @Test
@@ -1385,8 +1453,8 @@ public class RecoveryTaskCreatorTest {
             TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore)).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
 
@@ -1399,13 +1467,16 @@ public class RecoveryTaskCreatorTest {
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
-    assertThat(snapshotMetadataStore.listSyncUncached()).contains(partition1);
+    await().until(() -> snapshotMetadataStore.listSync().contains(partition1));
     assertThat(
             getHighestDurableOffsetForPartition(
-                snapshotMetadataStore.listSyncUncached(), Collections.emptyList(), partitionId))
+                KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore),
+                Collections.emptyList(),
+                partitionId))
         .isEqualTo(100);
     assertThat(recoveryTaskCreator.determineStartingOffset(1150)).isEqualTo(1150);
-    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSyncUncached();
+    List<RecoveryTaskMetadata> recoveryTasks1 =
+        KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore);
     assertThat(recoveryTasks1.size()).isEqualTo(1);
     assertThat(recoveryTasks1.get(0).startOffset).isEqualTo(101);
     assertThat(recoveryTasks1.get(0).endOffset).isEqualTo(1149);
@@ -1417,12 +1488,14 @@ public class RecoveryTaskCreatorTest {
     doThrow(new InternalMetadataStoreException(""))
         .doCallRealMethod()
         .when(recoveryTaskStore)
-        .listSyncUncached();
+        .listSync();
 
     assertThatExceptionOfType(RuntimeException.class)
         .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(1350));
-    assertThat(recoveryTaskStore.listSyncUncached()).containsExactly(recoveryTasks1.get(0));
-    assertThat(snapshotMetadataStore.listSyncUncached()).containsExactly(partition1);
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore))
+        .containsExactly(recoveryTasks1.get(0));
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
+        .containsExactly(partition1);
   }
 
   @Test
@@ -1437,8 +1510,8 @@ public class RecoveryTaskCreatorTest {
             TEST_MAX_MESSAGES_PER_RECOVERY_TASK,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore)).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
 
@@ -1451,13 +1524,16 @@ public class RecoveryTaskCreatorTest {
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
-    assertThat(snapshotMetadataStore.listSyncUncached()).contains(partition1);
+    await().until(() -> snapshotMetadataStore.listSync().contains(partition1));
     assertThat(
             getHighestDurableOffsetForPartition(
-                snapshotMetadataStore.listSyncUncached(), Collections.emptyList(), partitionId))
+                KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore),
+                Collections.emptyList(),
+                partitionId))
         .isEqualTo(100);
     assertThat(recoveryTaskCreator.determineStartingOffset(1150)).isEqualTo(1150);
-    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSyncUncached();
+    List<RecoveryTaskMetadata> recoveryTasks1 =
+        KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore);
     assertThat(recoveryTasks1.size()).isEqualTo(1);
     assertThat(recoveryTasks1.get(0).startOffset).isEqualTo(101);
     assertThat(recoveryTasks1.get(0).endOffset).isEqualTo(1149);
@@ -1476,7 +1552,8 @@ public class RecoveryTaskCreatorTest {
             partitionId,
             LOGS_LUCENE9);
     snapshotMetadataStore.createSync(livePartition1);
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    await().until(() -> snapshotMetadataStore.listSync().contains(livePartition1));
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .containsExactlyInAnyOrder(partition1, livePartition1);
     // Fail deletion on snapshot metadata store.
     doThrow(new IllegalStateException())
@@ -1486,8 +1563,9 @@ public class RecoveryTaskCreatorTest {
 
     assertThatIllegalStateException()
         .isThrownBy(() -> recoveryTaskCreator.determineStartingOffset(1350));
-    assertThat(recoveryTaskStore.listSyncUncached()).containsExactly(recoveryTasks1.get(0));
-    assertThat(snapshotMetadataStore.listSyncUncached())
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore))
+        .containsExactly(recoveryTasks1.get(0));
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .containsExactlyInAnyOrder(partition1, livePartition1);
   }
 
@@ -1504,9 +1582,10 @@ public class RecoveryTaskCreatorTest {
             meterRegistry);
 
     // Long range - 1 chunk
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
     recoveryTaskCreator.createRecoveryTasks("1", 10, 100, maxMessagesPerRecoveryTask);
-    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSyncUncached();
+    List<RecoveryTaskMetadata> recoveryTasks =
+        KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore);
     assertThat(recoveryTasks.size()).isEqualTo(1);
     assertThat(recoveryTasks.get(0).startOffset).isEqualTo(10);
     assertThat(recoveryTasks.get(0).endOffset).isEqualTo(100);
@@ -1527,9 +1606,10 @@ public class RecoveryTaskCreatorTest {
             maxMessagesPerRecoveryTask,
             meterRegistry);
 
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
     recoveryTaskCreator.createRecoveryTasks(testPartitionId, 100, 101, maxMessagesPerRecoveryTask);
-    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSyncUncached();
+    List<RecoveryTaskMetadata> recoveryTasks =
+        KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore);
     assertThat(recoveryTasks.size()).isEqualTo(1);
     assertThat(recoveryTasks.get(0).startOffset).isEqualTo(100);
     assertThat(recoveryTasks.get(0).endOffset).isEqualTo(101);
@@ -1544,9 +1624,10 @@ public class RecoveryTaskCreatorTest {
         new RecoveryTaskCreator(
             snapshotMetadataStore, recoveryTaskStore, testPartitionId, 100, 2, meterRegistry);
 
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
     recoveryTaskCreator.createRecoveryTasks(testPartitionId, 100, 105, 2);
-    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSyncUncached();
+    List<RecoveryTaskMetadata> recoveryTasks =
+        KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore);
     assertThat(recoveryTasks.size()).isEqualTo(3);
     assertThat(recoveryTasks.stream().mapToLong(r -> r.startOffset).sorted().toArray())
         .containsExactly(100, 102, 104);
@@ -1565,9 +1646,10 @@ public class RecoveryTaskCreatorTest {
         new RecoveryTaskCreator(
             snapshotMetadataStore, recoveryTaskStore, partitionId, 100, 2, meterRegistry);
 
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
     recoveryTaskCreator.createRecoveryTasks(partitionId, 100, 104, 2);
-    List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskStore.listSyncUncached();
+    List<RecoveryTaskMetadata> recoveryTasks =
+        KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore);
     assertThat(recoveryTasks.size()).isEqualTo(3);
     assertThat(recoveryTasks.stream().mapToLong(r -> r.startOffset).sorted().toArray())
         .containsExactly(100, 102, 104);
@@ -1593,11 +1675,11 @@ public class RecoveryTaskCreatorTest {
             maxMessagesPerRecoveryTask,
             meterRegistry);
 
-    assertThat(snapshotMetadataStore.listSyncUncached()).isEmpty();
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore)).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
     // When there is no data return -1.
     assertThat(recoveryTaskCreator.determineStartingOffset(1000)).isNegative();
-    assertThat(recoveryTaskStore.listSyncUncached()).isEmpty();
+    assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore)).isEmpty();
 
     final String name = "testSnapshotId";
     final String path = "/testPath_" + name;
@@ -1608,13 +1690,16 @@ public class RecoveryTaskCreatorTest {
     final SnapshotMetadata partition1 =
         new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
     snapshotMetadataStore.createSync(partition1);
-    assertThat(snapshotMetadataStore.listSyncUncached()).contains(partition1);
+    await().until(() -> snapshotMetadataStore.listSync().contains(partition1));
     assertThat(
             getHighestDurableOffsetForPartition(
-                snapshotMetadataStore.listSyncUncached(), Collections.emptyList(), partitionId))
+                KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore),
+                Collections.emptyList(),
+                partitionId))
         .isEqualTo(100);
     assertThat(recoveryTaskCreator.determineStartingOffset(1150)).isEqualTo(1150);
-    List<RecoveryTaskMetadata> recoveryTasks1 = recoveryTaskStore.listSyncUncached();
+    List<RecoveryTaskMetadata> recoveryTasks1 =
+        KaldbMetadataTestUtils.listSyncUncached(recoveryTaskStore);
     assertThat(recoveryTasks1.size()).isEqualTo(3);
     assertThat(recoveryTasks1.stream().mapToLong(r -> r.startOffset).sorted().toArray())
         .containsExactly(101, 601, 1101);

--- a/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceTest.java
@@ -18,6 +18,7 @@ import com.slack.kaldb.chunkManager.RollOverChunkTask;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.logstore.LogWireMessage;
 import com.slack.kaldb.metadata.core.CuratorBuilder;
+import com.slack.kaldb.metadata.core.KaldbMetadataTestUtils;
 import com.slack.kaldb.metadata.dataset.DatasetMetadata;
 import com.slack.kaldb.metadata.dataset.DatasetMetadataStore;
 import com.slack.kaldb.metadata.dataset.DatasetPartitionMetadata;
@@ -98,7 +99,7 @@ public class ZipkinServiceTest {
         new DatasetMetadata(
             TEST_DATASET_NAME, "serviceOwner", 1000, partitionConfigs, TEST_DATASET_NAME);
     datasetMetadataStore.createSync(datasetMetadata);
-    await().until(() -> datasetMetadataStore.listSyncUncached().size() == 1);
+    await().until(() -> KaldbMetadataTestUtils.listSyncUncached(datasetMetadataStore).size() == 1);
   }
 
   @AfterEach


### PR DESCRIPTION
###  Summary

This PR completes the deprecation of all uses of `listSyncUncached` from production code. This is done by refactoring the existing `listSyncUncached` method to a test-only class, and updating the few production scenarios which relied on this method including:
* ManagerApiGrpc
* RecoveryTaskCreator