### PR TITLE
Add Kubernetes HPA metric support for Cache nodes

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ClusterHpaMetricService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ClusterHpaMetricService.java
@@ -1,0 +1,173 @@
+package com.slack.kaldb.clusterManager;
+
+import com.google.common.util.concurrent.AbstractScheduledService;
+import com.slack.kaldb.metadata.cache.CacheSlotMetadataStore;
+import com.slack.kaldb.metadata.hpa.HpaMetricMetadata;
+import com.slack.kaldb.metadata.hpa.HpaMetricMetadataStore;
+import com.slack.kaldb.metadata.replica.ReplicaMetadata;
+import com.slack.kaldb.metadata.replica.ReplicaMetadataStore;
+import com.slack.kaldb.proto.metadata.Metadata;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The Cluster HPA metrics service is intended to be run on the manager node, and is used for making
+ * centralized, application-aware decisions that can be used to inform a Kubernetes horizontal pod
+ * autoscaler (HPA).
+ *
+ * @see <a
+ *     href="https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/">Kubernetes
+ *     HPA</a>
+ */
+public class ClusterHpaMetricService extends AbstractScheduledService {
+  private static final Logger LOG = LoggerFactory.getLogger(ClusterHpaMetricService.class);
+
+  // todo - consider making over-provision and lock duration configurable values
+  private static final Double CACHE_OVER_PROVISION = 1.1;
+
+  protected Duration CACHE_SCALEDOWN_LOCK = Duration.of(15, ChronoUnit.MINUTES);
+  protected static final String CACHE_HPA_METRIC_NAME = "hpa_cache_demand_factor_%s";
+
+  private final ReplicaMetadataStore replicaMetadataStore;
+  private final CacheSlotMetadataStore cacheSlotMetadataStore;
+  private final HpaMetricMetadataStore hpaMetricMetadataStore;
+  protected final Map<String, Instant> cacheScalingLock = new ConcurrentHashMap<>();
+
+  public ClusterHpaMetricService(
+      ReplicaMetadataStore replicaMetadataStore,
+      CacheSlotMetadataStore cacheSlotMetadataStore,
+      HpaMetricMetadataStore hpaMetricMetadataStore) {
+    this.replicaMetadataStore = replicaMetadataStore;
+    this.cacheSlotMetadataStore = cacheSlotMetadataStore;
+    this.hpaMetricMetadataStore = hpaMetricMetadataStore;
+  }
+
+  @Override
+  protected Scheduler scheduler() {
+    return Scheduler.newFixedRateSchedule(Duration.ofSeconds(15), Duration.ofSeconds(30));
+  }
+
+  @Override
+  protected void runOneIteration() {
+    LOG.info("Running ClusterHpaMetricService");
+    try {
+      publishCacheHpaMetrics();
+    } catch (Exception e) {
+      LOG.error("Error running ClusterHpaMetricService", e);
+    }
+  }
+
+  /**
+   * Calculates and publishes HPA scaling metric(s) to Zookeeper for the Cache nodes. This makes use
+   * of the Kubernetes HPA formula, which is:
+   *
+   * <p>desiredReplicas = ceil[currentReplicas * ( currentMetricValue / desiredMetricValue )]
+   *
+   * <p>Using this formula, if we inform the user what value to set for the desiredMetricValue, we
+   * can vary the currentMetricValue to control the scale of the cluster. This is accomplished by
+   * producing a metric (hpa_cache_demand_factor_REPLICASET) that targets a value of 1.0. As long as
+   * the HPA is configured to target a value of 1.0 this will result in an optimized cluster size
+   * based on cache slots vs replicas, plus a small buffer.
+   *
+   * <pre>
+   * metrics:
+   *   - type: Pods
+   *     pods:
+   *       metric:
+   *         name: hpa_cache_demand_factor_REPLICASET
+   *       target:
+   *         type: AverageValue
+   *         averageValue: 1.0
+   * </pre>
+   */
+  private void publishCacheHpaMetrics() {
+    Set<String> replicaSets =
+        replicaMetadataStore.listSync().stream()
+            .map(ReplicaMetadata::getReplicaSet)
+            .collect(Collectors.toSet());
+
+    for (String replicaSet : replicaSets) {
+      long totalCacheSlotCapacity =
+          cacheSlotMetadataStore.listSync().stream()
+              .filter(cacheSlotMetadata -> cacheSlotMetadata.replicaSet.equals(replicaSet))
+              .count();
+      long totalReplicaDemand =
+          replicaMetadataStore.listSync().stream()
+              .filter(replicaMetadata -> replicaMetadata.getReplicaSet().equals(replicaSet))
+              .count();
+      double rawDemandFactor =
+          (totalReplicaDemand * CACHE_OVER_PROVISION + 1) / (totalCacheSlotCapacity + 1);
+      double demandFactor = (double) Math.round(rawDemandFactor * 100) / 100;
+      LOG.info(
+          "Cache autoscaler for replicaSet '{}' calculated a demandFactor of '{}' - totalReplicaDemand: '{}', overProvision: '{}', totalCacheSlotCapacity: '{}'",
+          replicaSet,
+          demandFactor,
+          totalReplicaDemand,
+          CACHE_OVER_PROVISION,
+          totalCacheSlotCapacity);
+
+      if (demandFactor >= 1.0) {
+        // Publish a scale-up metric
+        persistCacheConfig(replicaSet, demandFactor);
+        LOG.debug("Publishing scale-up request for replicaset '{}'", replicaSet);
+      } else {
+        if (tryCacheReplicasetLock(replicaSet)) {
+          // Publish a scale-down metric
+          persistCacheConfig(replicaSet, demandFactor);
+          LOG.debug("Acquired scale-down lock for replicaSet '{}'", replicaSet);
+        } else {
+          // Publish a no-op scale metric (0) to disable the HPA from applying
+          // https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#implicit-maintenance-mode-deactivation
+          persistCacheConfig(replicaSet, 0.0);
+          LOG.debug("Unable to acquire scale-down lock for replicaSet '{}'", replicaSet);
+        }
+      }
+    }
+  }
+
+  /** Updates or inserts an (ephemeral) HPA metric for the cache nodes. This is NOT threadsafe. */
+  private void persistCacheConfig(String replicaSet, Double demandFactor) {
+    String key = String.format(CACHE_HPA_METRIC_NAME, replicaSet);
+    if (hpaMetricMetadataStore.hasSync(key)) {
+      hpaMetricMetadataStore.updateSync(
+          new HpaMetricMetadata(key, Metadata.HpaMetricMetadata.NodeRole.CACHE, demandFactor));
+    } else {
+      hpaMetricMetadataStore.createSync(
+          new HpaMetricMetadata(key, Metadata.HpaMetricMetadata.NodeRole.CACHE, demandFactor));
+    }
+  }
+
+  /**
+   * Either acquires or refreshes an existing time-based lock for the given replicaset. Used to
+   * prevent scale-down operations from happening to quickly between replicasets, causing issues
+   * with re-balancing.
+   */
+  protected boolean tryCacheReplicasetLock(String replicaset) {
+    Optional<Instant> lastOtherScaleOperation =
+        cacheScalingLock.entrySet().stream()
+            .filter(entry -> !Objects.equals(entry.getKey(), replicaset))
+            .map(Map.Entry::getValue)
+            .max(Instant::compareTo);
+
+    // if another replicaset was scaled down in the last CACHE_SCALEDOWN_LOCK mins, prevent this one
+    // from scaling
+    if (lastOtherScaleOperation.isPresent()) {
+      if (!lastOtherScaleOperation.get().isBefore(Instant.now().minus(CACHE_SCALEDOWN_LOCK))) {
+        return false;
+      }
+    }
+
+    // update the last-updated lock time to now
+    cacheScalingLock.put(replicaset, Instant.now());
+    return true;
+  }
+}

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/core/CuratorBuilder.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/core/CuratorBuilder.java
@@ -4,6 +4,7 @@ import static com.slack.kaldb.util.ArgValidationUtils.ensureNonEmptyString;
 import static com.slack.kaldb.util.ArgValidationUtils.ensureTrue;
 
 import com.slack.kaldb.proto.config.KaldbConfigs;
