### PR TITLE
Add replicaSet support

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -57,7 +57,7 @@ metadataStoreConfig:
 
 cacheConfig:
   slotsPerInstance: ${KALDB_CACHE_SLOTS_PER_INSTANCE:-10}
-  replicaPartition: ${KALDB_CACHE_PARTITION:-rep1}
+  replicaSet: ${KALDB_CACHE_REPLICA_SET:-rep1}
   dataDirectory: ${KALDB_CACHE_DATA_DIR:-/tmp}
   defaultQueryTimeoutMs: ${KALDB_CACHE_DEFAULT_QUERY_TIMEOUT_MS:-2500}
   serverConfig:
@@ -75,10 +75,10 @@ managerConfig:
   replicaCreationServiceConfig:
     schedulePeriodMins: ${KALDB_MANAGER_REPLICAS_PERIOD_MINS:-15}
     replicaLifespanMins: ${KALDB_MANAGER_REPLICA_LIFESPAN_MINS:-1440}
-    replicaPartitions: [${KALDB_MANAGER_REPLICA_PARTITIONS:-rep1}]
+    replicaSets: [${KALDB_MANAGER_REPLICA_SETS:-rep1}]
   replicaAssignmentServiceConfig:
     schedulePeriodMins: ${KALDB_MANAGER_CACHE_SLOT_PERIOD_MINS:-15}
-    replicaPartitions: [${KALDB_MANAGER_REPLICA_PARTITIONS:-rep1}]
+    replicaSets: [${KALDB_MANAGER_REPLICA_SETS:-rep1}]
   replicaEvictionServiceConfig:
     schedulePeriodMins: ${KALDB_MANAGER_REPLICA_EVICT_PERIOD_MINS:-15}
   replicaDeletionServiceConfig:
@@ -92,7 +92,7 @@ managerConfig:
     schedulePeriodMins: ${KALDB_MANAGER_REPLICA_RESTORE_PERIOD_MINS:-15}
     maxReplicasPerRequest: ${KALDB_MANAGER_REPLICA_RESTORE_MAX_REPLICAS_PER_REQUEST:-200}
     replicaLifespanMins: ${KALDB_MANAGER_REPLICA_RESTORE_LIFESPAN_MINS:-60}
-    replicaPartitions: [${KALDB_MANAGER_REPLICA_PARTITIONS:-rep1}]
+    replicaSets: [${KALDB_MANAGER_REPLICA_SETS:-rep1}]
 
 clusterConfig:
   clusterName: ${KALDB_CLUSTER_NAME:-kaldb_local}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -57,6 +57,7 @@ metadataStoreConfig:
 
 cacheConfig:
   slotsPerInstance: ${KALDB_CACHE_SLOTS_PER_INSTANCE:-10}
+  replicaPartition: ${KALDB_CACHE_PARTITION:-rep1}
   dataDirectory: ${KALDB_CACHE_DATA_DIR:-/tmp}
   defaultQueryTimeoutMs: ${KALDB_CACHE_DEFAULT_QUERY_TIMEOUT_MS:-2500}
   serverConfig:
@@ -72,11 +73,12 @@ managerConfig:
     serverAddress: ${KALDB_MANAGER_SERVER_ADDRESS:-localhost}
     requestTimeoutMs: ${KALDB_MANAGER_REQUEST_TIMEOUT_MS:-5000}
   replicaCreationServiceConfig:
-    replicasPerSnapshot: ${KALDB_MANAGER_REPLICAS_PER_SNAPSHOT:-1}
     schedulePeriodMins: ${KALDB_MANAGER_REPLICAS_PERIOD_MINS:-15}
     replicaLifespanMins: ${KALDB_MANAGER_REPLICA_LIFESPAN_MINS:-1440}
+    replicaPartitions: [${KALDB_MANAGER_REPLICA_PARTITIONS:-rep1}]
   replicaAssignmentServiceConfig:
     schedulePeriodMins: ${KALDB_MANAGER_CACHE_SLOT_PERIOD_MINS:-15}
+    replicaPartitions: [${KALDB_MANAGER_REPLICA_PARTITIONS:-rep1}]
   replicaEvictionServiceConfig:
     schedulePeriodMins: ${KALDB_MANAGER_REPLICA_EVICT_PERIOD_MINS:-15}
   replicaDeletionServiceConfig:
@@ -90,6 +92,7 @@ managerConfig:
     schedulePeriodMins: ${KALDB_MANAGER_REPLICA_RESTORE_PERIOD_MINS:-15}
     maxReplicasPerRequest: ${KALDB_MANAGER_REPLICA_RESTORE_MAX_REPLICAS_PER_REQUEST:-200}
     replicaLifespanMins: ${KALDB_MANAGER_REPLICA_RESTORE_LIFESPAN_MINS:-60}
+    replicaPartitions: [${KALDB_MANAGER_REPLICA_PARTITIONS:-rep1}]
 
 clusterConfig:
   clusterName: ${KALDB_CLUSTER_NAME:-kaldb_local}

--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
@@ -89,7 +89,7 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
       SearchContext searchContext,
       String s3Bucket,
       String dataDirectoryPrefix,
-      String replicaPartition,
+      String replicaSet,
       CacheSlotMetadataStore cacheSlotMetadataStore,
       ReplicaMetadataStore replicaMetadataStore,
       SnapshotMetadataStore snapshotMetadataStore,
@@ -117,7 +117,7 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
             Instant.now().toEpochMilli(),
             List.of(Metadata.IndexType.LOGS_LUCENE9),
             searchContext.hostname,
-            replicaPartition);
+            replicaSet);
     cacheSlotMetadataStore.createSync(cacheSlotMetadata);
     cacheSlotMetadataStore.addListener(cacheSlotListener);
 

--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
@@ -89,6 +89,7 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
       SearchContext searchContext,
       String s3Bucket,
       String dataDirectoryPrefix,
+      String replicaPartition,
       CacheSlotMetadataStore cacheSlotMetadataStore,
       ReplicaMetadataStore replicaMetadataStore,
       SnapshotMetadataStore snapshotMetadataStore,
@@ -115,7 +116,8 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
             "",
             Instant.now().toEpochMilli(),
             List.of(Metadata.IndexType.LOGS_LUCENE9),
-            searchContext.hostname);
+            searchContext.hostname,
+            replicaPartition);
     cacheSlotMetadataStore.createSync(cacheSlotMetadata);
     cacheSlotMetadataStore.addListener(cacheSlotListener);
 

--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/CachingChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/CachingChunkManager.java
@@ -31,6 +31,7 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
   private final SearchContext searchContext;
   private final String s3Bucket;
   private final String dataDirectoryPrefix;
+  private final String replicaPartition;
   private final int slotCountPerInstance;
   private ReplicaMetadataStore replicaMetadataStore;
   private SnapshotMetadataStore snapshotMetadataStore;
@@ -45,6 +46,7 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
       SearchContext searchContext,
       String s3Bucket,
       String dataDirectoryPrefix,
+      String replicaPartition,
       int slotCountPerInstance) {
     this.meterRegistry = registry;
     this.curatorFramework = curatorFramework;
@@ -52,6 +54,7 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
     this.searchContext = searchContext;
     this.s3Bucket = s3Bucket;
     this.dataDirectoryPrefix = dataDirectoryPrefix;
+    this.replicaPartition = replicaPartition;
     this.slotCountPerInstance = slotCountPerInstance;
 
     // todo - consider making the thread count a config option; this would allow for more
@@ -85,6 +88,7 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
               searchContext,
               s3Bucket,
               dataDirectoryPrefix,
+              replicaPartition,
               cacheSlotMetadataStore,
               replicaMetadataStore,
               snapshotMetadataStore,
@@ -132,6 +136,7 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
         SearchContext.fromConfig(cacheConfig.getServerConfig()),
         s3Config.getS3Bucket(),
         cacheConfig.getDataDirectory(),
+        cacheConfig.getReplicaPartition(),
         cacheConfig.getSlotsPerInstance());
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/CachingChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/CachingChunkManager.java
@@ -31,7 +31,7 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
   private final SearchContext searchContext;
   private final String s3Bucket;
   private final String dataDirectoryPrefix;
-  private final String replicaPartition;
+  private final String replicaSet;
   private final int slotCountPerInstance;
   private ReplicaMetadataStore replicaMetadataStore;
   private SnapshotMetadataStore snapshotMetadataStore;
@@ -46,7 +46,7 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
       SearchContext searchContext,
       String s3Bucket,
       String dataDirectoryPrefix,
