### PR TITLE
Increase cpu allocated for Lucene merge operations

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreImpl.java
@@ -148,10 +148,15 @@ public class LuceneIndexStoreImpl implements LogStore<LogMessage> {
       SnapshotDeletionPolicy snapshotDeletionPolicy,
       LuceneIndexStoreConfig config,
       MeterRegistry metricsRegistry) {
+
+    int coreCount = Runtime.getRuntime().availableProcessors();
+    KalDBMergeScheduler mergeScheduler = new KalDBMergeScheduler(metricsRegistry);
+    mergeScheduler.setMaxMergesAndThreads(coreCount * 2, Math.min(1, coreCount - 1));
+
     final IndexWriterConfig indexWriterCfg =
         new IndexWriterConfig(analyzer)
             .setOpenMode(IndexWriterConfig.OpenMode.CREATE)
-            .setMergeScheduler(new KalDBMergeScheduler(metricsRegistry))
+            .setMergeScheduler(mergeScheduler)
             // we sort by timestamp descending, as that is the order we expect to return results the
             // majority of the time
             .setIndexSort(


### PR DESCRIPTION
###  Summary

The default cpu utilization for merge operations is rather conservative, and can be increased. This moves to a `cores - 1` max, where the default is the larger of - 4, or half of the cores.