### PR TITLE
Expose merge throttling parameter

### DIFF
--- a/benchmarks/src/main/java/com/slack/kaldb/IndexAPILog.java
+++ b/benchmarks/src/main/java/com/slack/kaldb/IndexAPILog.java
@@ -56,6 +56,7 @@ public class IndexAPILog {
             commitInterval,
             refreshInterval,
             true,
+            true,
             SchemaAwareLogDocumentBuilderImpl.FieldConflictPolicy.CONVERT_VALUE_AND_DUPLICATE_FIELD,
             registry);
 

--- a/benchmarks/src/main/java/com/slack/kaldb/IndexingBenchmark.java
+++ b/benchmarks/src/main/java/com/slack/kaldb/IndexingBenchmark.java
@@ -55,6 +55,7 @@ public class IndexingBenchmark {
             commitInterval,
             refreshInterval,
             true,
+            true,
             CONVERT_VALUE_AND_DUPLICATE_FIELD,
             registry);
 

--- a/benchmarks/src/main/java/com/slack/kaldb/QueryBenchmark.java
+++ b/benchmarks/src/main/java/com/slack/kaldb/QueryBenchmark.java
@@ -70,6 +70,7 @@ public class QueryBenchmark {
             commitInterval,
             refreshInterval,
             true,
+            true,
             SchemaAwareLogDocumentBuilderImpl.FieldConflictPolicy.CONVERT_VALUE_AND_DUPLICATE_FIELD,
             registry);
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,6 +7,7 @@ indexerConfig:
     commitDurationSecs: ${INDEXER_COMMIT_DURATION_SECS:-10}
     refreshDurationSecs: ${INDEXER_REFRESH_DURATION_SECS:-11}
     enableFullTextSearch: ${INDEXER_ENABLE_FULL_TEXT_SEARCH:-false}
