### PR TITLE
Add index searcher reference for opensearch query optimization

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/LogIndexSearcherImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/LogIndexSearcherImpl.java
@@ -105,14 +105,14 @@ public class LogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
 
     Stopwatch elapsedTime = Stopwatch.createStarted();
     try {
-      Query query =
-          openSearchAdapter.buildQuery(dataset, queryStr, startTimeMsEpoch, endTimeMsEpoch);
-      span.tag("lucene_query", query.toString());
-
       // Acquire an index searcher from searcher manager.
       // This is a useful optimization for indexes that are static.
-
       IndexSearcher searcher = searcherManager.acquire();
+
+      Query query =
+          openSearchAdapter.buildQuery(
+              dataset, queryStr, startTimeMsEpoch, endTimeMsEpoch, searcher);
+      span.tag("lucene_query", query.toString());
       try {
         List<LogMessage> results;
         InternalAggregation internalAggregation = null;


### PR DESCRIPTION
###  Summary

Refactors code such that the opensearch adapter can make use of the index searcher for query optimizations.