### PR TITLE
use string fields for reserved "texty" fields

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
@@ -51,67 +51,42 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder<LogMes
   private static ImmutableMap<String, LuceneFieldDef> getDefaultLuceneFieldDefinitions(
       boolean enableFullTextSearch) {
     ImmutableMap.Builder<String, LuceneFieldDef> fieldDefBuilder = ImmutableMap.builder();
+
     addTextField(fieldDefBuilder, LogMessage.SystemField.SOURCE.fieldName, true, false);
+    addTextField(fieldDefBuilder, LogMessage.ReservedField.MESSAGE.fieldName, false, true);
     if (enableFullTextSearch) {
       addTextField(fieldDefBuilder, LogMessage.SystemField.ALL.fieldName, false, true);
     }
-    fieldDefBuilder.put(
-        LogMessage.SystemField.ID.fieldName,
-        new LuceneFieldDef(
-            LogMessage.SystemField.ID.fieldName, FieldType.STRING.name, false, true, true));
-    fieldDefBuilder.put(
-        LogMessage.SystemField.INDEX.fieldName,
-        new LuceneFieldDef(
-            LogMessage.SystemField.INDEX.fieldName, FieldType.TEXT.name, false, true, false));
 
-    fieldDefBuilder.put(
-        LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName,
-        new LuceneFieldDef(
-            LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName,
-            FieldType.LONG.name,
-            false,
-            true,
-            true));
-    fieldDefBuilder.put(
-        LogMessage.ReservedField.TYPE.fieldName,
-        new LuceneFieldDef(
-            LogMessage.ReservedField.TYPE.fieldName, FieldType.STRING.name, false, true, true));
+    String[] fieldsAsString = {
+      LogMessage.SystemField.ID.fieldName,
+      LogMessage.SystemField.INDEX.fieldName,
+      LogMessage.ReservedField.TYPE.fieldName,
+      LogMessage.ReservedField.HOSTNAME.fieldName,
+      LogMessage.ReservedField.PACKAGE.fieldName,
+      LogMessage.ReservedField.TAG.fieldName,
+      LogMessage.ReservedField.USERNAME.fieldName,
+      LogMessage.ReservedField.PAYLOAD.fieldName,
+      LogMessage.ReservedField.NAME.fieldName,
+      LogMessage.ReservedField.SERVICE_NAME.fieldName,
+      LogMessage.ReservedField.TRACE_ID.fieldName,
+      LogMessage.ReservedField.PARENT_ID.fieldName
+    };
 
-    addTextField(fieldDefBuilder, LogMessage.ReservedField.HOSTNAME.fieldName, false, true);
-    addTextField(fieldDefBuilder, LogMessage.ReservedField.PACKAGE.fieldName, false, true);
-    addTextField(fieldDefBuilder, LogMessage.ReservedField.MESSAGE.fieldName, false, true);
-    addTextField(fieldDefBuilder, LogMessage.ReservedField.TAG.fieldName, false, true);
-    addTextField(fieldDefBuilder, LogMessage.ReservedField.USERNAME.fieldName, false, true);
-    addTextField(fieldDefBuilder, LogMessage.ReservedField.PAYLOAD.fieldName, false, true);
-    addTextField(fieldDefBuilder, LogMessage.ReservedField.NAME.fieldName, false, true);
-    fieldDefBuilder.put(
-        LogMessage.ReservedField.SERVICE_NAME.fieldName,
-        new LuceneFieldDef(
-            LogMessage.ReservedField.SERVICE_NAME.fieldName,
-            FieldType.STRING.name,
-            false,
-            true,
-            true));
-    fieldDefBuilder.put(
-        LogMessage.ReservedField.DURATION_MS.fieldName,
-        new LuceneFieldDef(
-            LogMessage.ReservedField.DURATION_MS.fieldName,
-            FieldType.LONG.name,
-            false,
-            true,
-            true));
-    fieldDefBuilder.put(
-        LogMessage.ReservedField.TRACE_ID.fieldName,
-        new LuceneFieldDef(
-            LogMessage.ReservedField.TRACE_ID.fieldName, FieldType.STRING.name, false, true, true));
-    fieldDefBuilder.put(
-        LogMessage.ReservedField.PARENT_ID.fieldName,
-        new LuceneFieldDef(
-            LogMessage.ReservedField.PARENT_ID.fieldName,
-            FieldType.STRING.name,
-            false,
-            true,
-            true));
+    for (String fieldName : fieldsAsString) {
+      fieldDefBuilder.put(
+          fieldName, new LuceneFieldDef(fieldName, FieldType.STRING.name, false, true, true));
+    }
+
+    String[] fieldsAsLong = {
+      LogMessage.ReservedField.DURATION_MS.fieldName,
+      LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName,
+    };
+
+    for (String fieldName : fieldsAsLong) {
+      fieldDefBuilder.put(
+          fieldName, new LuceneFieldDef(fieldName, FieldType.LONG.name, false, true, true));
+    }
 
     return fieldDefBuilder.build();
   }

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
@@ -261,7 +261,7 @@ public class LuceneIndexStoreImplTest {
       logStore.logStore.refresh();
 
       Collection<LogMessage> results =
-          findAllMessages(logStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "tag:foo", 1000);
+          findAllMessages(logStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "tag:foo-bar", 1000);
       assertThat(results.size()).isEqualTo(1);
 
       Collection<LogMessage> results2 =
@@ -287,19 +287,9 @@ public class LuceneIndexStoreImplTest {
               logStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "hostname:abc", 1000);
       assertThat(results5.size()).isEqualTo(0);
 
-      Collection<LogMessage> results6 =
-          findAllMessages(
-              logStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "hostname:abc.com", 1000);
-      assertThat(results6.size()).isEqualTo(1);
-
-      Collection<LogMessage> results7 =
-          findAllMessages(
-              logStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "hostname:host1-dc2", 1000);
-      assertThat(results7.size()).isEqualTo(1);
-
       Collection<LogMessage> results8 =
           findAllMessages(
-              logStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "hostname:com.abc", 1000);
+              logStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "hostname:abc.com", 1000);
       assertThat(results8.size()).isEqualTo(0);
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, logStore.metricsRegistry)).isEqualTo(1);

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/schema/ConvertFieldValueAndDuplicateTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/schema/ConvertFieldValueAndDuplicateTest.java
@@ -69,7 +69,7 @@ public class ConvertFieldValueAndDuplicateTest {
                     Map.of("leaf2", "value2", "leaf21", 3, "nestedList", List.of(1)))));
 
     Document testDocument = docBuilder.fromMessage(message);