+    throttleMerges: ${INDEXER_THROTTLE_MERGES:-true}
   staleDurationSecs: ${INDEXER_STALE_DURATION_SECS:-7200}
   dataTransformer: ${INDEXER_DATA_TRANSFORMER:-trace_span}
   dataDirectory: ${INDEXER_DATA_DIR:-/tmp}

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreConfig.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreConfig.java
@@ -29,6 +29,9 @@ public class LuceneIndexStoreConfig {
   // A flag that turns on internal logging.
   public final boolean enableTracing;
 
+  // setting for the merge scheduler
+  public final boolean throttleMerges;
+
   // TODO: Tweak the default values once in prod.
   static final Duration defaultCommitDuration = Duration.ofSeconds(15);
   static final Duration defaultRefreshDuration = Duration.ofSeconds(15);
@@ -44,8 +47,18 @@ public class LuceneIndexStoreConfig {
   }
 
   public LuceneIndexStoreConfig(
-      Duration commitDuration, Duration refreshDuration, String indexRoot, boolean enableTracing) {
-    this(commitDuration, refreshDuration, indexRoot, DEFAULT_LOG_FILE_NAME, enableTracing);
+      Duration commitDuration,
+      Duration refreshDuration,
+      String indexRoot,
+      boolean enableTracing,
+      boolean throttleMerges) {
+    this(
+        commitDuration,
+        refreshDuration,
+        indexRoot,
+        DEFAULT_LOG_FILE_NAME,
+        enableTracing,
+        throttleMerges);
   }
 
   public LuceneIndexStoreConfig(
@@ -53,7 +66,8 @@ public class LuceneIndexStoreConfig {
       Duration refreshDuration,
       String indexRoot,
       String logFileName,
-      boolean enableTracing) {
+      boolean enableTracing,
+      boolean throttleMerges) {
     ensureTrue(
         !(commitDuration.isZero() || commitDuration.isNegative()),
         "Commit duration should be greater than zero");
@@ -65,6 +79,7 @@ public class LuceneIndexStoreConfig {
     this.indexRoot = indexRoot;
     this.logFileName = logFileName;
     this.enableTracing = enableTracing;
+    this.throttleMerges = throttleMerges;
   }
 
   public File indexFolder(String id) {

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreImpl.java
@@ -62,8 +62,6 @@ public class LuceneIndexStoreImpl implements LogStore<LogMessage> {
   private final io.micrometer.core.instrument.Timer commitsTimer;
   private final io.micrometer.core.instrument.Timer refreshesTimer;
 
-  private final String MAX_RAM_BUFFER_SIZE_MB = "maxRamBufferSizeMb";
-
   // TODO: Set the policy via a lucene config file.
   public static LuceneIndexStoreImpl makeLogStore(
       File dataDirectory, KaldbConfigs.LuceneConfig luceneConfig, MeterRegistry metricsRegistry)
@@ -152,14 +150,10 @@ public class LuceneIndexStoreImpl implements LogStore<LogMessage> {
       SnapshotDeletionPolicy snapshotDeletionPolicy,
       LuceneIndexStoreConfig config,
       MeterRegistry metricsRegistry) {
-    int ramBufferSizeMb = Integer.getInteger(MAX_RAM_BUFFER_SIZE_MB, 1024);
-    boolean useCFSFiles = ramBufferSizeMb <= 128;
     final IndexWriterConfig indexWriterCfg =
         new IndexWriterConfig(analyzer)
             .setOpenMode(IndexWriterConfig.OpenMode.CREATE)
             .setMergeScheduler(new KalDBMergeScheduler(metricsRegistry, config.throttleMerges))
-            .setRAMBufferSizeMB(ramBufferSizeMb)
-            .setUseCompoundFile(useCFSFiles)
             // we sort by timestamp descending, as that is the order we expect to return results the
             // majority of the time
             .setIndexSort(
@@ -169,13 +163,6 @@ public class LuceneIndexStoreImpl implements LogStore<LogMessage> {
                         SortField.Type.LONG,
                         true)))
             .setIndexDeletionPolicy(snapshotDeletionPolicy);
-
-    // See
-    // https://lucene.apache.org/core/9_5_0/core/org/apache/lucene/index/IndexWriterConfig.html#setUseCompoundFile(boolean)
-    if (ramBufferSizeMb >= 128) {
-      indexWriterCfg.getMergePolicy().setNoCFSRatio(0.0);
-    }
-
     if (config.enableTracing) {
       indexWriterCfg.setInfoStream(System.out);
     }

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreImpl.java
@@ -89,7 +89,11 @@ public class LuceneIndexStoreImpl implements LogStore<LogMessage> {
     // TODO: Chunk should create log store?
     LuceneIndexStoreConfig indexStoreCfg =
         new LuceneIndexStoreConfig(
-            commitInterval, refreshInterval, dataDirectory.getAbsolutePath(), false, true);
+            commitInterval,
+            refreshInterval,
+            dataDirectory.getAbsolutePath(),
+            false,
+            throttleMerges);
 
     return new LuceneIndexStoreImpl(
         indexStoreCfg,

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -115,6 +115,7 @@ message LuceneConfig {
   int64 commit_duration_secs = 1;
   int64 refresh_duration_secs = 2;
   bool enable_full_text_search = 3;
+  bool throttle_merges = 4;
 }
 
 // ServerConfig contains the address and port info of a Kaldb service.

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
@@ -121,7 +121,7 @@ public class IndexingChunkImplTest {
               COMMIT_INTERVAL,
               REFRESH_INTERVAL,
               true,
-              false,
+              true,
               SchemaAwareLogDocumentBuilderImpl.FieldConflictPolicy
                   .CONVERT_VALUE_AND_DUPLICATE_FIELD,
               registry);
@@ -468,7 +468,7 @@ public class IndexingChunkImplTest {
               COMMIT_INTERVAL,
               REFRESH_INTERVAL,
               true,
-              false,
+              true,
               SchemaAwareLogDocumentBuilderImpl.FieldConflictPolicy.RAISE_ERROR,
               registry);
       chunk =
@@ -553,7 +553,7 @@ public class IndexingChunkImplTest {
               COMMIT_INTERVAL,
               REFRESH_INTERVAL,
               true,
-              false,
+              true,
               SchemaAwareLogDocumentBuilderImpl.FieldConflictPolicy
                   .CONVERT_VALUE_AND_DUPLICATE_FIELD,
               registry);

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
@@ -121,6 +121,7 @@ public class IndexingChunkImplTest {
               COMMIT_INTERVAL,
               REFRESH_INTERVAL,
               true,
+              false,
               SchemaAwareLogDocumentBuilderImpl.FieldConflictPolicy
                   .CONVERT_VALUE_AND_DUPLICATE_FIELD,
               registry);
@@ -467,6 +468,7 @@ public class IndexingChunkImplTest {
               COMMIT_INTERVAL,
               REFRESH_INTERVAL,
               true,
+              false,
               SchemaAwareLogDocumentBuilderImpl.FieldConflictPolicy.RAISE_ERROR,
               registry);
       chunk =
@@ -551,6 +553,7 @@ public class IndexingChunkImplTest {
               COMMIT_INTERVAL,
               REFRESH_INTERVAL,
               true,
+              false,
               SchemaAwareLogDocumentBuilderImpl.FieldConflictPolicy
                   .CONVERT_VALUE_AND_DUPLICATE_FIELD,
               registry);

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -508,7 +508,7 @@ public class ReadOnlyChunkImplTest {
             Duration.ofSeconds(60),
             Duration.ofSeconds(60),
             true,
-            false,
+            true,
             SchemaAwareLogDocumentBuilderImpl.FieldConflictPolicy.CONVERT_VALUE_AND_DUPLICATE_FIELD,
             meterRegistry);
     addMessages(logStore, 1, 10, true);

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -508,6 +508,7 @@ public class ReadOnlyChunkImplTest {
             Duration.ofSeconds(60),
             Duration.ofSeconds(60),
             true,
+            false,
             SchemaAwareLogDocumentBuilderImpl.FieldConflictPolicy.CONVERT_VALUE_AND_DUPLICATE_FIELD,
             meterRegistry);
     addMessages(logStore, 1, 10, true);

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
@@ -100,6 +100,7 @@ public class RecoveryChunkImplTest {
               COMMIT_INTERVAL,
               REFRESH_INTERVAL,
               true,
+              false,
               SchemaAwareLogDocumentBuilderImpl.FieldConflictPolicy
                   .CONVERT_VALUE_AND_DUPLICATE_FIELD,
               registry);
@@ -455,6 +456,7 @@ public class RecoveryChunkImplTest {
               COMMIT_INTERVAL,
               REFRESH_INTERVAL,
               true,
+              false,
               SchemaAwareLogDocumentBuilderImpl.FieldConflictPolicy.RAISE_ERROR,
               registry);
       chunk =
@@ -541,6 +543,7 @@ public class RecoveryChunkImplTest {
               COMMIT_INTERVAL,
               REFRESH_INTERVAL,
               true,
+              false,
               SchemaAwareLogDocumentBuilderImpl.FieldConflictPolicy
                   .CONVERT_VALUE_AND_DUPLICATE_FIELD,
               registry);

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreConfigTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreConfigTest.java
@@ -12,7 +12,7 @@ public class LuceneIndexStoreConfigTest {
         .isThrownBy(
             () ->
                 new LuceneIndexStoreConfig(
-                    Duration.ZERO, Duration.ofSeconds(10), "indexRoot", "logfile", true, false));
+                    Duration.ZERO, Duration.ofSeconds(10), "indexRoot", "logfile", true, true));
   }
 
   @Test
@@ -21,7 +21,7 @@ public class LuceneIndexStoreConfigTest {
         .isThrownBy(
             () ->
                 new LuceneIndexStoreConfig(
-                    Duration.ofSeconds(10), Duration.ZERO, "indexRoot", "logfile", true, false));
+                    Duration.ofSeconds(10), Duration.ZERO, "indexRoot", "logfile", true, true));
   }
 
   @Test
@@ -35,7 +35,7 @@ public class LuceneIndexStoreConfigTest {
                     "indexRoot",
                     "logfile",
                     true,
-                    false));
+                    true));
   }
 
   @Test