-      String replicaPartition,
+      String replicaSet,
       int slotCountPerInstance) {
     this.meterRegistry = registry;
     this.curatorFramework = curatorFramework;
@@ -54,7 +54,7 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
     this.searchContext = searchContext;
     this.s3Bucket = s3Bucket;
     this.dataDirectoryPrefix = dataDirectoryPrefix;
-    this.replicaPartition = replicaPartition;
+    this.replicaSet = replicaSet;
     this.slotCountPerInstance = slotCountPerInstance;
 
     // todo - consider making the thread count a config option; this would allow for more
@@ -88,7 +88,7 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
               searchContext,
               s3Bucket,
               dataDirectoryPrefix,
-              replicaPartition,
+              replicaSet,
               cacheSlotMetadataStore,
               replicaMetadataStore,
               snapshotMetadataStore,
@@ -136,7 +136,7 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
         SearchContext.fromConfig(cacheConfig.getServerConfig()),
         s3Config.getS3Bucket(),
         cacheConfig.getDataDirectory(),
-        cacheConfig.getReplicaPartition(),
+        cacheConfig.getReplicaSet(),
         cacheConfig.getSlotsPerInstance());
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaCreationService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaCreationService.java
@@ -229,8 +229,9 @@ public class ReplicaCreationService extends AbstractScheduledService {
           assignmentTimer.stop(
               replicaAssignmentTimer.tag("replicaSet", replicaSet).register(meterRegistry));
       LOG.info(
-          "Completed replica creation for unassigned snapshots in replicaSet {} - successfully created {} replicas, failed {} replicas in {} ms",
+          "Completed replica creation for unassigned snapshots in replicaSet {} - {} existing replicas - successfully created {} replicas, failed {} replicas in {} ms",
           replicaSet,
+          existingReplicas.size(),
           createdReplicas,
           failedReplicas,
           nanosToMillis(assignmentDuration));

--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaRestoreService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaRestoreService.java
@@ -43,15 +43,17 @@ public class ReplicaRestoreService extends AbstractScheduledService {
   private final BlockingQueue<SnapshotMetadata> queue = new LinkedBlockingQueue<>();
   private final ReplicaMetadataStore replicaMetadataStore;
   private final MeterRegistry meterRegistry;
-  private final Counter successfullyCreatedReplicas;
-  private final Counter failedReplicas;
-  private final Counter skippedReplicas;
-  private final Timer restoreTimer;
+
   protected static final Logger LOG = LoggerFactory.getLogger(ReplicaCreationService.class);
   public static String REPLICAS_CREATED = "replicas_created";
   public static String REPLICAS_FAILED = "replicas_failed";
   public static String REPLICAS_SKIPPED = "replicas_skipped";
   public static String REPLICAS_RESTORE_TIMER = "replicas_restore_timer";
+
+  private final Counter.Builder replicasCreated;
+  private final Counter.Builder replicasFailed;
+  private final Counter.Builder replicasSkipped;
+  private final Timer.Builder replicasRestoreTimer;
 
   public ReplicaRestoreService(
       ReplicaMetadataStore replicaMetadataStore,
@@ -60,10 +62,11 @@ public class ReplicaRestoreService extends AbstractScheduledService {
     this.managerConfig = managerConfig;
     this.replicaMetadataStore = replicaMetadataStore;
     this.meterRegistry = meterRegistry;
-    this.skippedReplicas = meterRegistry.counter(REPLICAS_SKIPPED);
-    this.successfullyCreatedReplicas = meterRegistry.counter(REPLICAS_CREATED);
-    this.failedReplicas = meterRegistry.counter(REPLICAS_FAILED);
-    this.restoreTimer = meterRegistry.timer(REPLICAS_RESTORE_TIMER);
+
+    this.replicasCreated = Counter.builder(REPLICAS_CREATED);
+    this.replicasFailed = Counter.builder(REPLICAS_FAILED);
+    this.replicasSkipped = Counter.builder(REPLICAS_SKIPPED);
+    this.replicasRestoreTimer = Timer.builder(REPLICAS_RESTORE_TIMER);
   }
 
   @Override
@@ -127,32 +130,46 @@ public class ReplicaRestoreService extends AbstractScheduledService {
       return;
     }
 
-    Timer.Sample restoreReplicasTimer = Timer.start(meterRegistry);
+    // foreach partition
+    for (String replicaPartition :
+        managerConfig.getReplicaRestoreServiceConfig().getReplicaPartitionsList()) {
+      Timer.Sample restoreReplicasTimer = Timer.start(meterRegistry);
 
-    List<SnapshotMetadata> snapshotsToRestore = new ArrayList<>();
-    Set<String> createdReplicas = new HashSet<>();
+      List<SnapshotMetadata> snapshotsToRestore = new ArrayList<>();
+      Set<String> createdReplicas = new HashSet<>();
 
-    for (ReplicaMetadata replicaMetadata : replicaMetadataStore.listSync()) {
-      createdReplicas.add(replicaMetadata.snapshotId);
-    }
-
-    queue.drainTo(snapshotsToRestore);
-
-    for (SnapshotMetadata snapshotMetadata : snapshotsToRestore) {
-      try {
-        restoreOrSkipSnapshot(snapshotMetadata, createdReplicas);
-        createdReplicas.add(snapshotMetadata.snapshotId);
-      } catch (InterruptedException e) {
-        LOG.error("Something went wrong dequeueing snapshot ID {}", snapshotMetadata.snapshotId, e);
-        failedReplicas.increment();
+      for (ReplicaMetadata replicaMetadata : replicaMetadataStore.listSync()) {
+        createdReplicas.add(replicaMetadata.snapshotId);
       }
+
+      queue.drainTo(snapshotsToRestore);
+
+      for (SnapshotMetadata snapshotMetadata : snapshotsToRestore) {
+        try {
+          restoreOrSkipSnapshot(snapshotMetadata, replicaPartition, createdReplicas);
+          createdReplicas.add(snapshotMetadata.snapshotId);
+        } catch (InterruptedException e) {
+          LOG.error(
+              "Something went wrong dequeueing snapshot ID {} for partition {}",
+              snapshotMetadata.snapshotId,
+              replicaPartition,
+              e);
+          replicasFailed
+              .tag("replicaPartition", replicaPartition)
+              .register(meterRegistry)
+              .increment();
+        }
+      }
+      restoreReplicasTimer.stop(
+          replicasRestoreTimer.tag("replicaPartition", replicaPartition).register(meterRegistry));
+      LOG.info(
+          "Restored {} snapshots for partition {}.", snapshotsToRestore.size(), replicaPartition);
     }
-    restoreReplicasTimer.stop(restoreTimer);
-    LOG.info("Restored {} snapshots.", snapshotsToRestore.size());
   }
 
   /** Creates replica from given snapshot if its ID doesn't already exist in createdReplicas */
-  private void restoreOrSkipSnapshot(SnapshotMetadata snapshot, Set<String> createdReplicas)
+  private void restoreOrSkipSnapshot(
+      SnapshotMetadata snapshot, String replicaPartition, Set<String> createdReplicas)
       throws InterruptedException {
     if (!createdReplicas.contains(snapshot.snapshotId)) {
       LOG.info("Restoring replica with ID {}", snapshot.snapshotId);
@@ -161,6 +178,7 @@ public class ReplicaRestoreService extends AbstractScheduledService {
         replicaMetadataStore.createSync(
             replicaMetadataFromSnapshotId(
                 snapshot.snapshotId,
+                replicaPartition,
                 Instant.now()
                     .plus(
                         managerConfig.getReplicaRestoreServiceConfig().getReplicaLifespanMins(),
@@ -170,10 +188,10 @@ public class ReplicaRestoreService extends AbstractScheduledService {
         LOG.error("Error restoring replica for snapshot {}", snapshot.snapshotId, e);
       }
       createdReplicas.add(snapshot.snapshotId);
-      successfullyCreatedReplicas.increment();
+      replicasCreated.tag("replicaPartition", replicaPartition).register(meterRegistry).increment();
     } else {
       LOG.info("Skipping Snapshot ID {} ", snapshot.snapshotId);
-      skippedReplicas.increment();
+      replicasSkipped.tag("replicaPartition", replicaPartition).register(meterRegistry).increment();
     }
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadata.java
@@ -6,6 +6,7 @@ import com.slack.kaldb.metadata.core.KaldbPartitionedMetadata;
 import com.slack.kaldb.proto.metadata.Metadata;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * TODO: Currently, application code directly manipulates cache slot states which is error prone.
@@ -13,6 +14,7 @@ import java.util.List;
  */
 public class CacheSlotMetadata extends KaldbPartitionedMetadata {
   public final String hostname;
+  public final String replicaPartition;
   public final Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState;
   public final String replicaId;
   public final long updatedTimeEpochMs;
@@ -24,7 +26,8 @@ public class CacheSlotMetadata extends KaldbPartitionedMetadata {
       String replicaId,
       long updatedTimeEpochMs,
       List<Metadata.IndexType> supportedIndexTypes,
-      String hostname) {
+      String hostname,
+      String replicaPartition) {
     super(name);
     checkArgument(hostname != null && !hostname.isEmpty(), "Hostname cannot be null or empty");
     checkArgument(cacheSlotState != null, "Cache slot state cannot be null");
@@ -43,6 +46,7 @@ public class CacheSlotMetadata extends KaldbPartitionedMetadata {
     }
 
     this.hostname = hostname;
+    this.replicaPartition = replicaPartition;
     this.cacheSlotState = cacheSlotState;
     this.replicaId = replicaId;
     this.updatedTimeEpochMs = updatedTimeEpochMs;
@@ -57,6 +61,7 @@ public class CacheSlotMetadata extends KaldbPartitionedMetadata {
 
     if (updatedTimeEpochMs != that.updatedTimeEpochMs) return false;
     if (!hostname.equals(that.hostname)) return false;
+    if (!Objects.equals(replicaPartition, that.replicaPartition)) return false;
     if (cacheSlotState != that.cacheSlotState) return false;
     if (!replicaId.equals(that.replicaId)) return false;
     return supportedIndexTypes.equals(that.supportedIndexTypes);
@@ -66,6 +71,7 @@ public class CacheSlotMetadata extends KaldbPartitionedMetadata {
   public int hashCode() {
     int result = super.hashCode();
     result = 31 * result + hostname.hashCode();
+    result = 31 * result + (replicaPartition != null ? replicaPartition.hashCode() : 0);
     result = 31 * result + cacheSlotState.hashCode();
     result = 31 * result + replicaId.hashCode();
     result = 31 * result + (int) (updatedTimeEpochMs ^ (updatedTimeEpochMs >>> 32));
@@ -78,6 +84,9 @@ public class CacheSlotMetadata extends KaldbPartitionedMetadata {
     return "CacheSlotMetadata{"
         + "hostname='"
         + hostname
+        + '\''
+        + ", replicaPartition='"
+        + replicaPartition
         + '\''
         + ", cacheSlotState="
         + cacheSlotState

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadata.java
@@ -14,7 +14,7 @@ import java.util.Objects;
  */
 public class CacheSlotMetadata extends KaldbPartitionedMetadata {
   public final String hostname;
-  public final String replicaPartition;
+  public final String replicaSet;
   public final Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState;
   public final String replicaId;
   public final long updatedTimeEpochMs;
@@ -27,7 +27,7 @@ public class CacheSlotMetadata extends KaldbPartitionedMetadata {
       long updatedTimeEpochMs,
       List<Metadata.IndexType> supportedIndexTypes,
       String hostname,
-      String replicaPartition) {
+      String replicaSet) {
     super(name);
     checkArgument(hostname != null && !hostname.isEmpty(), "Hostname cannot be null or empty");
     checkArgument(cacheSlotState != null, "Cache slot state cannot be null");
@@ -46,7 +46,7 @@ public class CacheSlotMetadata extends KaldbPartitionedMetadata {
     }
 
     this.hostname = hostname;
-    this.replicaPartition = replicaPartition;
+    this.replicaSet = replicaSet;
     this.cacheSlotState = cacheSlotState;
     this.replicaId = replicaId;
     this.updatedTimeEpochMs = updatedTimeEpochMs;
@@ -61,7 +61,7 @@ public class CacheSlotMetadata extends KaldbPartitionedMetadata {
 
     if (updatedTimeEpochMs != that.updatedTimeEpochMs) return false;
     if (!hostname.equals(that.hostname)) return false;
-    if (!Objects.equals(replicaPartition, that.replicaPartition)) return false;
+    if (!Objects.equals(replicaSet, that.replicaSet)) return false;
     if (cacheSlotState != that.cacheSlotState) return false;
     if (!replicaId.equals(that.replicaId)) return false;
     return supportedIndexTypes.equals(that.supportedIndexTypes);
@@ -71,7 +71,7 @@ public class CacheSlotMetadata extends KaldbPartitionedMetadata {
   public int hashCode() {
     int result = super.hashCode();
     result = 31 * result + hostname.hashCode();
-    result = 31 * result + (replicaPartition != null ? replicaPartition.hashCode() : 0);
+    result = 31 * result + (replicaSet != null ? replicaSet.hashCode() : 0);
     result = 31 * result + cacheSlotState.hashCode();
     result = 31 * result + replicaId.hashCode();
     result = 31 * result + (int) (updatedTimeEpochMs ^ (updatedTimeEpochMs >>> 32));
@@ -85,8 +85,8 @@ public class CacheSlotMetadata extends KaldbPartitionedMetadata {
         + "hostname='"
         + hostname
         + '\''
-        + ", replicaPartition='"
-        + replicaPartition
+        + ", replicaSet='"
+        + replicaSet
         + '\''
         + ", cacheSlotState="
         + cacheSlotState

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializer.java
@@ -15,7 +15,8 @@ public class CacheSlotMetadataSerializer implements MetadataSerializer<CacheSlot
         cacheSlotMetadataProto.getReplicaId(),
         cacheSlotMetadataProto.getUpdatedTimeEpochMs(),
         cacheSlotMetadataProto.getSupportedIndexTypesList(),
-        cacheSlotMetadataProto.getHostname());
+        cacheSlotMetadataProto.getHostname(),
+        cacheSlotMetadataProto.getReplicaPartition());
   }
 
   private static Metadata.CacheSlotMetadata toCacheSlotMetadataProto(CacheSlotMetadata metadata) {
@@ -26,6 +27,7 @@ public class CacheSlotMetadataSerializer implements MetadataSerializer<CacheSlot
         .setUpdatedTimeEpochMs(metadata.updatedTimeEpochMs)
         .addAllSupportedIndexTypes(metadata.supportedIndexTypes)
         .setHostname(metadata.hostname)
+        .setReplicaPartition(metadata.replicaPartition)
         .build();
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializer.java
@@ -16,7 +16,7 @@ public class CacheSlotMetadataSerializer implements MetadataSerializer<CacheSlot
         cacheSlotMetadataProto.getUpdatedTimeEpochMs(),
         cacheSlotMetadataProto.getSupportedIndexTypesList(),
         cacheSlotMetadataProto.getHostname(),
-        cacheSlotMetadataProto.getReplicaPartition());
+        cacheSlotMetadataProto.getReplicaSet());
   }
 
   private static Metadata.CacheSlotMetadata toCacheSlotMetadataProto(CacheSlotMetadata metadata) {
@@ -27,7 +27,7 @@ public class CacheSlotMetadataSerializer implements MetadataSerializer<CacheSlot
         .setUpdatedTimeEpochMs(metadata.updatedTimeEpochMs)
         .addAllSupportedIndexTypes(metadata.supportedIndexTypes)
         .setHostname(metadata.hostname)
-        .setReplicaPartition(metadata.replicaPartition)
+        .setReplicaSet(metadata.replicaSet)
         .build();
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStore.java
@@ -51,7 +51,8 @@ public class CacheSlotMetadataStore extends KaldbPartitioningMetadataStore<Cache
             replicaId,
             Instant.now().toEpochMilli(),
             cacheSlotMetadata.supportedIndexTypes,
-            cacheSlotMetadata.hostname);
+            cacheSlotMetadata.hostname,
+            cacheSlotMetadata.replicaPartition);
     // todo - consider refactoring this to return a completable future instead
     return JdkFutureAdapters.listenInPoolThread(
         updateAsync(updatedChunkMetadata).toCompletableFuture());

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStore.java
@@ -52,7 +52,7 @@ public class CacheSlotMetadataStore extends KaldbPartitioningMetadataStore<Cache
             Instant.now().toEpochMilli(),
             cacheSlotMetadata.supportedIndexTypes,
             cacheSlotMetadata.hostname,
-            cacheSlotMetadata.replicaPartition);
+            cacheSlotMetadata.replicaSet);
     // todo - consider refactoring this to return a completable future instead
     return JdkFutureAdapters.listenInPoolThread(
         updateAsync(updatedChunkMetadata).toCompletableFuture());

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadata.java
@@ -18,7 +18,7 @@ public class ReplicaMetadata extends KaldbPartitionedMetadata {
 
   public final String snapshotId;
 
-  public final String replicaPartition;
+  public final String replicaSet;
 
   public final long createdTimeEpochMs;
   public final long expireAfterEpochMs;
@@ -28,7 +28,7 @@ public class ReplicaMetadata extends KaldbPartitionedMetadata {
   public ReplicaMetadata(
       String name,
       String snapshotId,
-      String replicaPartition,
+      String replicaSet,
       long createdTimeEpochMs,
       long expireAfterEpochMs,
       boolean isRestored,
@@ -40,7 +40,7 @@ public class ReplicaMetadata extends KaldbPartitionedMetadata {
         snapshotId != null && !snapshotId.isEmpty(), "SnapshotId must not be null or empty");
 
     this.snapshotId = snapshotId;
-    this.replicaPartition = replicaPartition;
+    this.replicaSet = replicaSet;
     this.createdTimeEpochMs = createdTimeEpochMs;
     this.expireAfterEpochMs = expireAfterEpochMs;
     this.isRestored = isRestored;
@@ -51,8 +51,8 @@ public class ReplicaMetadata extends KaldbPartitionedMetadata {
     return snapshotId;
   }
 
-  public String getReplicaPartition() {
-    return replicaPartition;
+  public String getReplicaSet() {
+    return replicaSet;
   }
 
   public long getCreatedTimeEpochMs() {
@@ -77,7 +77,7 @@ public class ReplicaMetadata extends KaldbPartitionedMetadata {
     if (expireAfterEpochMs != that.expireAfterEpochMs) return false;
     if (isRestored != that.isRestored) return false;
     if (!snapshotId.equals(that.snapshotId)) return false;
-    if (!replicaPartition.equals(that.replicaPartition)) return false;
+    if (!replicaSet.equals(that.replicaSet)) return false;
     return indexType == that.indexType;
   }
 
@@ -85,7 +85,7 @@ public class ReplicaMetadata extends KaldbPartitionedMetadata {
   public int hashCode() {
     int result = super.hashCode();
     result = 31 * result + snapshotId.hashCode();
-    result = 31 * result + replicaPartition.hashCode();
+    result = 31 * result + replicaSet.hashCode();
     result = 31 * result + (int) (createdTimeEpochMs ^ (createdTimeEpochMs >>> 32));
     result = 31 * result + (int) (expireAfterEpochMs ^ (expireAfterEpochMs >>> 32));
     result = 31 * result + (isRestored ? 1 : 0);
@@ -99,8 +99,8 @@ public class ReplicaMetadata extends KaldbPartitionedMetadata {
         + "snapshotId='"
         + snapshotId
         + '\''
-        + ", replicaPartition='"
-        + replicaPartition
+        + ", replicaSet='"
+        + replicaSet
         + '\''
         + ", createdTimeEpochMs="
         + createdTimeEpochMs

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadata.java
@@ -17,6 +17,9 @@ import java.time.temporal.ChronoField;
 public class ReplicaMetadata extends KaldbPartitionedMetadata {
 
   public final String snapshotId;
+
+  public final String replicaPartition;
+
   public final long createdTimeEpochMs;
   public final long expireAfterEpochMs;
   public boolean isRestored;
@@ -25,6 +28,7 @@ public class ReplicaMetadata extends KaldbPartitionedMetadata {
   public ReplicaMetadata(
       String name,
       String snapshotId,
+      String replicaPartition,
       long createdTimeEpochMs,
       long expireAfterEpochMs,
       boolean isRestored,
@@ -36,6 +40,7 @@ public class ReplicaMetadata extends KaldbPartitionedMetadata {
         snapshotId != null && !snapshotId.isEmpty(), "SnapshotId must not be null or empty");
 
     this.snapshotId = snapshotId;
+    this.replicaPartition = replicaPartition;
     this.createdTimeEpochMs = createdTimeEpochMs;
     this.expireAfterEpochMs = expireAfterEpochMs;
     this.isRestored = isRestored;
@@ -44,6 +49,10 @@ public class ReplicaMetadata extends KaldbPartitionedMetadata {
 
   public String getSnapshotId() {
     return snapshotId;
+  }
+
+  public String getReplicaPartition() {
+    return replicaPartition;
   }
 
   public long getCreatedTimeEpochMs() {
@@ -61,38 +70,37 @@ public class ReplicaMetadata extends KaldbPartitionedMetadata {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof ReplicaMetadata that)) return false;
     if (!super.equals(o)) return false;
-
-    ReplicaMetadata that = (ReplicaMetadata) o;
 
     if (createdTimeEpochMs != that.createdTimeEpochMs) return false;
     if (expireAfterEpochMs != that.expireAfterEpochMs) return false;
     if (isRestored != that.isRestored) return false;
-    if (snapshotId != null ? !snapshotId.equals(that.snapshotId) : that.snapshotId != null)
-      return false;
+    if (!snapshotId.equals(that.snapshotId)) return false;
+    if (!replicaPartition.equals(that.replicaPartition)) return false;
     return indexType == that.indexType;
   }
 
   @Override
   public int hashCode() {
     int result = super.hashCode();
-    result = 31 * result + (snapshotId != null ? snapshotId.hashCode() : 0);
+    result = 31 * result + snapshotId.hashCode();
+    result = 31 * result + replicaPartition.hashCode();
     result = 31 * result + (int) (createdTimeEpochMs ^ (createdTimeEpochMs >>> 32));
     result = 31 * result + (int) (expireAfterEpochMs ^ (expireAfterEpochMs >>> 32));
     result = 31 * result + (isRestored ? 1 : 0);
-    result = 31 * result + (indexType != null ? indexType.hashCode() : 0);
+    result = 31 * result + indexType.hashCode();
     return result;
   }
 
   @Override
   public String toString() {
     return "ReplicaMetadata{"
-        + "name='"
-        + name
-        + '\''
-        + ", snapshotId='"
+        + "snapshotId='"
         + snapshotId
+        + '\''
+        + ", replicaPartition='"
+        + replicaPartition
         + '\''
         + ", createdTimeEpochMs="
         + createdTimeEpochMs
@@ -102,6 +110,9 @@ public class ReplicaMetadata extends KaldbPartitionedMetadata {
         + isRestored
         + ", indexType="
         + indexType
+        + ", name='"
+        + name
+        + '\''
         + '}';
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializer.java
@@ -11,7 +11,7 @@ public class ReplicaMetadataSerializer implements MetadataSerializer<ReplicaMeta
     return new ReplicaMetadata(
         replicaMetadataProto.getName(),
         replicaMetadataProto.getSnapshotId(),
-        replicaMetadataProto.getReplicaPartition(),
+        replicaMetadataProto.getReplicaSet(),
         replicaMetadataProto.getCreatedTimeEpochMs(),
         replicaMetadataProto.getExpireAfterEpochMs(),
         replicaMetadataProto.getIsRestored(),
@@ -22,7 +22,7 @@ public class ReplicaMetadataSerializer implements MetadataSerializer<ReplicaMeta
     return Metadata.ReplicaMetadata.newBuilder()
         .setName(metadata.name)
         .setSnapshotId(metadata.snapshotId)
-        .setReplicaPartition(metadata.replicaPartition)
+        .setReplicaSet(metadata.replicaSet)
         .setCreatedTimeEpochMs(metadata.createdTimeEpochMs)
         .setExpireAfterEpochMs(metadata.expireAfterEpochMs)
         .setIsRestored(metadata.isRestored)

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializer.java
@@ -11,6 +11,7 @@ public class ReplicaMetadataSerializer implements MetadataSerializer<ReplicaMeta
     return new ReplicaMetadata(
         replicaMetadataProto.getName(),
         replicaMetadataProto.getSnapshotId(),
+        replicaMetadataProto.getReplicaPartition(),
         replicaMetadataProto.getCreatedTimeEpochMs(),
         replicaMetadataProto.getExpireAfterEpochMs(),
         replicaMetadataProto.getIsRestored(),
@@ -21,6 +22,7 @@ public class ReplicaMetadataSerializer implements MetadataSerializer<ReplicaMeta
     return Metadata.ReplicaMetadata.newBuilder()
         .setName(metadata.name)
         .setSnapshotId(metadata.snapshotId)
+        .setReplicaPartition(metadata.replicaPartition)
         .setCreatedTimeEpochMs(metadata.createdTimeEpochMs)
         .setExpireAfterEpochMs(metadata.expireAfterEpochMs)
         .setIsRestored(metadata.isRestored)

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -132,7 +132,7 @@ message CacheConfig {
   // Path on local disk to store downloaded files.
   ServerConfig server_config = 3;
   int32 default_query_timeout_ms = 4;
-  string replica_partition = 5;
+  string replica_set = 5;
 }
 
 // Cluster manager config. As a convention we define a config struct for
@@ -141,12 +141,12 @@ message ManagerConfig {
   message ReplicaCreationServiceConfig {
     int32 schedule_period_mins = 1;
     int32 replica_lifespan_mins = 2;
-    repeated string replica_partitions = 3;
+    repeated string replica_sets = 3;
   }
 
   message ReplicaAssignmentServiceConfig {
     int32 schedule_period_mins = 1;
-    repeated string replica_partitions = 2;
+    repeated string replica_sets = 2;
   }
 
   message ReplicaEvictionServiceConfig {
@@ -170,7 +170,7 @@ message ManagerConfig {
     int32 schedule_period_mins = 1;
     int32 max_replicas_per_request = 2;
     int32 replica_lifespan_mins = 3;
-    repeated string replica_partitions = 4;
+    repeated string replica_sets = 4;
   }
 
   // Event aggregation secs is a de-bounce setting. It's the time

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -132,19 +132,21 @@ message CacheConfig {
   // Path on local disk to store downloaded files.
   ServerConfig server_config = 3;
   int32 default_query_timeout_ms = 4;
+  string replica_partition = 5;
 }
 
 // Cluster manager config. As a convention we define a config struct for
 // every service in the cluster manager.
 message ManagerConfig {
   message ReplicaCreationServiceConfig {
-    int32 replicas_per_snapshot = 1;
-    int32 schedule_period_mins = 2;
-    int32 replica_lifespan_mins = 3;
+    int32 schedule_period_mins = 1;
+    int32 replica_lifespan_mins = 2;
+    repeated string replica_partitions = 3;
   }
 
   message ReplicaAssignmentServiceConfig {
     int32 schedule_period_mins = 1;
+    repeated string replica_partitions = 2;
   }
 
   message ReplicaEvictionServiceConfig {
@@ -168,6 +170,7 @@ message ManagerConfig {
     int32 schedule_period_mins = 1;
     int32 max_replicas_per_request = 2;
     int32 replica_lifespan_mins = 3;
+    repeated string replica_partitions = 4;
   }
 
   // Event aggregation secs is a de-bounce setting. It's the time

--- a/kaldb/src/main/proto/metadata.proto
+++ b/kaldb/src/main/proto/metadata.proto
@@ -37,8 +37,8 @@ message CacheSlotMetadata {
   // Unique string identifying the host
   string hostname = 6;
 
-  // String identify the partition this cache slot participates in
-  string replica_partition = 7;
+  // String identify the set this cache slot participates in
+  string replica_set = 7;
 }
 
 message ReplicaMetadata {
@@ -48,8 +48,8 @@ message ReplicaMetadata {
   // Unique ID for the snapshot blob
   string snapshot_id = 2;
 
-  // String identify the partition this replica participates in
-  string replica_partition = 3;
+  // String identify the set this replica participates in
+  string replica_set = 3;
 
   // Last updated timestamp
   int64 created_time_epoch_ms = 4;

--- a/kaldb/src/main/proto/metadata.proto
+++ b/kaldb/src/main/proto/metadata.proto
@@ -36,6 +36,9 @@ message CacheSlotMetadata {
 
   // Unique string identifying the host
   string hostname = 6;
+
+  // String identify the partition this cache slot participates in
+  string replica_partition = 7;
 }
 
 message ReplicaMetadata {
@@ -44,6 +47,9 @@ message ReplicaMetadata {
 
   // Unique ID for the snapshot blob
   string snapshot_id = 2;
+
+  // String identify the partition this replica participates in
+  string replica_partition = 3;
 
   // Last updated timestamp
   int64 created_time_epoch_ms = 4;

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -132,7 +132,7 @@ public class ReadOnlyChunkImplTest {
             searchContext,
             kaldbConfig.getS3Config().getS3Bucket(),
             kaldbConfig.getCacheConfig().getDataDirectory(),
-            kaldbConfig.getCacheConfig().getReplicaPartition(),
+            kaldbConfig.getCacheConfig().getReplicaSet(),
             cacheSlotMetadataStore,
             replicaMetadataStore,
             snapshotMetadataStore,
@@ -262,7 +262,7 @@ public class ReadOnlyChunkImplTest {
             SearchContext.fromConfig(kaldbConfig.getCacheConfig().getServerConfig()),
             kaldbConfig.getS3Config().getS3Bucket(),
             kaldbConfig.getCacheConfig().getDataDirectory(),
-            kaldbConfig.getCacheConfig().getReplicaPartition(),
+            kaldbConfig.getCacheConfig().getReplicaSet(),
             cacheSlotMetadataStore,
             replicaMetadataStore,
             snapshotMetadataStore,
@@ -329,7 +329,7 @@ public class ReadOnlyChunkImplTest {
             SearchContext.fromConfig(kaldbConfig.getCacheConfig().getServerConfig()),
             kaldbConfig.getS3Config().getS3Bucket(),
             kaldbConfig.getCacheConfig().getDataDirectory(),
-            kaldbConfig.getCacheConfig().getReplicaPartition(),
+            kaldbConfig.getCacheConfig().getReplicaSet(),
             cacheSlotMetadataStore,
             replicaMetadataStore,
             snapshotMetadataStore,
@@ -397,7 +397,7 @@ public class ReadOnlyChunkImplTest {
             SearchContext.fromConfig(kaldbConfig.getCacheConfig().getServerConfig()),
             kaldbConfig.getS3Config().getS3Bucket(),
             kaldbConfig.getCacheConfig().getDataDirectory(),
-            kaldbConfig.getCacheConfig().getReplicaPartition(),
+            kaldbConfig.getCacheConfig().getReplicaSet(),
             cacheSlotMetadataStore,
             replicaMetadataStore,
             snapshotMetadataStore,
@@ -550,7 +550,7 @@ public class ReadOnlyChunkImplTest {
     KaldbConfigs.CacheConfig cacheConfig =
         KaldbConfigs.CacheConfig.newBuilder()
             .setSlotsPerInstance(3)
-            .setReplicaPartition("rep1")
+            .setReplicaSet("rep1")
             .setDataDirectory(
                 String.format(
                     "/tmp/%s/%s", this.getClass().getSimpleName(), RandomStringUtils.random(10)))

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -132,6 +132,7 @@ public class ReadOnlyChunkImplTest {
             searchContext,
             kaldbConfig.getS3Config().getS3Bucket(),
             kaldbConfig.getCacheConfig().getDataDirectory(),
+            kaldbConfig.getCacheConfig().getReplicaPartition(),
             cacheSlotMetadataStore,
             replicaMetadataStore,
             snapshotMetadataStore,
@@ -261,6 +262,7 @@ public class ReadOnlyChunkImplTest {
             SearchContext.fromConfig(kaldbConfig.getCacheConfig().getServerConfig()),
             kaldbConfig.getS3Config().getS3Bucket(),
             kaldbConfig.getCacheConfig().getDataDirectory(),
+            kaldbConfig.getCacheConfig().getReplicaPartition(),
             cacheSlotMetadataStore,
             replicaMetadataStore,
             snapshotMetadataStore,
@@ -327,6 +329,7 @@ public class ReadOnlyChunkImplTest {
             SearchContext.fromConfig(kaldbConfig.getCacheConfig().getServerConfig()),
             kaldbConfig.getS3Config().getS3Bucket(),
             kaldbConfig.getCacheConfig().getDataDirectory(),
+            kaldbConfig.getCacheConfig().getReplicaPartition(),
             cacheSlotMetadataStore,
             replicaMetadataStore,
             snapshotMetadataStore,
@@ -394,6 +397,7 @@ public class ReadOnlyChunkImplTest {
             SearchContext.fromConfig(kaldbConfig.getCacheConfig().getServerConfig()),
             kaldbConfig.getS3Config().getS3Bucket(),
             kaldbConfig.getCacheConfig().getDataDirectory(),
+            kaldbConfig.getCacheConfig().getReplicaPartition(),
             cacheSlotMetadataStore,
             replicaMetadataStore,
             snapshotMetadataStore,
@@ -469,7 +473,8 @@ public class ReadOnlyChunkImplTest {
             replicaId,
             Instant.now().toEpochMilli(),
             List.of(LOGS_LUCENE9),
-            readOnlyChunk.searchContext.hostname);
+            readOnlyChunk.searchContext.hostname,
+            "rep1");
     cacheSlotMetadataStore.updateAsync(updatedCacheSlotMetadata);
   }
 
@@ -495,6 +500,7 @@ public class ReadOnlyChunkImplTest {
         new ReplicaMetadata(
             replicaId,
             snapshotId,
+            "rep1",
             Instant.now().toEpochMilli(),
             Instant.now().plusSeconds(60).toEpochMilli(),
             false,
@@ -544,6 +550,7 @@ public class ReadOnlyChunkImplTest {
     KaldbConfigs.CacheConfig cacheConfig =
         KaldbConfigs.CacheConfig.newBuilder()
             .setSlotsPerInstance(3)
+            .setReplicaPartition("rep1")
             .setDataDirectory(
                 String.format(
                     "/tmp/%s/%s", this.getClass().getSimpleName(), RandomStringUtils.random(10)))

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/CachingChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/CachingChunkManagerTest.java
@@ -74,6 +74,7 @@ public class CachingChunkManagerTest {
     KaldbConfigs.CacheConfig cacheConfig =
         KaldbConfigs.CacheConfig.newBuilder()
             .setSlotsPerInstance(3)
+            .setReplicaPartition("rep1")
             .setDataDirectory(
                 String.format(
                     "/tmp/%s/%s", this.getClass().getSimpleName(), RandomStringUtils.random(10)))
@@ -115,6 +116,7 @@ public class CachingChunkManagerTest {
             SearchContext.fromConfig(kaldbConfig.getCacheConfig().getServerConfig()),
             kaldbConfig.getS3Config().getS3Bucket(),
             kaldbConfig.getCacheConfig().getDataDirectory(),
+            kaldbConfig.getCacheConfig().getReplicaPartition(),
             kaldbConfig.getCacheConfig().getSlotsPerInstance());
 
     cachingChunkManager.startAsync();

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/CachingChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/CachingChunkManagerTest.java
@@ -74,7 +74,7 @@ public class CachingChunkManagerTest {
     KaldbConfigs.CacheConfig cacheConfig =
         KaldbConfigs.CacheConfig.newBuilder()
             .setSlotsPerInstance(3)
-            .setReplicaPartition("rep1")
+            .setReplicaSet("rep1")
             .setDataDirectory(
                 String.format(
                     "/tmp/%s/%s", this.getClass().getSimpleName(), RandomStringUtils.random(10)))
@@ -116,7 +116,7 @@ public class CachingChunkManagerTest {
             SearchContext.fromConfig(kaldbConfig.getCacheConfig().getServerConfig()),
             kaldbConfig.getS3Config().getS3Bucket(),
             kaldbConfig.getCacheConfig().getDataDirectory(),
-            kaldbConfig.getCacheConfig().getReplicaPartition(),
+            kaldbConfig.getCacheConfig().getReplicaSet(),
             kaldbConfig.getCacheConfig().getSlotsPerInstance());
 
     cachingChunkManager.startAsync();

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
@@ -44,7 +44,7 @@ public class ReplicaAssignmentServiceTest {
 
   private static final List<Metadata.IndexType> SUPPORTED_INDEX_TYPES = List.of(LOGS_LUCENE9);
   public static final String HOSTNAME = "hostname";
-  public static final String REPLICA_PARTITION = "rep1";
+  public static final String REPLICA_SET = "rep1";
 
   private TestingServer testingServer;
   private MeterRegistry meterRegistry;
@@ -87,7 +87,7 @@ public class ReplicaAssignmentServiceTest {
   public void shouldCheckInvalidEventAggregation() {
     KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig replicaAssignmentServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig.newBuilder()
-            .addAllReplicaPartitions(List.of(REPLICA_PARTITION))
+            .addAllReplicaSets(List.of(REPLICA_SET))
             .setSchedulePeriodMins(1)
             .build();
     KaldbConfigs.ManagerConfig managerConfig =
@@ -109,7 +109,7 @@ public class ReplicaAssignmentServiceTest {
     KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig replicaAssignmentServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig.newBuilder()
             .setSchedulePeriodMins(-1)
-            .addAllReplicaPartitions(List.of(REPLICA_PARTITION))
+            .addAllReplicaSets(List.of(REPLICA_SET))
             .build();
     KaldbConfigs.ManagerConfig managerConfig =
         KaldbConfigs.ManagerConfig.newBuilder()
@@ -131,7 +131,7 @@ public class ReplicaAssignmentServiceTest {
     KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig replicaAssignmentServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig.newBuilder()
             .setSchedulePeriodMins(1)
-            .addAllReplicaPartitions(List.of(REPLICA_PARTITION))
+            .addAllReplicaSets(List.of(REPLICA_SET))
             .build();
     KaldbConfigs.ManagerConfig managerConfig =
         KaldbConfigs.ManagerConfig.newBuilder()
@@ -171,7 +171,7 @@ public class ReplicaAssignmentServiceTest {
     KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig replicaAssignmentServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig.newBuilder()
             .setSchedulePeriodMins(1)
-            .addAllReplicaPartitions(List.of(REPLICA_PARTITION))
+            .addAllReplicaSets(List.of(REPLICA_SET))
             .build();
     KaldbConfigs.ManagerConfig managerConfig =
         KaldbConfigs.ManagerConfig.newBuilder()
@@ -190,7 +190,7 @@ public class ReplicaAssignmentServiceTest {
           new ReplicaMetadata(
               UUID.randomUUID().toString(),
               UUID.randomUUID().toString(),
-              REPLICA_PARTITION,
+              REPLICA_SET,
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
               false,
@@ -231,7 +231,7 @@ public class ReplicaAssignmentServiceTest {
     KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig replicaAssignmentServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig.newBuilder()
             .setSchedulePeriodMins(1)
-            .addAllReplicaPartitions(List.of(REPLICA_PARTITION))
+            .addAllReplicaSets(List.of(REPLICA_SET))
             .build();
     KaldbConfigs.ManagerConfig managerConfig =
         KaldbConfigs.ManagerConfig.newBuilder()
@@ -254,7 +254,7 @@ public class ReplicaAssignmentServiceTest {
               Instant.now().toEpochMilli(),
               SUPPORTED_INDEX_TYPES,
               HOSTNAME,
-              REPLICA_PARTITION);
+              REPLICA_SET);
       cacheSlotMetadataList.add(cacheSlotMetadata);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
@@ -291,7 +291,7 @@ public class ReplicaAssignmentServiceTest {
     KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig replicaAssignmentServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig.newBuilder()
             .setSchedulePeriodMins(1)
-            .addAllReplicaPartitions(List.of(REPLICA_PARTITION))
+            .addAllReplicaSets(List.of(REPLICA_SET))
             .build();
     KaldbConfigs.ManagerConfig managerConfig =
         KaldbConfigs.ManagerConfig.newBuilder()
@@ -310,7 +310,7 @@ public class ReplicaAssignmentServiceTest {
           new ReplicaMetadata(
               UUID.randomUUID().toString(),
               UUID.randomUUID().toString(),
-              REPLICA_PARTITION,
+              REPLICA_SET,
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
               false,
@@ -329,7 +329,7 @@ public class ReplicaAssignmentServiceTest {
               Instant.now().toEpochMilli(),
               SUPPORTED_INDEX_TYPES,
               HOSTNAME,
-              REPLICA_PARTITION);
+              REPLICA_SET);
       cacheSlotMetadataList.add(cacheSlotMetadata);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
@@ -343,7 +343,7 @@ public class ReplicaAssignmentServiceTest {
               Instant.now().toEpochMilli(),
               SUPPORTED_INDEX_TYPES,
               HOSTNAME,
-              REPLICA_PARTITION);
+              REPLICA_SET);
       cacheSlotMetadataList.add(cacheSlotMetadata);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
@@ -384,7 +384,7 @@ public class ReplicaAssignmentServiceTest {
     KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig replicaAssignmentServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig.newBuilder()
             .setSchedulePeriodMins(1)
-            .addAllReplicaPartitions(List.of(REPLICA_PARTITION))
+            .addAllReplicaSets(List.of(REPLICA_SET))
             .build();
     KaldbConfigs.ManagerConfig managerConfig =
         KaldbConfigs.ManagerConfig.newBuilder()
@@ -403,7 +403,7 @@ public class ReplicaAssignmentServiceTest {
           new ReplicaMetadata(
               UUID.randomUUID().toString(),
               UUID.randomUUID().toString(),
-              REPLICA_PARTITION,
+              REPLICA_SET,
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
               false,
@@ -421,7 +421,7 @@ public class ReplicaAssignmentServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     unmutatedSlots.add(cacheSlotWithAssignment);
     cacheSlotMetadataStore.createAsync(cacheSlotWithAssignment);
 
@@ -433,7 +433,7 @@ public class ReplicaAssignmentServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     unmutatedSlots.add(cacheSlotLive);
     cacheSlotMetadataStore.createAsync(cacheSlotLive);
 
@@ -445,7 +445,7 @@ public class ReplicaAssignmentServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     unmutatedSlots.add(cacheSlotEvicting);
     cacheSlotMetadataStore.createAsync(cacheSlotEvicting);
 
@@ -457,7 +457,7 @@ public class ReplicaAssignmentServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     cacheSlotMetadataStore.createAsync(cacheSlotFree);
 
     await().until(() -> cacheSlotMetadataStore.listSync().size() == 4);
@@ -502,7 +502,7 @@ public class ReplicaAssignmentServiceTest {
     KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig replicaAssignmentServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig.newBuilder()
             .setSchedulePeriodMins(1)
-            .addAllReplicaPartitions(List.of(REPLICA_PARTITION))
+            .addAllReplicaSets(List.of(REPLICA_SET))
             .build();
     KaldbConfigs.ManagerConfig managerConfig =
         KaldbConfigs.ManagerConfig.newBuilder()
@@ -521,7 +521,7 @@ public class ReplicaAssignmentServiceTest {
           new ReplicaMetadata(
               UUID.randomUUID().toString(),
               UUID.randomUUID().toString(),
-              REPLICA_PARTITION,
+              REPLICA_SET,
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
               false,
@@ -540,7 +540,7 @@ public class ReplicaAssignmentServiceTest {
               Instant.now().toEpochMilli(),
               SUPPORTED_INDEX_TYPES,
               HOSTNAME,
-              REPLICA_PARTITION);
+              REPLICA_SET);
       cacheSlotMetadataList.add(cacheSlotMetadata);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
@@ -581,7 +581,7 @@ public class ReplicaAssignmentServiceTest {
     KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig replicaAssignmentServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig.newBuilder()
             .setSchedulePeriodMins(1)
-            .addAllReplicaPartitions(List.of(REPLICA_PARTITION))
+            .addAllReplicaSets(List.of(REPLICA_SET))
             .build();
     KaldbConfigs.ManagerConfig managerConfig =
         KaldbConfigs.ManagerConfig.newBuilder()
@@ -600,7 +600,7 @@ public class ReplicaAssignmentServiceTest {
           new ReplicaMetadata(
               UUID.randomUUID().toString(),
               UUID.randomUUID().toString(),
-              REPLICA_PARTITION,
+              REPLICA_SET,
               Instant.now().minus(1500, ChronoUnit.MINUTES).toEpochMilli(),
               Instant.now().minusSeconds(60).toEpochMilli(),
               false,
@@ -614,7 +614,7 @@ public class ReplicaAssignmentServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
-            REPLICA_PARTITION,
+            REPLICA_SET,
             Instant.now().minus(1500, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             false,
@@ -627,7 +627,7 @@ public class ReplicaAssignmentServiceTest {
           new ReplicaMetadata(
               UUID.randomUUID().toString(),
               UUID.randomUUID().toString(),
-              REPLICA_PARTITION,
+              REPLICA_SET,
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
               false,
@@ -644,7 +644,7 @@ public class ReplicaAssignmentServiceTest {
               Instant.now().toEpochMilli(),
               SUPPORTED_INDEX_TYPES,
               HOSTNAME,
-              REPLICA_PARTITION);
+              REPLICA_SET);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
@@ -702,7 +702,7 @@ public class ReplicaAssignmentServiceTest {
     KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig replicaAssignmentServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig.newBuilder()
             .setSchedulePeriodMins(1)
-            .addAllReplicaPartitions(List.of(REPLICA_PARTITION))
+            .addAllReplicaSets(List.of(REPLICA_SET))
             .build();
     KaldbConfigs.ManagerConfig managerConfig =
         KaldbConfigs.ManagerConfig.newBuilder()
@@ -720,7 +720,7 @@ public class ReplicaAssignmentServiceTest {
           new ReplicaMetadata(
               UUID.randomUUID().toString(),
               UUID.randomUUID().toString(),
-              REPLICA_PARTITION,
+              REPLICA_SET,
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
               false,
@@ -737,7 +737,7 @@ public class ReplicaAssignmentServiceTest {
               Instant.now().toEpochMilli(),
               SUPPORTED_INDEX_TYPES,
               HOSTNAME,
-              REPLICA_PARTITION);
+              REPLICA_SET);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
@@ -751,7 +751,7 @@ public class ReplicaAssignmentServiceTest {
     doCallRealMethod().doReturn(asyncStage).when(cacheSlotMetadataStore).updateAsync(any());
 
     Map<String, Integer> firstAssignment = replicaAssignmentService.assignReplicasToCacheSlots();
-    assertThat(firstAssignment.get(REPLICA_PARTITION)).isEqualTo(1);
+    assertThat(firstAssignment.get(REPLICA_SET)).isEqualTo(1);
 
     assertThat(KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore).size()).isEqualTo(2);
     assertThat(KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).size()).isEqualTo(3);
@@ -790,7 +790,7 @@ public class ReplicaAssignmentServiceTest {
     doCallRealMethod().when(cacheSlotMetadataStore).updateAsync(any());
 
     Map<String, Integer> secondAssignment = replicaAssignmentService.assignReplicasToCacheSlots();
-    assertThat(secondAssignment.get(REPLICA_PARTITION)).isEqualTo(1);
+    assertThat(secondAssignment.get(REPLICA_SET)).isEqualTo(1);
 
     assertThat(KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore).size()).isEqualTo(2);
     assertThat(KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).size()).isEqualTo(3);
@@ -830,7 +830,7 @@ public class ReplicaAssignmentServiceTest {
     KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig replicaAssignmentServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig.newBuilder()
             .setSchedulePeriodMins(1)
-            .addAllReplicaPartitions(List.of(REPLICA_PARTITION))
+            .addAllReplicaSets(List.of(REPLICA_SET))
             .build();
     KaldbConfigs.ManagerConfig managerConfig =
         KaldbConfigs.ManagerConfig.newBuilder()
@@ -848,7 +848,7 @@ public class ReplicaAssignmentServiceTest {
           new ReplicaMetadata(
               UUID.randomUUID().toString(),
               UUID.randomUUID().toString(),
-              REPLICA_PARTITION,
+              REPLICA_SET,
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
               false,
@@ -865,7 +865,7 @@ public class ReplicaAssignmentServiceTest {
               Instant.now().toEpochMilli(),
               SUPPORTED_INDEX_TYPES,
               HOSTNAME,
-              REPLICA_PARTITION);
+              REPLICA_SET);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
@@ -890,7 +890,7 @@ public class ReplicaAssignmentServiceTest {
     doCallRealMethod().doReturn(asyncStage).when(cacheSlotMetadataStore).updateAsync(any());
 
     Map<String, Integer> firstAssignment = replicaAssignmentService.assignReplicasToCacheSlots();
-    assertThat(firstAssignment.get(REPLICA_PARTITION)).isEqualTo(1);
+    assertThat(firstAssignment.get(REPLICA_SET)).isEqualTo(1);
 
     assertThat(KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore).size()).isEqualTo(2);
     assertThat(KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).size()).isEqualTo(3);
@@ -932,7 +932,7 @@ public class ReplicaAssignmentServiceTest {
     KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig replicaAssignmentServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig.newBuilder()
             .setSchedulePeriodMins(1)
-            .addAllReplicaPartitions(List.of(REPLICA_PARTITION))
+            .addAllReplicaSets(List.of(REPLICA_SET))
             .build();
     KaldbConfigs.ManagerConfig managerConfig =
         KaldbConfigs.ManagerConfig.newBuilder()
@@ -950,7 +950,7 @@ public class ReplicaAssignmentServiceTest {
           new ReplicaMetadata(
               UUID.randomUUID().toString(),
               UUID.randomUUID().toString(),
-              REPLICA_PARTITION,
+              REPLICA_SET,
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
               false,
@@ -967,7 +967,7 @@ public class ReplicaAssignmentServiceTest {
               Instant.now().toEpochMilli(),
               SUPPORTED_INDEX_TYPES,
               HOSTNAME,
-              REPLICA_PARTITION);
+              REPLICA_SET);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
@@ -981,7 +981,7 @@ public class ReplicaAssignmentServiceTest {
     doCallRealMethod().doReturn(asyncStage).when(cacheSlotMetadataStore).updateAsync(any());
 
     Map<String, Integer> firstAssignment = replicaAssignmentService.assignReplicasToCacheSlots();
-    assertThat(firstAssignment.get(REPLICA_PARTITION)).isEqualTo(1);
+    assertThat(firstAssignment.get(REPLICA_SET)).isEqualTo(1);
 
     assertThat(KaldbMetadataTestUtils.listSyncUncached(replicaMetadataStore).size()).isEqualTo(2);
     assertThat(KaldbMetadataTestUtils.listSyncUncached(cacheSlotMetadataStore).size()).isEqualTo(3);
@@ -1021,7 +1021,7 @@ public class ReplicaAssignmentServiceTest {
     KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig replicaAssignmentServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig.newBuilder()
             .setSchedulePeriodMins(1)
-            .addAllReplicaPartitions(List.of(REPLICA_PARTITION))
+            .addAllReplicaSets(List.of(REPLICA_SET))
             .build();
     KaldbConfigs.ManagerConfig managerConfig =
         KaldbConfigs.ManagerConfig.newBuilder()
@@ -1043,7 +1043,7 @@ public class ReplicaAssignmentServiceTest {
               Instant.now().toEpochMilli(),
               SUPPORTED_INDEX_TYPES,
               HOSTNAME,
-              REPLICA_PARTITION);
+              REPLICA_SET);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
@@ -1066,7 +1066,7 @@ public class ReplicaAssignmentServiceTest {
           new ReplicaMetadata(
               UUID.randomUUID().toString(),
               UUID.randomUUID().toString(),
-              REPLICA_PARTITION,
+              REPLICA_SET,
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
               false,
@@ -1118,7 +1118,7 @@ public class ReplicaAssignmentServiceTest {
     KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig replicaAssignmentServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig.newBuilder()
             .setSchedulePeriodMins(1)
-            .addAllReplicaPartitions(List.of(REPLICA_PARTITION))
+            .addAllReplicaSets(List.of(REPLICA_SET))
             .build();
     KaldbConfigs.ManagerConfig managerConfig =
         KaldbConfigs.ManagerConfig.newBuilder()
@@ -1137,7 +1137,7 @@ public class ReplicaAssignmentServiceTest {
           new ReplicaMetadata(
               UUID.randomUUID().toString(),
               UUID.randomUUID().toString(),
-              REPLICA_PARTITION,
+              REPLICA_SET,
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
               false,
@@ -1160,7 +1160,7 @@ public class ReplicaAssignmentServiceTest {
               Instant.now().toEpochMilli(),
               SUPPORTED_INDEX_TYPES,
               HOSTNAME,
-              REPLICA_PARTITION);
+              REPLICA_SET);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
@@ -1213,7 +1213,7 @@ public class ReplicaAssignmentServiceTest {
     KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig replicaAssignmentServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig.newBuilder()
             .setSchedulePeriodMins(1)
-            .addAllReplicaPartitions(List.of(REPLICA_PARTITION))
+            .addAllReplicaSets(List.of(REPLICA_SET))
             .build();
     KaldbConfigs.ManagerConfig managerConfig =
         KaldbConfigs.ManagerConfig.newBuilder()
@@ -1231,7 +1231,7 @@ public class ReplicaAssignmentServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
-            REPLICA_PARTITION,
+            REPLICA_SET,
             now.minus(1, ChronoUnit.HOURS).toEpochMilli(),
             now.plusSeconds(60).toEpochMilli(),
             false,
@@ -1242,7 +1242,7 @@ public class ReplicaAssignmentServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
-            REPLICA_PARTITION,
+            REPLICA_SET,
             now.toEpochMilli(),
             now.plusSeconds(60).toEpochMilli(),
             false,
@@ -1262,7 +1262,7 @@ public class ReplicaAssignmentServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
 
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     await()
@@ -1285,7 +1285,7 @@ public class ReplicaAssignmentServiceTest {
     KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig replicaAssignmentServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaAssignmentServiceConfig.newBuilder()
             .setSchedulePeriodMins(1)
-            .addAllReplicaPartitions(List.of(REPLICA_PARTITION))
+            .addAllReplicaSets(List.of(REPLICA_SET))
             .build();
     KaldbConfigs.ManagerConfig managerConfig =
         KaldbConfigs.ManagerConfig.newBuilder()
@@ -1303,7 +1303,7 @@ public class ReplicaAssignmentServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
-            REPLICA_PARTITION,
+            REPLICA_SET,
             now.minus(1, ChronoUnit.HOURS).toEpochMilli(),
             now.plusSeconds(60).toEpochMilli(),
             false,
@@ -1314,7 +1314,7 @@ public class ReplicaAssignmentServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
-            REPLICA_PARTITION,
+            REPLICA_SET,
             now.toEpochMilli(),
             now.plusSeconds(60).toEpochMilli(),
             false,
@@ -1335,7 +1335,7 @@ public class ReplicaAssignmentServiceTest {
             Instant.now().toEpochMilli(),
             suppportedIndexTypes,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
 
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     await()

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaCreationServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaCreationServiceTest.java
@@ -108,7 +108,7 @@ public class ReplicaCreationServiceTest {
 
     KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
-            .addAllReplicaPartitions(List.of("rep1", "rep2"))
+            .addAllReplicaSets(List.of("rep1", "rep2"))
             .setSchedulePeriodMins(10)
             .setReplicaLifespanMins(1440)
             .build();
@@ -150,7 +150,7 @@ public class ReplicaCreationServiceTest {
 
     KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
-            .addAllReplicaPartitions(List.of())
+            .addAllReplicaSets(List.of())
             .setSchedulePeriodMins(10)
             .setReplicaLifespanMins(1440)
             .build();
@@ -193,7 +193,7 @@ public class ReplicaCreationServiceTest {
 
     KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
-            .addAllReplicaPartitions(List.of("rep1", "rep2", "rep3", "rep4"))
+            .addAllReplicaSets(List.of("rep1", "rep2", "rep3", "rep4"))
             .setSchedulePeriodMins(10)
             .setReplicaLifespanMins(1440)
             .build();
@@ -256,7 +256,7 @@ public class ReplicaCreationServiceTest {
 
     KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
-            .addAllReplicaPartitions(List.of("rep1"))
+            .addAllReplicaSets(List.of("rep1"))
             .setSchedulePeriodMins(10)
             .setReplicaLifespanMins(1440)
             .build();
@@ -310,7 +310,7 @@ public class ReplicaCreationServiceTest {
 
     KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
-            .addAllReplicaPartitions(List.of("rep1", "rep2"))
+            .addAllReplicaSets(List.of("rep1", "rep2"))
             .setSchedulePeriodMins(10)
             .setReplicaLifespanMins(1440)
             .build();
@@ -421,7 +421,7 @@ public class ReplicaCreationServiceTest {
   public void shouldCreateReplicaWhenSnapshotAddedAfterRunning() throws Exception {
     KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
-            .addAllReplicaPartitions(List.of("rep1", "rep2"))
+            .addAllReplicaSets(List.of("rep1", "rep2"))
             .setSchedulePeriodMins(10)
             .setReplicaLifespanMins(1440)
             .build();
@@ -472,7 +472,7 @@ public class ReplicaCreationServiceTest {
   public void shouldStillCreateReplicaIfFirstAttemptFails() throws Exception {
     KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
-            .addAllReplicaPartitions(List.of("rep1", "rep2"))
+            .addAllReplicaSets(List.of("rep1", "rep2"))
             .setSchedulePeriodMins(10)
             .setReplicaLifespanMins(1440)
             .build();
@@ -584,7 +584,7 @@ public class ReplicaCreationServiceTest {
 
     KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
-            .addAllReplicaPartitions(List.of("rep1", "rep2"))
+            .addAllReplicaSets(List.of("rep1", "rep2"))
             .setSchedulePeriodMins(10)
             .setReplicaLifespanMins(1440)
             .build();
@@ -633,7 +633,7 @@ public class ReplicaCreationServiceTest {
 
     KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
-            .addAllReplicaPartitions(List.of("rep1", "rep2"))
+            .addAllReplicaSets(List.of("rep1", "rep2"))
             .setSchedulePeriodMins(10)
             .setReplicaLifespanMins(1440)
             .build();
@@ -686,7 +686,7 @@ public class ReplicaCreationServiceTest {
   public void shouldThrowOnInvalidAggregationSecs() {
     KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
-            .addAllReplicaPartitions(List.of("rep1", "rep2"))
+            .addAllReplicaSets(List.of("rep1", "rep2"))
             .setSchedulePeriodMins(10)
             .setReplicaLifespanMins(1440)
             .build();
@@ -709,7 +709,7 @@ public class ReplicaCreationServiceTest {
   public void shouldThrowOnInvalidLifespanMins() {
     KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig.newBuilder()
-            .addAllReplicaPartitions(List.of("rep1", "rep2"))
+            .addAllReplicaSets(List.of("rep1", "rep2"))
             .setSchedulePeriodMins(10)
             .setReplicaLifespanMins(0)
             .build();

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaDeletionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaDeletionServiceTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Test;
 public class ReplicaDeletionServiceTest {
   public static final List<Metadata.IndexType> SUPPORTED_INDEX_TYPES = List.of(LOGS_LUCENE9);
   public static final String HOSTNAME = "hostname";
+  private static final String REPLICA_PARTITION = "rep1";
   private TestingServer testingServer;
   private MeterRegistry meterRegistry;
 
@@ -146,6 +147,7 @@ public class ReplicaDeletionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
+            REPLICA_PARTITION,
             Instant.now().minusSeconds(30).toEpochMilli(),
             Instant.now().minusSeconds(10).toEpochMilli(),
             false,
@@ -159,7 +161,8 @@ public class ReplicaDeletionServiceTest {
             "",
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
-            HOSTNAME);
+            HOSTNAME,
+            REPLICA_PARTITION);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
     await().until(() -> replicaMetadataStore.listSync().size() == 1);
@@ -203,6 +206,7 @@ public class ReplicaDeletionServiceTest {
           new ReplicaMetadata(
               UUID.randomUUID().toString(),
               UUID.randomUUID().toString(),
+              REPLICA_PARTITION,
               Instant.now().minusSeconds(30).toEpochMilli(),
               Instant.now().minusSeconds(10).toEpochMilli(),
               false,
@@ -218,7 +222,8 @@ public class ReplicaDeletionServiceTest {
             replicaMetadataList.get(0).name,
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
-            HOSTNAME);
+            HOSTNAME,
+            REPLICA_PARTITION);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadataAssigned);
 
     CacheSlotMetadata cacheSlotMetadataEvict =
@@ -228,7 +233,8 @@ public class ReplicaDeletionServiceTest {
             replicaMetadataList.get(1).name,
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
-            HOSTNAME);
+            HOSTNAME,
+            REPLICA_PARTITION);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadataEvict);
 
     CacheSlotMetadata cacheSlotMetadataEvicting =
@@ -238,7 +244,8 @@ public class ReplicaDeletionServiceTest {
             replicaMetadataList.get(2).name,
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
-            HOSTNAME);
+            HOSTNAME,
+            REPLICA_PARTITION);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadataEvicting);
 
     await().until(() -> replicaMetadataStore.listSync().size() == 3);
@@ -283,6 +290,7 @@ public class ReplicaDeletionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
+            REPLICA_PARTITION,
             Instant.now().minusSeconds(30).toEpochMilli(),
             Instant.now().plusSeconds(30).toEpochMilli(),
             false,
@@ -296,7 +304,8 @@ public class ReplicaDeletionServiceTest {
             "",
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
-            HOSTNAME);
+            HOSTNAME,
+            REPLICA_PARTITION);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
     await().until(() -> replicaMetadataStore.listSync().size() == 1);
@@ -338,6 +347,7 @@ public class ReplicaDeletionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
+            REPLICA_PARTITION,
             Instant.now().minusSeconds(30).toEpochMilli(),
             Instant.now().minusSeconds(10).toEpochMilli(),
             false,
@@ -351,7 +361,8 @@ public class ReplicaDeletionServiceTest {
             "",
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
-            HOSTNAME);
+            HOSTNAME,
+            REPLICA_PARTITION);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
     await().until(() -> replicaMetadataStore.listSync().size() == 1);
@@ -417,6 +428,7 @@ public class ReplicaDeletionServiceTest {
           new ReplicaMetadata(
               UUID.randomUUID().toString(),
               UUID.randomUUID().toString(),
+              REPLICA_PARTITION,
               Instant.now().minusSeconds(30).toEpochMilli(),
               Instant.now().minusSeconds(10).toEpochMilli(),
               false,
@@ -433,7 +445,8 @@ public class ReplicaDeletionServiceTest {
               "",
               Instant.now().toEpochMilli(),
               SUPPORTED_INDEX_TYPES,
-              HOSTNAME);
+              HOSTNAME,
+              REPLICA_PARTITION);
       cacheSlotMetadataList.add(cacheSlotMetadata);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
@@ -517,6 +530,7 @@ public class ReplicaDeletionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
+            REPLICA_PARTITION,
             Instant.now().minusSeconds(30).toEpochMilli(),
             Instant.now().minusSeconds(10).toEpochMilli(),
             false,
@@ -527,6 +541,7 @@ public class ReplicaDeletionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
+            REPLICA_PARTITION,
             Instant.now().minusSeconds(30).toEpochMilli(),
             Instant.now().minusSeconds(10).toEpochMilli(),
             false,
@@ -540,7 +555,8 @@ public class ReplicaDeletionServiceTest {
             "",
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
-            HOSTNAME);
+            HOSTNAME,
+            REPLICA_PARTITION);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadataUnassigned);
 
     CacheSlotMetadata cacheSlotMetadataAssigned =
@@ -550,7 +566,8 @@ public class ReplicaDeletionServiceTest {
             replicaMetadataAssigned.name,
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
-            HOSTNAME);
+            HOSTNAME,
+            REPLICA_PARTITION);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadataAssigned);
 
     await().until(() -> replicaMetadataStore.listSync().size() == 2);

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaDeletionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaDeletionServiceTest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
 public class ReplicaDeletionServiceTest {
   public static final List<Metadata.IndexType> SUPPORTED_INDEX_TYPES = List.of(LOGS_LUCENE9);
   public static final String HOSTNAME = "hostname";
-  private static final String REPLICA_PARTITION = "rep1";
+  private static final String REPLICA_SET = "rep1";
   private TestingServer testingServer;
   private MeterRegistry meterRegistry;
 
@@ -147,7 +147,7 @@ public class ReplicaDeletionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
-            REPLICA_PARTITION,
+            REPLICA_SET,
             Instant.now().minusSeconds(30).toEpochMilli(),
             Instant.now().minusSeconds(10).toEpochMilli(),
             false,
@@ -162,7 +162,7 @@ public class ReplicaDeletionServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
     await().until(() -> replicaMetadataStore.listSync().size() == 1);
@@ -206,7 +206,7 @@ public class ReplicaDeletionServiceTest {
           new ReplicaMetadata(
               UUID.randomUUID().toString(),
               UUID.randomUUID().toString(),
-              REPLICA_PARTITION,
+              REPLICA_SET,
               Instant.now().minusSeconds(30).toEpochMilli(),
               Instant.now().minusSeconds(10).toEpochMilli(),
               false,
@@ -223,7 +223,7 @@ public class ReplicaDeletionServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadataAssigned);
 
     CacheSlotMetadata cacheSlotMetadataEvict =
@@ -234,7 +234,7 @@ public class ReplicaDeletionServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadataEvict);
 
     CacheSlotMetadata cacheSlotMetadataEvicting =
@@ -245,7 +245,7 @@ public class ReplicaDeletionServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadataEvicting);
 
     await().until(() -> replicaMetadataStore.listSync().size() == 3);
@@ -290,7 +290,7 @@ public class ReplicaDeletionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
-            REPLICA_PARTITION,
+            REPLICA_SET,
             Instant.now().minusSeconds(30).toEpochMilli(),
             Instant.now().plusSeconds(30).toEpochMilli(),
             false,
@@ -305,7 +305,7 @@ public class ReplicaDeletionServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
     await().until(() -> replicaMetadataStore.listSync().size() == 1);
@@ -347,7 +347,7 @@ public class ReplicaDeletionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
-            REPLICA_PARTITION,
+            REPLICA_SET,
             Instant.now().minusSeconds(30).toEpochMilli(),
             Instant.now().minusSeconds(10).toEpochMilli(),
             false,
@@ -362,7 +362,7 @@ public class ReplicaDeletionServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
     await().until(() -> replicaMetadataStore.listSync().size() == 1);
@@ -428,7 +428,7 @@ public class ReplicaDeletionServiceTest {
           new ReplicaMetadata(
               UUID.randomUUID().toString(),
               UUID.randomUUID().toString(),
-              REPLICA_PARTITION,
+              REPLICA_SET,
               Instant.now().minusSeconds(30).toEpochMilli(),
               Instant.now().minusSeconds(10).toEpochMilli(),
               false,
@@ -446,7 +446,7 @@ public class ReplicaDeletionServiceTest {
               Instant.now().toEpochMilli(),
               SUPPORTED_INDEX_TYPES,
               HOSTNAME,
-              REPLICA_PARTITION);
+              REPLICA_SET);
       cacheSlotMetadataList.add(cacheSlotMetadata);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
@@ -530,7 +530,7 @@ public class ReplicaDeletionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
-            REPLICA_PARTITION,
+            REPLICA_SET,
             Instant.now().minusSeconds(30).toEpochMilli(),
             Instant.now().minusSeconds(10).toEpochMilli(),
             false,
@@ -541,7 +541,7 @@ public class ReplicaDeletionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
-            REPLICA_PARTITION,
+            REPLICA_SET,
             Instant.now().minusSeconds(30).toEpochMilli(),
             Instant.now().minusSeconds(10).toEpochMilli(),
             false,
@@ -556,7 +556,7 @@ public class ReplicaDeletionServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadataUnassigned);
 
     CacheSlotMetadata cacheSlotMetadataAssigned =
@@ -567,7 +567,7 @@ public class ReplicaDeletionServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadataAssigned);
 
     await().until(() -> replicaMetadataStore.listSync().size() == 2);

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.Test;
 public class ReplicaEvictionServiceTest {
   private static final List<Metadata.IndexType> SUPPORTED_INDEX_TYPES = List.of(LOGS_LUCENE9);
   public static final String HOSTNAME = "hostname";
+  public static final String REPLICA_PARTITION = "rep1";
   private TestingServer testingServer;
   private MeterRegistry meterRegistry;
 
@@ -160,6 +161,7 @@ public class ReplicaEvictionServiceTest {
           new ReplicaMetadata(
               UUID.randomUUID().toString(),
               UUID.randomUUID().toString(),
+              REPLICA_PARTITION,
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
               false,
@@ -176,7 +178,8 @@ public class ReplicaEvictionServiceTest {
             replicas.get(0).name,
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
-            HOSTNAME);
+            HOSTNAME,
+            REPLICA_PARTITION);
     cacheSlots.add(cacheSlotAssigned);
     cacheSlotMetadataStore.createAsync(cacheSlotAssigned);
 
@@ -187,7 +190,8 @@ public class ReplicaEvictionServiceTest {
             replicas.get(1).name,
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
-            HOSTNAME);
+            HOSTNAME,
+            REPLICA_PARTITION);
     cacheSlots.add(cacheSlotLive);
     cacheSlotMetadataStore.createAsync(cacheSlotLive);
 
@@ -198,7 +202,8 @@ public class ReplicaEvictionServiceTest {
             replicas.get(2).name,
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
-            HOSTNAME);
+            HOSTNAME,
+            REPLICA_PARTITION);
     cacheSlots.add(cacheSlotLoading);
     cacheSlotMetadataStore.createAsync(cacheSlotLoading);
 
@@ -246,6 +251,7 @@ public class ReplicaEvictionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
+            REPLICA_PARTITION,
             Instant.now().toEpochMilli(),
             0,
             false,
@@ -261,7 +267,8 @@ public class ReplicaEvictionServiceTest {
             replicaMetadata.name,
             Instant.now().toEpochMilli(),
             supportedIndexTypes,
-            HOSTNAME);
+            HOSTNAME,
+            REPLICA_PARTITION);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     assertThat(cacheSlotMetadata.supportedIndexTypes.size()).isEqualTo(2);
 
@@ -326,6 +333,7 @@ public class ReplicaEvictionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
+            REPLICA_PARTITION,
             Instant.now().toEpochMilli(),
             0,
             false,
@@ -339,7 +347,8 @@ public class ReplicaEvictionServiceTest {
             replicaMetadata.name,
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
-            HOSTNAME);
+            HOSTNAME,
+            REPLICA_PARTITION);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
     await().until(() -> replicaMetadataStore.listSync().size() == 1);
@@ -401,6 +410,7 @@ public class ReplicaEvictionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
+            REPLICA_PARTITION,
             Instant.now().toEpochMilli(),
             Instant.now().minusSeconds(60).toEpochMilli(),
             false,
@@ -414,7 +424,8 @@ public class ReplicaEvictionServiceTest {
             replicaMetadata.name,
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
-            HOSTNAME);
+            HOSTNAME,
+            REPLICA_PARTITION);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
     await().until(() -> replicaMetadataStore.listSync().size() == 1);
@@ -461,6 +472,7 @@ public class ReplicaEvictionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
+            REPLICA_PARTITION,
             Instant.now().toEpochMilli(),
             Instant.now().minusSeconds(60).toEpochMilli(),
             false,
@@ -474,7 +486,8 @@ public class ReplicaEvictionServiceTest {
             replicaMetadata.name,
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
-            HOSTNAME);
+            HOSTNAME,
+            REPLICA_PARTITION);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
     await().until(() -> replicaMetadataStore.listSync().size() == 1);
@@ -521,6 +534,7 @@ public class ReplicaEvictionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
+            REPLICA_PARTITION,
             Instant.now().toEpochMilli(),
             Instant.now().minusSeconds(60).toEpochMilli(),
             false,
@@ -534,7 +548,8 @@ public class ReplicaEvictionServiceTest {
             replicaMetadata.name,
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
-            HOSTNAME);
+            HOSTNAME,
+            REPLICA_PARTITION);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
     await().until(() -> replicaMetadataStore.listSync().size() == 1);
@@ -626,6 +641,7 @@ public class ReplicaEvictionServiceTest {
           new ReplicaMetadata(
               UUID.randomUUID().toString(),
               UUID.randomUUID().toString(),
+              REPLICA_PARTITION,
               Instant.now().toEpochMilli(),
               Instant.now().minusSeconds(60).toEpochMilli(),
               false,
@@ -642,7 +658,8 @@ public class ReplicaEvictionServiceTest {
               replicas.get(0).name,
               Instant.now().toEpochMilli(),
               SUPPORTED_INDEX_TYPES,
-              HOSTNAME);
+              HOSTNAME,
+              REPLICA_PARTITION);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
@@ -754,6 +771,7 @@ public class ReplicaEvictionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
+            REPLICA_PARTITION,
             Instant.now().toEpochMilli(),
             Instant.now().minusSeconds(60).toEpochMilli(),
             false,
@@ -766,13 +784,15 @@ public class ReplicaEvictionServiceTest {
             replicaMetadataExpiredOne.name,
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
-            HOSTNAME);
+            HOSTNAME,
+            REPLICA_PARTITION);
     cacheSlotMetadataStore.createAsync(cacheSlotReplicaExpiredOne);
 
     ReplicaMetadata replicaMetadataExpiredTwo =
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
+            REPLICA_PARTITION,
             Instant.now().toEpochMilli(),
             Instant.now().minusSeconds(60).toEpochMilli(),
             false,
@@ -785,13 +805,15 @@ public class ReplicaEvictionServiceTest {
             replicaMetadataExpiredTwo.name,
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
-            HOSTNAME);
+            HOSTNAME,
+            REPLICA_PARTITION);
     cacheSlotMetadataStore.createAsync(cacheSlotReplicaExpireTwo);
 
     ReplicaMetadata replicaMetadataUnexpiredOne =
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
+            REPLICA_PARTITION,
             Instant.now().toEpochMilli(),
             Instant.now().plusSeconds(360).toEpochMilli(),
             false,
@@ -804,13 +826,15 @@ public class ReplicaEvictionServiceTest {
             replicaMetadataUnexpiredOne.name,
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
-            HOSTNAME);
+            HOSTNAME,
+            REPLICA_PARTITION);
     cacheSlotMetadataStore.createAsync(cacheSlotReplicaUnexpiredOne);
 
     ReplicaMetadata replicaMetadataUnexpiredTwo =
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
+            REPLICA_PARTITION,
             Instant.now().toEpochMilli(),
             Instant.now().plusSeconds(360).toEpochMilli(),
             false,
@@ -823,7 +847,8 @@ public class ReplicaEvictionServiceTest {
             "",
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
-            HOSTNAME);
+            HOSTNAME,
+            REPLICA_PARTITION);
     cacheSlotMetadataStore.createAsync(cacheSlotFree);
 
     await().until(() -> replicaMetadataStore.listSync().size() == 4);

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test;
 public class ReplicaEvictionServiceTest {
   private static final List<Metadata.IndexType> SUPPORTED_INDEX_TYPES = List.of(LOGS_LUCENE9);
   public static final String HOSTNAME = "hostname";
-  public static final String REPLICA_PARTITION = "rep1";
+  public static final String REPLICA_SET = "rep1";
   private TestingServer testingServer;
   private MeterRegistry meterRegistry;
 
@@ -161,7 +161,7 @@ public class ReplicaEvictionServiceTest {
           new ReplicaMetadata(
               UUID.randomUUID().toString(),
               UUID.randomUUID().toString(),
-              REPLICA_PARTITION,
+              REPLICA_SET,
               Instant.now().toEpochMilli(),
               Instant.now().plusSeconds(60).toEpochMilli(),
               false,
@@ -179,7 +179,7 @@ public class ReplicaEvictionServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     cacheSlots.add(cacheSlotAssigned);
     cacheSlotMetadataStore.createAsync(cacheSlotAssigned);
 
@@ -191,7 +191,7 @@ public class ReplicaEvictionServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     cacheSlots.add(cacheSlotLive);
     cacheSlotMetadataStore.createAsync(cacheSlotLive);
 
@@ -203,7 +203,7 @@ public class ReplicaEvictionServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     cacheSlots.add(cacheSlotLoading);
     cacheSlotMetadataStore.createAsync(cacheSlotLoading);
 
@@ -251,7 +251,7 @@ public class ReplicaEvictionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
-            REPLICA_PARTITION,
+            REPLICA_SET,
             Instant.now().toEpochMilli(),
             0,
             false,
@@ -268,7 +268,7 @@ public class ReplicaEvictionServiceTest {
             Instant.now().toEpochMilli(),
             supportedIndexTypes,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     assertThat(cacheSlotMetadata.supportedIndexTypes.size()).isEqualTo(2);
 
@@ -333,7 +333,7 @@ public class ReplicaEvictionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
-            REPLICA_PARTITION,
+            REPLICA_SET,
             Instant.now().toEpochMilli(),
             0,
             false,
@@ -348,7 +348,7 @@ public class ReplicaEvictionServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
     await().until(() -> replicaMetadataStore.listSync().size() == 1);
@@ -410,7 +410,7 @@ public class ReplicaEvictionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
-            REPLICA_PARTITION,
+            REPLICA_SET,
             Instant.now().toEpochMilli(),
             Instant.now().minusSeconds(60).toEpochMilli(),
             false,
@@ -425,7 +425,7 @@ public class ReplicaEvictionServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
     await().until(() -> replicaMetadataStore.listSync().size() == 1);
@@ -472,7 +472,7 @@ public class ReplicaEvictionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
-            REPLICA_PARTITION,
+            REPLICA_SET,
             Instant.now().toEpochMilli(),
             Instant.now().minusSeconds(60).toEpochMilli(),
             false,
@@ -487,7 +487,7 @@ public class ReplicaEvictionServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
     await().until(() -> replicaMetadataStore.listSync().size() == 1);
@@ -534,7 +534,7 @@ public class ReplicaEvictionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
-            REPLICA_PARTITION,
+            REPLICA_SET,
             Instant.now().toEpochMilli(),
             Instant.now().minusSeconds(60).toEpochMilli(),
             false,
@@ -549,7 +549,7 @@ public class ReplicaEvictionServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
 
     await().until(() -> replicaMetadataStore.listSync().size() == 1);
@@ -641,7 +641,7 @@ public class ReplicaEvictionServiceTest {
           new ReplicaMetadata(
               UUID.randomUUID().toString(),
               UUID.randomUUID().toString(),
-              REPLICA_PARTITION,
+              REPLICA_SET,
               Instant.now().toEpochMilli(),
               Instant.now().minusSeconds(60).toEpochMilli(),
               false,
@@ -659,7 +659,7 @@ public class ReplicaEvictionServiceTest {
               Instant.now().toEpochMilli(),
               SUPPORTED_INDEX_TYPES,
               HOSTNAME,
-              REPLICA_PARTITION);
+              REPLICA_SET);
       cacheSlotMetadataStore.createAsync(cacheSlotMetadata);
     }
 
@@ -771,7 +771,7 @@ public class ReplicaEvictionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
-            REPLICA_PARTITION,
+            REPLICA_SET,
             Instant.now().toEpochMilli(),
             Instant.now().minusSeconds(60).toEpochMilli(),
             false,
@@ -785,14 +785,14 @@ public class ReplicaEvictionServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     cacheSlotMetadataStore.createAsync(cacheSlotReplicaExpiredOne);
 
     ReplicaMetadata replicaMetadataExpiredTwo =
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
-            REPLICA_PARTITION,
+            REPLICA_SET,
             Instant.now().toEpochMilli(),
             Instant.now().minusSeconds(60).toEpochMilli(),
             false,
@@ -806,14 +806,14 @@ public class ReplicaEvictionServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     cacheSlotMetadataStore.createAsync(cacheSlotReplicaExpireTwo);
 
     ReplicaMetadata replicaMetadataUnexpiredOne =
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
-            REPLICA_PARTITION,
+            REPLICA_SET,
             Instant.now().toEpochMilli(),
             Instant.now().plusSeconds(360).toEpochMilli(),
             false,
@@ -827,14 +827,14 @@ public class ReplicaEvictionServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     cacheSlotMetadataStore.createAsync(cacheSlotReplicaUnexpiredOne);
 
     ReplicaMetadata replicaMetadataUnexpiredTwo =
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
-            REPLICA_PARTITION,
+            REPLICA_SET,
             Instant.now().toEpochMilli(),
             Instant.now().plusSeconds(360).toEpochMilli(),
             false,
@@ -848,7 +848,7 @@ public class ReplicaEvictionServiceTest {
             Instant.now().toEpochMilli(),
             SUPPORTED_INDEX_TYPES,
             HOSTNAME,
-            REPLICA_PARTITION);
+            REPLICA_SET);
     cacheSlotMetadataStore.createAsync(cacheSlotFree);
 
     await().until(() -> replicaMetadataStore.listSync().size() == 4);

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaRestoreServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaRestoreServiceTest.java
@@ -57,7 +57,7 @@ public class ReplicaRestoreServiceTest {
 
     KaldbConfigs.ManagerConfig.ReplicaRestoreServiceConfig replicaRecreationServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaRestoreServiceConfig.newBuilder()
-            .addAllReplicaPartitions(List.of("rep1"))
+            .addAllReplicaSets(List.of("rep1"))
             .setMaxReplicasPerRequest(200)
             .setReplicaLifespanMins(60)
             .setSchedulePeriodMins(30)
@@ -173,7 +173,7 @@ public class ReplicaRestoreServiceTest {
   public void shouldRemoveDuplicates() throws Exception {
     KaldbConfigs.ManagerConfig.ReplicaRestoreServiceConfig replicaRecreationServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaRestoreServiceConfig.newBuilder()
-            .addAllReplicaPartitions(List.of("rep1"))
+            .addAllReplicaSets(List.of("rep1"))
             .setMaxReplicasPerRequest(200)
             .setReplicaLifespanMins(60)
             .setSchedulePeriodMins(30)

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/SnapshotDeletionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/SnapshotDeletionServiceTest.java
@@ -231,6 +231,7 @@ public class SnapshotDeletionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             snapshotMetadata.name,
+            "rep1",
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             Instant.now().minus(500, ChronoUnit.MINUTES).toEpochMilli(),
             false,
@@ -404,6 +405,7 @@ public class SnapshotDeletionServiceTest {
         new ReplicaMetadata(
             UUID.randomUUID().toString(),
             snapshotMetadata.name,
+            "rep1",
             Instant.now().minus(11000, ChronoUnit.MINUTES).toEpochMilli(),
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             false,

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializerTest.java
@@ -17,6 +17,7 @@ public class CacheSlotMetadataSerializerTest {
   public void testCacheSlotMetadataSerializer() throws InvalidProtocolBufferException {
     String name = "name";
     String hostname = "hostname";
+    String replicaPartition = "rep1";
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState =
         Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED;
     String replicaId = "123";
@@ -25,7 +26,13 @@ public class CacheSlotMetadataSerializerTest {
 
     CacheSlotMetadata cacheSlotMetadata =
         new CacheSlotMetadata(
-            name, cacheSlotState, replicaId, updatedTimeEpochMs, supportedIndexTypes, hostname);
+            name,
+            cacheSlotState,
+            replicaId,
+            updatedTimeEpochMs,
+            supportedIndexTypes,
+            hostname,
+            replicaPartition);
 
     String serializedCacheSlotMetadata = serDe.toJsonStr(cacheSlotMetadata);
     assertThat(serializedCacheSlotMetadata).isNotEmpty();
@@ -36,6 +43,7 @@ public class CacheSlotMetadataSerializerTest {
 
     assertThat(deserializedCacheSlotMetadata.name).isEqualTo(name);
     assertThat(deserializedCacheSlotMetadata.hostname).isEqualTo(hostname);
+    assertThat(deserializedCacheSlotMetadata.replicaPartition).isEqualTo(replicaPartition);
     assertThat(deserializedCacheSlotMetadata.cacheSlotState).isEqualTo(cacheSlotState);
     assertThat(deserializedCacheSlotMetadata.replicaId).isEqualTo(replicaId);
     assertThat(deserializedCacheSlotMetadata.updatedTimeEpochMs).isEqualTo(updatedTimeEpochMs);

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataSerializerTest.java
@@ -17,7 +17,7 @@ public class CacheSlotMetadataSerializerTest {
   public void testCacheSlotMetadataSerializer() throws InvalidProtocolBufferException {
     String name = "name";
     String hostname = "hostname";
-    String replicaPartition = "rep1";
+    String replicaSet = "rep1";
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState =
         Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED;
     String replicaId = "123";
@@ -32,7 +32,7 @@ public class CacheSlotMetadataSerializerTest {
             updatedTimeEpochMs,
             supportedIndexTypes,
             hostname,
-            replicaPartition);
+            replicaSet);
 
     String serializedCacheSlotMetadata = serDe.toJsonStr(cacheSlotMetadata);
     assertThat(serializedCacheSlotMetadata).isNotEmpty();
@@ -43,7 +43,7 @@ public class CacheSlotMetadataSerializerTest {
 
     assertThat(deserializedCacheSlotMetadata.name).isEqualTo(name);
     assertThat(deserializedCacheSlotMetadata.hostname).isEqualTo(hostname);
-    assertThat(deserializedCacheSlotMetadata.replicaPartition).isEqualTo(replicaPartition);
+    assertThat(deserializedCacheSlotMetadata.replicaSet).isEqualTo(replicaSet);
     assertThat(deserializedCacheSlotMetadata.cacheSlotState).isEqualTo(cacheSlotState);
     assertThat(deserializedCacheSlotMetadata.replicaId).isEqualTo(replicaId);
     assertThat(deserializedCacheSlotMetadata.updatedTimeEpochMs).isEqualTo(updatedTimeEpochMs);

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStoreTest.java
@@ -61,13 +61,20 @@ public class CacheSlotMetadataStoreTest {
   public void testUpdateNonFreeCacheSlotStateSync() throws Exception {
     final String name = "slot1";
     final String hostname = "hostname";
+    final String replicaPartition = "rep1";
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState = CacheSlotState.ASSIGNED;
     final String replicaId = "3456";
     long updatedTimeEpochMs = Instant.now().toEpochMilli();
 
     final CacheSlotMetadata cacheSlotMetadata =
         new CacheSlotMetadata(
-            name, cacheSlotState, replicaId, updatedTimeEpochMs, SUPPORTED_INDEX_TYPES, hostname);
+            name,
+            cacheSlotState,
+            replicaId,
+            updatedTimeEpochMs,
+            SUPPORTED_INDEX_TYPES,
+            hostname,
+            replicaPartition);
     assertThat(cacheSlotMetadata.name).isEqualTo(name);
     assertThat(cacheSlotMetadata.cacheSlotState).isEqualTo(cacheSlotState);
     assertThat(cacheSlotMetadata.replicaId).isEqualTo(replicaId);
@@ -136,13 +143,20 @@ public class CacheSlotMetadataStoreTest {
   public void testNonFreeCacheSlotState() throws Exception {
     final String name = "slot1";
     final String hostname = "hostname";
+    final String replicaPartition = "rep1";
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState = CacheSlotState.ASSIGNED;
     final String replicaId = "3456";
     long updatedTimeEpochMs = Instant.now().toEpochMilli();
 
     final CacheSlotMetadata cacheSlotMetadata =
         new CacheSlotMetadata(
-            name, cacheSlotState, replicaId, updatedTimeEpochMs, SUPPORTED_INDEX_TYPES, hostname);
+            name,
+            cacheSlotState,
+            replicaId,
+            updatedTimeEpochMs,
+            SUPPORTED_INDEX_TYPES,
+            hostname,
+            replicaPartition);
     assertThat(cacheSlotMetadata.name).isEqualTo(name);
     assertThat(cacheSlotMetadata.cacheSlotState).isEqualTo(cacheSlotState);
     assertThat(cacheSlotMetadata.replicaId).isEqualTo(replicaId);
@@ -207,6 +221,7 @@ public class CacheSlotMetadataStoreTest {
   public void testCacheSlotStateWithReplica() throws Exception {
     String name = "slot1";
     final String hostname = "hostname";
+    final String replicaPartition = "rep1";
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState =
         Metadata.CacheSlotMetadata.CacheSlotState.FREE;
     String emptyReplicaId = "";
@@ -219,7 +234,8 @@ public class CacheSlotMetadataStoreTest {
             emptyReplicaId,
             updatedTimeEpochMs,
             SUPPORTED_INDEX_TYPES,
-            hostname);
+            hostname,
+            replicaPartition);
     assertThat(cacheSlotMetadata.name).isEqualTo(name);
     assertThat(cacheSlotMetadata.cacheSlotState).isEqualTo(cacheSlotState);
     assertThat(cacheSlotMetadata.replicaId).isEqualTo(emptyReplicaId);

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStoreTest.java
@@ -61,7 +61,7 @@ public class CacheSlotMetadataStoreTest {
   public void testUpdateNonFreeCacheSlotStateSync() throws Exception {
     final String name = "slot1";
     final String hostname = "hostname";
-    final String replicaPartition = "rep1";
+    final String replicaSet = "rep1";
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState = CacheSlotState.ASSIGNED;
     final String replicaId = "3456";
     long updatedTimeEpochMs = Instant.now().toEpochMilli();
@@ -74,7 +74,7 @@ public class CacheSlotMetadataStoreTest {
             updatedTimeEpochMs,
             SUPPORTED_INDEX_TYPES,
             hostname,
-            replicaPartition);
+            replicaSet);
     assertThat(cacheSlotMetadata.name).isEqualTo(name);
     assertThat(cacheSlotMetadata.cacheSlotState).isEqualTo(cacheSlotState);
     assertThat(cacheSlotMetadata.replicaId).isEqualTo(replicaId);
@@ -143,7 +143,7 @@ public class CacheSlotMetadataStoreTest {
   public void testNonFreeCacheSlotState() throws Exception {
     final String name = "slot1";
     final String hostname = "hostname";
-    final String replicaPartition = "rep1";
+    final String replicaSet = "rep1";
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState = CacheSlotState.ASSIGNED;
     final String replicaId = "3456";
     long updatedTimeEpochMs = Instant.now().toEpochMilli();
@@ -156,7 +156,7 @@ public class CacheSlotMetadataStoreTest {
             updatedTimeEpochMs,
             SUPPORTED_INDEX_TYPES,
             hostname,
-            replicaPartition);
+            replicaSet);
     assertThat(cacheSlotMetadata.name).isEqualTo(name);
     assertThat(cacheSlotMetadata.cacheSlotState).isEqualTo(cacheSlotState);
     assertThat(cacheSlotMetadata.replicaId).isEqualTo(replicaId);
@@ -221,7 +221,7 @@ public class CacheSlotMetadataStoreTest {
   public void testCacheSlotStateWithReplica() throws Exception {
     String name = "slot1";
     final String hostname = "hostname";
-    final String replicaPartition = "rep1";
+    final String replicaSet = "rep1";
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState =
         Metadata.CacheSlotMetadata.CacheSlotState.FREE;
     String emptyReplicaId = "";
@@ -235,7 +235,7 @@ public class CacheSlotMetadataStoreTest {
             updatedTimeEpochMs,
             SUPPORTED_INDEX_TYPES,
             hostname,
-            replicaPartition);
+            replicaSet);
     assertThat(cacheSlotMetadata.name).isEqualTo(name);
     assertThat(cacheSlotMetadata.cacheSlotState).isEqualTo(cacheSlotState);
     assertThat(cacheSlotMetadata.replicaId).isEqualTo(emptyReplicaId);

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataTest.java
@@ -18,6 +18,7 @@ public class CacheSlotMetadataTest {
   public void testCacheSlotMetadata() {
     String hostname = "hostname";
     String name = "name";
+    String replicaPartition = "rep1";
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState =
         Metadata.CacheSlotMetadata.CacheSlotState.FREE;
     String replicaId = "";
@@ -25,9 +26,16 @@ public class CacheSlotMetadataTest {
 
     CacheSlotMetadata cacheSlotMetadata =
         new CacheSlotMetadata(
-            name, cacheSlotState, replicaId, updatedTimeEpochMs, SUPPORTED_INDEX_TYPES, hostname);
+            name,
+            cacheSlotState,
+            replicaId,
+            updatedTimeEpochMs,
+            SUPPORTED_INDEX_TYPES,
+            hostname,
+            replicaPartition);
     assertThat(cacheSlotMetadata.name).isEqualTo(name);
     assertThat(cacheSlotMetadata.hostname).isEqualTo(hostname);
+    assertThat(cacheSlotMetadata.replicaPartition).isEqualTo(replicaPartition);
     assertThat(cacheSlotMetadata.cacheSlotState).isEqualTo(cacheSlotState);
     assertThat(cacheSlotMetadata.replicaId).isEqualTo(replicaId);
     assertThat(cacheSlotMetadata.updatedTimeEpochMs).isEqualTo(updatedTimeEpochMs);
@@ -38,6 +46,7 @@ public class CacheSlotMetadataTest {
   public void testCacheSlotEqualsHashcode() {
     String hostname = "hostname";
     String name = "name";
+    String replicaPartition = "rep1";
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState =
         Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED;
     String replicaId = "123";
@@ -45,10 +54,22 @@ public class CacheSlotMetadataTest {
 
     CacheSlotMetadata cacheSlot =
         new CacheSlotMetadata(
-            name, cacheSlotState, replicaId, updatedTimeEpochMs, SUPPORTED_INDEX_TYPES, hostname);
+            name,
+            cacheSlotState,
+            replicaId,
+            updatedTimeEpochMs,
+            SUPPORTED_INDEX_TYPES,
+            hostname,
+            replicaPartition);
     CacheSlotMetadata cacheSlotDuplicate =
         new CacheSlotMetadata(
-            name, cacheSlotState, replicaId, updatedTimeEpochMs, SUPPORTED_INDEX_TYPES, hostname);
+            name,
+            cacheSlotState,
+            replicaId,
+            updatedTimeEpochMs,
+            SUPPORTED_INDEX_TYPES,
+            hostname,
+            replicaPartition);
     CacheSlotMetadata cacheSlotDifferentState =
         new CacheSlotMetadata(
             name,
@@ -56,10 +77,17 @@ public class CacheSlotMetadataTest {
             replicaId,
             updatedTimeEpochMs,
             SUPPORTED_INDEX_TYPES,
-            hostname);
+            hostname,
+            replicaPartition);
     CacheSlotMetadata cacheSlotDifferentReplicaId =
         new CacheSlotMetadata(
-            name, cacheSlotState, "321", updatedTimeEpochMs, SUPPORTED_INDEX_TYPES, hostname);
+            name,
+            cacheSlotState,
+            "321",
+            updatedTimeEpochMs,
+            SUPPORTED_INDEX_TYPES,
+            hostname,
+            replicaPartition);
     CacheSlotMetadata cacheSlotDifferentUpdatedTime =
         new CacheSlotMetadata(
             name,
@@ -67,7 +95,8 @@ public class CacheSlotMetadataTest {
             replicaId,
             updatedTimeEpochMs + 1,
             SUPPORTED_INDEX_TYPES,
-            hostname);
+            hostname,
+            replicaPartition);
     CacheSlotMetadata cacheSlotDifferentSupportedIndexType =
         new CacheSlotMetadata(
             name,
@@ -75,7 +104,8 @@ public class CacheSlotMetadataTest {
             replicaId,
             updatedTimeEpochMs + 1,
             List.of(LOGS_LUCENE9, LOGS_LUCENE9),
-            hostname);
+            hostname,
+            replicaPartition);
     CacheSlotMetadata cacheSlotDifferentHostname =
         new CacheSlotMetadata(
             name,
@@ -83,7 +113,18 @@ public class CacheSlotMetadataTest {
             replicaId,
             updatedTimeEpochMs,
             SUPPORTED_INDEX_TYPES,
-            "hostname2");
+            "hostname2",
+            replicaPartition);
+
+    CacheSlotMetadata cacheSlotDifferentReplicaPartition =
+        new CacheSlotMetadata(
+            name,
+            cacheSlotState,
+            replicaId,
+            updatedTimeEpochMs,
+            SUPPORTED_INDEX_TYPES,
+            hostname,
+            "rep2");
 
     assertThat(cacheSlot.hashCode()).isEqualTo(cacheSlotDuplicate.hashCode());
     assertThat(cacheSlot).isEqualTo(cacheSlotDuplicate);
@@ -98,6 +139,8 @@ public class CacheSlotMetadataTest {
     assertThat(cacheSlot.hashCode()).isNotEqualTo(cacheSlotDifferentSupportedIndexType.hashCode());
     assertThat(cacheSlot).isNotEqualTo(cacheSlotDifferentHostname);
     assertThat(cacheSlot.hashCode()).isNotEqualTo(cacheSlotDifferentHostname.hashCode());
+    assertThat(cacheSlot).isNotEqualTo(cacheSlotDifferentReplicaPartition);
+    assertThat(cacheSlot.hashCode()).isNotEqualTo(cacheSlotDifferentReplicaPartition.hashCode());
   }
 
   @Test
@@ -111,7 +154,8 @@ public class CacheSlotMetadataTest {
                     "123",
                     Instant.now().toEpochMilli(),
                     SUPPORTED_INDEX_TYPES,
-                    "hostname"));
+                    "hostname",
+                    "rep1"));
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
@@ -121,7 +165,8 @@ public class CacheSlotMetadataTest {
                     "",
                     Instant.now().toEpochMilli(),
                     SUPPORTED_INDEX_TYPES,
-                    "hostname"));
+                    "hostname",
+                    "rep1"));
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
@@ -131,7 +176,8 @@ public class CacheSlotMetadataTest {
                     "",
                     Instant.now().toEpochMilli(),
                     SUPPORTED_INDEX_TYPES,
-                    "hostname"));
+                    "hostname",
+                    "rep1"));
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
@@ -141,7 +187,8 @@ public class CacheSlotMetadataTest {
                     "",
                     Instant.now().toEpochMilli(),
                     SUPPORTED_INDEX_TYPES,
-                    "hostname"));
+                    "hostname",
+                    "rep1"));
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
@@ -151,7 +198,8 @@ public class CacheSlotMetadataTest {
                     "",
                     Instant.now().toEpochMilli(),
                     SUPPORTED_INDEX_TYPES,
-                    "hostname"));
+                    "hostname",
+                    "rep1"));
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
@@ -161,7 +209,8 @@ public class CacheSlotMetadataTest {
                     "",
                     Instant.now().toEpochMilli(),
                     SUPPORTED_INDEX_TYPES,
-                    "hostname"));
+                    "hostname",
+                    "rep1"));
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
@@ -171,7 +220,8 @@ public class CacheSlotMetadataTest {
                     "",
                     0,
                     SUPPORTED_INDEX_TYPES,
-                    "hostname"));
+                    "hostname",
+                    "rep1"));
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
@@ -181,7 +231,8 @@ public class CacheSlotMetadataTest {
                     null,
                     Instant.now().toEpochMilli(),
                     SUPPORTED_INDEX_TYPES,
-                    "hostname"));
+                    "hostname",
+                    "rep1"));
     assertThatIllegalArgumentException()
         .isThrownBy(
             () -> {
@@ -191,7 +242,8 @@ public class CacheSlotMetadataTest {
                   "123",
                   100000,
                   Collections.emptyList(),
-                  "hostname");
+                  "hostname",
+                  "rep1");
             });
     assertThatIllegalArgumentException()
         .isThrownBy(
@@ -202,7 +254,8 @@ public class CacheSlotMetadataTest {
                   "123",
                   100000,
                   SUPPORTED_INDEX_TYPES,
-                  "hostname");
+                  "hostname",
+                  "rep1");
             });
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataTest.java
@@ -18,7 +18,7 @@ public class CacheSlotMetadataTest {
   public void testCacheSlotMetadata() {
     String hostname = "hostname";
     String name = "name";
-    String replicaPartition = "rep1";
+    String replicaSet = "rep1";
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState =
         Metadata.CacheSlotMetadata.CacheSlotState.FREE;
     String replicaId = "";
@@ -32,10 +32,10 @@ public class CacheSlotMetadataTest {
             updatedTimeEpochMs,
             SUPPORTED_INDEX_TYPES,
             hostname,
-            replicaPartition);
+            replicaSet);
     assertThat(cacheSlotMetadata.name).isEqualTo(name);
     assertThat(cacheSlotMetadata.hostname).isEqualTo(hostname);
-    assertThat(cacheSlotMetadata.replicaPartition).isEqualTo(replicaPartition);
+    assertThat(cacheSlotMetadata.replicaSet).isEqualTo(replicaSet);
     assertThat(cacheSlotMetadata.cacheSlotState).isEqualTo(cacheSlotState);
     assertThat(cacheSlotMetadata.replicaId).isEqualTo(replicaId);
     assertThat(cacheSlotMetadata.updatedTimeEpochMs).isEqualTo(updatedTimeEpochMs);
@@ -46,7 +46,7 @@ public class CacheSlotMetadataTest {
   public void testCacheSlotEqualsHashcode() {
     String hostname = "hostname";
     String name = "name";
-    String replicaPartition = "rep1";
+    String replicaSet = "rep1";
     Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState =
         Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED;
     String replicaId = "123";
@@ -60,7 +60,7 @@ public class CacheSlotMetadataTest {
             updatedTimeEpochMs,
             SUPPORTED_INDEX_TYPES,
             hostname,
-            replicaPartition);
+            replicaSet);
     CacheSlotMetadata cacheSlotDuplicate =
         new CacheSlotMetadata(
             name,
@@ -69,7 +69,7 @@ public class CacheSlotMetadataTest {
             updatedTimeEpochMs,
             SUPPORTED_INDEX_TYPES,
             hostname,
-            replicaPartition);
+            replicaSet);
     CacheSlotMetadata cacheSlotDifferentState =
         new CacheSlotMetadata(
             name,
@@ -78,7 +78,7 @@ public class CacheSlotMetadataTest {
             updatedTimeEpochMs,
             SUPPORTED_INDEX_TYPES,
             hostname,
-            replicaPartition);
+            replicaSet);
     CacheSlotMetadata cacheSlotDifferentReplicaId =
         new CacheSlotMetadata(
             name,
@@ -87,7 +87,7 @@ public class CacheSlotMetadataTest {
             updatedTimeEpochMs,
             SUPPORTED_INDEX_TYPES,
             hostname,
-            replicaPartition);
+            replicaSet);
     CacheSlotMetadata cacheSlotDifferentUpdatedTime =
         new CacheSlotMetadata(
             name,
@@ -96,7 +96,7 @@ public class CacheSlotMetadataTest {
             updatedTimeEpochMs + 1,
             SUPPORTED_INDEX_TYPES,
             hostname,
-            replicaPartition);
+            replicaSet);
     CacheSlotMetadata cacheSlotDifferentSupportedIndexType =
         new CacheSlotMetadata(
             name,
@@ -105,7 +105,7 @@ public class CacheSlotMetadataTest {
             updatedTimeEpochMs + 1,
             List.of(LOGS_LUCENE9, LOGS_LUCENE9),
             hostname,
-            replicaPartition);
+            replicaSet);
     CacheSlotMetadata cacheSlotDifferentHostname =
         new CacheSlotMetadata(
             name,
@@ -114,7 +114,7 @@ public class CacheSlotMetadataTest {
             updatedTimeEpochMs,
             SUPPORTED_INDEX_TYPES,
             "hostname2",
-            replicaPartition);
+            replicaSet);
 
     CacheSlotMetadata cacheSlotDifferentReplicaPartition =
         new CacheSlotMetadata(

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializerTest.java
@@ -15,7 +15,7 @@ public class ReplicaMetadataSerializerTest {
   public void testReplicaMetadataSerializer() throws InvalidProtocolBufferException {
     String name = "name";
     String snapshotId = "snapshotId";
-    String replicaPartition = "rep1";
+    String replicaSet = "rep1";
     long createdTimeEpochMs = Instant.now().toEpochMilli();
     long expireAfterEpochMs = Instant.now().plusSeconds(60).toEpochMilli();
 
@@ -23,7 +23,7 @@ public class ReplicaMetadataSerializerTest {
         new ReplicaMetadata(
             name,
             snapshotId,
-            replicaPartition,
+            replicaSet,
             createdTimeEpochMs,
             expireAfterEpochMs,
             true,
@@ -37,7 +37,7 @@ public class ReplicaMetadataSerializerTest {
 
     assertThat(deserializedReplicaMetadata.name).isEqualTo(name);
     assertThat(deserializedReplicaMetadata.snapshotId).isEqualTo(snapshotId);
-    assertThat(deserializedReplicaMetadata.replicaPartition).isEqualTo(replicaPartition);
+    assertThat(deserializedReplicaMetadata.replicaSet).isEqualTo(replicaSet);
     assertThat(deserializedReplicaMetadata.createdTimeEpochMs).isEqualTo(createdTimeEpochMs);
     assertThat(deserializedReplicaMetadata.expireAfterEpochMs).isEqualTo(expireAfterEpochMs);
     assertThat(deserializedReplicaMetadata.isRestored).isTrue();

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataSerializerTest.java
@@ -15,12 +15,19 @@ public class ReplicaMetadataSerializerTest {
   public void testReplicaMetadataSerializer() throws InvalidProtocolBufferException {
     String name = "name";
     String snapshotId = "snapshotId";
+    String replicaPartition = "rep1";
     long createdTimeEpochMs = Instant.now().toEpochMilli();
     long expireAfterEpochMs = Instant.now().plusSeconds(60).toEpochMilli();
 
     ReplicaMetadata replicaMetadata =
         new ReplicaMetadata(
-            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, true, LOGS_LUCENE9);
+            name,
+            snapshotId,
+            replicaPartition,
+            createdTimeEpochMs,
+            expireAfterEpochMs,
+            true,
+            LOGS_LUCENE9);
 
     String serializedReplicaMetadata = serDe.toJsonStr(replicaMetadata);
     assertThat(serializedReplicaMetadata).isNotEmpty();
@@ -30,6 +37,7 @@ public class ReplicaMetadataSerializerTest {
 
     assertThat(deserializedReplicaMetadata.name).isEqualTo(name);
     assertThat(deserializedReplicaMetadata.snapshotId).isEqualTo(snapshotId);
+    assertThat(deserializedReplicaMetadata.replicaPartition).isEqualTo(replicaPartition);
     assertThat(deserializedReplicaMetadata.createdTimeEpochMs).isEqualTo(createdTimeEpochMs);
     assertThat(deserializedReplicaMetadata.expireAfterEpochMs).isEqualTo(expireAfterEpochMs);
     assertThat(deserializedReplicaMetadata.isRestored).isTrue();

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataTest.java
@@ -13,15 +13,23 @@ public class ReplicaMetadataTest {
   public void testReplicaMetadata() {
     String name = "name";
     String snapshotId = "snapshotId";
+    String replicaPartition = "rep1";
     long createdTimeEpochMs = Instant.now().toEpochMilli();
     long expireAfterEpochMs = Instant.now().toEpochMilli();
 
     ReplicaMetadata replicaMetadata =
         new ReplicaMetadata(
-            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, false, LOGS_LUCENE9);
+            name,
+            snapshotId,
+            replicaPartition,
+            createdTimeEpochMs,
+            expireAfterEpochMs,
+            false,
+            LOGS_LUCENE9);
 
     assertThat(replicaMetadata.name).isEqualTo(name);
     assertThat(replicaMetadata.snapshotId).isEqualTo(snapshotId);
+    assertThat(replicaMetadata.replicaPartition).isEqualTo(replicaPartition);
     assertThat(replicaMetadata.createdTimeEpochMs).isEqualTo(createdTimeEpochMs);
     assertThat(replicaMetadata.expireAfterEpochMs).isEqualTo(expireAfterEpochMs);
     assertThat(replicaMetadata.isRestored).isFalse();
@@ -29,10 +37,17 @@ public class ReplicaMetadataTest {
 
     ReplicaMetadata restoredReplicaMetadata =
         new ReplicaMetadata(
-            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, true, LOGS_LUCENE9);
+            name,
+            snapshotId,
+            replicaPartition,
+            createdTimeEpochMs,
+            expireAfterEpochMs,
+            true,
+            LOGS_LUCENE9);
 
     assertThat(restoredReplicaMetadata.name).isEqualTo(name);
     assertThat(restoredReplicaMetadata.snapshotId).isEqualTo(snapshotId);
+    assertThat(restoredReplicaMetadata.replicaPartition).isEqualTo(replicaPartition);
     assertThat(restoredReplicaMetadata.createdTimeEpochMs).isEqualTo(createdTimeEpochMs);
     assertThat(restoredReplicaMetadata.expireAfterEpochMs).isEqualTo(expireAfterEpochMs);
     assertThat(restoredReplicaMetadata.isRestored).isTrue();
@@ -43,34 +58,70 @@ public class ReplicaMetadataTest {
   public void testReplicaMetadataEqualsHashcode() {
     String name = "name";
     String snapshotId = "snapshotId";
+    String replicaPartition = "rep1";
     long createdTimeEpochMs = Instant.now().toEpochMilli();
     long expireAfterEpochMs = Instant.now().toEpochMilli();
 
     ReplicaMetadata replicaMetadataA =
         new ReplicaMetadata(
-            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, true, LOGS_LUCENE9);
+            name,
+            snapshotId,
+            replicaPartition,
+            createdTimeEpochMs,
+            expireAfterEpochMs,
+            true,
+            LOGS_LUCENE9);
     ReplicaMetadata replicaMetadataB =
         new ReplicaMetadata(
-            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs, true, LOGS_LUCENE9);
+            name,
+            snapshotId,
+            replicaPartition,
+            createdTimeEpochMs,
+            expireAfterEpochMs,
+            true,
+            LOGS_LUCENE9);
     ReplicaMetadata replicaMetadataC =
         new ReplicaMetadata(
-            "nameC", snapshotId, createdTimeEpochMs, expireAfterEpochMs, true, LOGS_LUCENE9);
+            "nameC",
+            snapshotId,
+            replicaPartition,
+            createdTimeEpochMs,
+            expireAfterEpochMs,
+            true,
+            LOGS_LUCENE9);
     ReplicaMetadata replicaMetadataD =
         new ReplicaMetadata(
-            name, snapshotId, createdTimeEpochMs + 1, expireAfterEpochMs, false, LOGS_LUCENE9);
+            name,
+            snapshotId,
+            replicaPartition,
+            createdTimeEpochMs + 1,
+            expireAfterEpochMs,
+            false,
+            LOGS_LUCENE9);
     ReplicaMetadata replicaMetadataE =
         new ReplicaMetadata(
-            name, snapshotId, createdTimeEpochMs, expireAfterEpochMs + 1, false, LOGS_LUCENE9);
+            name,
+            snapshotId,
+            replicaPartition,
+            createdTimeEpochMs,
+            expireAfterEpochMs + 1,
+            false,
+            LOGS_LUCENE9);
+    ReplicaMetadata replicaMetadataF =
+        new ReplicaMetadata(
+            name, snapshotId, "rep2", createdTimeEpochMs, expireAfterEpochMs, true, LOGS_LUCENE9);
 
     assertThat(replicaMetadataA).isEqualTo(replicaMetadataB);
     assertThat(replicaMetadataA).isNotEqualTo(replicaMetadataC);
     assertThat(replicaMetadataA).isNotEqualTo(replicaMetadataD);
     assertThat(replicaMetadataA).isNotEqualTo(replicaMetadataE);
+    assertThat(replicaMetadataA).isNotEqualTo(replicaMetadataF);
 
     assertThat(replicaMetadataA.hashCode()).isEqualTo(replicaMetadataB.hashCode());
     assertThat(replicaMetadataA.hashCode()).isNotEqualTo(replicaMetadataC.hashCode());
     assertThat(replicaMetadataA.hashCode()).isNotEqualTo(replicaMetadataD.hashCode());
     assertThat(replicaMetadataA.hashCode()).isNotEqualTo(replicaMetadataE.hashCode());
+    assertThat(replicaMetadataA.hashCode()).isNotEqualTo(replicaMetadataF.hashCode());
   }
 
   @Test
@@ -81,6 +132,7 @@ public class ReplicaMetadataTest {
                 new ReplicaMetadata(
                     "name",
                     "",
+                    "rep1",
                     Instant.now().toEpochMilli(),
                     Instant.now().toEpochMilli(),
                     false,
@@ -91,6 +143,7 @@ public class ReplicaMetadataTest {
                 new ReplicaMetadata(
                     "name",
                     null,
+                    "rep1",
                     Instant.now().toEpochMilli(),
                     Instant.now().toEpochMilli(),
                     true,
@@ -99,11 +152,11 @@ public class ReplicaMetadataTest {
         .isThrownBy(
             () ->
                 new ReplicaMetadata(
-                    "name", "123", 0, Instant.now().toEpochMilli(), false, LOGS_LUCENE9));
+                    "name", "123", "rep1", 0, Instant.now().toEpochMilli(), false, LOGS_LUCENE9));
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
                 new ReplicaMetadata(
-                    "name", "123", Instant.now().toEpochMilli(), -1, true, LOGS_LUCENE9));
+                    "name", "123", "rep1", Instant.now().toEpochMilli(), -1, true, LOGS_LUCENE9));
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/replica/ReplicaMetadataTest.java
@@ -13,7 +13,7 @@ public class ReplicaMetadataTest {
   public void testReplicaMetadata() {
     String name = "name";
     String snapshotId = "snapshotId";
-    String replicaPartition = "rep1";
+    String replicaSet = "rep1";
     long createdTimeEpochMs = Instant.now().toEpochMilli();
     long expireAfterEpochMs = Instant.now().toEpochMilli();
 
@@ -21,7 +21,7 @@ public class ReplicaMetadataTest {
         new ReplicaMetadata(
             name,
             snapshotId,
-            replicaPartition,
+            replicaSet,
             createdTimeEpochMs,
             expireAfterEpochMs,
             false,
@@ -29,7 +29,7 @@ public class ReplicaMetadataTest {
 
     assertThat(replicaMetadata.name).isEqualTo(name);
     assertThat(replicaMetadata.snapshotId).isEqualTo(snapshotId);
-    assertThat(replicaMetadata.replicaPartition).isEqualTo(replicaPartition);
+    assertThat(replicaMetadata.replicaSet).isEqualTo(replicaSet);
     assertThat(replicaMetadata.createdTimeEpochMs).isEqualTo(createdTimeEpochMs);
     assertThat(replicaMetadata.expireAfterEpochMs).isEqualTo(expireAfterEpochMs);
     assertThat(replicaMetadata.isRestored).isFalse();
@@ -39,7 +39,7 @@ public class ReplicaMetadataTest {
         new ReplicaMetadata(
             name,
             snapshotId,
-            replicaPartition,
+            replicaSet,
             createdTimeEpochMs,
             expireAfterEpochMs,
             true,
@@ -47,7 +47,7 @@ public class ReplicaMetadataTest {
 
     assertThat(restoredReplicaMetadata.name).isEqualTo(name);
     assertThat(restoredReplicaMetadata.snapshotId).isEqualTo(snapshotId);
-    assertThat(restoredReplicaMetadata.replicaPartition).isEqualTo(replicaPartition);
+    assertThat(restoredReplicaMetadata.replicaSet).isEqualTo(replicaSet);
     assertThat(restoredReplicaMetadata.createdTimeEpochMs).isEqualTo(createdTimeEpochMs);
     assertThat(restoredReplicaMetadata.expireAfterEpochMs).isEqualTo(expireAfterEpochMs);
     assertThat(restoredReplicaMetadata.isRestored).isTrue();
@@ -58,7 +58,7 @@ public class ReplicaMetadataTest {
   public void testReplicaMetadataEqualsHashcode() {
     String name = "name";
     String snapshotId = "snapshotId";
-    String replicaPartition = "rep1";
+    String replicaSet = "rep1";
     long createdTimeEpochMs = Instant.now().toEpochMilli();
     long expireAfterEpochMs = Instant.now().toEpochMilli();
 
@@ -66,7 +66,7 @@ public class ReplicaMetadataTest {
         new ReplicaMetadata(
             name,
             snapshotId,
-            replicaPartition,
+            replicaSet,
             createdTimeEpochMs,
             expireAfterEpochMs,
             true,
@@ -75,7 +75,7 @@ public class ReplicaMetadataTest {
         new ReplicaMetadata(
             name,
             snapshotId,
-            replicaPartition,
+            replicaSet,
             createdTimeEpochMs,
             expireAfterEpochMs,
             true,
@@ -84,7 +84,7 @@ public class ReplicaMetadataTest {
         new ReplicaMetadata(
             "nameC",
             snapshotId,
-            replicaPartition,
+            replicaSet,
             createdTimeEpochMs,
             expireAfterEpochMs,
             true,
@@ -93,7 +93,7 @@ public class ReplicaMetadataTest {
         new ReplicaMetadata(
             name,
             snapshotId,
-            replicaPartition,
+            replicaSet,
             createdTimeEpochMs + 1,
             expireAfterEpochMs,
             false,
@@ -102,7 +102,7 @@ public class ReplicaMetadataTest {
         new ReplicaMetadata(
             name,
             snapshotId,
-            replicaPartition,
+            replicaSet,
             createdTimeEpochMs,
             expireAfterEpochMs + 1,
             false,

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
@@ -240,7 +240,7 @@ public class KaldbConfigTest {
 
     final KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
         managerConfig.getReplicaCreationServiceConfig();
-    assertThat(replicaCreationServiceConfig.getReplicaPartitionsList()).isEqualTo(List.of("rep1"));
+    assertThat(replicaCreationServiceConfig.getReplicaSetsList()).isEqualTo(List.of("rep1"));
     assertThat(replicaCreationServiceConfig.getSchedulePeriodMins()).isEqualTo(15);
     assertThat(replicaCreationServiceConfig.getReplicaLifespanMins()).isEqualTo(1440);
 
@@ -410,7 +410,7 @@ public class KaldbConfigTest {
 
     final KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
         managerConfig.getReplicaCreationServiceConfig();
-    assertThat(replicaCreationServiceConfig.getReplicaPartitionsList()).isEqualTo(List.of("rep1"));
+    assertThat(replicaCreationServiceConfig.getReplicaSetsList()).isEqualTo(List.of("rep1"));
     assertThat(replicaCreationServiceConfig.getSchedulePeriodMins()).isEqualTo(15);
     assertThat(replicaCreationServiceConfig.getReplicaLifespanMins()).isEqualTo(1440);
 
@@ -567,7 +567,7 @@ public class KaldbConfigTest {
 
     final KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
         managerConfig.getReplicaCreationServiceConfig();
-    assertThat(replicaCreationServiceConfig.getReplicaPartitionsCount()).isZero();
+    assertThat(replicaCreationServiceConfig.getReplicaSetsCount()).isZero();
     assertThat(replicaCreationServiceConfig.getSchedulePeriodMins()).isZero();
     assertThat(replicaCreationServiceConfig.getReplicaLifespanMins()).isZero();
 
@@ -703,7 +703,7 @@ public class KaldbConfigTest {
 
     final KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
         managerConfig.getReplicaCreationServiceConfig();
-    assertThat(replicaCreationServiceConfig.getReplicaPartitionsCount()).isZero();
+    assertThat(replicaCreationServiceConfig.getReplicaSetsCount()).isZero();
     assertThat(replicaCreationServiceConfig.getSchedulePeriodMins()).isZero();
     assertThat(replicaCreationServiceConfig.getReplicaLifespanMins()).isZero();
 

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
@@ -240,7 +240,7 @@ public class KaldbConfigTest {
 
     final KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
         managerConfig.getReplicaCreationServiceConfig();
-    assertThat(replicaCreationServiceConfig.getReplicasPerSnapshot()).isEqualTo(2);
+    assertThat(replicaCreationServiceConfig.getReplicaPartitionsList()).isEqualTo(List.of("rep1"));
     assertThat(replicaCreationServiceConfig.getSchedulePeriodMins()).isEqualTo(15);
     assertThat(replicaCreationServiceConfig.getReplicaLifespanMins()).isEqualTo(1440);
 
@@ -410,7 +410,7 @@ public class KaldbConfigTest {
 
     final KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
         managerConfig.getReplicaCreationServiceConfig();
-    assertThat(replicaCreationServiceConfig.getReplicasPerSnapshot()).isEqualTo(2);
+    assertThat(replicaCreationServiceConfig.getReplicaPartitionsList()).isEqualTo(List.of("rep1"));
     assertThat(replicaCreationServiceConfig.getSchedulePeriodMins()).isEqualTo(15);
     assertThat(replicaCreationServiceConfig.getReplicaLifespanMins()).isEqualTo(1440);
 
@@ -567,7 +567,7 @@ public class KaldbConfigTest {
 
     final KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
         managerConfig.getReplicaCreationServiceConfig();
-    assertThat(replicaCreationServiceConfig.getReplicasPerSnapshot()).isZero();
+    assertThat(replicaCreationServiceConfig.getReplicaPartitionsCount()).isZero();
     assertThat(replicaCreationServiceConfig.getSchedulePeriodMins()).isZero();
     assertThat(replicaCreationServiceConfig.getReplicaLifespanMins()).isZero();
 
@@ -703,7 +703,7 @@ public class KaldbConfigTest {
 
     final KaldbConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
         managerConfig.getReplicaCreationServiceConfig();
-    assertThat(replicaCreationServiceConfig.getReplicasPerSnapshot()).isZero();
+    assertThat(replicaCreationServiceConfig.getReplicaPartitionsCount()).isZero();
     assertThat(replicaCreationServiceConfig.getSchedulePeriodMins()).isZero();
     assertThat(replicaCreationServiceConfig.getReplicaLifespanMins()).isZero();
 

--- a/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
@@ -83,7 +83,7 @@ public class ManagerApiGrpcTest {
 
     KaldbConfigs.ManagerConfig.ReplicaRestoreServiceConfig replicaRecreationServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaRestoreServiceConfig.newBuilder()
-            .addAllReplicaPartitions(List.of("rep1"))
+            .addAllReplicaSets(List.of("rep1"))
             .setMaxReplicasPerRequest(200)
             .setReplicaLifespanMins(60)
             .setSchedulePeriodMins(30)

--- a/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
@@ -83,6 +83,7 @@ public class ManagerApiGrpcTest {
 
     KaldbConfigs.ManagerConfig.ReplicaRestoreServiceConfig replicaRecreationServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaRestoreServiceConfig.newBuilder()
+            .addAllReplicaPartitions(List.of("rep1"))
             .setMaxReplicasPerRequest(200)
             .setReplicaLifespanMins(60)
             .setSchedulePeriodMins(30)

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/MetricsUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/MetricsUtil.java
@@ -1,6 +1,9 @@
 package com.slack.kaldb.testlib;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,7 +33,7 @@ public class MetricsUtil {
 
   public static double getCount(String counterName, MeterRegistry metricsRegistry) {
     try {
-      return metricsRegistry.get(counterName).counter().count();
+      return metricsRegistry.get(counterName).counters().stream().mapToDouble(Counter::count).sum();
     } catch (MeterNotFoundException e) {
       LOG.warn("Metric not found", e);
       return 0;
@@ -42,7 +45,7 @@ public class MetricsUtil {
 
   public static double getValue(String guageName, MeterRegistry metricsRegistry) {
     try {
-      return metricsRegistry.get(guageName).gauge().value();
+      return metricsRegistry.get(guageName).gauges().stream().mapToDouble(Gauge::value).sum();
     } catch (MeterNotFoundException e) {
       LOG.warn("Metric not found", e);
       return 0;
@@ -54,7 +57,7 @@ public class MetricsUtil {
 
   public static double getTimerCount(String timerName, MeterRegistry metricsRegistry) {
     try {
-      return metricsRegistry.get(timerName).timer().count();
+      return metricsRegistry.get(timerName).timers().stream().mapToDouble(Timer::count).sum();
     } catch (MeterNotFoundException e) {
       LOG.warn("Metric not found", e);
       return 0;

--- a/kaldb/src/test/resources/test_config.json
+++ b/kaldb/src/test/resources/test_config.json
@@ -88,13 +88,13 @@
     "replicaCreationServiceConfig": {
       "schedulePeriodMins": 15,
       "replicaLifespanMins": 1440,
-      "replicaPartitions": [
+      "replicaSets": [
         "rep1"
       ]
     },
     "replicaAssignmentServiceConfig": {
       "schedulePeriodMins": 10,
-      "replicaPartitions": [
+      "replicaSets": [
         "rep1"
       ]
     },

--- a/kaldb/src/test/resources/test_config.json
+++ b/kaldb/src/test/resources/test_config.json
@@ -86,12 +86,17 @@
       "requestTimeoutMs": 3000
     },
     "replicaCreationServiceConfig": {
-      "replicasPerSnapshot": 2,
       "schedulePeriodMins": 15,
-      "replicaLifespanMins": 1440
+      "replicaLifespanMins": 1440,
+      "replicaPartitions": [
+        "rep1"
+      ]
     },
     "replicaAssignmentServiceConfig": {
-      "schedulePeriodMins": 10
+      "schedulePeriodMins": 10,
+      "replicaPartitions": [
+        "rep1"
+      ]
     },
     "replicaEvictionServiceConfig": {
       "schedulePeriodMins": 10

--- a/kaldb/src/test/resources/test_config.yaml
+++ b/kaldb/src/test/resources/test_config.yaml
@@ -72,11 +72,11 @@ managerConfig:
   replicaCreationServiceConfig:
     schedulePeriodMins: 15
     replicaLifespanMins: 1440
-    replicaPartitions:
+    replicaSets:
       - rep1
   replicaAssignmentServiceConfig:
     schedulePeriodMins: 10
-    replicaPartitions:
+    replicaSets:
       - rep1
   replicaEvictionServiceConfig:
     schedulePeriodMins: 10

--- a/kaldb/src/test/resources/test_config.yaml
+++ b/kaldb/src/test/resources/test_config.yaml
@@ -70,11 +70,14 @@ managerConfig:
     serverPort: 8083
     serverAddress: localhost
   replicaCreationServiceConfig:
-    replicasPerSnapshot: 2
     schedulePeriodMins: 15
     replicaLifespanMins: 1440
+    replicaPartitions:
+      - rep1
   replicaAssignmentServiceConfig:
     schedulePeriodMins: 10
+    replicaPartitions:
+      - rep1
   replicaEvictionServiceConfig:
     schedulePeriodMins: 10
   replicaDeletionServiceConfig:


### PR DESCRIPTION
###  Summary

This reworks the concept of replicas being created by an integer count, and instead moves to creating the replicas keyed against a string (`replicaSet`). This allows running completely separate pools of cache nodes, and will enable zero-downtime cache deploys.