+import com.slack.kaldb.util.RuntimeHalterImpl;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.curator.RetryPolicy;
@@ -70,6 +71,7 @@ public class CuratorBuilder {
                   && curatorEvent.getWatchedEvent().getState()
                       == Watcher.Event.KeeperState.Expired) {
                 LOG.warn("The ZK session has expired {}.", curatorEvent);
+                new RuntimeHalterImpl().handleFatal(new Throwable("ZK session expired."));
               }
             });
     curator.start();

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/hpa/HpaMetricMetadata.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/hpa/HpaMetricMetadata.java
@@ -1,0 +1,68 @@
+package com.slack.kaldb.metadata.hpa;
+
+import com.slack.kaldb.metadata.core.KaldbMetadata;
+import com.slack.kaldb.proto.metadata.Metadata;
+
+/**
+ * HPA (horizontal pod autoscaler) metrics are calculated by the manager, and then stored in ZK so
+ * that each node can individually locally their scaling metrics. This allows use of an HPA while
+ * still centralizing the decision-making.
+ */
+public class HpaMetricMetadata extends KaldbMetadata {
+  public Metadata.HpaMetricMetadata.NodeRole nodeRole;
+  public Double value;
+
+  public HpaMetricMetadata(
+      String name, Metadata.HpaMetricMetadata.NodeRole nodeRole, Double value) {
+    super(name);
+    this.nodeRole = nodeRole;
+    this.value = value;
+  }
+
+  public Metadata.HpaMetricMetadata.NodeRole getNodeRole() {
+    return nodeRole;
+  }
+
+  public void setNodeRole(Metadata.HpaMetricMetadata.NodeRole nodeRole) {
+    this.nodeRole = nodeRole;
+  }
+
+  public Double getValue() {
+    return value;
+  }
+
+  public void setValue(Double value) {
+    this.value = value;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof HpaMetricMetadata that)) return false;
+    if (!super.equals(o)) return false;
+
+    if (nodeRole != that.nodeRole) return false;
+    return value.equals(that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + nodeRole.hashCode();
+    result = 31 * result + value.hashCode();
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "HpaMetricMetadata{"
+        + "nodeRole="
+        + nodeRole
+        + ", value="
+        + value
+        + ", name='"
+        + name
+        + '\''
+        + '}';
+  }
+}

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/hpa/HpaMetricMetadataSerializer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/hpa/HpaMetricMetadataSerializer.java
@@ -1,0 +1,41 @@
+package com.slack.kaldb.metadata.hpa;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import com.slack.kaldb.metadata.core.MetadataSerializer;
+import com.slack.kaldb.proto.metadata.Metadata;
+
+public class HpaMetricMetadataSerializer implements MetadataSerializer<HpaMetricMetadata> {
+  private static HpaMetricMetadata fromAutoscalerMetadataProto(
+      Metadata.HpaMetricMetadata autoscalerMetadata) {
+    return new HpaMetricMetadata(
+        autoscalerMetadata.getName(),
+        autoscalerMetadata.getNodeRole(),
+        autoscalerMetadata.getValue());
+  }
+
+  private static Metadata.HpaMetricMetadata toAutoscalerMetadataProto(
+      HpaMetricMetadata hpaMetricMetadata) {
+
+    return Metadata.HpaMetricMetadata.newBuilder()
+        .setName(hpaMetricMetadata.name)
+        .setNodeRole(hpaMetricMetadata.nodeRole)
+        .setValue(hpaMetricMetadata.value)
+        .build();
+  }
+
+  @Override
+  public String toJsonStr(HpaMetricMetadata metadata) throws InvalidProtocolBufferException {
+    if (metadata == null) throw new IllegalArgumentException("metadata object can't be null");
+
+    return printer.print(toAutoscalerMetadataProto(metadata));
+  }
+
+  @Override
+  public HpaMetricMetadata fromJsonStr(String data) throws InvalidProtocolBufferException {
+    Metadata.HpaMetricMetadata.Builder autoscalerMetadataBuilder =
+        Metadata.HpaMetricMetadata.newBuilder();
+    JsonFormat.parser().ignoringUnknownFields().merge(data, autoscalerMetadataBuilder);
+    return fromAutoscalerMetadataProto(autoscalerMetadataBuilder.build());
+  }
+}

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/hpa/HpaMetricMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/hpa/HpaMetricMetadataStore.java
@@ -1,0 +1,18 @@
+package com.slack.kaldb.metadata.hpa;
+
+import com.slack.kaldb.metadata.core.KaldbMetadataStore;
+import org.apache.curator.x.async.AsyncCuratorFramework;
+import org.apache.zookeeper.CreateMode;
+
+public class HpaMetricMetadataStore extends KaldbMetadataStore<HpaMetricMetadata> {
+  public static final String AUTOSCALER_METADATA_STORE_ZK_PATH = "/hpa_metrics";
+
+  public HpaMetricMetadataStore(AsyncCuratorFramework curator, boolean shouldCache) {
+    super(
+        curator,
+        CreateMode.EPHEMERAL,
+        shouldCache,
+        new HpaMetricMetadataSerializer().toModelSerializer(),
+        AUTOSCALER_METADATA_STORE_ZK_PATH);
+  }
+}

