### PR TITLE
Handle OffsetOutofRangeException during broker leadership change

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbMetadataStore.java
@@ -29,7 +29,6 @@ import org.apache.zookeeper.data.Stat;
  * performing batch operations and a sync if you are performing a synchronous operation on a node.
  */
 public class KaldbMetadataStore<T extends KaldbMetadata> implements Closeable {
-
   protected final String storeFolder;
 
   private final ZPath zPath;

--- a/kaldb/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/kafka/KaldbKafkaConsumer.java
@@ -222,7 +222,7 @@ public class KaldbKafkaConsumer {
         break;
       } catch (OffsetOutOfRangeException ex) {
         kafkaError = ex;
-        LOG.warn("Caught unexpected exception, retry number: {}, exception: {}", i, ex);
+        LOG.warn(String.format("Caught unexpected exception, retry number: %d", i), ex);
         try {
           Thread.sleep((i + 1) * 3000);
         } catch (InterruptedException exex) {


### PR DESCRIPTION
###  Summary
This is to address https://github.com/slackhq/kaldb/issues/647

When a broker restarted, leadership switch, the consumer client in indexer restarted because of the following exception:

host:kaldb-index-traces-dev-3 log.message:FATAL: Unhandled exception @timestamp:Aug 14, 2023 @ 00:30:01.362 @version:1 error_message:Fetch position FetchPosition{offset=28770033742, offsetEpoch=Optional[86], currentLeader=LeaderAndEpoch{leader=Optional[events-a-kafka-dev-iad-zosl.nebula.tinyspeck.com:9092 (id: 1017 rack: us-east-1a)], epoch=87}} is out of range for partition kaldb_preprocessor-3

Handle this by retrying few times (with added delay each time) on consumer.poll()


Describe the goal of this PR. Mention any related Issue numbers.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
