### PR TITLE
S3 CRT Client

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -32,6 +32,7 @@ s3Config:
   s3Region: ${S3_REGION:-us-east-1}
   s3EndPoint: ${S3_ENDPOINT:-http://localhost:9090}
   s3Bucket: ${S3_BUCKET:-test-s3-bucket}
+  s3TargetThroughputGbps: ${S3_TARGET_THROUGHPUT_GBPS:-25}
 
 tracingConfig:
   zipkinEndpoint: ${ZIPKIN_TRACING_ENDPOINT:-http://localhost:9411/api/v2/spans}

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -313,6 +313,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk.crt</groupId>
+            <artifactId>aws-crt</artifactId>
+            <version>0.22.1</version>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/kaldb/src/main/java/com/slack/kaldb/blobfs/s3/S3BlobFs.java
+++ b/kaldb/src/main/java/com/slack/kaldb/blobfs/s3/S3BlobFs.java
@@ -230,7 +230,7 @@ public class S3BlobFs extends BlobFs {
 
   @Override
   public boolean mkdir(URI uri) throws IOException {
-    LOG.info("mkdir {}", uri);
+    LOG.debug("mkdir {}", uri);
     try {
       Preconditions.checkNotNull(uri, "uri is null");
       String path = normalizeToDirectoryPrefix(uri);
@@ -253,7 +253,7 @@ public class S3BlobFs extends BlobFs {
 
   @Override
   public boolean delete(URI segmentUri, boolean forceDelete) throws IOException {
-    LOG.info("Deleting uri {} force {}", segmentUri, forceDelete);
+    LOG.debug("Deleting uri {} force {}", segmentUri, forceDelete);
     try {
       if (isDirectory(segmentUri)) {
         if (!forceDelete) {
@@ -316,7 +316,7 @@ public class S3BlobFs extends BlobFs {
 
   @Override
   public boolean copy(URI srcUri, URI dstUri) throws IOException {
-    LOG.info("Copying uri {} to uri {}", srcUri, dstUri);
+    LOG.debug("Copying uri {} to uri {}", srcUri, dstUri);
     Preconditions.checkState(exists(srcUri), "Source URI '%s' does not exist", srcUri);
     if (srcUri.equals(dstUri)) {
       return true;
@@ -415,7 +415,7 @@ public class S3BlobFs extends BlobFs {
         continuationToken = listObjectsV2Response.nextContinuationToken();
       }
       String[] listedFiles = builder.build().toArray(new String[0]);
-      LOG.info(
+      LOG.debug(
           "Listed {} files from URI: {}, is recursive: {}", listedFiles.length, fileUri, recursive);
       return listedFiles;
     } catch (Throwable t) {

--- a/kaldb/src/main/java/com/slack/kaldb/blobfs/s3/S3CrtBlobFs.java
+++ b/kaldb/src/main/java/com/slack/kaldb/blobfs/s3/S3CrtBlobFs.java
@@ -236,7 +236,7 @@ public class S3CrtBlobFs extends BlobFs {
 
   @Override
   public boolean mkdir(URI uri) throws IOException {
-    LOG.info("mkdir {}", uri);
+    LOG.debug("mkdir {}", uri);
     try {
       Preconditions.checkNotNull(uri, "uri is null");
       String path = normalizeToDirectoryPrefix(uri);
@@ -259,7 +259,7 @@ public class S3CrtBlobFs extends BlobFs {
 
   @Override
   public boolean delete(URI segmentUri, boolean forceDelete) throws IOException {
-    LOG.info("Deleting uri {} force {}", segmentUri, forceDelete);
+    LOG.debug("Deleting uri {} force {}", segmentUri, forceDelete);
     try {
       if (isDirectory(segmentUri)) {
         if (!forceDelete) {
@@ -324,7 +324,7 @@ public class S3CrtBlobFs extends BlobFs {
 
   @Override
   public boolean copy(URI srcUri, URI dstUri) throws IOException {
-    LOG.info("Copying uri {} to uri {}", srcUri, dstUri);
+    LOG.debug("Copying uri {} to uri {}", srcUri, dstUri);
     Preconditions.checkState(exists(srcUri), "Source URI '%s' does not exist", srcUri);
     if (srcUri.equals(dstUri)) {
       return true;
@@ -424,7 +424,7 @@ public class S3CrtBlobFs extends BlobFs {
         continuationToken = listObjectsV2Response.nextContinuationToken();
       }
       String[] listedFiles = builder.build().toArray(new String[0]);
-      LOG.info(
+      LOG.debug(
           "Listed {} files from URI: {}, is recursive: {}", listedFiles.length, fileUri, recursive);
       return listedFiles;
     } catch (Throwable t) {

--- a/kaldb/src/main/java/com/slack/kaldb/blobfs/s3/S3CrtBlobFs.java
+++ b/kaldb/src/main/java/com/slack/kaldb/blobfs/s3/S3CrtBlobFs.java
@@ -26,7 +26,6 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.regions.Region;
@@ -79,13 +78,9 @@ public class S3CrtBlobFs extends BlobFs {
         awsCredentialsProvider = DefaultCredentialsProvider.create();
       }
 
-      // TODO: Remove hard coded HTTP IMPL property setting by only having 1 http client on the
-      // classpath.
-      System.setProperty(
-          SdkSystemSetting.SYNC_HTTP_SERVICE_IMPL.property(),
-          "software.amazon.awssdk.http.apache.ApacheSdkHttpService");
       S3CrtAsyncClientBuilder s3AsyncClient =
           S3AsyncClient.crtBuilder()
+              .targetThroughputInGbps(config.getS3TargetThroughputGbps())
               .region(Region.of(region))
               .credentialsProvider(awsCredentialsProvider);
 

--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -4,7 +4,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.Service;
 import com.google.common.util.concurrent.ServiceManager;
 import com.slack.kaldb.blobfs.BlobFs;
-import com.slack.kaldb.blobfs.s3.S3BlobFs;
+import com.slack.kaldb.blobfs.s3.S3CrtBlobFs;
 import com.slack.kaldb.chunkManager.CachingChunkManager;
 import com.slack.kaldb.chunkManager.ChunkCleanerService;
 import com.slack.kaldb.chunkManager.IndexingChunkManager;
@@ -53,7 +53,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 /**
  * Main class of Kaldb that sets up the basic infra needed for all the other end points like an a
@@ -65,13 +65,13 @@ public class Kaldb {
   private final PrometheusMeterRegistry prometheusMeterRegistry;
 
   private final KaldbConfigs.KaldbConfig kaldbConfig;
-  private final S3Client s3Client;
+  private final S3AsyncClient s3Client;
   protected ServiceManager serviceManager;
   protected AsyncCuratorFramework curatorFramework;
 
   Kaldb(
       KaldbConfigs.KaldbConfig kaldbConfig,
-      S3Client s3Client,
+      S3AsyncClient s3Client,
       PrometheusMeterRegistry prometheusMeterRegistry) {
     this.prometheusMeterRegistry = prometheusMeterRegistry;
     this.kaldbConfig = kaldbConfig;
@@ -81,7 +81,7 @@ public class Kaldb {
   }
 
   Kaldb(KaldbConfigs.KaldbConfig kaldbConfig, PrometheusMeterRegistry prometheusMeterRegistry) {
-    this(kaldbConfig, S3BlobFs.initS3Client(kaldbConfig.getS3Config()), prometheusMeterRegistry);
+    this(kaldbConfig, S3CrtBlobFs.initS3Client(kaldbConfig.getS3Config()), prometheusMeterRegistry);
   }
 
   public static void main(String[] args) throws Exception {
@@ -130,7 +130,7 @@ public class Kaldb {
             prometheusMeterRegistry, kaldbConfig.getMetadataStoreConfig().getZookeeperConfig());
 
     // Initialize blobfs. Only S3 is supported currently.
-    S3BlobFs s3BlobFs = new S3BlobFs(s3Client);
+    S3CrtBlobFs s3BlobFs = new S3CrtBlobFs(s3Client);
 
     Set<Service> services =
         getServices(curatorFramework, kaldbConfig, s3BlobFs, prometheusMeterRegistry);

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -71,6 +71,7 @@ message S3Config {
   string s3_region = 3;
   string s3_end_point = 4;
   string s3_bucket = 5;
+  double s3_target_throughput_gbps = 6;
 }
 
 message TracingConfig {

--- a/kaldb/src/test/java/com/slack/kaldb/blobfs/s3/S3TestUtils.java
+++ b/kaldb/src/test/java/com/slack/kaldb/blobfs/s3/S3TestUtils.java
@@ -1,5 +1,11 @@
 package com.slack.kaldb.blobfs.s3;
 
+import java.net.URI;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.crt.S3CrtHttpConfiguration;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -24,5 +30,23 @@ public class S3TestUtils {
     }
 
     return listObjectsV2RequestBuilder.build();
+  }
+
+  /**
+   * Based off of S3_MOCK_EXTENSION.createS3ClientV2();
+   *
+   * @see com.adobe.testing.s3mock.testsupport.common.S3MockStarter
+   */
+  public static S3AsyncClient createS3CrtClient(String serviceEndpoint) {
+    return S3AsyncClient.crtBuilder()
+        .region(Region.of("us-east-1"))
+        .credentialsProvider(
+            StaticCredentialsProvider.create(AwsBasicCredentials.create("foo", "bar")))
+        .forcePathStyle(true)
+        .checksumValidationEnabled(false) // https://github.com/adobe/S3Mock/issues/1123
+        .endpointOverride(URI.create(serviceEndpoint))
+        .httpConfiguration(
+            S3CrtHttpConfiguration.builder().trustAllCertificatesEnabled(true).build())
+        .build();
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOf
 
 import brave.Tracing;
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
-import com.slack.kaldb.blobfs.s3.S3BlobFs;
+import com.slack.kaldb.blobfs.s3.S3CrtBlobFs;
 import com.slack.kaldb.blobfs.s3.S3TestUtils;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.logstore.LuceneIndexStoreImpl;
@@ -58,7 +58,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 
@@ -620,11 +620,12 @@ public class IndexingChunkImplTest {
 
       // create an S3 client for test
       String bucket = "invalid-bucket";
-      S3Client s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
-      S3BlobFs s3BlobFs = new S3BlobFs(s3Client);
+      S3AsyncClient s3AsyncClient =
+          S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
+      S3CrtBlobFs s3CrtBlobFs = new S3CrtBlobFs(s3AsyncClient);
 
       // Snapshot to S3 without creating the s3 bucket.
-      assertThat(chunk.snapshotToS3(bucket, "", s3BlobFs)).isFalse();
+      assertThat(chunk.snapshotToS3(bucket, "", s3CrtBlobFs)).isFalse();
       assertThat(chunk.info().getSnapshotPath()).isEqualTo(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
 
       // Metadata checks
@@ -681,13 +682,14 @@ public class IndexingChunkImplTest {
 
       // create an S3 client for test
       String bucket = "test-bucket-with-prefix";
-      S3Client s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
-      S3BlobFs s3BlobFs = new S3BlobFs(s3Client);
-      s3Client.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+      S3AsyncClient s3AsyncClient =
+          S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
+      S3CrtBlobFs s3CrtBlobFs = new S3CrtBlobFs(s3AsyncClient);
+      s3AsyncClient.createBucket(CreateBucketRequest.builder().bucket(bucket).build()).get();
 
       // Snapshot to S3
       assertThat(chunk.info().getSnapshotPath()).isEqualTo(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
-      assertThat(chunk.snapshotToS3(bucket, "", s3BlobFs)).isTrue();
+      assertThat(chunk.snapshotToS3(bucket, "", s3CrtBlobFs)).isTrue();
       assertThat(chunk.info().getSnapshotPath()).isNotEmpty();
 
       // depending on heap and CFS files this can be 5 or 19.
@@ -697,7 +699,7 @@ public class IndexingChunkImplTest {
 
       // Check schema file exists in s3
       ListObjectsV2Response objectsResponse =
-          s3Client.listObjectsV2(S3TestUtils.getListObjectRequest(bucket, "", true));
+          s3AsyncClient.listObjectsV2(S3TestUtils.getListObjectRequest(bucket, "", true)).get();
       assertThat(
               objectsResponse.contents().stream()
                   .filter(o -> o.key().equals(SCHEMA_FILE_NAME))

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
@@ -15,7 +15,8 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOf
 
 import brave.Tracing;
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
-import com.slack.kaldb.blobfs.s3.S3BlobFs;
+import com.slack.kaldb.blobfs.s3.S3CrtBlobFs;
+import com.slack.kaldb.blobfs.s3.S3TestUtils;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.logstore.LuceneIndexStoreImpl;
 import com.slack.kaldb.logstore.schema.SchemaAwareLogDocumentBuilderImpl;
@@ -52,7 +53,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 
 public class RecoveryChunkImplTest {
@@ -513,7 +514,7 @@ public class RecoveryChunkImplTest {
     private AsyncCuratorFramework curatorFramework;
     private SnapshotMetadataStore snapshotMetadataStore;
     private SearchMetadataStore searchMetadataStore;
-    private S3BlobFs s3BlobFs;
+    private S3CrtBlobFs s3CrtBlobFs;
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -566,8 +567,8 @@ public class RecoveryChunkImplTest {
       curatorFramework.unwrap().close();
       testingServer.close();
       registry.close();
-      if (s3BlobFs != null) {
-        s3BlobFs.close();
+      if (s3CrtBlobFs != null) {
+        s3CrtBlobFs.close();
       }
     }
 
@@ -606,11 +607,13 @@ public class RecoveryChunkImplTest {
 
       // create an S3 client for test
       String bucket = "invalid-bucket";
-      S3Client s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
-      s3BlobFs = new S3BlobFs(s3Client);
+
+      S3AsyncClient s3AsyncClient =
+          S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
+      s3CrtBlobFs = new S3CrtBlobFs(s3AsyncClient);
 
       // Snapshot to S3 without creating the s3 bucket.
-      assertThat(chunk.snapshotToS3(bucket, "", s3BlobFs)).isFalse();
+      assertThat(chunk.snapshotToS3(bucket, "", s3CrtBlobFs)).isFalse();
       assertThat(chunk.info().getSnapshotPath()).isEqualTo(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
 
       // No live snapshot or search metadata is published since the S3 snapshot failed.
@@ -655,13 +658,14 @@ public class RecoveryChunkImplTest {
 
       // create an S3 client for test
       String bucket = "test-bucket-with-prefix";
-      S3Client s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
-      S3BlobFs s3BlobFs = new S3BlobFs(s3Client);
-      s3Client.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+      S3AsyncClient s3AsyncClient =
+          S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
+      S3CrtBlobFs s3CrtBlobFs = new S3CrtBlobFs(s3AsyncClient);
+      s3AsyncClient.createBucket(CreateBucketRequest.builder().bucket(bucket).build()).get();
 
       // Snapshot to S3
       assertThat(chunk.info().getSnapshotPath()).isEqualTo(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
-      assertThat(chunk.snapshotToS3(bucket, "", s3BlobFs)).isTrue();
+      assertThat(chunk.snapshotToS3(bucket, "", s3CrtBlobFs)).isTrue();
       assertThat(chunk.info().getSnapshotPath()).isNotEmpty();
 
       // depending on heap and CFS files this can be 5 or 19.
@@ -677,7 +681,7 @@ public class RecoveryChunkImplTest {
           KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore);
       assertThat(afterSnapshots.size()).isEqualTo(1);
       assertThat(afterSnapshots).contains(ChunkInfo.toSnapshotMetadata(chunk.info(), ""));
-      assertThat(s3BlobFs.exists(URI.create(afterSnapshots.get(0).snapshotPath))).isTrue();
+      assertThat(s3CrtBlobFs.exists(URI.create(afterSnapshots.get(0).snapshotPath))).isTrue();
       // Only non-live snapshots. No live snapshots.
       assertThat(afterSnapshots.stream().filter(SnapshotMetadata::isLive).count()).isZero();
       // No search nodes are added for recovery chunk.

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/CachingChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/CachingChunkManagerTest.java
@@ -5,7 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
-import com.slack.kaldb.blobfs.s3.S3BlobFs;
+import com.slack.kaldb.blobfs.s3.S3CrtBlobFs;
+import com.slack.kaldb.blobfs.s3.S3TestUtils;
 import com.slack.kaldb.chunk.Chunk;
 import com.slack.kaldb.chunk.ReadOnlyChunkImpl;
 import com.slack.kaldb.chunk.SearchContext;
@@ -27,14 +28,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 public class CachingChunkManagerTest {
   private static final String TEST_S3_BUCKET = "caching-chunkmanager-test";
 
   private TestingServer testingServer;
   private MeterRegistry meterRegistry;
-  private S3BlobFs s3BlobFs;
+  private S3CrtBlobFs s3CrtBlobFs;
 
   @RegisterExtension
   public static final S3MockExtension S3_MOCK_EXTENSION =
@@ -52,8 +53,9 @@ public class CachingChunkManagerTest {
     meterRegistry = new SimpleMeterRegistry();
     testingServer = new TestingServer();
 
-    S3Client s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
-    s3BlobFs = new S3BlobFs(s3Client);
+    S3AsyncClient s3AsyncClient =
+        S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
+    s3CrtBlobFs = new S3CrtBlobFs(s3AsyncClient);
   }
 
   @AfterEach
@@ -65,7 +67,7 @@ public class CachingChunkManagerTest {
     if (curatorFramework != null) {
       curatorFramework.unwrap().close();
     }
-    s3BlobFs.close();
+    s3CrtBlobFs.close();
     testingServer.close();
     meterRegistry.close();
   }
@@ -112,7 +114,7 @@ public class CachingChunkManagerTest {
         new CachingChunkManager<>(
             meterRegistry,
             curatorFramework,
-            s3BlobFs,
+            s3CrtBlobFs,
             SearchContext.fromConfig(kaldbConfig.getCacheConfig().getServerConfig()),
             kaldbConfig.getS3Config().getS3Bucket(),
             kaldbConfig.getCacheConfig().getDataDirectory(),

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
@@ -22,7 +22,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import brave.Tracing;
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
-import com.slack.kaldb.blobfs.s3.S3BlobFs;
+import com.slack.kaldb.blobfs.s3.S3CrtBlobFs;
+import com.slack.kaldb.blobfs.s3.S3TestUtils;
 import com.slack.kaldb.chunk.ChunkInfo;
 import com.slack.kaldb.chunk.ReadWriteChunk;
 import com.slack.kaldb.logstore.LogMessage;
@@ -53,7 +54,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 public class RecoveryChunkManagerTest {
   // TODO: Ensure clean close after all chunks are uploaded.
@@ -74,10 +75,10 @@ public class RecoveryChunkManagerTest {
   private RecoveryChunkManager<LogMessage> chunkManager = null;
 
   private SimpleMeterRegistry metricsRegistry;
-  private S3Client s3Client;
+  private S3AsyncClient s3AsyncClient;
 
   private static final String ZK_PATH_PREFIX = "testZK";
-  private S3BlobFs s3BlobFs;
+  private S3CrtBlobFs s3CrtBlobFs;
   private TestingServer localZkServer;
   private AsyncCuratorFramework curatorFramework;
   private SearchMetadataStore searchMetadataStore;
@@ -88,8 +89,8 @@ public class RecoveryChunkManagerTest {
     Tracing.newBuilder().build();
     metricsRegistry = new SimpleMeterRegistry();
     // create an S3 client.
-    s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
-    s3BlobFs = new S3BlobFs(s3Client);
+    s3AsyncClient = S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
+    s3CrtBlobFs = new S3CrtBlobFs(s3AsyncClient);
 
     localZkServer = new TestingServer();
     localZkServer.start();
@@ -118,7 +119,7 @@ public class RecoveryChunkManagerTest {
     searchMetadataStore.close();
     snapshotMetadataStore.close();
     curatorFramework.unwrap().close();
-    s3Client.close();
+    s3AsyncClient.close();
     localZkServer.stop();
   }
 
@@ -147,7 +148,7 @@ public class RecoveryChunkManagerTest {
             searchMetadataStore,
             snapshotMetadataStore,
             kaldbCfg.getIndexerConfig(),
-            s3BlobFs,
+            s3CrtBlobFs,
             kaldbCfg.getS3Config());
     chunkManager.startAsync();
     chunkManager.awaitRunning(DEFAULT_START_STOP_DURATION);

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
@@ -19,7 +19,7 @@ import static org.awaitility.Awaitility.await;
 import brave.Tracing;
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
 import com.slack.kaldb.blobfs.LocalBlobFs;
-import com.slack.kaldb.blobfs.s3.S3BlobFs;
+import com.slack.kaldb.blobfs.s3.S3CrtBlobFs;
 import com.slack.kaldb.blobfs.s3.S3TestUtils;
 import com.slack.kaldb.logstore.LogMessage.ReservedField;
 import com.slack.kaldb.logstore.schema.SchemaAwareLogDocumentBuilderImpl;
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 
@@ -372,27 +372,30 @@ public class LuceneIndexStoreImplTest {
           .isGreaterThanOrEqualTo(activeFiles.size());
 
       // create an S3 client
-      S3Client s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
-      S3BlobFs s3BlobFs = new S3BlobFs(s3Client);
-      s3Client.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+      S3AsyncClient s3AsyncClient =
+          S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
+      S3CrtBlobFs s3CrtBlobFs = new S3CrtBlobFs(s3AsyncClient);
+      s3AsyncClient.createBucket(CreateBucketRequest.builder().bucket(bucket).build()).get();
 
       // Copy files to S3.
-      copyToS3(dirPath, activeFiles, bucket, prefix, s3BlobFs);
+      copyToS3(dirPath, activeFiles, bucket, prefix, s3CrtBlobFs);
 
       for (String fileName : activeFiles) {
         File fileToCopy = new File(dirPath.toString(), fileName);
         HeadObjectResponse headObjectResponse =
-            s3Client.headObject(
-                S3TestUtils.getHeadObjectRequest(
-                    bucket,
-                    prefix != null && !prefix.isEmpty()
-                        ? prefix + DELIMITER + fileName
-                        : fileName));
+            s3AsyncClient
+                .headObject(
+                    S3TestUtils.getHeadObjectRequest(
+                        bucket,
+                        prefix != null && !prefix.isEmpty()
+                            ? prefix + DELIMITER + fileName
+                            : fileName))
+                .get();
         assertThat(headObjectResponse.contentLength()).isEqualTo(fileToCopy.length());
       }
 
       // Download files from S3 to local FS.
-      String[] s3Files = copyFromS3(bucket, prefix, s3BlobFs, tmpPath.toAbsolutePath());
+      String[] s3Files = copyFromS3(bucket, prefix, s3CrtBlobFs, tmpPath.toAbsolutePath());
       assertThat(s3Files.length).isEqualTo(activeFiles.size());
 
       // Search files in local FS.
@@ -407,7 +410,7 @@ public class LuceneIndexStoreImplTest {
       // Clean up
       logStore.releaseIndexCommit(indexCommit);
       newSearcher.close();
-      s3BlobFs.close();
+      s3CrtBlobFs.close();
     }
 
     @Test

--- a/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
@@ -25,7 +25,8 @@ import brave.Tracing;
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
 import com.google.common.collect.Maps;
 import com.slack.kaldb.blobfs.BlobFs;
-import com.slack.kaldb.blobfs.s3.S3BlobFs;
+import com.slack.kaldb.blobfs.s3.S3CrtBlobFs;
+import com.slack.kaldb.blobfs.s3.S3TestUtils;
 import com.slack.kaldb.logstore.BlobFsUtils;
 import com.slack.kaldb.metadata.core.CuratorBuilder;
 import com.slack.kaldb.metadata.core.KaldbMetadataTestUtils;
@@ -63,7 +64,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.stubbing.Answer;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 public class RecoveryServiceTest {
 
@@ -84,7 +85,7 @@ public class RecoveryServiceTest {
   private MeterRegistry meterRegistry;
   private BlobFs blobFs;
   private TestKafkaServer kafkaServer;
-  private S3Client s3Client;
+  private S3AsyncClient s3AsyncClient;
   private RecoveryService recoveryService;
   private AsyncCuratorFramework curatorFramework;
 
@@ -94,8 +95,8 @@ public class RecoveryServiceTest {
     kafkaServer = new TestKafkaServer();
     meterRegistry = new SimpleMeterRegistry();
     zkServer = new TestingServer();
-    s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
-    blobFs = new S3BlobFs(s3Client);
+    s3AsyncClient = S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
+    blobFs = new S3CrtBlobFs(s3AsyncClient);
   }
 
   @AfterEach
@@ -119,8 +120,8 @@ public class RecoveryServiceTest {
     if (meterRegistry != null) {
       meterRegistry.close();
     }
-    if (s3Client != null) {
-      s3Client.close();
+    if (s3AsyncClient != null) {
+      s3AsyncClient.close();
     }
   }
 
@@ -371,9 +372,10 @@ public class RecoveryServiceTest {
     final Instant startTime = Instant.now();
     produceMessagesToKafka(kafkaServer.getBroker(), startTime, TEST_KAFKA_TOPIC_1, 0);
 
-    assertThat(s3Client.listBuckets().buckets().size()).isEqualTo(1);
-    assertThat(s3Client.listBuckets().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
-    assertThat(s3Client.listBuckets().buckets().get(0).name()).isNotEqualTo(fakeS3Bucket);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().size()).isEqualTo(1);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name())
+        .isNotEqualTo(fakeS3Bucket);
     SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
     assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
 
@@ -382,9 +384,10 @@ public class RecoveryServiceTest {
         new RecoveryTaskMetadata("testRecoveryTask", "0", 30, 60, Instant.now().toEpochMilli());
     assertThat(recoveryService.handleRecoveryTask(recoveryTask)).isFalse();
 
-    assertThat(s3Client.listBuckets().buckets().size()).isEqualTo(1);
-    assertThat(s3Client.listBuckets().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
-    assertThat(s3Client.listBuckets().buckets().get(0).name()).isNotEqualTo(fakeS3Bucket);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().size()).isEqualTo(1);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name())
+        .isNotEqualTo(fakeS3Bucket);
 
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, meterRegistry)).isEqualTo(31);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
@@ -408,8 +411,8 @@ public class RecoveryServiceTest {
     final Instant startTime = Instant.now();
     produceMessagesToKafka(kafkaServer.getBroker(), startTime, TEST_KAFKA_TOPIC_1, 0);
 
-    assertThat(s3Client.listBuckets().buckets().size()).isEqualTo(1);
-    assertThat(s3Client.listBuckets().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().size()).isEqualTo(1);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
     SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
     assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
 
@@ -449,8 +452,8 @@ public class RecoveryServiceTest {
     assertThat(getCount(RECOVERY_NODE_ASSIGNMENT_FAILED, meterRegistry)).isZero();
 
     // Check metadata
-    assertThat(s3Client.listBuckets().buckets().size()).isEqualTo(1);
-    assertThat(s3Client.listBuckets().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().size()).isEqualTo(1);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
 
     // Post recovery checks
     assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore).size())
@@ -493,8 +496,8 @@ public class RecoveryServiceTest {
     produceMessagesToKafka(kafkaServer.getBroker(), startTime, TEST_KAFKA_TOPIC_1, 0);
 
     // fakeS3Bucket is not present.
-    assertThat(s3Client.listBuckets().buckets().size()).isEqualTo(1);
-    assertThat(s3Client.listBuckets().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().size()).isEqualTo(1);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
     SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
     assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
 
@@ -536,8 +539,8 @@ public class RecoveryServiceTest {
     assertThat(getCount(RECOVERY_NODE_ASSIGNMENT_SUCCESS, meterRegistry)).isZero();
 
     // Check metadata
-    assertThat(s3Client.listBuckets().buckets().size()).isEqualTo(1);
-    assertThat(s3Client.listBuckets().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().size()).isEqualTo(1);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
 
     // Post recovery checks
     assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore).size())

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
@@ -13,6 +13,7 @@ import com.adobe.testing.s3mock.junit5.S3MockExtension;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import com.slack.kaldb.blobfs.s3.S3TestUtils;
 import com.slack.kaldb.chunkManager.RollOverChunkTask;
 import com.slack.kaldb.logstore.schema.SchemaAwareLogDocumentBuilderImpl;
 import com.slack.kaldb.metadata.core.CuratorBuilder;
@@ -50,7 +51,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 public class KaldbTest {
   private static final Logger LOG = LoggerFactory.getLogger(KaldbTest.class);
@@ -104,13 +105,13 @@ public class KaldbTest {
 
   private TestKafkaServer kafkaServer;
   private TestingServer zkServer;
-  private S3Client s3Client;
+  private S3AsyncClient s3Client;
 
   @BeforeEach
   public void setUp() throws Exception {
     zkServer = new TestingServer();
     kafkaServer = new TestKafkaServer();
-    s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
+    s3Client = S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
 
     // We side load a service metadata entry telling it to create an entry with the partitions that
     // we use in test

--- a/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceTest.java
@@ -14,6 +14,7 @@ import static org.awaitility.Awaitility.await;
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.slack.kaldb.blobfs.s3.S3TestUtils;
 import com.slack.kaldb.chunkManager.RollOverChunkTask;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.logstore.LogWireMessage;
@@ -47,7 +48,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 public class ZipkinServiceTest {
 
@@ -71,13 +72,13 @@ public class ZipkinServiceTest {
 
   private TestKafkaServer kafkaServer;
   private TestingServer zkServer;
-  private S3Client s3Client;
+  private S3AsyncClient s3Client;
 
   @BeforeEach
   public void setUp() throws Exception {
     zkServer = new TestingServer();
     kafkaServer = new TestKafkaServer();
-    s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
+    s3Client = S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
 
     // We side load a service metadata entry telling it to create an entry with the partitions that
     // we use in test

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/ChunkManagerUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/ChunkManagerUtil.java
@@ -5,7 +5,8 @@ import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
 import com.google.common.io.Files;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.slack.kaldb.blobfs.s3.S3BlobFs;
+import com.slack.kaldb.blobfs.s3.S3CrtBlobFs;
+import com.slack.kaldb.blobfs.s3.S3TestUtils;
 import com.slack.kaldb.chunk.SearchContext;
 import com.slack.kaldb.chunkManager.IndexingChunkManager;
 import com.slack.kaldb.chunkrollover.ChunkRollOverStrategy;
@@ -24,7 +25,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.apache.curator.test.TestingServer;
 import org.apache.curator.x.async.AsyncCuratorFramework;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 /**
  * This class creates a chunk manager that can be used in unit tests.
@@ -37,7 +38,7 @@ public class ChunkManagerUtil<T> {
   public static final int TEST_PORT = 34567;
 
   private final File tempFolder;
-  public final S3Client s3Client;
+  public S3AsyncClient s3AsyncClient;
   public static final String ZK_PATH_PREFIX = "testZK";
   public final IndexingChunkManager<T> chunkManager;
   private final TestingServer zkServer;
@@ -87,9 +88,9 @@ public class ChunkManagerUtil<T> {
       throws Exception {
 
     tempFolder = Files.createTempDir(); // TODO: don't use beta func.
-    s3Client = s3MockExtension.createS3ClientV2();
+    s3AsyncClient = S3TestUtils.createS3CrtClient(s3MockExtension.getServiceEndpoint());
+    S3CrtBlobFs s3CrtBlobFs = new S3CrtBlobFs(s3AsyncClient);
 
-    S3BlobFs s3BlobFs = new S3BlobFs(s3Client);
     this.zkServer = zkServer;
     // noop if zk has already been started by the caller
     this.zkServer.start();
@@ -106,7 +107,7 @@ public class ChunkManagerUtil<T> {
             tempFolder.getAbsolutePath(),
             chunkRollOverStrategy,
             meterRegistry,
-            s3BlobFs,
+            s3CrtBlobFs,
             s3Bucket,
             MoreExecutors.newDirectExecutorService(),
             curatorFramework,
@@ -117,7 +118,7 @@ public class ChunkManagerUtil<T> {
   public void close() throws IOException, TimeoutException {
     chunkManager.stopAsync();
     chunkManager.awaitTerminated(DEFAULT_START_STOP_DURATION);
-    s3Client.close();
+    s3AsyncClient.close();
     curatorFramework.unwrap().close();
     zkServer.close();
     FileUtils.deleteDirectory(tempFolder);

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/KaldbConfigUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/KaldbConfigUtil.java
@@ -36,6 +36,7 @@ public class KaldbConfigUtil {
             .setS3Region("us-east-1")
             .setS3AccessKey("")
             .setS3SecretKey("")
+            .setS3TargetThroughputGbps(10D)
             .build();
 
     KaldbConfigs.IndexerConfig indexerConfig =


### PR DESCRIPTION
###  Summary

Switches to the AWS CRT-based S3 client (https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/crt-based-s3-client.html). This is mostly a drop-in replacement, and makes use of the multipart APIs which should be broadly available on multiple S3-compatible API services.

https://aws.amazon.com/blogs/developer/introducing-crt-based-s3-client-and-the-s3-transfer-manager-in-the-aws-sdk-for-java-2-x/