--- a/kaldb/src/main/java/com/slack/kaldb/server/HpaMetricPublisherService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/HpaMetricPublisherService.java
@@ -1,0 +1,67 @@
+package com.slack.kaldb.server;
+
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.slack.kaldb.metadata.core.KaldbMetadataStoreChangeListener;
+import com.slack.kaldb.metadata.hpa.HpaMetricMetadata;
+import com.slack.kaldb.metadata.hpa.HpaMetricMetadataStore;
+import com.slack.kaldb.proto.metadata.Metadata;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This service reads stored HPA (horizontal pod autoscaler) metrics from Zookeeper as calculated by
+ * the manager node, and then reports these as pod-level metrics.
+ */
+public class HpaMetricPublisherService extends AbstractIdleService {
+  private static final Logger LOG = LoggerFactory.getLogger(HpaMetricPublisherService.class);
+  private final HpaMetricMetadataStore hpaMetricMetadataStore;
+  private final Metadata.HpaMetricMetadata.NodeRole nodeRole;
+  private final MeterRegistry meterRegistry;
+  private final KaldbMetadataStoreChangeListener<HpaMetricMetadata> listener = changeListener();
+
+  public HpaMetricPublisherService(
+      HpaMetricMetadataStore hpaMetricMetadataStore,
+      MeterRegistry meterRegistry,
+      Metadata.HpaMetricMetadata.NodeRole nodeRole) {
+    this.hpaMetricMetadataStore = hpaMetricMetadataStore;
+    this.nodeRole = nodeRole;
+    this.meterRegistry = meterRegistry;
+  }
+
+  private KaldbMetadataStoreChangeListener<HpaMetricMetadata> changeListener() {
+    return metadata -> {
+      if (metadata.getNodeRole().equals(nodeRole)) {
+        meterRegistry.gauge(
+            metadata.getName(),
+            hpaMetricMetadataStore,
+            store -> {
+              Optional<HpaMetricMetadata> metric =
+                  store.listSync().stream()
+                      .filter(m -> m.getName().equals(metadata.getName()))
+                      .findFirst();
+              if (metric.isPresent()) {
+                return metric.get().getValue();
+              } else {
+                // store no longer has this metric - report a 0
+                // https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#implicit-maintenance-mode-deactivation
+                return 0;
+              }
+            });
+      }
+    };
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    LOG.info("Starting autoscaler publisher service");
+    hpaMetricMetadataStore.addListener(listener);
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    LOG.info("Stopping autoscaler publisher service");
+    hpaMetricMetadataStore.removeListener(listener);
+  }
+}

--- a/kaldb/src/main/proto/metadata.proto
+++ b/kaldb/src/main/proto/metadata.proto
@@ -152,6 +152,26 @@ message DatasetMetadata {
   string service_name_pattern = 5;
 }
 
