### PR TITLE
Use lucene directory abstraction to compute file size

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadWriteChunk.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadWriteChunk.java
@@ -220,7 +220,7 @@ public abstract class ReadWriteChunk<T> implements Chunk<T> {
 
     IndexCommit indexCommit = null;
     try {
-      Path dirPath = logStore.getDirectory().toAbsolutePath();
+      Path dirPath = logStore.getDirectory().getDirectory().toAbsolutePath();
 
       // Create schema file to upload
       ChunkSchema chunkSchema =

--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/IndexingChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/IndexingChunkManager.java
@@ -256,7 +256,7 @@ public class IndexingChunkManager<T> extends ChunkManagerBase<T> {
               LuceneIndexStoreImpl.makeLogStore(
                   dataDirectory, indexerConfig.getLuceneConfig(), meterRegistry);
 
-      chunkRollOverStrategy.setActiveChunkDirectory(logStore.getDirectory().toFile());
+      chunkRollOverStrategy.setActiveChunkDirectory(logStore.getDirectory());
 
       ReadWriteChunk<T> newChunk =
           new IndexingChunkImpl<>(

--- a/kaldb/src/main/java/com/slack/kaldb/chunkrollover/ChunkRollOverStrategy.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkrollover/ChunkRollOverStrategy.java
@@ -1,13 +1,13 @@
 package com.slack.kaldb.chunkrollover;
 
-import java.io.File;
+import org.apache.lucene.store.FSDirectory;
 
 // TODO: ChunkRollOverStrategy should take a chunk as an input and get statistics
 //  like message count, size etc. from the chunk
 public interface ChunkRollOverStrategy {
   boolean shouldRollOver(long currentBytesIndexed, long currentMessagesIndexed);
 
-  public void setActiveChunkDirectory(File activeChunkDirectory);
+  public void setActiveChunkDirectory(FSDirectory directory);
 
   public void close();
 }

--- a/kaldb/src/main/java/com/slack/kaldb/chunkrollover/DiskOrMessageCountBasedRolloverStrategy.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkrollover/DiskOrMessageCountBasedRolloverStrategy.java
@@ -98,17 +98,21 @@ public class DiskOrMessageCountBasedRolloverStrategy implements ChunkRollOverStr
     approximateDirectoryBytes.set(0);
   }
 
-  public static long calculateDirectorySize(AtomicReference<FSDirectory> activeChunkDirectory) {
+  public static long calculateDirectorySize(AtomicReference<FSDirectory> activeChunkDirectoryRef) {
+    FSDirectory activeChunkDirectory = activeChunkDirectoryRef.get();
+    return calculateDirectorySize(activeChunkDirectory);
+  }
+
+  public static long calculateDirectorySize(FSDirectory activeChunkDirectory) {
     try {
-      FSDirectory activeChunkDir = activeChunkDirectory.get();
-      if (activeChunkDir != null && activeChunkDir.listAll().length > 0) {
+      if (activeChunkDirectory != null && activeChunkDirectory.listAll().length > 0) {
 
         long directorySize =
-            Arrays.stream(activeChunkDir.listAll())
+            Arrays.stream(activeChunkDirectory.listAll())
                 .mapToLong(
                     file -> {
                       try {
-                        return activeChunkDir.fileLength(file);
+                        return activeChunkDirectory.fileLength(file);
                       } catch (IOException e) {
                         // There can be a race condition b/w the listAll which filters
                         // pendingDeletes and then fileLength method which will throw

--- a/kaldb/src/main/java/com/slack/kaldb/chunkrollover/DiskOrMessageCountBasedRolloverStrategy.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkrollover/DiskOrMessageCountBasedRolloverStrategy.java
@@ -61,7 +61,7 @@ public class DiskOrMessageCountBasedRolloverStrategy implements ChunkRollOverStr
 
     directorySizeExecutorService.scheduleAtFixedRate(
         () -> {
-          var dirSize = calculateDirectorySize(activeChunkDirectory);
+          long dirSize = calculateDirectorySize(activeChunkDirectory);
           // in case the method fails to calculate we return -1 so don't update the old value
           if (dirSize > 0) {
             approximateDirectoryBytes.set(dirSize);

--- a/kaldb/src/main/java/com/slack/kaldb/chunkrollover/MessageSizeOrCountBasedRolloverStrategy.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkrollover/MessageSizeOrCountBasedRolloverStrategy.java
@@ -4,7 +4,7 @@ import static com.slack.kaldb.util.ArgValidationUtils.ensureTrue;
 
 import com.slack.kaldb.proto.config.KaldbConfigs;
 import io.micrometer.core.instrument.MeterRegistry;
-import java.io.File;
+import org.apache.lucene.store.FSDirectory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +52,7 @@ public class MessageSizeOrCountBasedRolloverStrategy implements ChunkRollOverStr
   }
 
   @Override
-  public void setActiveChunkDirectory(File activeChunkDirectory) {}
+  public void setActiveChunkDirectory(FSDirectory activeChunkDirectory) {}
 
   @Override
   public void close() {}

--- a/kaldb/src/main/java/com/slack/kaldb/chunkrollover/NeverRolloverChunkStrategy.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkrollover/NeverRolloverChunkStrategy.java
@@ -1,6 +1,6 @@
 package com.slack.kaldb.chunkrollover;
 
-import java.io.File;
+import org.apache.lucene.store.FSDirectory;
 
 /**
  * The NeverRolloverChunkStrategy always responds in the negative for a chunk roll over request. It
@@ -13,7 +13,7 @@ public class NeverRolloverChunkStrategy implements ChunkRollOverStrategy {
   }
 
   @Override
-  public void setActiveChunkDirectory(File activeChunkDirectory) {}
+  public void setActiveChunkDirectory(FSDirectory activeChunkDirectory) {}
 
   @Override
   public void close() {}

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LogStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LogStore.java
@@ -3,11 +3,11 @@ package com.slack.kaldb.logstore;
 import com.slack.kaldb.metadata.schema.LuceneFieldDef;
 import java.io.Closeable;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.search.SearcherManager;
+import org.apache.lucene.store.FSDirectory;
 
 /* An interface that implements a read and write interface for the LogStore */
 public interface LogStore<T> extends Closeable {
@@ -24,7 +24,7 @@ public interface LogStore<T> extends Closeable {
 
   void cleanup() throws IOException;
 
-  Path getDirectory();
+  FSDirectory getDirectory();
 
   /**
    * After a commit, lucene may merge multiple segments into one in the background. So, getting a

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LuceneIndexStoreImpl.java
@@ -8,7 +8,6 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.time.Duration;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -220,8 +219,8 @@ public class LuceneIndexStoreImpl implements LogStore<LogMessage> {
   }
 
   @Override
-  public Path getDirectory() {
-    return indexDirectory.getDirectory();
+  public FSDirectory getDirectory() {
+    return indexDirectory;
   }
 
   private void handleNonFatal(Throwable ex) {
@@ -289,7 +288,7 @@ public class LuceneIndexStoreImpl implements LogStore<LogMessage> {
         + id
         + '\''
         + ", at="
-        + getDirectory().toAbsolutePath()
+        + getDirectory().getDirectory().toAbsolutePath()
         + '}';
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -522,7 +522,7 @@ public class ReadOnlyChunkImplTest {
     assertThat(getTimerCount(REFRESHES_TIMER, meterRegistry)).isEqualTo(1);
     assertThat(getTimerCount(COMMITS_TIMER, meterRegistry)).isEqualTo(1);
 
-    Path dirPath = logStore.getDirectory().toAbsolutePath();
+    Path dirPath = logStore.getDirectory().getDirectory().toAbsolutePath();
 
     // Create schema file to upload
     ChunkSchema chunkSchema =

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/LuceneIndexStoreImplTest.java
@@ -359,7 +359,7 @@ public class LuceneIndexStoreImplTest {
       assertThat(getTimerCount(REFRESHES_TIMER, strictLogStore.metricsRegistry)).isEqualTo(1);
       assertThat(getTimerCount(COMMITS_TIMER, strictLogStore.metricsRegistry)).isEqualTo(1);
 
-      Path dirPath = logStore.getDirectory().toAbsolutePath();
+      Path dirPath = logStore.getDirectory().getDirectory().toAbsolutePath();
       IndexCommit indexCommit = logStore.getIndexCommit();
       Collection<String> activeFiles = indexCommit.getFileNames();
       LocalBlobFs localBlobFs = new LocalBlobFs();
@@ -424,7 +424,7 @@ public class LuceneIndexStoreImplTest {
       assertThat(getTimerCount(REFRESHES_TIMER, strictLogStore.metricsRegistry)).isEqualTo(1);
       assertThat(getTimerCount(COMMITS_TIMER, strictLogStore.metricsRegistry)).isEqualTo(1);
 
-      Path dirPath = logStore.getDirectory().toAbsolutePath();
+      Path dirPath = logStore.getDirectory().getDirectory().toAbsolutePath();
       IndexCommit indexCommit = logStore.getIndexCommit();
       Collection<String> activeFiles = indexCommit.getFileNames();
       LocalBlobFs blobFs = new LocalBlobFs();
@@ -472,7 +472,7 @@ public class LuceneIndexStoreImplTest {
       strictLogStore.logStore.close();
       strictLogStore.logSearcher.close();
 
-      File tempFolder = strictLogStore.logStore.getDirectory().toFile();
+      File tempFolder = strictLogStore.logStore.getDirectory().getDirectory().toFile();
       assertThat(tempFolder.exists()).isTrue();
       strictLogStore.logStore.cleanup();
       assertThat(tempFolder.exists()).isFalse();


### PR DESCRIPTION
###  Summary

When we use the regular file abstractions to calculate the size of the lucene index, lucene might be merging segments. This means the function has a race condition between the time it fetches the list and the time the calculation is done. 

This is harmless in practice as we just try again and keep the old value. But it leads to noisy logs. When we use Lucene's FS abstraction it has a list of pendingDeletes which helps avoid this race condition.

Another advantage of this PR is during the happy case i.e when the java file abstraction computes the size it can take the pending deletes into account. So the disk size is smaller than what we want to. This will address that problem as well as noted by Bryan