### PR TITLE
Fix stale cache state error in cache nodes, duplicate partitioning ZK events

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
@@ -132,24 +132,32 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
   private void cacheNodeListener(CacheSlotMetadata cacheSlotMetadata) {
     if (Objects.equals(cacheSlotMetadata.name, slotId)) {
       Metadata.CacheSlotMetadata.CacheSlotState newSlotState = cacheSlotMetadata.cacheSlotState;
-
-      if (newSlotState.equals(Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED)) {
-        LOG.info("Chunk - ASSIGNED received");
-        if (!cacheSlotLastKnownState.equals(Metadata.CacheSlotMetadata.CacheSlotState.FREE)) {
-          LOG.warn(
-              "Unexpected state transition from {} to {}", cacheSlotLastKnownState, newSlotState);
+      if (newSlotState != cacheSlotLastKnownState) {
+        if (newSlotState.equals(Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED)) {
+          LOG.info("Chunk - ASSIGNED received - {}", cacheSlotMetadata);
+          if (!cacheSlotLastKnownState.equals(Metadata.CacheSlotMetadata.CacheSlotState.FREE)) {
+            LOG.warn(
+                "Unexpected state transition from {} to {} - {}",
+                cacheSlotLastKnownState,
+                newSlotState,
+                cacheSlotMetadata);
+          }
+          executorService.execute(() -> handleChunkAssignment(cacheSlotMetadata));
+        } else if (newSlotState.equals(Metadata.CacheSlotMetadata.CacheSlotState.EVICT)) {
+          LOG.info("Chunk - EVICT received - {}", cacheSlotMetadata);
+          if (!cacheSlotLastKnownState.equals(Metadata.CacheSlotMetadata.CacheSlotState.LIVE)) {
+            LOG.warn(
+                "Unexpected state transition from {} to {} - {}",
+                cacheSlotLastKnownState,
+                newSlotState,
+                cacheSlotMetadata);
+          }
+          executorService.execute(() -> handleChunkEviction(cacheSlotMetadata));
         }
-        executorService.execute(() -> handleChunkAssignment(cacheSlotMetadata));
-      } else if (newSlotState.equals(Metadata.CacheSlotMetadata.CacheSlotState.EVICT)) {
-        LOG.info("Chunk - EVICT received");
-        if (!cacheSlotLastKnownState.equals(Metadata.CacheSlotMetadata.CacheSlotState.LIVE)) {
-          LOG.warn(
-              "Unexpected state transition from {} to {}", cacheSlotLastKnownState, newSlotState);
-        }
-        executorService.execute(() -> handleChunkEviction(cacheSlotMetadata));
+        cacheSlotLastKnownState = newSlotState;
+      } else {
+        LOG.info("Cache node listener fired but slot state was the same - {}", cacheSlotMetadata);
       }
-
-      cacheSlotLastKnownState = newSlotState;
     }
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStore.java
@@ -23,17 +23,11 @@ public class CacheSlotMetadataStore extends KaldbPartitioningMetadataStore<Cache
         CACHE_SLOT_ZK_PATH);
   }
 
-  /** Fetch the node given a slotName and update the slot state. */
-  public ListenableFuture<?> getAndUpdateNonFreeCacheSlotState(
-      String partition, String slotName, Metadata.CacheSlotMetadata.CacheSlotState slotState) {
-    CacheSlotMetadata cacheSlotMetadata = getSync(partition, slotName);
-    return updateNonFreeCacheSlotState(cacheSlotMetadata, slotState);
-  }
-
   /** Update the cache slot state, if the slot is not FREE. */
   public ListenableFuture<?> updateNonFreeCacheSlotState(
       final CacheSlotMetadata cacheSlotMetadata,
       final Metadata.CacheSlotMetadata.CacheSlotState slotState) {
+
     if (cacheSlotMetadata.cacheSlotState.equals(Metadata.CacheSlotMetadata.CacheSlotState.FREE)) {
       throw new IllegalArgumentException(
           "Current state of slot can't be free: " + cacheSlotMetadata.name);

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbPartitioningMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbPartitioningMetadataStore.java
@@ -291,8 +291,10 @@ public class KaldbPartitioningMetadataStore<T extends KaldbPartitionedMetadata>
   }
 
   public void addListener(KaldbMetadataStoreChangeListener<T> watcher) {
+    // add this watcher to the list for new stores to add
     listeners.add(watcher);
-    metadataStoreMap.forEach((partition, store) -> listeners.forEach(store::addListener));
+    // add this watcher to existing stores
+    metadataStoreMap.forEach((partition, store) -> store.addListener(watcher));
   }
 
   public void removeListener(KaldbMetadataStoreChangeListener<T> watcher) {

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -185,11 +185,11 @@ public class ReadOnlyChunkImplTest {
         .isEqualTo(SearchMetadata.generateSearchContextSnapshotId(snapshotId, "localhost"));
 
     // mark the chunk for eviction
+    CacheSlotMetadata cacheSlotMetadata =
+        cacheSlotMetadataStore.getSync(searchContext.hostname, readOnlyChunk.slotId);
     cacheSlotMetadataStore
-        .getAndUpdateNonFreeCacheSlotState(
-            searchContext.hostname,
-            readOnlyChunk.slotId,
-            Metadata.CacheSlotMetadata.CacheSlotState.EVICT)
+        .updateNonFreeCacheSlotState(
+            cacheSlotMetadata, Metadata.CacheSlotMetadata.CacheSlotState.EVICT)
         .get(1, TimeUnit.SECONDS);
 
     // ensure that the evicted chunk was released

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStoreTest.java
@@ -58,7 +58,7 @@ public class CacheSlotMetadataStoreTest {
   }
 
   @Test
-  public void testGetAndUpdateNonFreeCacheSlotStateSync() throws Exception {
+  public void testUpdateNonFreeCacheSlotStateSync() throws Exception {
     final String name = "slot1";
     final String hostname = "hostname";
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState = CacheSlotState.ASSIGNED;
@@ -79,7 +79,7 @@ public class CacheSlotMetadataStoreTest {
     assertThat(KaldbMetadataTestUtils.listSyncUncached(store).size()).isEqualTo(1);
 
     store
-        .getAndUpdateNonFreeCacheSlotState(hostname, name, CacheSlotState.LIVE)
+        .updateNonFreeCacheSlotState(cacheSlotMetadata, CacheSlotState.LIVE)
         .get(1, TimeUnit.SECONDS);
     await()
         .until(
@@ -94,7 +94,7 @@ public class CacheSlotMetadataStoreTest {
     assertThat(liveNode.supportedIndexTypes).isEqualTo(SUPPORTED_INDEX_TYPES);
 
     store
-        .getAndUpdateNonFreeCacheSlotState(hostname, name, CacheSlotState.EVICT)
+        .updateNonFreeCacheSlotState(cacheSlotMetadata, CacheSlotState.EVICT)
         .get(1, TimeUnit.SECONDS);
     await()
         .until(
@@ -109,7 +109,7 @@ public class CacheSlotMetadataStoreTest {
     assertThat(evictNode.supportedIndexTypes).isEqualTo(SUPPORTED_INDEX_TYPES);
 
     store
-        .getAndUpdateNonFreeCacheSlotState(hostname, name, CacheSlotState.FREE)
+        .updateNonFreeCacheSlotState(cacheSlotMetadata, CacheSlotState.FREE)
         .get(1, TimeUnit.SECONDS);
     await()
         .until(
@@ -128,7 +128,7 @@ public class CacheSlotMetadataStoreTest {
         .isThrownBy(
             () ->
                 store
-                    .getAndUpdateNonFreeCacheSlotState(hostname, name, CacheSlotState.ASSIGNED)
+                    .updateNonFreeCacheSlotState(freeNode, CacheSlotState.ASSIGNED)
                     .get(1, TimeUnit.SECONDS));
   }
 


### PR DESCRIPTION
###  Summary

This addresses an issue with the cache nodes where switching to a cached ZK store resulted in stale data within a method call. This was then breaking the logic around the state machine, causing unexpected exceptions.

I've replaced the `getAndUpdateNonFreeCacheSlotState` method with `updateNonFreeCacheSlotState`, which takes a cache slot metadata as an argument and no longer does the lookup internally. This allows us to utilize the slot metadata from the event callback instead of attempting to lookup a slot, which frequently was returning an older cached state.

This also addresses an event amplification in ZK events depending on if they were added before or after the original store initialization. 