-    assertThat(testDocument.getFields().size()).isEqualTo(22);
+    assertThat(testDocument.getFields().size()).isEqualTo(23);
     assertThat(docBuilder.getSchema().size()).isEqualTo(23);
     assertThat(docBuilder.getSchema().keySet())
         .containsAll(
@@ -125,7 +125,7 @@ public class ConvertFieldValueAndDuplicateTest {
                     Map.of("leaf2", "value2", "leaf21", 3, "nestedList", List.of(1)))));
 
     Document testDocument = docBuilder.fromMessage(message);
-    assertThat(testDocument.getFields().size()).isEqualTo(21);
+    assertThat(testDocument.getFields().size()).isEqualTo(22);
     assertThat(docBuilder.getSchema().size()).isEqualTo(22);
     assertThat(docBuilder.getSchema().keySet())
         .containsAll(
@@ -177,7 +177,7 @@ public class ConvertFieldValueAndDuplicateTest {
                 "1"));
 
     Document msg1Doc = convertFieldBuilder.fromMessage(msg1);
-    assertThat(msg1Doc.getFields().size()).isEqualTo(14);
+    assertThat(msg1Doc.getFields().size()).isEqualTo(17);
     assertThat(
             msg1Doc.getFields().stream()
                 .filter(f -> f.name().equals(conflictingFieldName))
@@ -207,7 +207,7 @@ public class ConvertFieldValueAndDuplicateTest {
                 conflictingFieldName,
                 1));
     Document msg2Doc = convertFieldBuilder.fromMessage(msg2);
