### PR TITLE
Indexer couldn't find all previous metadata snapshots #651

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/server/RecoveryTaskCreator.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/RecoveryTaskCreator.java
@@ -151,6 +151,7 @@ public class RecoveryTaskCreator {
     }
 
     List<SnapshotMetadata> snapshots = snapshotMetadataStore.listSync();
+    LOG.info("There are {} snapshots", snapshots.size());
     List<SnapshotMetadata> snapshotsForPartition =
         snapshots.stream()
             .filter(
@@ -165,15 +166,18 @@ public class RecoveryTaskCreator {
                       && snapshotMetadata.partitionId.equals(partitionId);
                 })
             .collect(Collectors.toUnmodifiableList());
+    LOG.info("There are {} snapshots for partition {}", snapshotsForPartition.size(), partitionId);
     List<SnapshotMetadata> deletedSnapshots = deleteStaleLiveSnapshots(snapshotsForPartition);
 
     List<SnapshotMetadata> nonLiveSnapshotsForPartition =
         snapshotsForPartition.stream()
             .filter(s -> !deletedSnapshots.contains(s))
             .collect(Collectors.toUnmodifiableList());
+    LOG.info("There are {} nonLive snapshots.", nonLiveSnapshotsForPartition.size());
 
     // Get the highest offset that is indexed in durable store.
     List<RecoveryTaskMetadata> recoveryTasks = recoveryTaskMetadataStore.listSync();
+    LOG.info("There are {} recoveryTasks", recoveryTasks.size());
     long highestDurableOffsetForPartition =
         getHighestDurableOffsetForPartition(
             nonLiveSnapshotsForPartition, recoveryTasks, partitionId);


### PR DESCRIPTION
This fixed issue: https://github.com/slackhq/kaldb/issues/651

During indexer starts up, it was supposed to find all the existing metadata snapshots from ZK and only pull the newer data after the last snapshot.

But the listAsync() call from KaldbPartitionMetadataStore couldn't retrieve all existing snapshots from ZK (in fact most of the time it retrieved 0 snapshots), changing the listAsync() to listSync() seems fixing the problem.

See discussion thread here: https://slack-pde.slack.com/archives/C02028H9LHJ/p1692300820984549?thread_ts=1691511612.465979&cid=C02028H9LHJ

###  Summary

Describe the goal of this PR. Mention any related Issue numbers.

### Requirements

* [ ] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