@@ -49,6 +49,6 @@ public class LuceneIndexStoreConfigTest {
                     "indexRoot",
                     "logfile",
                     true,
-                    false));
+                    true));
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreConfigTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreConfigTest.java
@@ -12,7 +12,7 @@ public class LuceneIndexStoreConfigTest {
         .isThrownBy(
             () ->
                 new LuceneIndexStoreConfig(
-                    Duration.ZERO, Duration.ofSeconds(10), "indexRoot", "logfile", true));
+                    Duration.ZERO, Duration.ofSeconds(10), "indexRoot", "logfile", true, false));
   }
 
   @Test
@@ -21,7 +21,7 @@ public class LuceneIndexStoreConfigTest {
         .isThrownBy(
             () ->
                 new LuceneIndexStoreConfig(
-                    Duration.ofSeconds(10), Duration.ZERO, "indexRoot", "logfile", true));
+                    Duration.ofSeconds(10), Duration.ZERO, "indexRoot", "logfile", true, false));
   }
 
   @Test
@@ -30,7 +30,12 @@ public class LuceneIndexStoreConfigTest {
         .isThrownBy(
             () ->
                 new LuceneIndexStoreConfig(
-                    Duration.ofSeconds(-10), Duration.ofSeconds(10), "indexRoot", "logfile", true));
+                    Duration.ofSeconds(-10),
+                    Duration.ofSeconds(10),
+                    "indexRoot",
+                    "logfile",
+                    true,
+                    false));
   }
 
   @Test