-    assertThat(msg2Doc.getFields().size()).isEqualTo(16);
+    assertThat(msg2Doc.getFields().size()).isEqualTo(19);
     String additionalCreatedFieldName = makeNewFieldOfType(conflictingFieldName, FieldType.INTEGER);
     // Value converted and new field is added.
     assertThat(
@@ -272,7 +272,7 @@ public class ConvertFieldValueAndDuplicateTest {
                 true));
 
     Document msg1Doc = convertFieldBuilder.fromMessage(msg1);
-    assertThat(msg1Doc.getFields().size()).isEqualTo(14);
+    assertThat(msg1Doc.getFields().size()).isEqualTo(17);
     assertThat(
             msg1Doc.getFields().stream()
                 .filter(f -> f.name().equals(conflictingFieldName))
@@ -302,7 +302,7 @@ public class ConvertFieldValueAndDuplicateTest {
                 conflictingFieldName,
                 "random"));
     Document msg2Doc = convertFieldBuilder.fromMessage(msg2);
-    assertThat(msg2Doc.getFields().size()).isEqualTo(16);
+    assertThat(msg2Doc.getFields().size()).isEqualTo(19);
     String additionalCreatedFieldName = makeNewFieldOfType(conflictingFieldName, FieldType.STRING);
     // Value converted and new field is added.
     assertThat(
@@ -360,7 +360,7 @@ public class ConvertFieldValueAndDuplicateTest {
                 additionalCreatedFieldName,
                 true));
     Document msg3Doc = convertFieldBuilder.fromMessage(msg3);
-    assertThat(msg3Doc.getFields().size()).isEqualTo(16);
+    assertThat(msg3Doc.getFields().size()).isEqualTo(19);
     assertThat(
             msg3Doc.getFields().stream()
                 .filter(
@@ -415,7 +415,7 @@ public class ConvertFieldValueAndDuplicateTest {
                 "1"));
 
     Document msg1Doc = convertFieldBuilder.fromMessage(msg1);
-    assertThat(msg1Doc.getFields().size()).isEqualTo(14);
+    assertThat(msg1Doc.getFields().size()).isEqualTo(17);
     assertThat(
             msg1Doc.getFields().stream()
                 .filter(f -> f.name().equals(conflictingFieldName))
@@ -446,7 +446,7 @@ public class ConvertFieldValueAndDuplicateTest {
                 conflictingFieldName,
                 conflictingFloatValue));
     Document msg2Doc = convertFieldBuilder.fromMessage(msg2);
-    assertThat(msg2Doc.getFields().size()).isEqualTo(16);
+    assertThat(msg2Doc.getFields().size()).isEqualTo(19);
     String additionalCreatedFieldName = makeNewFieldOfType(conflictingFieldName, FieldType.FLOAT);
     // Value converted and new field is added.
     assertThat(
@@ -516,7 +516,7 @@ public class ConvertFieldValueAndDuplicateTest {
                     Map.of("leaf2", "value2", "leaf21", 3, "nestedList", List.of(1)))));
 
     Document testDocument1 = docBuilder.fromMessage(msg1);
-    final int expectedDocFieldsAfterMsg1 = 22;
+    final int expectedDocFieldsAfterMsg1 = 23;
     assertThat(testDocument1.getFields().size()).isEqualTo(expectedDocFieldsAfterMsg1);
     final int expectedFieldsAfterMsg1 = 23;
     assertThat(docBuilder.getSchema().size()).isEqualTo(expectedFieldsAfterMsg1);
@@ -627,7 +627,7 @@ public class ConvertFieldValueAndDuplicateTest {
                     Map.of("leaf2", "value2", "leaf21", 3, "nestedList", List.of(1)))));
 
     Document testDocument1 = docBuilder.fromMessage(msg1);
