### PR TITLE
Zipkin service will look back 24h instead of 2h for requests

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreImpl.java
@@ -62,8 +62,6 @@ public class LuceneIndexStoreImpl implements LogStore<LogMessage> {
   private final io.micrometer.core.instrument.Timer commitsTimer;
   private final io.micrometer.core.instrument.Timer refreshesTimer;
 
-  private final String MAX_RAM_BUFFER_SIZE_MB = "maxRamBufferSizeMb";
-
   // TODO: Set the policy via a lucene config file.
   public static LuceneIndexStoreImpl makeLogStore(
       File dataDirectory, KaldbConfigs.LuceneConfig luceneConfig, MeterRegistry metricsRegistry)
@@ -150,14 +148,10 @@ public class LuceneIndexStoreImpl implements LogStore<LogMessage> {
       SnapshotDeletionPolicy snapshotDeletionPolicy,
       LuceneIndexStoreConfig config,
       MeterRegistry metricsRegistry) {
-    int ramBufferSizeMb = Integer.getInteger(MAX_RAM_BUFFER_SIZE_MB, 1024);
-    boolean useCFSFiles = ramBufferSizeMb <= 128;
     final IndexWriterConfig indexWriterCfg =
         new IndexWriterConfig(analyzer)
             .setOpenMode(IndexWriterConfig.OpenMode.CREATE)
             .setMergeScheduler(new KalDBMergeScheduler(metricsRegistry))
-            .setRAMBufferSizeMB(ramBufferSizeMb)
-            .setUseCompoundFile(useCFSFiles)
             // we sort by timestamp descending, as that is the order we expect to return results the
             // majority of the time
             .setIndexSort(
@@ -167,12 +161,6 @@ public class LuceneIndexStoreImpl implements LogStore<LogMessage> {
                         SortField.Type.LONG,
                         true)))
             .setIndexDeletionPolicy(snapshotDeletionPolicy);
-
-    // See
-    // https://lucene.apache.org/core/9_5_0/core/org/apache/lucene/index/IndexWriterConfig.html#setUseCompoundFile(boolean)
-    if (ramBufferSizeMb >= 128) {
-      indexWriterCfg.getMergePolicy().setNoCFSRatio(0.0);
-    }
 
     if (config.enableTracing) {
       indexWriterCfg.setInfoStream(System.out);

--- a/kaldb/src/main/java/com/slack/kaldb/server/ZipkinService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ZipkinService.java
@@ -158,7 +158,7 @@ public class ZipkinService {
   }
 
   private static final Logger LOG = LoggerFactory.getLogger(ZipkinService.class);
-  private static long LOOKBACK_MINS = 60 * 2;
+  private static long LOOKBACK_MINS = 60 * 24;
 
   private static final int MAX_SPANS = 20_000;
 


### PR DESCRIPTION
###  Summary

Zipkin service will look back 24h instead of 2h for requests

Currently we support 24h retention queries. Increasing zipkin lookback will improve the user experience