+message HpaMetricMetadata {
+  enum NodeRole {
+    INDEX = 0;
+    QUERY = 1;
+    CACHE = 2;
+    MANAGER = 3;
+    RECOVERY = 4;
+    PREPROCESSOR = 5;
+  };
+
+  // Unique name for hpa metric
+  string name = 1;
+
+  // Node role this metric applies to
+  NodeRole node_role = 2;
+
+  // Value to report for this metric
+  double value = 3;
+}
+
 // Describes a set of partitions along with their effective start and end times
 message DatasetPartitionMetadata {
   // Start time this partition received traffic

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ClusterHpaMetricServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ClusterHpaMetricServiceTest.java
@@ -94,6 +94,8 @@ class ClusterHpaMetricServiceTest {
     ClusterHpaMetricService clusterHpaMetricService =
         new ClusterHpaMetricService(
             replicaMetadataStore, cacheSlotMetadataStore, hpaMetricMetadataStore);
+    clusterHpaMetricService.CACHE_SLOT_OVER_PROVISION = 1;
+
     when(replicaMetadataStore.listSync())
         .thenReturn(
             List.of(
@@ -165,11 +167,11 @@ class ClusterHpaMetricServiceTest {
             .findFirst()
             .get();
 
-    // 2 replicas, 3 slots (2 * 1.1)) +1)/(3+1)
-    assertThat(rep1Metadata.getValue()).isEqualTo(0.8);
+    // 2 replicas, 3 slots (2+1)/(3+1)
+    assertThat(rep1Metadata.getValue()).isEqualTo(0.75);
 
-    // 1 replica, 1 slot (1 * 1.1)+1)/(1+1)
-    assertThat(rep2Metadata.getValue()).isEqualTo(1.05);
+    // 1 replica, 1 slot (1+1)/(1+1)
+    assertThat(rep2Metadata.getValue()).isEqualTo(1.0);
   }
 
   @Test
@@ -178,6 +180,8 @@ class ClusterHpaMetricServiceTest {
     ClusterHpaMetricService clusterHpaMetricService =
         new ClusterHpaMetricService(
             replicaMetadataStore, cacheSlotMetadataStore, hpaMetricMetadataStore);
+    clusterHpaMetricService.CACHE_SLOT_OVER_PROVISION = 1;
+
     when(replicaMetadataStore.listSync())
         .thenReturn(
             List.of(
@@ -247,12 +251,12 @@ class ClusterHpaMetricServiceTest {
             .findFirst()
             .get();
 
-    // only one should get a lock, the other should be ((2 * 1.1) + 1 / ((2 + 1))
+    // only one should get a lock, the other should be (1 + 1) / (2 + 1))
     if (rep1Metadata.getValue().equals(0.0)) {
       assertThat(rep1Metadata.getValue()).isEqualTo(0.0);
-      assertThat(rep2Metadata.getValue()).isEqualTo(0.7);
+      assertThat(rep2Metadata.getValue()).isEqualTo(0.67);
     } else {
-      assertThat(rep1Metadata.getValue()).isEqualTo(0.7);
+      assertThat(rep1Metadata.getValue()).isEqualTo(0.67);
       assertThat(rep2Metadata.getValue()).isEqualTo(0.0);
     }
   }
@@ -263,6 +267,8 @@ class ClusterHpaMetricServiceTest {
     ClusterHpaMetricService clusterHpaMetricService =
         new ClusterHpaMetricService(
             replicaMetadataStore, cacheSlotMetadataStore, hpaMetricMetadataStore);
+    clusterHpaMetricService.CACHE_SLOT_OVER_PROVISION = 1;
+
     when(replicaMetadataStore.listSync())
         .thenReturn(
             List.of(
@@ -312,10 +318,10 @@ class ClusterHpaMetricServiceTest {
             .findFirst()
             .get();
 
-    // (2 * 1.1) + 1 / (1 + 1)
-    assertThat(rep1Metadata.getValue()).isEqualTo(1.6);
+    // (2 + 1) / (1 + 1)
+    assertThat(rep1Metadata.getValue()).isEqualTo(1.5);
 
-    // (2 * 1.1) + 1 / 1
-    assertThat(rep2Metadata.getValue()).isEqualTo(3.2);
+    // (2 + 1) / 1
+    assertThat(rep2Metadata.getValue()).isEqualTo(3.0);
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ClusterHpaMetricServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ClusterHpaMetricServiceTest.java
@@ -1,0 +1,321 @@
+package com.slack.kaldb.clusterManager;
+
+import static com.slack.kaldb.clusterManager.ClusterHpaMetricService.CACHE_HPA_METRIC_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import brave.Tracing;
+import com.slack.kaldb.metadata.cache.CacheSlotMetadata;
+import com.slack.kaldb.metadata.cache.CacheSlotMetadataStore;
+import com.slack.kaldb.metadata.core.CuratorBuilder;
+import com.slack.kaldb.metadata.hpa.HpaMetricMetadata;
+import com.slack.kaldb.metadata.hpa.HpaMetricMetadataStore;
+import com.slack.kaldb.metadata.replica.ReplicaMetadata;
+import com.slack.kaldb.metadata.replica.ReplicaMetadataStore;
+import com.slack.kaldb.proto.config.KaldbConfigs;
+import com.slack.kaldb.proto.metadata.Metadata;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.curator.test.TestingServer;
+import org.apache.curator.x.async.AsyncCuratorFramework;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ClusterHpaMetricServiceTest {
+
+  private TestingServer testingServer;
+  private MeterRegistry meterRegistry;
+  private AsyncCuratorFramework curatorFramework;
+
+  private ReplicaMetadataStore replicaMetadataStore;
+  private CacheSlotMetadataStore cacheSlotMetadataStore;
+
+  private HpaMetricMetadataStore hpaMetricMetadataStore;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    Tracing.newBuilder().build();
+    meterRegistry = new SimpleMeterRegistry();
+    testingServer = new TestingServer();
+
+    KaldbConfigs.ZookeeperConfig zkConfig =
+        KaldbConfigs.ZookeeperConfig.newBuilder()
+            .setZkConnectString(testingServer.getConnectString())
+            .setZkPathPrefix("ClusterHpaMetricServiceTest")
+            .setZkSessionTimeoutMs(1000)
+            .setZkConnectionTimeoutMs(1000)
+            .setSleepBetweenRetriesMs(1000)
+            .build();
+
+    curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
+
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
+    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework));
+    hpaMetricMetadataStore = spy(new HpaMetricMetadataStore(curatorFramework, true));
+  }
+
+  @AfterEach
+  public void shutdown() throws IOException {
+    hpaMetricMetadataStore.close();
+    cacheSlotMetadataStore.close();
+    replicaMetadataStore.close();
+    curatorFramework.unwrap().close();
+
+    testingServer.close();
+    meterRegistry.close();
+  }
+
+  @Test
+  void testLocking() throws Exception {
+    ClusterHpaMetricService clusterHpaMetricService =
+        new ClusterHpaMetricService(
+            replicaMetadataStore, cacheSlotMetadataStore, hpaMetricMetadataStore);
+    clusterHpaMetricService.CACHE_SCALEDOWN_LOCK = Duration.ofSeconds(2);
+
+    assertThat(clusterHpaMetricService.tryCacheReplicasetLock("foo")).isTrue();
+    assertThat(clusterHpaMetricService.tryCacheReplicasetLock("bar")).isFalse();
+    assertThat(clusterHpaMetricService.tryCacheReplicasetLock("foo")).isTrue();
+    Thread.sleep(2000);
+    assertThat(clusterHpaMetricService.tryCacheReplicasetLock("bar")).isTrue();
+    assertThat(clusterHpaMetricService.tryCacheReplicasetLock("bar")).isTrue();
+    assertThat(clusterHpaMetricService.tryCacheReplicasetLock("foo")).isFalse();
+  }
+
+  @Test
+  @SuppressWarnings("OptionalGetWithoutIsPresent")
+  void oneReplicasetScaledown() {
+    ClusterHpaMetricService clusterHpaMetricService =
+        new ClusterHpaMetricService(
+            replicaMetadataStore, cacheSlotMetadataStore, hpaMetricMetadataStore);
+    when(replicaMetadataStore.listSync())
+        .thenReturn(
+            List.of(
+                new ReplicaMetadata(
+                    "foo", "foo", "rep1", 1L, 0L, false, Metadata.IndexType.LOGS_LUCENE9),
+                new ReplicaMetadata(
+                    "bar", "bar", "rep2", 1L, 0L, false, Metadata.IndexType.LOGS_LUCENE9),
+                new ReplicaMetadata(
+                    "baz", "baz", "rep1", 1L, 0L, false, Metadata.IndexType.LOGS_LUCENE9)));
+
+    when(cacheSlotMetadataStore.listSync())
+        .thenReturn(
+            List.of(
+                new CacheSlotMetadata(
+                    "foo",
+                    Metadata.CacheSlotMetadata.CacheSlotState.FREE,
+                    "",
+                    1,
+                    List.of(Metadata.IndexType.LOGS_LUCENE9),
+                    "localhost",
+                    "rep1"),
+                new CacheSlotMetadata(
+                    "bar",
+                    Metadata.CacheSlotMetadata.CacheSlotState.FREE,
+                    "",
+                    1,
+                    List.of(Metadata.IndexType.LOGS_LUCENE9),
+                    "localhost",
+                    "rep1"),
+                new CacheSlotMetadata(
+                    "baz",
+                    Metadata.CacheSlotMetadata.CacheSlotState.FREE,
+                    "",
+                    1,
+                    List.of(Metadata.IndexType.LOGS_LUCENE9),
+                    "localhost",
+                    "rep2"),
+                new CacheSlotMetadata(
+                    "bal",
+                    Metadata.CacheSlotMetadata.CacheSlotState.FREE,
+                    "",
+                    1,
+                    List.of(Metadata.IndexType.LOGS_LUCENE9),
+                    "localhost",
+                    "rep1")));
+
+    clusterHpaMetricService.runOneIteration();
+
+    AtomicReference<List<HpaMetricMetadata>> hpaMetricMetadataList = new AtomicReference<>();
+    await()
+        .until(
+            () -> {
+              hpaMetricMetadataList.set(hpaMetricMetadataStore.listSync());
+              return hpaMetricMetadataList.get().size();
+            },
+            size -> size == 2);
+
+    HpaMetricMetadata rep1Metadata =
+        hpaMetricMetadataList.get().stream()
+            .filter(
+                metadata -> metadata.getName().equals(String.format(CACHE_HPA_METRIC_NAME, "rep1")))
+            .findFirst()
+            .get();
+
+    HpaMetricMetadata rep2Metadata =
+        hpaMetricMetadataList.get().stream()
+            .filter(
+                metadata -> metadata.getName().equals(String.format(CACHE_HPA_METRIC_NAME, "rep2")))
+            .findFirst()
+            .get();
+
+    // 2 replicas, 3 slots (2 * 1.1)) +1)/(3+1)
+    assertThat(rep1Metadata.getValue()).isEqualTo(0.8);
+
+    // 1 replica, 1 slot (1 * 1.1)+1)/(1+1)
+    assertThat(rep2Metadata.getValue()).isEqualTo(1.05);
+  }
+
+  @Test
+  @SuppressWarnings("OptionalGetWithoutIsPresent")
+  void twoReplicasetScaledown() {
+    ClusterHpaMetricService clusterHpaMetricService =
+        new ClusterHpaMetricService(
+            replicaMetadataStore, cacheSlotMetadataStore, hpaMetricMetadataStore);
+    when(replicaMetadataStore.listSync())
+        .thenReturn(
+            List.of(
+                new ReplicaMetadata(
+                    "foo", "foo", "rep1", 1L, 0L, false, Metadata.IndexType.LOGS_LUCENE9),
+                new ReplicaMetadata(
+                    "bar", "bar", "rep2", 1L, 0L, false, Metadata.IndexType.LOGS_LUCENE9)));
+
+    when(cacheSlotMetadataStore.listSync())
+        .thenReturn(
+            List.of(
+                new CacheSlotMetadata(
+                    "foo",
+                    Metadata.CacheSlotMetadata.CacheSlotState.FREE,
+                    "",
+                    1,
+                    List.of(Metadata.IndexType.LOGS_LUCENE9),
+                    "localhost",
+                    "rep1"),
+                new CacheSlotMetadata(
+                    "bar",
+                    Metadata.CacheSlotMetadata.CacheSlotState.FREE,
+                    "",
+                    1,
+                    List.of(Metadata.IndexType.LOGS_LUCENE9),
+                    "localhost",
+                    "rep1"),
+                new CacheSlotMetadata(
+                    "baz",
+                    Metadata.CacheSlotMetadata.CacheSlotState.FREE,
+                    "",
+                    1,
+                    List.of(Metadata.IndexType.LOGS_LUCENE9),
+                    "localhost",
+                    "rep2"),
+                new CacheSlotMetadata(
+                    "bal",
+                    Metadata.CacheSlotMetadata.CacheSlotState.FREE,
+                    "",
+                    1,
+                    List.of(Metadata.IndexType.LOGS_LUCENE9),
+                    "localhost",
+                    "rep2")));
+
+    clusterHpaMetricService.runOneIteration();
+
+    AtomicReference<List<HpaMetricMetadata>> hpaMetricMetadataList = new AtomicReference<>();
+    await()
+        .until(
+            () -> {
+              hpaMetricMetadataList.set(hpaMetricMetadataStore.listSync());
+              return hpaMetricMetadataList.get().size();
+            },
+            size -> size == 2);
+
+    HpaMetricMetadata rep1Metadata =
+        hpaMetricMetadataList.get().stream()
+            .filter(
+                metadata -> metadata.getName().equals(String.format(CACHE_HPA_METRIC_NAME, "rep1")))
+            .findFirst()
+            .get();
+
+    HpaMetricMetadata rep2Metadata =
+        hpaMetricMetadataList.get().stream()
+            .filter(
+                metadata -> metadata.getName().equals(String.format(CACHE_HPA_METRIC_NAME, "rep2")))
+            .findFirst()
+            .get();
+
+    // only one should get a lock, the other should be ((2 * 1.1) + 1 / ((2 + 1))
+    if (rep1Metadata.getValue().equals(0.0)) {
+      assertThat(rep1Metadata.getValue()).isEqualTo(0.0);
+      assertThat(rep2Metadata.getValue()).isEqualTo(0.7);
+    } else {
+      assertThat(rep1Metadata.getValue()).isEqualTo(0.7);
+      assertThat(rep2Metadata.getValue()).isEqualTo(0.0);
+    }
+  }
+
+  @Test
+  @SuppressWarnings("OptionalGetWithoutIsPresent")
+  void twoReplicasetScaleup() {
+    ClusterHpaMetricService clusterHpaMetricService =
+        new ClusterHpaMetricService(
+            replicaMetadataStore, cacheSlotMetadataStore, hpaMetricMetadataStore);
+    when(replicaMetadataStore.listSync())
+        .thenReturn(
+            List.of(
+                new ReplicaMetadata(
+                    "foo", "foo", "rep1", 1L, 0L, false, Metadata.IndexType.LOGS_LUCENE9),
+                new ReplicaMetadata(
+                    "bar", "bar", "rep1", 1L, 0L, false, Metadata.IndexType.LOGS_LUCENE9),
+                new ReplicaMetadata(
+                    "baz", "bar", "rep2", 1L, 0L, false, Metadata.IndexType.LOGS_LUCENE9),
+                new ReplicaMetadata(
+                    "bal", "bar", "rep2", 1L, 0L, false, Metadata.IndexType.LOGS_LUCENE9)));
+
+    when(cacheSlotMetadataStore.listSync())
+        .thenReturn(
+            List.of(
+                new CacheSlotMetadata(
+                    "foo",
+                    Metadata.CacheSlotMetadata.CacheSlotState.FREE,
+                    "",
+                    1,
+                    List.of(Metadata.IndexType.LOGS_LUCENE9),
+                    "localhost",
+                    "rep1")));
+
+    clusterHpaMetricService.runOneIteration();
+
+    AtomicReference<List<HpaMetricMetadata>> hpaMetricMetadataList = new AtomicReference<>();
+    await()
+        .until(
+            () -> {
+              hpaMetricMetadataList.set(hpaMetricMetadataStore.listSync());
+              return hpaMetricMetadataList.get().size();
+            },
+            size -> size == 2);
+
+    HpaMetricMetadata rep1Metadata =
+        hpaMetricMetadataList.get().stream()
+            .filter(
+                metadata -> metadata.getName().equals(String.format(CACHE_HPA_METRIC_NAME, "rep1")))
+            .findFirst()
+            .get();
+
+    HpaMetricMetadata rep2Metadata =
+        hpaMetricMetadataList.get().stream()
+            .filter(
+                metadata -> metadata.getName().equals(String.format(CACHE_HPA_METRIC_NAME, "rep2")))
+            .findFirst()
+            .get();
+
+    // (2 * 1.1) + 1 / (1 + 1)
+    assertThat(rep1Metadata.getValue()).isEqualTo(1.6);
+
+    // (2 * 1.1) + 1 / 1
+    assertThat(rep2Metadata.getValue()).isEqualTo(3.2);
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
@@ -19,6 +19,7 @@ import org.apache.curator.x.async.modeled.ModelSerializer;
 import org.apache.zookeeper.CreateMode;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class KaldbMetadataStoreTest {
@@ -265,6 +266,7 @@ public class KaldbMetadataStoreTest {
   }
 
   @Test
+  @Disabled("ZK reconnect support currently disabled")
   public void testListenersWithZkReconnect() throws Exception {
     class TestMetadataStore extends KaldbMetadataStore<TestMetadata> {
       public TestMetadataStore() {

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbPartitioningMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbPartitioningMetadataStoreTest.java
@@ -26,6 +26,7 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.server.EphemeralType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -431,6 +432,7 @@ class KaldbPartitioningMetadataStoreTest {
   }
 
   @Test
+  @Disabled("ZK reconnect support currently disabled")
   void testListenersWithZkReconnect() throws Exception {
     class TestMetadataStore extends KaldbPartitioningMetadataStore<ExampleMetadata> {
       public TestMetadataStore() {

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/hpa/HpaMetricMetadataSerializerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/hpa/HpaMetricMetadataSerializerTest.java
@@ -1,0 +1,47 @@
+package com.slack.kaldb.metadata.hpa;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.slack.kaldb.proto.metadata.Metadata;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class HpaMetricMetadataSerializerTest {
+
+  private final HpaMetricMetadataSerializer serDe = new HpaMetricMetadataSerializer();
+
+  @Test
+  void testHpaMetricMetadataSerializer() throws InvalidProtocolBufferException {
+    String name = "name";
+    Metadata.HpaMetricMetadata.NodeRole nodeRole = Metadata.HpaMetricMetadata.NodeRole.CACHE;
+    Double value = 1.0;
+    HpaMetricMetadata hpaMetricMetadata = new HpaMetricMetadata(name, nodeRole, value);
+
+    String serializedHpaMetricMetadata = serDe.toJsonStr(hpaMetricMetadata);
+    assertThat(serializedHpaMetricMetadata).isNotEmpty();
+
+    HpaMetricMetadata deserializedHpaMetric = serDe.fromJsonStr(serializedHpaMetricMetadata);
+    assertThat(deserializedHpaMetric).isEqualTo(hpaMetricMetadata);
+
+    assertThat(deserializedHpaMetric.getName()).isEqualTo(name);
+    assertThat(deserializedHpaMetric.getNodeRole()).isEqualTo(nodeRole);
+    assertThat(deserializedHpaMetric.getValue()).isEqualTo(value);
+  }
+
+  @Test
+  public void testInvalidSerializations() {
+    Throwable serializeNull = catchThrowable(() -> serDe.toJsonStr(null));
+    Assertions.assertThat(serializeNull).isInstanceOf(IllegalArgumentException.class);
+
+    Throwable deserializeNull = catchThrowable(() -> serDe.fromJsonStr(null));
+    Assertions.assertThat(deserializeNull).isInstanceOf(InvalidProtocolBufferException.class);
+
+    Throwable deserializeEmpty = catchThrowable(() -> serDe.fromJsonStr(""));
+    Assertions.assertThat(deserializeEmpty).isInstanceOf(InvalidProtocolBufferException.class);
+
+    Throwable deserializeCorrupt = catchThrowable(() -> serDe.fromJsonStr("test"));
+    Assertions.assertThat(deserializeCorrupt).isInstanceOf(InvalidProtocolBufferException.class);
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/hpa/HpaMetricMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/hpa/HpaMetricMetadataTest.java
@@ -1,0 +1,45 @@
+package com.slack.kaldb.metadata.hpa;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.slack.kaldb.proto.metadata.Metadata;
+import org.junit.jupiter.api.Test;
+
+class HpaMetricMetadataTest {
+
+  @Test
+  void testHpaMetadata() {
+    String name = "name";
+    Metadata.HpaMetricMetadata.NodeRole nodeRole = Metadata.HpaMetricMetadata.NodeRole.CACHE;
+    Double value = 1.0;
+    HpaMetricMetadata hpaMetricMetadata = new HpaMetricMetadata(name, nodeRole, value);
+
+    assertThat(hpaMetricMetadata.getName()).isEqualTo(name);
+    assertThat(hpaMetricMetadata.getNodeRole()).isEqualTo(nodeRole);
+    assertThat(hpaMetricMetadata.getValue()).isEqualTo(value);
+  }
+
+  @Test
+  void testEqualsHashcode() {
+    String name = "name";
+    Metadata.HpaMetricMetadata.NodeRole nodeRole = Metadata.HpaMetricMetadata.NodeRole.CACHE;
+    Double value = 1.0;
+    HpaMetricMetadata hpaMetricMetadata1 = new HpaMetricMetadata(name, nodeRole, value);
+    HpaMetricMetadata hpaMetricMetadata2 = new HpaMetricMetadata(name, nodeRole, value);
+
+    HpaMetricMetadata hpaMetricMetadataDiff1 = new HpaMetricMetadata("name2", nodeRole, value);
+    HpaMetricMetadata hpaMetricMetadataDiff2 =
+        new HpaMetricMetadata(name, Metadata.HpaMetricMetadata.NodeRole.INDEX, value);
+    HpaMetricMetadata hpaMetricMetadataDiff3 = new HpaMetricMetadata(name, nodeRole, 1.1);
+
+    assertThat(hpaMetricMetadata1).isEqualTo(hpaMetricMetadata2);
+    assertThat(hpaMetricMetadata1.hashCode()).isEqualTo(hpaMetricMetadata2.hashCode());
+
+    assertThat(hpaMetricMetadata1).isNotEqualTo(hpaMetricMetadataDiff1);
+    assertThat(hpaMetricMetadata1.hashCode()).isNotEqualTo(hpaMetricMetadataDiff1.hashCode());
+    assertThat(hpaMetricMetadata1).isNotEqualTo(hpaMetricMetadataDiff2);
+    assertThat(hpaMetricMetadata1.hashCode()).isNotEqualTo(hpaMetricMetadataDiff2.hashCode());
+    assertThat(hpaMetricMetadata1).isNotEqualTo(hpaMetricMetadataDiff3);
+    assertThat(hpaMetricMetadata1.hashCode()).isNotEqualTo(hpaMetricMetadataDiff3.hashCode());
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
@@ -2,6 +2,7 @@ package com.slack.kaldb.preprocessor;
 
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_START_STOP_DURATION;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.awaitility.Awaitility.await;
 
 import com.google.common.util.concurrent.Service;
@@ -53,6 +54,7 @@ public class PreprocessorServiceIntegrationTest {
   }
 
   @Test
+  @Disabled("ZK reconnect support currently disabled")
   public void shouldHandleStreamError() throws Exception {
     SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
     KaldbConfigs.ZookeeperConfig zkConfig =
@@ -108,6 +110,8 @@ public class PreprocessorServiceIntegrationTest {
 
     // restarting ZK should cause a stream application error due to missing source topics
     zkServer.restart();
+
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> zkServer.restart());
 
     await()
         .until(

--- a/kaldb/src/test/java/com/slack/kaldb/server/HpaMetricPublisherServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/HpaMetricPublisherServiceTest.java
@@ -1,0 +1,84 @@
+package com.slack.kaldb.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.spy;
+
+import brave.Tracing;
+import com.slack.kaldb.metadata.core.CuratorBuilder;
+import com.slack.kaldb.metadata.hpa.HpaMetricMetadata;
+import com.slack.kaldb.metadata.hpa.HpaMetricMetadataStore;
+import com.slack.kaldb.proto.config.KaldbConfigs;
+import com.slack.kaldb.proto.metadata.Metadata;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import org.apache.curator.test.TestingServer;
+import org.apache.curator.x.async.AsyncCuratorFramework;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class HpaMetricPublisherServiceTest {
+
+  private TestingServer testingServer;
+  private MeterRegistry meterRegistry;
+  private AsyncCuratorFramework curatorFramework;
+  private HpaMetricMetadataStore hpaMetricMetadataStore;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    Tracing.newBuilder().build();
+    meterRegistry = new SimpleMeterRegistry();
+    testingServer = new TestingServer();
+
+    KaldbConfigs.ZookeeperConfig zkConfig =
+        KaldbConfigs.ZookeeperConfig.newBuilder()
+            .setZkConnectString(testingServer.getConnectString())
+            .setZkPathPrefix("HpaMetricPublisherServiceTest")
+            .setZkSessionTimeoutMs(1000)
+            .setZkConnectionTimeoutMs(1000)
+            .setSleepBetweenRetriesMs(1000)
+            .build();
+
+    curatorFramework = CuratorBuilder.build(new SimpleMeterRegistry(), zkConfig);
+    hpaMetricMetadataStore = spy(new HpaMetricMetadataStore(curatorFramework, true));
+  }
+
+  @AfterEach
+  public void shutdown() throws IOException {
+    hpaMetricMetadataStore.close();
+    curatorFramework.unwrap().close();
+
+    testingServer.close();
+    meterRegistry.close();
+  }
+
+  @Test
+  void shouldRegisterMetersAsAdded() throws Exception {
+    HpaMetricPublisherService hpaMetricPublisherService =
+        new HpaMetricPublisherService(
+            hpaMetricMetadataStore, meterRegistry, Metadata.HpaMetricMetadata.NodeRole.CACHE);
+    hpaMetricPublisherService.startUp();
+
+    assertThat(meterRegistry.getMeters()).isEmpty();
+
+    hpaMetricMetadataStore.createSync(
+        new HpaMetricMetadata("foo", Metadata.HpaMetricMetadata.NodeRole.CACHE, 1.0));
+
+    await().until(() -> hpaMetricMetadataStore.listSync().size() == 1);
+    await().until(() -> meterRegistry.getMeters().size() == 1);
+
+    hpaMetricMetadataStore.createSync(
+        new HpaMetricMetadata("bar", Metadata.HpaMetricMetadata.NodeRole.INDEX, 1.0));
+
+    await().until(() -> hpaMetricMetadataStore.listSync().size() == 2);
+    await().until(() -> meterRegistry.getMeters().size() == 1);
+
+    hpaMetricMetadataStore.createSync(
+        new HpaMetricMetadata("baz", Metadata.HpaMetricMetadata.NodeRole.CACHE, 0.0));
+
+    await().until(() -> hpaMetricMetadataStore.listSync().size() == 3);
+    await().until(() -> meterRegistry.getMeters().size() == 2);
+  }
+}


### PR DESCRIPTION
###  Summary

Adds support for reporting HPA (horizontal pod autoscaling) Kubernetes metrics for the cache nodes. As we need to provide an application-aware implementation, this is calculated by the manager and stored in ZK as ephemeral nodes with the scaling decision. Cache nodes then read this value and report it as a pod-level metric. This allows the end user to deploy an HPA using the below configuration to enable auto-scaling on their cluster.

```yaml
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: ${APP}
  minReplicas: 1
  maxReplicas: ${MAX_REPLICAS}
  metrics:
    - type: Pods
      pods:
        metric:
          name: hpa_cache_demand_factor_${REPLICA_SET}
        target:
          type: AverageValue
          averageValue: 1.0
```

Manager node is responsible for doing calculation of target nodes using replica demand and cache slot availability, and ensures that scale-down operations are time-locked to a replica set using the Kubernetes implicit maintenance mode functionality.