-    final int expectedDocFieldsAfterMsg1 = 22;
+    final int expectedDocFieldsAfterMsg1 = 23;
     assertThat(testDocument1.getFields().size()).isEqualTo(expectedDocFieldsAfterMsg1);
     final int expectedFieldsAfterMsg1 = 23;
     assertThat(docBuilder.getSchema().size()).isEqualTo(expectedFieldsAfterMsg1);

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/schema/ConvertFieldValueTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/schema/ConvertFieldValueTest.java
@@ -60,7 +60,7 @@ public class ConvertFieldValueTest {
                 "1"));
 
     Document msg1Doc = convertFieldBuilder.fromMessage(msg1);
-    assertThat(msg1Doc.getFields().size()).isEqualTo(14);
+    assertThat(msg1Doc.getFields().size()).isEqualTo(17);
     assertThat(
             msg1Doc.getFields().stream()
                 .filter(f -> f.name().equals(conflictingFieldName))
@@ -90,7 +90,7 @@ public class ConvertFieldValueTest {
                 conflictingFieldName,
                 1));
     Document msg2Doc = convertFieldBuilder.fromMessage(msg2);
-    assertThat(msg2Doc.getFields().size()).isEqualTo(14);
+    assertThat(msg2Doc.getFields().size()).isEqualTo(17);
     // Value is converted for conflicting field.
     assertThat(
             msg2Doc.getFields().stream()
@@ -148,7 +148,7 @@ public class ConvertFieldValueTest {
                     Map.of("leaf2", "value2", "leaf21", 3, "nestedList", List.of(1)))));
 
     Document testDocument1 = docBuilder.fromMessage(msg1);
