### PR TITLE
sample nodes to query while fetching schema

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
@@ -92,8 +91,6 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase implemen
 
   private final KaldbMetadataStoreChangeListener<SearchMetadata> searchMetadataListener =
       (searchMetadata) -> updateStubs();
-
-  private final Random random = new Random();
 
   // For now we will use SearchMetadataStore to populate servers
   // But this is wasteful since we add snapshots more often than we add/remove nodes ( hopefully )

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
@@ -471,10 +471,11 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase implemen
 
     List<ListenableFuture<KaldbSearch.SchemaResult>> queryServers = new ArrayList<>(stubs.size());
 
+    int count = 0;
     for (Map.Entry<String, List<String>> searchNode : nodesAndSnapshotsToQuery.entrySet()) {
-      // Sample about 1/10th of the nodes if number of nodes is more than 10
-      if (nodesAndSnapshotsToQuery.size() > 10 && random.nextInt(10) != 0) {
-        continue;
+      // limit to 5 nodes
+      if (count++ > 5) {
+        break;
       }
       KaldbServiceGrpc.KaldbServiceFutureStub stub = getStub(searchNode.getKey());
       if (stub == null) {

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
@@ -514,6 +514,7 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase implemen
       LOG.error(
           "Schema failed with timeout exception. This is potentially due to CPU saturation of the query node.",
           e);
+      span.error(e);
       return KaldbSearch.SchemaResult.newBuilder().build();
     } catch (Exception e) {
       LOG.error("Schema failed with ", e);

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
@@ -466,7 +466,11 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase implemen
         getNodesAndSnapshotsToQuery(searchMetadataNodesMatchingQuery);
 
     List<ListenableFuture<KaldbSearch.SchemaResult>> queryServers = new ArrayList<>(stubs.size());
+    int count = 0;
     for (Map.Entry<String, List<String>> searchNode : nodesAndSnapshotsToQuery.entrySet()) {
+      if (count++ > 5) {
+        break;
+      }
       KaldbServiceGrpc.KaldbServiceFutureStub stub = getStub(searchNode.getKey());
       if (stub == null) {
         // TODO: insert a failed result in the results object that we return from this method


### PR DESCRIPTION
###  Summary

hitting every indexer and cache node for schema is expensive and makes fetching this data very slow - In our production systems they timeout

~This PR is adding sampling. I went with sampling rather than a fixed count to be able to hit some index and some cache nodes~

Limit to 5
