### PR TITLE
pass index sort to the open search adapter

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/opensearch/OpenSearchAdapter.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/opensearch/OpenSearchAdapter.java
@@ -330,6 +330,13 @@ public class OpenSearchAdapter {
             .put(IndexMetadata.SETTING_VERSION_CREATED, Version.V_2_7_0)
             .put(
                 MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey(), TOTAL_FIELDS_LIMIT)
+
+            // Kaldb time sorts the indexes while building it
+            // {LuceneIndexStoreImpl#buildIndexWriterConfig}
+            // When we were using the lucene query parser the sort info was leveraged by lucene
+            // automatically ( as the sort info persists in the segment info ) at query time.
+            // However the OpenSearch query parser has a custom implementation which relies on the
+            // index sort info to be present as a setting here.
             .put("index.sort.field", LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName)
             .put("index.sort.order", "desc")
             .build();

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/opensearch/OpenSearchAdapter.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/opensearch/OpenSearchAdapter.java
@@ -330,6 +330,8 @@ public class OpenSearchAdapter {
             .put(IndexMetadata.SETTING_VERSION_CREATED, Version.V_2_7_0)
             .put(
                 MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey(), TOTAL_FIELDS_LIMIT)
+            .put("index.sort.field", LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName)
+            .put("index.sort.order", "desc")
             .build();
     return new IndexSettings(
         IndexMetadata.builder("index").settings(settings).build(), Settings.EMPTY);


### PR DESCRIPTION
###  Summary

We want to pass the index sort to the open search adapter. That way it is aware of it and when it rewrites the query is able to leverage this info

![Screenshot 2023-06-27 at 4 51 36 PM](https://github.com/slackhq/kaldb/assets/158041/f77eea70-0d88-4045-bdb3-00f38c936985)