-    final int expectedDocFieldsAfterMsg1 = 22;
+    final int expectedDocFieldsAfterMsg1 = 23;
     assertThat(testDocument1.getFields().size()).isEqualTo(expectedDocFieldsAfterMsg1);
     final int expectedFieldsAfterMsg1 = 23;
     assertThat(docBuilder.getSchema().size()).isEqualTo(expectedFieldsAfterMsg1);

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/schema/DropPolicyTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/schema/DropPolicyTest.java
@@ -44,7 +44,7 @@ public class DropPolicyTest {
     assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
     final LogMessage message = MessageUtil.makeMessage(0);
     Document testDocument = docBuilder.fromMessage(message);
-    assertThat(testDocument.getFields().size()).isEqualTo(20);
+    assertThat(testDocument.getFields().size()).isEqualTo(21);
     assertThat(docBuilder.getSchema().size()).isEqualTo(22);
     assertThat(docBuilder.getSchema().keySet())
         .containsAll(
@@ -62,12 +62,13 @@ public class DropPolicyTest {
                             && f instanceof SortedDocValuesField)
                 .count())
         .isEqualTo(1);
-    assertThat(docBuilder.getSchema().get("_index").fieldType.name).isEqualTo(FieldType.TEXT.name);
+    assertThat(docBuilder.getSchema().get("_index").fieldType.name)
+        .isEqualTo(FieldType.STRING.name);
     assertThat(
             testDocument.getFields().stream()
                 .filter(f -> f.name().equals("_index") && f instanceof SortedDocValuesField)
                 .count())
-        .isZero();
+        .isEqualTo(1);
     assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
     assertThat(
             testDocument.getFields().stream()
@@ -89,7 +90,7 @@ public class DropPolicyTest {
         .doesNotContain(LogMessage.SystemField.ALL.fieldName);
     final LogMessage message = MessageUtil.makeMessage(0);
     Document testDocument = docBuilder.fromMessage(message);
-    assertThat(testDocument.getFields().size()).isEqualTo(19);
+    assertThat(testDocument.getFields().size()).isEqualTo(20);
     assertThat(docBuilder.getSchema().size()).isEqualTo(21);
     assertThat(docBuilder.getSchema().keySet())
         .containsAll(
@@ -107,12 +108,13 @@ public class DropPolicyTest {
                             && f instanceof SortedDocValuesField)
                 .count())
         .isEqualTo(1);
-    assertThat(docBuilder.getSchema().get("_index").fieldType.name).isEqualTo(FieldType.TEXT.name);
+    assertThat(docBuilder.getSchema().get("_index").fieldType.name)
+        .isEqualTo(FieldType.STRING.name);
     assertThat(
             testDocument.getFields().stream()
                 .filter(f -> f.name().equals("_index") && f instanceof SortedDocValuesField)
                 .count())
-        .isZero();
+        .isEqualTo(1);
     assertThat(docBuilder.getSchema().keySet())
         .doesNotContain(LogMessage.SystemField.ALL.fieldName);
     assertThat(
@@ -150,7 +152,7 @@ public class DropPolicyTest {
                 Map.of("nested1", "value1", "nested2", 2)));
 
     Document testDocument = docBuilder.fromMessage(message);
-    assertThat(testDocument.getFields().size()).isEqualTo(18);
+    assertThat(testDocument.getFields().size()).isEqualTo(19);
     assertThat(docBuilder.getSchema().size()).isEqualTo(21);
     assertThat(docBuilder.getSchema().keySet())
         .containsAll(
@@ -201,7 +203,7 @@ public class DropPolicyTest {
                         Map.of("nested31", 31, "nested32", Map.of("nested41", 41))))));
 
     Document testDocument = docBuilder.fromMessage(message);
-    assertThat(testDocument.getFields().size()).isEqualTo(24);
+    assertThat(testDocument.getFields().size()).isEqualTo(25);
     assertThat(docBuilder.getSchema().size()).isEqualTo(24);
     assertThat(docBuilder.getSchema().keySet())
         .containsAll(
@@ -253,7 +255,7 @@ public class DropPolicyTest {
                 Map.of("leaf1", "value1", "nested", Map.of("leaf2", "value2", "leaf21", 3))));
 
     Document testDocument = docBuilder.fromMessage(message);
-    assertThat(testDocument.getFields().size()).isEqualTo(18);
+    assertThat(testDocument.getFields().size()).isEqualTo(19);
     assertThat(docBuilder.getSchema().size()).isEqualTo(21);
     assertThat(docBuilder.getSchema().keySet())
         .containsAll(
@@ -296,7 +298,7 @@ public class DropPolicyTest {
                 Map.of("leaf1", "value1", "nested", Map.of("leaf2", "value2", "leaf21", 3))));
 
     Document testDocument = docBuilder.fromMessage(message);
-    assertThat(testDocument.getFields().size()).isEqualTo(17);
+    assertThat(testDocument.getFields().size()).isEqualTo(18);
     assertThat(docBuilder.getSchema().size()).isEqualTo(20);
     assertThat(docBuilder.getSchema().keySet())
         .containsAll(
@@ -341,7 +343,7 @@ public class DropPolicyTest {
                 "1"));
 
     Document msg1Doc = docBuilder.fromMessage(msg1);
-    assertThat(msg1Doc.getFields().size()).isEqualTo(14);
+    assertThat(msg1Doc.getFields().size()).isEqualTo(17);
     assertThat(
             msg1Doc.getFields().stream()
                 .filter(f -> f.name().equals(conflictingFieldName))
@@ -371,7 +373,7 @@ public class DropPolicyTest {
                 conflictingFieldName,
                 1));
     Document msg2Doc = docBuilder.fromMessage(msg2);
-    assertThat(msg2Doc.getFields().size()).isEqualTo(12);
+    assertThat(msg2Doc.getFields().size()).isEqualTo(15);
     // Conflicting field is dropped.
     assertThat(
             msg2Doc.getFields().stream()
@@ -417,7 +419,7 @@ public class DropPolicyTest {
                     Map.of("leaf2", "value2", "leaf21", 3, "nestedList", List.of(1)))));
 
     Document testDocument = docBuilder.fromMessage(message);
