### PR TITLE
Dynamically allocate Lucene RAM buffer based on heap

### DIFF
--- a/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
@@ -539,4 +539,11 @@ public class LuceneIndexStoreImplTest {
               (value) -> value >= 1 && value <= 3);
     }
   }
+
+  @Test
+  public void testMaxRamBufferCalculations() {
+    assertThat(LuceneIndexStoreImpl.getRAMBufferSizeMB((long) 8e+9)).isEqualTo(800);
+    assertThat(LuceneIndexStoreImpl.getRAMBufferSizeMB(Long.MAX_VALUE)).isEqualTo(256);
+    assertThat(LuceneIndexStoreImpl.getRAMBufferSizeMB((long) 24e+9)).isEqualTo(2048);
+  }
 }


### PR DESCRIPTION
###  Summary

Dynamically allocate a larger ram buffer to Lucene, based on the heap size. Uses 10% of the heap as the target, maxing out at 2048 (see [here](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java#L238-L239), and [here](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/index/LiveIndexWriterConfig.java#LL136C46-L136C82) for why 2048). If heap is not set uses default of 256.

Original default is 16mb if not provided, which is significantly too many merges for our use case. Using this we would expect to set the heap on the recovery nodes to ~20gb to ensure we max out.