### PR TITLE
Update code-review.yml to use common ancestor and do not thumbs up

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
-      - uses: fxchen/code-review@v0.2.5-alpha
+      - uses: fxchen/code-review@v0.2.6-alpha
         with:
           model: 'gpt-3.5-turbo-16k'
           openai-key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
-      - uses: fxchen/code-review@v0.2.6-alpha
+      - uses: fxchen/code-review@v0.2.7-alpha
         with:
           model: 'gpt-3.5-turbo-16k'
           openai-key: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
###  Summary

Currently the code review tool uses the HEAD sha (`main`) instead of the PR ancestor. This results in code being reviewed that is unnecessary.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