-    final int expectedFieldsInDocumentAfterMesssage = 22;
+    final int expectedFieldsInDocumentAfterMesssage = 23;
     assertThat(testDocument.getFields().size()).isEqualTo(expectedFieldsInDocumentAfterMesssage);
     final int fieldCountAfterIndexingFirstDocument = 23;
     assertThat(docBuilder.getSchema().size()).isEqualTo(fieldCountAfterIndexingFirstDocument);

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/schema/RaiseErrorFieldValueTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/schema/RaiseErrorFieldValueTest.java
@@ -56,7 +56,7 @@ public class RaiseErrorFieldValueTest {
                 1));
 
     Document msg1Doc = docBuilder.fromMessage(msg1);
-    assertThat(msg1Doc.getFields().size()).isEqualTo(14);
+    assertThat(msg1Doc.getFields().size()).isEqualTo(17);
     assertThat(
             msg1Doc.getFields().stream()
                 .filter(f -> f.name().equals(conflictingFieldName))
@@ -120,7 +120,7 @@ public class RaiseErrorFieldValueTest {
     assertThat(docBuilder.getSchema().get(conflictingFieldName).fieldType)
         .isEqualTo(FieldType.INTEGER);
     assertThat(docBuilder.getSchema().get(LogMessage.ReservedField.HOSTNAME.fieldName).fieldType)
-        .isEqualTo(FieldType.TEXT);
+        .isEqualTo(FieldType.STRING);
 
     assertThat(MetricsUtil.getCount(DROP_FIELDS_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isZero();
@@ -140,7 +140,7 @@ public class RaiseErrorFieldValueTest {
     assertThat(docBuilder.getSchema().keySet()).contains(LogMessage.SystemField.ALL.fieldName);
     final String hostNameField = LogMessage.ReservedField.HOSTNAME.fieldName;
     assertThat(docBuilder.getSchema().keySet()).contains(hostNameField);
-    assertThat(docBuilder.getSchema().get(hostNameField).fieldType).isEqualTo(FieldType.TEXT);
+    assertThat(docBuilder.getSchema().get(hostNameField).fieldType).isEqualTo(FieldType.STRING);
 
     LogMessage msg1 =
         new LogMessage(
@@ -160,7 +160,7 @@ public class RaiseErrorFieldValueTest {
         .isInstanceOf(FieldDefMismatchException.class);
     assertThat(docBuilder.getSchema().size()).isEqualTo(17);
     assertThat(docBuilder.getSchema().keySet()).contains(hostNameField);
-    assertThat(docBuilder.getSchema().get(hostNameField).fieldType).isEqualTo(FieldType.TEXT);
+    assertThat(docBuilder.getSchema().get(hostNameField).fieldType).isEqualTo(FieldType.STRING);
     assertThat(MetricsUtil.getCount(DROP_FIELDS_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();
@@ -175,7 +175,7 @@ public class RaiseErrorFieldValueTest {
         .doesNotContain(LogMessage.SystemField.ALL.fieldName);
     final String hostNameField = LogMessage.ReservedField.HOSTNAME.fieldName;
     assertThat(docBuilder.getSchema().keySet()).contains(hostNameField);
-    assertThat(docBuilder.getSchema().get(hostNameField).fieldType).isEqualTo(FieldType.TEXT);
+    assertThat(docBuilder.getSchema().get(hostNameField).fieldType).isEqualTo(FieldType.STRING);
 
     LogMessage msg1 =
         new LogMessage(
@@ -195,7 +195,7 @@ public class RaiseErrorFieldValueTest {
         .isInstanceOf(FieldDefMismatchException.class);
     assertThat(docBuilder.getSchema().size()).isEqualTo(16);
     assertThat(docBuilder.getSchema().keySet()).contains(hostNameField);
-    assertThat(docBuilder.getSchema().get(hostNameField).fieldType).isEqualTo(FieldType.TEXT);
+    assertThat(docBuilder.getSchema().get(hostNameField).fieldType).isEqualTo(FieldType.STRING);
     assertThat(MetricsUtil.getCount(DROP_FIELDS_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();


### PR DESCRIPTION
###  Summary

Use string fields for "texty" reserved fields. We use string as the default for texty fields for new fields. That should be the case for reserved fields as well
