### PR TITLE
S3 CRT Client

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -34,6 +34,7 @@ s3Config:
   s3Region: ${S3_REGION:-us-east-1}
   s3EndPoint: ${S3_ENDPOINT:-http://localhost:9090}
   s3Bucket: ${S3_BUCKET:-test-s3-bucket}
+  s3TargetThroughputGbps: ${S3_TARGET_THROUGHPUT_GBPS:-25}
 
 tracingConfig:
   zipkinEndpoint: ${ZIPKIN_TRACING_ENDPOINT:-http://localhost:9411/api/v2/spans}

--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -320,6 +320,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk.crt</groupId>
+            <artifactId>aws-crt</artifactId>
+            <version>0.22.1</version>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/kaldb/src/main/java/com/slack/kaldb/blobfs/s3/S3CrtBlobFs.java
+++ b/kaldb/src/main/java/com/slack/kaldb/blobfs/s3/S3CrtBlobFs.java
@@ -18,6 +18,7 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,12 +26,11 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.core.SdkSystemSetting;
-import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
@@ -47,25 +47,22 @@ import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
-/**
- * @see S3CrtBlobFs
- */
-@Deprecated
-public class S3BlobFs extends BlobFs {
+public class S3CrtBlobFs extends BlobFs {
   public static final String S3_SCHEME = "s3://";
-  private static final Logger LOG = LoggerFactory.getLogger(S3BlobFs.class);
+  private static final Logger LOG = LoggerFactory.getLogger(S3CrtBlobFs.class);
   private static final String DELIMITER = "/";
-  private S3Client s3Client;
 
-  public S3BlobFs(S3Client s3Client) {
-    this.s3Client = s3Client;
+  private final S3AsyncClient s3AsyncClient;
+
+  public S3CrtBlobFs(S3AsyncClient s3AsyncClient) {
+    this.s3AsyncClient = s3AsyncClient;
   }
 
   static boolean isNullOrEmpty(String target) {
     return target == null || "".equals(target);
   }
 
-  public static S3Client initS3Client(KaldbConfigs.S3Config config) {
+  public static S3AsyncClient initS3Client(KaldbConfigs.S3Config config) {
     Preconditions.checkArgument(!isNullOrEmpty(config.getS3Region()));
     String region = config.getS3Region();
 
@@ -81,22 +78,21 @@ public class S3BlobFs extends BlobFs {
         awsCredentialsProvider = DefaultCredentialsProvider.create();
       }
 
-      // TODO: Remove hard coded HTTP IMPL property setting by only having 1 http client on the
-      // classpath.
-      System.setProperty(
-          SdkSystemSetting.SYNC_HTTP_SERVICE_IMPL.property(),
-          "software.amazon.awssdk.http.apache.ApacheSdkHttpService");
-      S3ClientBuilder s3ClientBuilder =
-          S3Client.builder().region(Region.of(region)).credentialsProvider(awsCredentialsProvider);
+      S3CrtAsyncClientBuilder s3AsyncClient =
+          S3AsyncClient.crtBuilder()
+              .targetThroughputInGbps(config.getS3TargetThroughputGbps())
+              .region(Region.of(region))
+              .credentialsProvider(awsCredentialsProvider);
+
       if (!isNullOrEmpty(config.getS3EndPoint())) {
         String endpoint = config.getS3EndPoint();
         try {
-          s3ClientBuilder.endpointOverride(new URI(endpoint));
+          s3AsyncClient.endpointOverride(new URI(endpoint));
         } catch (URISyntaxException e) {
           throw new RuntimeException(e);
         }
       }
-      return s3ClientBuilder.build();
+      return s3AsyncClient.build();
     } catch (S3Exception e) {
       throw new RuntimeException("Could not initialize S3blobFs", e);
     }
@@ -115,7 +111,11 @@ public class S3BlobFs extends BlobFs {
     HeadObjectRequest headObjectRequest =
         HeadObjectRequest.builder().bucket(uri.getHost()).key(path).build();
 
-    return s3Client.headObject(headObjectRequest);
+    try {
+      return s3AsyncClient.headObject(headObjectRequest).get();
+    } catch (InterruptedException | ExecutionException e) {
+      throw new IOException(e);
+    }
   }
 
   private boolean isPathTerminatedByDelimiter(URI uri) {
@@ -165,12 +165,14 @@ public class S3BlobFs extends BlobFs {
       HeadObjectRequest headObjectRequest =
           HeadObjectRequest.builder().bucket(uri.getHost()).key(path).build();
 
-      s3Client.headObject(headObjectRequest);
+      s3AsyncClient.headObject(headObjectRequest).get();
       return true;
-    } catch (NoSuchKeyException e) {
-      return false;
-    } catch (S3Exception e) {
-      throw new IOException(e);
+    } catch (Exception e) {
+      if (e instanceof ExecutionException && e.getCause() instanceof NoSuchKeyException) {
+        return false;
+      } else {
+        throw new IOException(e);
+      }
     }
   }
 
@@ -189,7 +191,11 @@ public class S3BlobFs extends BlobFs {
     }
 
     ListObjectsV2Request listObjectsV2Request = listObjectsV2RequestBuilder.build();
-    listObjectsV2Response = s3Client.listObjectsV2(listObjectsV2Request);
+    try {
+      listObjectsV2Response = s3AsyncClient.listObjectsV2(listObjectsV2Request).get();
+    } catch (InterruptedException | ExecutionException e) {
+      throw new IOException(e);
+    }
 
     for (S3Object s3Object : listObjectsV2Response.contents()) {
       if (s3Object.key().equals(prefix)) {
@@ -221,9 +227,9 @@ public class S3BlobFs extends BlobFs {
               .destinationKey(dstPath)
               .build();
 
-      CopyObjectResponse copyObjectResponse = s3Client.copyObject(copyReq);
+      CopyObjectResponse copyObjectResponse = s3AsyncClient.copyObject(copyReq).get();
       return copyObjectResponse.sdkHttpResponse().isSuccessful();
-    } catch (S3Exception e) {
+    } catch (S3Exception | ExecutionException | InterruptedException e) {
       throw new IOException(e);
     }
   }
@@ -243,7 +249,7 @@ public class S3BlobFs extends BlobFs {
           PutObjectRequest.builder().bucket(uri.getHost()).key(path).build();
 
       PutObjectResponse putObjectResponse =
-          s3Client.putObject(putObjectRequest, RequestBody.fromBytes(new byte[0]));
+          s3AsyncClient.putObject(putObjectRequest, AsyncRequestBody.fromBytes(new byte[0])).get();
 
       return putObjectResponse.sdkHttpResponse().isSuccessful();
     } catch (Throwable t) {
@@ -269,11 +275,11 @@ public class S3BlobFs extends BlobFs {
 
         if (prefix.equals(DELIMITER)) {
           ListObjectsV2Request listObjectsV2Request = listObjectsV2RequestBuilder.build();
-          listObjectsV2Response = s3Client.listObjectsV2(listObjectsV2Request);
+          listObjectsV2Response = s3AsyncClient.listObjectsV2(listObjectsV2Request).get();
         } else {
           ListObjectsV2Request listObjectsV2Request =
               listObjectsV2RequestBuilder.prefix(prefix).build();
-          listObjectsV2Response = s3Client.listObjectsV2(listObjectsV2Request);
+          listObjectsV2Response = s3AsyncClient.listObjectsV2(listObjectsV2Request).get();
         }
         boolean deleteSucceeded = true;
         for (S3Object s3Object : listObjectsV2Response.contents()) {
@@ -283,7 +289,8 @@ public class S3BlobFs extends BlobFs {
                   .key(s3Object.key())
                   .build();
 
-          DeleteObjectResponse deleteObjectResponse = s3Client.deleteObject(deleteObjectRequest);
+          DeleteObjectResponse deleteObjectResponse =
+              s3AsyncClient.deleteObject(deleteObjectRequest).get();
 
           deleteSucceeded &= deleteObjectResponse.sdkHttpResponse().isSuccessful();
         }
@@ -293,7 +300,8 @@ public class S3BlobFs extends BlobFs {
         DeleteObjectRequest deleteObjectRequest =
             DeleteObjectRequest.builder().bucket(segmentUri.getHost()).key(prefix).build();
 
-        DeleteObjectResponse deleteObjectResponse = s3Client.deleteObject(deleteObjectRequest);
+        DeleteObjectResponse deleteObjectResponse =
+            s3AsyncClient.deleteObject(deleteObjectRequest).get();
 
         return deleteObjectResponse.sdkHttpResponse().isSuccessful();
       }
@@ -395,7 +403,8 @@ public class S3BlobFs extends BlobFs {
         }
         ListObjectsV2Request listObjectsV2Request = listObjectsV2RequestBuilder.build();
         LOG.debug("Trying to send ListObjectsV2Request {}", listObjectsV2Request);
-        ListObjectsV2Response listObjectsV2Response = s3Client.listObjectsV2(listObjectsV2Request);
+        ListObjectsV2Response listObjectsV2Response =
+            s3AsyncClient.listObjectsV2(listObjectsV2Request).get();
         LOG.debug("Getting ListObjectsV2Response: {}", listObjectsV2Response);
         List<S3Object> filesReturned = listObjectsV2Response.contents();
         filesReturned.stream()
@@ -432,7 +441,7 @@ public class S3BlobFs extends BlobFs {
     GetObjectRequest getObjectRequest =
         GetObjectRequest.builder().bucket(srcUri.getHost()).key(prefix).build();
 
-    s3Client.getObject(getObjectRequest, ResponseTransformer.toFile(dstFile));
+    s3AsyncClient.getObject(getObjectRequest, AsyncResponseTransformer.toFile(dstFile)).get();
   }
 
   @Override
@@ -443,7 +452,7 @@ public class S3BlobFs extends BlobFs {
     PutObjectRequest putObjectRequest =
         PutObjectRequest.builder().bucket(dstUri.getHost()).key(prefix).build();
 
-    s3Client.putObject(putObjectRequest, srcFile.toPath());
+    s3AsyncClient.putObject(putObjectRequest, AsyncRequestBody.fromFile(srcFile)).get();
   }
 
   @Override
@@ -456,11 +465,14 @@ public class S3BlobFs extends BlobFs {
 
       ListObjectsV2Request listObjectsV2Request =
           ListObjectsV2Request.builder().bucket(uri.getHost()).prefix(prefix).maxKeys(2).build();
-      ListObjectsV2Response listObjectsV2Response = s3Client.listObjectsV2(listObjectsV2Request);
+      ListObjectsV2Response listObjectsV2Response =
+          s3AsyncClient.listObjectsV2(listObjectsV2Request).get();
       return listObjectsV2Response.hasContents();
     } catch (NoSuchKeyException e) {
       LOG.error("Could not get directory entry for {}", uri);
       return false;
+    } catch (ExecutionException | InterruptedException e) {
+      throw new IOException(e);
     }
   }
 
@@ -493,16 +505,22 @@ public class S3BlobFs extends BlobFs {
               .metadataDirective(MetadataDirective.REPLACE)
               .build();
 
-      s3Client.copyObject(request);
+      s3AsyncClient.copyObject(request).get();
       long newUpdateTime = getS3ObjectMetadata(uri).lastModified().toEpochMilli();
       return newUpdateTime > s3ObjectMetadata.lastModified().toEpochMilli();
     } catch (NoSuchKeyException e) {
       String path = sanitizePath(uri.getPath());
-      s3Client.putObject(
-          PutObjectRequest.builder().bucket(uri.getHost()).key(path).build(),
-          RequestBody.fromBytes(new byte[0]));
+      try {
+        s3AsyncClient
+            .putObject(
+                PutObjectRequest.builder().bucket(uri.getHost()).key(path).build(),
+                AsyncRequestBody.fromBytes(new byte[0]))
+            .get();
+      } catch (InterruptedException | ExecutionException ex) {
+        throw new IOException(ex);
+      }
       return true;
-    } catch (S3Exception e) {
+    } catch (S3Exception | ExecutionException | InterruptedException e) {
       throw new IOException(e);
     }
   }
@@ -513,10 +531,13 @@ public class S3BlobFs extends BlobFs {
       String path = sanitizePath(uri.getPath());
       GetObjectRequest getObjectRequest =
           GetObjectRequest.builder().bucket(uri.getHost()).key(path).build();
-
-      return s3Client.getObjectAsBytes(getObjectRequest).asInputStream();
+      return s3AsyncClient
+          .getObject(getObjectRequest, AsyncResponseTransformer.toBlockingInputStream())
+          .get();
     } catch (S3Exception e) {
       throw e;
+    } catch (ExecutionException | InterruptedException e) {
+      throw new IOException(e);
     }
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -4,7 +4,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.Service;
 import com.google.common.util.concurrent.ServiceManager;
 import com.slack.kaldb.blobfs.BlobFs;
-import com.slack.kaldb.blobfs.s3.S3BlobFs;
+import com.slack.kaldb.blobfs.s3.S3CrtBlobFs;
 import com.slack.kaldb.chunkManager.CachingChunkManager;
 import com.slack.kaldb.chunkManager.ChunkCleanerService;
 import com.slack.kaldb.chunkManager.IndexingChunkManager;
@@ -56,7 +56,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 /**
  * Main class of Kaldb that sets up the basic infra needed for all the other end points like an a
@@ -68,13 +68,13 @@ public class Kaldb {
   private final PrometheusMeterRegistry prometheusMeterRegistry;
 
   private final KaldbConfigs.KaldbConfig kaldbConfig;
-  private final S3Client s3Client;
+  private final S3AsyncClient s3Client;
   protected ServiceManager serviceManager;
   protected AsyncCuratorFramework curatorFramework;
 
   Kaldb(
       KaldbConfigs.KaldbConfig kaldbConfig,
-      S3Client s3Client,
+      S3AsyncClient s3Client,
       PrometheusMeterRegistry prometheusMeterRegistry) {
     this.prometheusMeterRegistry = prometheusMeterRegistry;
     this.kaldbConfig = kaldbConfig;
@@ -84,7 +84,7 @@ public class Kaldb {
   }
 
   Kaldb(KaldbConfigs.KaldbConfig kaldbConfig, PrometheusMeterRegistry prometheusMeterRegistry) {
-    this(kaldbConfig, S3BlobFs.initS3Client(kaldbConfig.getS3Config()), prometheusMeterRegistry);
+    this(kaldbConfig, S3CrtBlobFs.initS3Client(kaldbConfig.getS3Config()), prometheusMeterRegistry);
   }
 
   public static void main(String[] args) throws Exception {
@@ -133,7 +133,7 @@ public class Kaldb {
             prometheusMeterRegistry, kaldbConfig.getMetadataStoreConfig().getZookeeperConfig());
 
     // Initialize blobfs. Only S3 is supported currently.
-    S3BlobFs s3BlobFs = new S3BlobFs(s3Client);
+    S3CrtBlobFs s3BlobFs = new S3CrtBlobFs(s3Client);
 
     Set<Service> services =
         getServices(curatorFramework, kaldbConfig, s3BlobFs, prometheusMeterRegistry);

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -71,6 +71,7 @@ message S3Config {
   string s3_region = 3;
   string s3_end_point = 4;
   string s3_bucket = 5;
+  double s3_target_throughput_gbps = 6;
 }
 
 message TracingConfig {

--- a/kaldb/src/test/java/com/slack/kaldb/blobfs/s3/S3TestUtils.java
+++ b/kaldb/src/test/java/com/slack/kaldb/blobfs/s3/S3TestUtils.java
@@ -1,5 +1,11 @@
 package com.slack.kaldb.blobfs.s3;
 
+import java.net.URI;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.crt.S3CrtHttpConfiguration;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -24,5 +30,23 @@ public class S3TestUtils {
     }
 
     return listObjectsV2RequestBuilder.build();
+  }
+
+  /**
+   * Based off of S3_MOCK_EXTENSION.createS3ClientV2();
+   *
+   * @see com.adobe.testing.s3mock.testsupport.common.S3MockStarter
+   */
+  public static S3AsyncClient createS3CrtClient(String serviceEndpoint) {
+    return S3AsyncClient.crtBuilder()
+        .region(Region.of("us-east-1"))
+        .credentialsProvider(
+            StaticCredentialsProvider.create(AwsBasicCredentials.create("foo", "bar")))
+        .forcePathStyle(true)
+        .checksumValidationEnabled(false) // https://github.com/adobe/S3Mock/issues/1123
+        .endpointOverride(URI.create(serviceEndpoint))
+        .httpConfiguration(
+            S3CrtHttpConfiguration.builder().trustAllCertificatesEnabled(true).build())
+        .build();
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOf
 
 import brave.Tracing;
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
-import com.slack.kaldb.blobfs.s3.S3BlobFs;
+import com.slack.kaldb.blobfs.s3.S3CrtBlobFs;
 import com.slack.kaldb.blobfs.s3.S3TestUtils;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.logstore.LuceneIndexStoreImpl;
@@ -58,7 +58,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 
@@ -620,11 +620,12 @@ public class IndexingChunkImplTest {
 
       // create an S3 client for test
       String bucket = "invalid-bucket";
-      S3Client s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
-      S3BlobFs s3BlobFs = new S3BlobFs(s3Client);
+      S3AsyncClient s3AsyncClient =
+          S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
+      S3CrtBlobFs s3CrtBlobFs = new S3CrtBlobFs(s3AsyncClient);
 
       // Snapshot to S3 without creating the s3 bucket.
-      assertThat(chunk.snapshotToS3(bucket, "", s3BlobFs)).isFalse();
+      assertThat(chunk.snapshotToS3(bucket, "", s3CrtBlobFs)).isFalse();
       assertThat(chunk.info().getSnapshotPath()).isEqualTo(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
 
       // Metadata checks
@@ -681,13 +682,14 @@ public class IndexingChunkImplTest {
 
       // create an S3 client for test
       String bucket = "test-bucket-with-prefix";
-      S3Client s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
-      S3BlobFs s3BlobFs = new S3BlobFs(s3Client);
-      s3Client.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+      S3AsyncClient s3AsyncClient =
+          S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
+      S3CrtBlobFs s3CrtBlobFs = new S3CrtBlobFs(s3AsyncClient);
+      s3AsyncClient.createBucket(CreateBucketRequest.builder().bucket(bucket).build()).get();
 
       // Snapshot to S3
       assertThat(chunk.info().getSnapshotPath()).isEqualTo(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
-      assertThat(chunk.snapshotToS3(bucket, "", s3BlobFs)).isTrue();
+      assertThat(chunk.snapshotToS3(bucket, "", s3CrtBlobFs)).isTrue();
       assertThat(chunk.info().getSnapshotPath()).isNotEmpty();
 
       // depending on heap and CFS files this can be 5 or 19.
@@ -697,7 +699,7 @@ public class IndexingChunkImplTest {
 
       // Check schema file exists in s3
       ListObjectsV2Response objectsResponse =
-          s3Client.listObjectsV2(S3TestUtils.getListObjectRequest(bucket, "", true));
+          s3AsyncClient.listObjectsV2(S3TestUtils.getListObjectRequest(bucket, "", true)).get();
       assertThat(
               objectsResponse.contents().stream()
                   .filter(o -> o.key().equals(SCHEMA_FILE_NAME))

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
@@ -15,7 +15,8 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOf
 
 import brave.Tracing;
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
-import com.slack.kaldb.blobfs.s3.S3BlobFs;
+import com.slack.kaldb.blobfs.s3.S3CrtBlobFs;
+import com.slack.kaldb.blobfs.s3.S3TestUtils;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.logstore.LuceneIndexStoreImpl;
 import com.slack.kaldb.logstore.schema.SchemaAwareLogDocumentBuilderImpl;
@@ -52,7 +53,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 
 public class RecoveryChunkImplTest {
@@ -513,7 +514,7 @@ public class RecoveryChunkImplTest {
     private AsyncCuratorFramework curatorFramework;
     private SnapshotMetadataStore snapshotMetadataStore;
     private SearchMetadataStore searchMetadataStore;
-    private S3BlobFs s3BlobFs;
+    private S3CrtBlobFs s3CrtBlobFs;
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -566,8 +567,8 @@ public class RecoveryChunkImplTest {
       curatorFramework.unwrap().close();
       testingServer.close();
       registry.close();
-      if (s3BlobFs != null) {
-        s3BlobFs.close();
+      if (s3CrtBlobFs != null) {
+        s3CrtBlobFs.close();
       }
     }
 
@@ -606,11 +607,13 @@ public class RecoveryChunkImplTest {
 
       // create an S3 client for test
       String bucket = "invalid-bucket";
-      S3Client s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
-      s3BlobFs = new S3BlobFs(s3Client);
+
+      S3AsyncClient s3AsyncClient =
+          S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
+      s3CrtBlobFs = new S3CrtBlobFs(s3AsyncClient);
 
       // Snapshot to S3 without creating the s3 bucket.
-      assertThat(chunk.snapshotToS3(bucket, "", s3BlobFs)).isFalse();
+      assertThat(chunk.snapshotToS3(bucket, "", s3CrtBlobFs)).isFalse();
       assertThat(chunk.info().getSnapshotPath()).isEqualTo(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
 
       // No live snapshot or search metadata is published since the S3 snapshot failed.
@@ -655,13 +658,14 @@ public class RecoveryChunkImplTest {
 
       // create an S3 client for test
       String bucket = "test-bucket-with-prefix";
-      S3Client s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
-      S3BlobFs s3BlobFs = new S3BlobFs(s3Client);
-      s3Client.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+      S3AsyncClient s3AsyncClient =
+          S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
+      S3CrtBlobFs s3CrtBlobFs = new S3CrtBlobFs(s3AsyncClient);
+      s3AsyncClient.createBucket(CreateBucketRequest.builder().bucket(bucket).build()).get();
 
       // Snapshot to S3
       assertThat(chunk.info().getSnapshotPath()).isEqualTo(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
-      assertThat(chunk.snapshotToS3(bucket, "", s3BlobFs)).isTrue();
+      assertThat(chunk.snapshotToS3(bucket, "", s3CrtBlobFs)).isTrue();
       assertThat(chunk.info().getSnapshotPath()).isNotEmpty();
 
       // depending on heap and CFS files this can be 5 or 19.
@@ -677,7 +681,7 @@ public class RecoveryChunkImplTest {
           KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore);
       assertThat(afterSnapshots.size()).isEqualTo(1);
       assertThat(afterSnapshots).contains(ChunkInfo.toSnapshotMetadata(chunk.info(), ""));
-      assertThat(s3BlobFs.exists(URI.create(afterSnapshots.get(0).snapshotPath))).isTrue();
+      assertThat(s3CrtBlobFs.exists(URI.create(afterSnapshots.get(0).snapshotPath))).isTrue();
       // Only non-live snapshots. No live snapshots.
       assertThat(afterSnapshots.stream().filter(SnapshotMetadata::isLive).count()).isZero();
       // No search nodes are added for recovery chunk.

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/CachingChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/CachingChunkManagerTest.java
@@ -5,7 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
-import com.slack.kaldb.blobfs.s3.S3BlobFs;
+import com.slack.kaldb.blobfs.s3.S3CrtBlobFs;
+import com.slack.kaldb.blobfs.s3.S3TestUtils;
 import com.slack.kaldb.chunk.Chunk;
 import com.slack.kaldb.chunk.ReadOnlyChunkImpl;
 import com.slack.kaldb.chunk.SearchContext;
@@ -27,14 +28,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 public class CachingChunkManagerTest {
   private static final String TEST_S3_BUCKET = "caching-chunkmanager-test";
 
   private TestingServer testingServer;
   private MeterRegistry meterRegistry;
-  private S3BlobFs s3BlobFs;
+  private S3CrtBlobFs s3CrtBlobFs;
 
   @RegisterExtension
   public static final S3MockExtension S3_MOCK_EXTENSION =
@@ -52,8 +53,9 @@ public class CachingChunkManagerTest {
     meterRegistry = new SimpleMeterRegistry();
     testingServer = new TestingServer();
 
-    S3Client s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
-    s3BlobFs = new S3BlobFs(s3Client);
+    S3AsyncClient s3AsyncClient =
+        S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
+    s3CrtBlobFs = new S3CrtBlobFs(s3AsyncClient);
   }
 
   @AfterEach
@@ -65,7 +67,7 @@ public class CachingChunkManagerTest {
     if (curatorFramework != null) {
       curatorFramework.unwrap().close();
     }
-    s3BlobFs.close();
+    s3CrtBlobFs.close();
     testingServer.close();
     meterRegistry.close();
   }
@@ -112,7 +114,7 @@ public class CachingChunkManagerTest {
         new CachingChunkManager<>(
             meterRegistry,
             curatorFramework,
-            s3BlobFs,
+            s3CrtBlobFs,
             SearchContext.fromConfig(kaldbConfig.getCacheConfig().getServerConfig()),
             kaldbConfig.getS3Config().getS3Bucket(),
             kaldbConfig.getCacheConfig().getDataDirectory(),

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
@@ -22,7 +22,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import brave.Tracing;
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
-import com.slack.kaldb.blobfs.s3.S3BlobFs;
+import com.slack.kaldb.blobfs.s3.S3CrtBlobFs;
+import com.slack.kaldb.blobfs.s3.S3TestUtils;
 import com.slack.kaldb.chunk.ChunkInfo;
 import com.slack.kaldb.chunk.ReadWriteChunk;
 import com.slack.kaldb.logstore.LogMessage;
@@ -53,7 +54,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 public class RecoveryChunkManagerTest {
   // TODO: Ensure clean close after all chunks are uploaded.
@@ -74,10 +75,10 @@ public class RecoveryChunkManagerTest {
   private RecoveryChunkManager<LogMessage> chunkManager = null;
 
   private SimpleMeterRegistry metricsRegistry;
-  private S3Client s3Client;
+  private S3AsyncClient s3AsyncClient;
 
   private static final String ZK_PATH_PREFIX = "testZK";
-  private S3BlobFs s3BlobFs;
+  private S3CrtBlobFs s3CrtBlobFs;
   private TestingServer localZkServer;
   private AsyncCuratorFramework curatorFramework;
   private SearchMetadataStore searchMetadataStore;
@@ -88,8 +89,8 @@ public class RecoveryChunkManagerTest {
     Tracing.newBuilder().build();
     metricsRegistry = new SimpleMeterRegistry();
     // create an S3 client.
-    s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
-    s3BlobFs = new S3BlobFs(s3Client);
+    s3AsyncClient = S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
+    s3CrtBlobFs = new S3CrtBlobFs(s3AsyncClient);
 
     localZkServer = new TestingServer();
     localZkServer.start();
@@ -118,7 +119,7 @@ public class RecoveryChunkManagerTest {
     searchMetadataStore.close();
     snapshotMetadataStore.close();
     curatorFramework.unwrap().close();
-    s3Client.close();
+    s3AsyncClient.close();
     localZkServer.stop();
   }
 
@@ -147,7 +148,7 @@ public class RecoveryChunkManagerTest {
             searchMetadataStore,
             snapshotMetadataStore,
             kaldbCfg.getIndexerConfig(),
-            s3BlobFs,
+            s3CrtBlobFs,
             kaldbCfg.getS3Config());
     chunkManager.startAsync();
     chunkManager.awaitRunning(DEFAULT_START_STOP_DURATION);

--- a/kaldb/src/test/java/com/slack/kaldb/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
@@ -16,7 +16,8 @@ import brave.Tracing;
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.slack.kaldb.blobfs.s3.S3BlobFs;
+import com.slack.kaldb.blobfs.s3.S3CrtBlobFs;
+import com.slack.kaldb.blobfs.s3.S3TestUtils;
 import com.slack.kaldb.chunk.SearchContext;
 import com.slack.kaldb.chunkManager.IndexingChunkManager;
 import com.slack.kaldb.chunkManager.RollOverChunkTask;
@@ -48,7 +49,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 public class DiskOrMessageCountBasedRolloverStrategyTest {
   private static final String S3_TEST_BUCKET = "test-kaldb-logs";
@@ -67,9 +68,9 @@ public class DiskOrMessageCountBasedRolloverStrategyTest {
   private IndexingChunkManager<LogMessage> chunkManager = null;
 
   private SimpleMeterRegistry metricsRegistry;
-  private final S3Client s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
+  private S3AsyncClient s3AsyncClient;
   private static final String ZK_PATH_PREFIX = "testZK";
-  private S3BlobFs s3BlobFs;
+  private S3CrtBlobFs s3CrtBlobFs;
   private TestingServer localZkServer;
   private AsyncCuratorFramework curatorFramework;
   private SnapshotMetadataStore snapshotMetadataStore;
@@ -84,7 +85,9 @@ public class DiskOrMessageCountBasedRolloverStrategyTest {
     DiskOrMessageCountBasedRolloverStrategy.DIRECTORY_SIZE_EXECUTOR_PERIOD_MS = 10;
     Tracing.newBuilder().build();
     metricsRegistry = new SimpleMeterRegistry();
-    s3BlobFs = new S3BlobFs(s3Client);
+
+    s3AsyncClient = S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
+    s3CrtBlobFs = new S3CrtBlobFs(s3AsyncClient);
 
     localZkServer = new TestingServer();
     localZkServer.start();
@@ -113,8 +116,8 @@ public class DiskOrMessageCountBasedRolloverStrategyTest {
     if (curatorFramework != null) {
       curatorFramework.unwrap().close();
     }
-    if (s3Client != null) {
-      s3Client.close();
+    if (s3AsyncClient != null) {
+      s3AsyncClient.close();
     }
     if (localZkServer != null) {
       localZkServer.stop();
@@ -133,7 +136,7 @@ public class DiskOrMessageCountBasedRolloverStrategyTest {
             tmpPath.toFile().getAbsolutePath(),
             chunkRollOverStrategy,
             metricsRegistry,
-            s3BlobFs,
+            s3CrtBlobFs,
             s3TestBucket,
             listeningExecutorService,
             curatorFramework,

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
@@ -19,7 +19,7 @@ import static org.awaitility.Awaitility.await;
 import brave.Tracing;
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
 import com.slack.kaldb.blobfs.LocalBlobFs;
-import com.slack.kaldb.blobfs.s3.S3BlobFs;
+import com.slack.kaldb.blobfs.s3.S3CrtBlobFs;
 import com.slack.kaldb.blobfs.s3.S3TestUtils;
 import com.slack.kaldb.logstore.LogMessage.ReservedField;
 import com.slack.kaldb.logstore.schema.SchemaAwareLogDocumentBuilderImpl;
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 
@@ -372,27 +372,30 @@ public class LuceneIndexStoreImplTest {
           .isGreaterThanOrEqualTo(activeFiles.size());
 
       // create an S3 client
-      S3Client s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
-      S3BlobFs s3BlobFs = new S3BlobFs(s3Client);
-      s3Client.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+      S3AsyncClient s3AsyncClient =
+          S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
+      S3CrtBlobFs s3CrtBlobFs = new S3CrtBlobFs(s3AsyncClient);
+      s3AsyncClient.createBucket(CreateBucketRequest.builder().bucket(bucket).build()).get();
 
       // Copy files to S3.
-      copyToS3(dirPath, activeFiles, bucket, prefix, s3BlobFs);
+      copyToS3(dirPath, activeFiles, bucket, prefix, s3CrtBlobFs);
 
       for (String fileName : activeFiles) {
         File fileToCopy = new File(dirPath.toString(), fileName);
         HeadObjectResponse headObjectResponse =
-            s3Client.headObject(
-                S3TestUtils.getHeadObjectRequest(
-                    bucket,
-                    prefix != null && !prefix.isEmpty()
-                        ? prefix + DELIMITER + fileName
-                        : fileName));
+            s3AsyncClient
+                .headObject(
+                    S3TestUtils.getHeadObjectRequest(
+                        bucket,
+                        prefix != null && !prefix.isEmpty()
+                            ? prefix + DELIMITER + fileName
+                            : fileName))
+                .get();
         assertThat(headObjectResponse.contentLength()).isEqualTo(fileToCopy.length());
       }
 
       // Download files from S3 to local FS.
-      String[] s3Files = copyFromS3(bucket, prefix, s3BlobFs, tmpPath.toAbsolutePath());
+      String[] s3Files = copyFromS3(bucket, prefix, s3CrtBlobFs, tmpPath.toAbsolutePath());
       assertThat(s3Files.length).isEqualTo(activeFiles.size());
 
       // Search files in local FS.
@@ -407,7 +410,7 @@ public class LuceneIndexStoreImplTest {
       // Clean up
       logStore.releaseIndexCommit(indexCommit);
       newSearcher.close();
-      s3BlobFs.close();
+      s3CrtBlobFs.close();
     }
 
     @Test

--- a/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
@@ -25,7 +25,8 @@ import brave.Tracing;
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
 import com.google.common.collect.Maps;
 import com.slack.kaldb.blobfs.BlobFs;
-import com.slack.kaldb.blobfs.s3.S3BlobFs;
+import com.slack.kaldb.blobfs.s3.S3CrtBlobFs;
+import com.slack.kaldb.blobfs.s3.S3TestUtils;
 import com.slack.kaldb.logstore.BlobFsUtils;
 import com.slack.kaldb.metadata.core.CuratorBuilder;
 import com.slack.kaldb.metadata.core.KaldbMetadataTestUtils;
@@ -63,7 +64,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.stubbing.Answer;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 public class RecoveryServiceTest {
 
@@ -84,7 +85,7 @@ public class RecoveryServiceTest {
   private MeterRegistry meterRegistry;
   private BlobFs blobFs;
   private TestKafkaServer kafkaServer;
-  private S3Client s3Client;
+  private S3AsyncClient s3AsyncClient;
   private RecoveryService recoveryService;
   private AsyncCuratorFramework curatorFramework;
 
@@ -94,8 +95,8 @@ public class RecoveryServiceTest {
     kafkaServer = new TestKafkaServer();
     meterRegistry = new SimpleMeterRegistry();
     zkServer = new TestingServer();
-    s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
-    blobFs = new S3BlobFs(s3Client);
+    s3AsyncClient = S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
+    blobFs = new S3CrtBlobFs(s3AsyncClient);
   }
 
   @AfterEach
@@ -119,8 +120,8 @@ public class RecoveryServiceTest {
     if (meterRegistry != null) {
       meterRegistry.close();
     }
-    if (s3Client != null) {
-      s3Client.close();
+    if (s3AsyncClient != null) {
+      s3AsyncClient.close();
     }
   }
 
@@ -371,9 +372,10 @@ public class RecoveryServiceTest {
     final Instant startTime = Instant.now();
     produceMessagesToKafka(kafkaServer.getBroker(), startTime, TEST_KAFKA_TOPIC_1, 0);
 
-    assertThat(s3Client.listBuckets().buckets().size()).isEqualTo(1);
-    assertThat(s3Client.listBuckets().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
-    assertThat(s3Client.listBuckets().buckets().get(0).name()).isNotEqualTo(fakeS3Bucket);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().size()).isEqualTo(1);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name())
+        .isNotEqualTo(fakeS3Bucket);
     SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
     assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
 
@@ -382,9 +384,10 @@ public class RecoveryServiceTest {
         new RecoveryTaskMetadata("testRecoveryTask", "0", 30, 60, Instant.now().toEpochMilli());
     assertThat(recoveryService.handleRecoveryTask(recoveryTask)).isFalse();
 
-    assertThat(s3Client.listBuckets().buckets().size()).isEqualTo(1);
-    assertThat(s3Client.listBuckets().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
-    assertThat(s3Client.listBuckets().buckets().get(0).name()).isNotEqualTo(fakeS3Bucket);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().size()).isEqualTo(1);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name())
+        .isNotEqualTo(fakeS3Bucket);
 
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, meterRegistry)).isEqualTo(31);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
@@ -408,8 +411,8 @@ public class RecoveryServiceTest {
     final Instant startTime = Instant.now();
     produceMessagesToKafka(kafkaServer.getBroker(), startTime, TEST_KAFKA_TOPIC_1, 0);
 
-    assertThat(s3Client.listBuckets().buckets().size()).isEqualTo(1);
-    assertThat(s3Client.listBuckets().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().size()).isEqualTo(1);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
     SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
     assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
 
@@ -449,8 +452,8 @@ public class RecoveryServiceTest {
     assertThat(getCount(RECOVERY_NODE_ASSIGNMENT_FAILED, meterRegistry)).isZero();
 
     // Check metadata
-    assertThat(s3Client.listBuckets().buckets().size()).isEqualTo(1);
-    assertThat(s3Client.listBuckets().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().size()).isEqualTo(1);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
 
     // Post recovery checks
     assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore).size())
@@ -493,8 +496,8 @@ public class RecoveryServiceTest {
     produceMessagesToKafka(kafkaServer.getBroker(), startTime, TEST_KAFKA_TOPIC_1, 0);
 
     // fakeS3Bucket is not present.
-    assertThat(s3Client.listBuckets().buckets().size()).isEqualTo(1);
-    assertThat(s3Client.listBuckets().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().size()).isEqualTo(1);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
     SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
     assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
 
@@ -536,8 +539,8 @@ public class RecoveryServiceTest {
     assertThat(getCount(RECOVERY_NODE_ASSIGNMENT_SUCCESS, meterRegistry)).isZero();
 
     // Check metadata
-    assertThat(s3Client.listBuckets().buckets().size()).isEqualTo(1);
-    assertThat(s3Client.listBuckets().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().size()).isEqualTo(1);
+    assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
 
     // Post recovery checks
     assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore).size())

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
@@ -13,6 +13,7 @@ import com.adobe.testing.s3mock.junit5.S3MockExtension;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import com.slack.kaldb.blobfs.s3.S3TestUtils;
 import com.slack.kaldb.chunkManager.RollOverChunkTask;
 import com.slack.kaldb.logstore.schema.SchemaAwareLogDocumentBuilderImpl;
 import com.slack.kaldb.metadata.core.CuratorBuilder;
@@ -50,7 +51,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 public class KaldbTest {
   private static final Logger LOG = LoggerFactory.getLogger(KaldbTest.class);
@@ -104,13 +105,13 @@ public class KaldbTest {
 
   private TestKafkaServer kafkaServer;
   private TestingServer zkServer;
-  private S3Client s3Client;
+  private S3AsyncClient s3Client;
 
   @BeforeEach
   public void setUp() throws Exception {
     zkServer = new TestingServer();
     kafkaServer = new TestKafkaServer();
-    s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
+    s3Client = S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
 
     // We side load a service metadata entry telling it to create an entry with the partitions that
     // we use in test

--- a/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ZipkinServiceTest.java
@@ -14,6 +14,7 @@ import static org.awaitility.Awaitility.await;
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.slack.kaldb.blobfs.s3.S3TestUtils;
 import com.slack.kaldb.chunkManager.RollOverChunkTask;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.logstore.LogWireMessage;
@@ -47,7 +48,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 public class ZipkinServiceTest {
 
@@ -71,13 +72,13 @@ public class ZipkinServiceTest {
 
   private TestKafkaServer kafkaServer;
   private TestingServer zkServer;
-  private S3Client s3Client;
+  private S3AsyncClient s3Client;
 
   @BeforeEach
   public void setUp() throws Exception {
     zkServer = new TestingServer();
     kafkaServer = new TestKafkaServer();
-    s3Client = S3_MOCK_EXTENSION.createS3ClientV2();
+    s3Client = S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
 
     // We side load a service metadata entry telling it to create an entry with the partitions that
     // we use in test

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/ChunkManagerUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/ChunkManagerUtil.java
@@ -5,7 +5,8 @@ import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
 import com.google.common.io.Files;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.slack.kaldb.blobfs.s3.S3BlobFs;
+import com.slack.kaldb.blobfs.s3.S3CrtBlobFs;
+import com.slack.kaldb.blobfs.s3.S3TestUtils;
 import com.slack.kaldb.chunk.SearchContext;
 import com.slack.kaldb.chunkManager.IndexingChunkManager;
 import com.slack.kaldb.chunkrollover.ChunkRollOverStrategy;
@@ -24,7 +25,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.apache.curator.test.TestingServer;
 import org.apache.curator.x.async.AsyncCuratorFramework;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 /**
  * This class creates a chunk manager that can be used in unit tests.
@@ -37,7 +38,7 @@ public class ChunkManagerUtil<T> {
   public static final int TEST_PORT = 34567;
 
   private final File tempFolder;
-  public final S3Client s3Client;
+  public S3AsyncClient s3AsyncClient;
   public static final String ZK_PATH_PREFIX = "testZK";
   public final IndexingChunkManager<T> chunkManager;
   private final TestingServer zkServer;
@@ -87,9 +88,9 @@ public class ChunkManagerUtil<T> {
       throws Exception {
 
     tempFolder = Files.createTempDir(); // TODO: don't use beta func.
-    s3Client = s3MockExtension.createS3ClientV2();
+    s3AsyncClient = S3TestUtils.createS3CrtClient(s3MockExtension.getServiceEndpoint());
+    S3CrtBlobFs s3CrtBlobFs = new S3CrtBlobFs(s3AsyncClient);
 
-    S3BlobFs s3BlobFs = new S3BlobFs(s3Client);
     this.zkServer = zkServer;
     // noop if zk has already been started by the caller
     this.zkServer.start();
@@ -106,7 +107,7 @@ public class ChunkManagerUtil<T> {
             tempFolder.getAbsolutePath(),
             chunkRollOverStrategy,
             meterRegistry,
-            s3BlobFs,
+            s3CrtBlobFs,
             s3Bucket,
             MoreExecutors.newDirectExecutorService(),
             curatorFramework,
@@ -117,7 +118,7 @@ public class ChunkManagerUtil<T> {
   public void close() throws IOException, TimeoutException {
     chunkManager.stopAsync();
     chunkManager.awaitTerminated(DEFAULT_START_STOP_DURATION);
-    s3Client.close();
+    s3AsyncClient.close();
     curatorFramework.unwrap().close();
     zkServer.close();
     FileUtils.deleteDirectory(tempFolder);

--- a/kaldb/src/test/java/com/slack/kaldb/testlib/KaldbConfigUtil.java
+++ b/kaldb/src/test/java/com/slack/kaldb/testlib/KaldbConfigUtil.java
@@ -36,6 +36,7 @@ public class KaldbConfigUtil {
             .setS3Region("us-east-1")
             .setS3AccessKey("")
             .setS3SecretKey("")
+            .setS3TargetThroughputGbps(10D)
             .build();
 
     KaldbConfigs.IndexerConfig indexerConfig =


### PR DESCRIPTION
Reverts slackhq/kaldb#609.

⚠️ Depends on `NO_PROXY` support before this can be merged - https://github.com/awslabs/aws-c-http/issues/413.

Today there exists no way to initialize the S3 CRT client from Java using no proxy, if the HTTP_PROXY/HTTPS_PROXY environment values are set. These are directly read from native C code when an empty proxy config is detected.

Attempting to initialize the proxy with null values does not bypass this behavior, nor does attempting to initialize the proxy with an empty string (throws errors in native code). Attempting to set the http.proxy/https.proxy Java values to empty also does not stop reading the ENV values, as this is also detected as an empty proxy config. The only way to avoid this behavior is to completely unset the proxy values from the system environment values, as mentioned in the issue above.

Initial benchmarks with this code (even running through the proxy) showed download speeds took less than 50% of the original time. As soon as some form of `no_proxy` support is added, or there exists a way to force disable reading of the env variables this should be revisited.