@@ -43,6 +48,7 @@ public class LuceneIndexStoreConfigTest {
                     Duration.ofSeconds(-100),
                     "indexRoot",
                     "logfile",
-                    true));
+                    true,
+                    false));
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImplTest.java
@@ -469,7 +469,8 @@ public class SearchResultAggregatorImplTest {
             Duration.of(1, ChronoUnit.MINUTES),
             Duration.of(1, ChronoUnit.MINUTES),
             tempFolder.getCanonicalPath(),
-            false);
+            false,
+            true);
     MeterRegistry metricsRegistry = new SimpleMeterRegistry();
     DocumentBuilder<LogMessage> documentBuilder =
         SchemaAwareLogDocumentBuilderImpl.build(

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/TemporaryLogStoreAndSearcherExtension.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/TemporaryLogStoreAndSearcherExtension.java
@@ -98,7 +98,7 @@ public class TemporaryLogStoreAndSearcherExtension implements AfterEachCallback 
   public static LuceneIndexStoreConfig getIndexStoreConfig(
       Duration commitInterval, Duration refreshInterval, File tempFolder) throws IOException {
     return new LuceneIndexStoreConfig(
-        commitInterval, refreshInterval, tempFolder.getCanonicalPath(), false);
+        commitInterval, refreshInterval, tempFolder.getCanonicalPath(), false, true);
   }
 
   @Override


### PR DESCRIPTION
###  Summary

On the recovery nodes we don't want to throttle merges. Throttling is useful when we want to balance indexing vs search performance.

However recovery nodes are not searchable while the recovery service is creating chunks. So we should be setting very high commit and refresh intervals ( which we have started doing last week ) and not throttling merges.

Another PR is tacking increasing the ram buffer size which also saw a significant improvement in overall throughput.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
