### PR TITLE
make larger segments

### DIFF
--- a/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
@@ -690,7 +690,8 @@ public class IndexingChunkImplTest {
       assertThat(chunk.snapshotToS3(bucket, "", s3BlobFs)).isTrue();
       assertThat(chunk.info().getSnapshotPath()).isNotEmpty();
 
-      assertThat(getCount(INDEX_FILES_UPLOAD, registry)).isEqualTo(5);
+      // depending on heap and CFS files this can be 5 or 19.
+      assertThat(getCount(INDEX_FILES_UPLOAD, registry)).isGreaterThan(5);
       assertThat(getCount(INDEX_FILES_UPLOAD_FAILED, registry)).isEqualTo(0);
       assertThat(registry.get(SNAPSHOT_TIMER).timer().totalTime(TimeUnit.SECONDS)).isGreaterThan(0);
 

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
@@ -664,7 +664,8 @@ public class RecoveryChunkImplTest {
       assertThat(chunk.snapshotToS3(bucket, "", s3BlobFs)).isTrue();
       assertThat(chunk.info().getSnapshotPath()).isNotEmpty();
 
-      assertThat(getCount(INDEX_FILES_UPLOAD, registry)).isEqualTo(5);
+      // depending on heap and CFS files this can be 5 or 19.
+      assertThat(getCount(INDEX_FILES_UPLOAD, registry)).isGreaterThan(5);
       assertThat(getCount(INDEX_FILES_UPLOAD_FAILED, registry)).isEqualTo(0);
       assertThat(registry.get(SNAPSHOT_TIMER).timer().totalTime(TimeUnit.SECONDS)).isGreaterThan(0);
 

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
@@ -529,4 +529,11 @@ public class LuceneIndexStoreImplTest {
               (value) -> value >= 1 && value <= 3);
     }
   }
+
+  @Test
+  public void testMaxRamBufferCalculations() {
+    assertThat(LuceneIndexStoreImpl.getRAMBufferSizeMB((long) 8e+9)).isEqualTo(800);
+    assertThat(LuceneIndexStoreImpl.getRAMBufferSizeMB(Long.MAX_VALUE)).isEqualTo(256);
+    assertThat(LuceneIndexStoreImpl.getRAMBufferSizeMB((long) 24e+9)).isEqualTo(2048);
+  }
 }


### PR DESCRIPTION
###  Summary

Increase the default maxRamBufferSize for lucene. This will improve indexing performance for recovery nodes as they don't receive any search traffic when it's being built.

Indexer nodes could also gain some improvements but the with soft commits flushing segments it might not help much?

Also based on the ramBufferSize decide if we should use compound files or not.

> For best indexing speed you should flush by RAM usage with a large RAM buffer.  

From https://lucene.apache.org/core/7_0_1/core/org/apache/lucene/index/IndexWriter.html