### PR TITLE
Register timestamp field as a date

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/opensearch/OpenSearchAdapter.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/opensearch/OpenSearchAdapter.java
@@ -205,7 +205,11 @@ public class OpenSearchAdapter {
     //  this needs to be adapted to include other field types once we have support
     for (Map.Entry<String, LuceneFieldDef> entry : chunkSchema.entrySet()) {
       try {
-        if (entry.getValue().fieldType == FieldType.TEXT) {
+        // currently Kaldb doesn't have support for date fields
+        // This is a quick workaround to ensure we can do data range queries on the timestamp field
+        if (entry.getValue().name.equals(LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName)) {
+          tryRegisterField(mapperService, entry.getValue().name, b -> b.field("type", "date"));
+        } else if (entry.getValue().fieldType == FieldType.TEXT) {
           tryRegisterField(mapperService, entry.getValue().name, b -> b.field("type", "text"));
         } else if (entry.getValue().fieldType == FieldType.STRING) {
           tryRegisterField(mapperService, entry.getValue().name, b -> b.field("type", "keyword"));

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/opensearch/OpenSearchQueryParserTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/opensearch/OpenSearchQueryParserTest.java
@@ -1,0 +1,45 @@
+package com.slack.kaldb.logstore.opensearch;
+
+import static com.slack.kaldb.testlib.MessageUtil.TEST_DATASET_NAME;
+import static com.slack.kaldb.testlib.MessageUtil.makeMessageWithIndexAndTimestamp;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import brave.Tracing;
+import com.slack.kaldb.logstore.LogMessage;
+import com.slack.kaldb.logstore.search.SearchResult;
+import com.slack.kaldb.testlib.TemporaryLogStoreAndSearcherExtension;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class OpenSearchQueryParserTest {
+
+  @RegisterExtension
+  public TemporaryLogStoreAndSearcherExtension logStoreAndSearcherRule =
+      new TemporaryLogStoreAndSearcherExtension(false);
+
+  public OpenSearchQueryParserTest() throws IOException {
+    Tracing.newBuilder().build();
+  }
+
+  @Test
+  public void testRangeQueryOnTimestampField() {
+    Instant time = Instant.now();
+    Instant timeMinus5 = time.minus(5, ChronoUnit.MINUTES);
+    logStoreAndSearcherRule.logStore.addMessage(
+        makeMessageWithIndexAndTimestamp(3, "new document", TEST_DATASET_NAME, time));
+    logStoreAndSearcherRule.logStore.commit();
+    logStoreAndSearcherRule.logStore.refresh();
+    SearchResult<LogMessage> results =
+        logStoreAndSearcherRule.logSearcher.search(
+            "dataset",
+            "_timesinceepoch:[now-5m TO now+5m]",
+            timeMinus5.toEpochMilli(),
+            time.toEpochMilli(),
+            500,
+            null);
+    assertThat(results.hits.size()).isEqualTo(1);
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -1525,13 +1526,15 @@ public class LogIndexSearcherImplTest {
     assertThat(histogram.getBuckets().get(0).getDocCount()).isEqualTo(1);
     assertThat(histogram.getBuckets().get(1).getDocCount()).isEqualTo(1);
 
-    assertThat(
-            Long.parseLong(histogram.getBuckets().get(0).getKeyAsString()) >= time.toEpochMilli())
-        .isTrue();
-    assertThat(
-            Long.parseLong(histogram.getBuckets().get(1).getKeyAsString())
-                <= time.plusSeconds(10).toEpochMilli())
-        .isTrue();
+    DateTimeFormatter formatter = DateTimeFormatter.ISO_INSTANT;
+    long bucket1AsLong =
+        Instant.from(formatter.parse(histogram.getBuckets().get(0).getKeyAsString()))
+            .toEpochMilli();
+    long bucket2AsLong =
+        Instant.from(formatter.parse((histogram.getBuckets().get(1).getKeyAsString())))
+            .toEpochMilli();
+    assertThat(bucket1AsLong >= time.toEpochMilli()).isTrue();
+    assertThat(bucket2AsLong <= time.plusSeconds(10).toEpochMilli()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
###  Summary

Builds on top of https://github.com/slackhq/kaldb/pull/587 to ensure we can make date range queries work against the `_timesinceepoch` field.

This field is what Kaldb uses as it's timestamp field. Even though Kaldb doesn't support date fields, we can register this specific field as a date field within the open search adapter. This will allow us to do range queries on the timestamp field.


We currently for the mapping API return `_timesinceepoch` as a date anyways
```
    // todo - remove this after we add support for a "date" type
    // override the timestamp as a date field for proper autocomplete
    propertiesMap.put(LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName, Map.of("type", "date"));
```