### PR TITLE
Revert "Add latch for ZK hydration initialization"

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbMetadataStore.java
@@ -2,14 +2,12 @@ package com.slack.kaldb.metadata.core;
 
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_ZK_TIMEOUT_SECS;
 
-import com.slack.kaldb.util.RuntimeHalterImpl;
 import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -34,8 +32,6 @@ public class KaldbMetadataStore<T extends KaldbMetadata> implements Closeable {
   protected final String storeFolder;
 
   private final ZPath zPath;
-
-  private final CountDownLatch cacheInitialized = new CountDownLatch(1);
 
   protected final ModeledFramework<T> modeledClient;
 
@@ -65,7 +61,6 @@ public class KaldbMetadataStore<T extends KaldbMetadata> implements Closeable {
 
     if (shouldCache) {
       cachedModeledFramework = modeledClient.cached();
-      cachedModeledFramework.listenable().addListener(getCacheInitializedListener());
       cachedModeledFramework.start();
     } else {
       cachedModeledFramework = null;
@@ -104,7 +99,6 @@ public class KaldbMetadataStore<T extends KaldbMetadata> implements Closeable {
 
   public CompletionStage<Stat> hasAsync(String path) {
     if (cachedModeledFramework != null) {
-      awaitCacheInitialized();
       return cachedModeledFramework.withPath(zPath.resolved(path)).checkExists();
     }
     return modeledClient.withPath(zPath.resolved(path)).checkExists();
@@ -161,11 +155,9 @@ public class KaldbMetadataStore<T extends KaldbMetadata> implements Closeable {
   }
 
   public CompletionStage<List<T>> listAsync() {
-    if (cachedModeledFramework == null) {
+    if (cachedModeledFramework == null)
       throw new UnsupportedOperationException("Caching is disabled");
-    }
 
-    awaitCacheInitialized();
     return cachedModeledFramework.list();
   }
 
@@ -178,9 +170,8 @@ public class KaldbMetadataStore<T extends KaldbMetadata> implements Closeable {
   }
 
   public void addListener(KaldbMetadataStoreChangeListener<T> watcher) {
-    if (cachedModeledFramework == null) {
+    if (cachedModeledFramework == null)
       throw new UnsupportedOperationException("Caching is disabled");
-    }
 
     // this mapping exists because the remove is by reference, and the listener is a different
     // object type
@@ -196,33 +187,9 @@ public class KaldbMetadataStore<T extends KaldbMetadata> implements Closeable {
   }
 
   public void removeListener(KaldbMetadataStoreChangeListener<T> watcher) {
-    if (cachedModeledFramework == null) {
+    if (cachedModeledFramework == null)
       throw new UnsupportedOperationException("Caching is disabled");
-    }
     cachedModeledFramework.listenable().removeListener(listenerMap.remove(watcher));
-  }
-
-  private void awaitCacheInitialized() {
-    try {
-      cacheInitialized.await();
-    } catch (InterruptedException e) {
-      new RuntimeHalterImpl().handleFatal(e);
-    }
-  }
-
-  private ModeledCacheListener<T> getCacheInitializedListener() {
-    return new ModeledCacheListener<T>() {
-      @Override
-      public void accept(Type type, ZPath path, Stat stat, T model) {
-        // no-op
-      }
-
-      @Override
-      public void initialized() {
-        ModeledCacheListener.super.initialized();
-        cacheInitialized.countDown();
-      }
-    };
   }
 
   @Override

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbMetadataStoreTest.java
@@ -42,7 +42,7 @@ public class KaldbMetadataStoreTest {
         KaldbConfigs.ZookeeperConfig.newBuilder()
             .setZkConnectString(testingServer.getConnectString())
             .setZkPathPrefix("Test")
-            .setZkSessionTimeoutMs(10000)
+            .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(500)
             .build();
@@ -392,58 +392,6 @@ public class KaldbMetadataStoreTest {
 
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
-    }
-  }
-
-  @Test
-  public void testSlowCacheInitialization() {
-    class FastMetadataStore extends KaldbMetadataStore<TestMetadata> {
-      public FastMetadataStore() {
-        super(
-            curatorFramework,
-            CreateMode.PERSISTENT,
-            true,
-            new JacksonModelSerializer<>(TestMetadata.class),
-            STORE_FOLDER);
-      }
-    }
-
-    class SlowSerializer implements ModelSerializer<TestMetadata> {
-      final JacksonModelSerializer<TestMetadata> serializer =
-          new JacksonModelSerializer<>(TestMetadata.class);
-
-      @Override
-      public byte[] serialize(TestMetadata model) {
-        return serializer.serialize(model);
-      }
-
-      @Override
-      public TestMetadata deserialize(byte[] bytes) {
-        try {
-          Thread.sleep(200);
-        } catch (InterruptedException e) {
-          throw new RuntimeException(e);
-        }
-        return serializer.deserialize(bytes);
-      }
-    }
-
-    class SlowMetadataStore extends KaldbMetadataStore<TestMetadata> {
-      public SlowMetadataStore() {
-        super(curatorFramework, CreateMode.PERSISTENT, true, new SlowSerializer(), STORE_FOLDER);
-      }
-    }
-
-    int testMetadataInitCount = 10;
-    try (KaldbMetadataStore<TestMetadata> init = new FastMetadataStore()) {
-      for (int i = 0; i < testMetadataInitCount; i++) {
-        init.createSync(new TestMetadata("name" + i, "value" + i));
-      }
-    }
-
-    try (KaldbMetadataStore<TestMetadata> init = new SlowMetadataStore()) {
-      List<TestMetadata> metadata = init.listSync();
-      assertThat(metadata.size()).isEqualTo(testMetadataInitCount);
     }
   }
 }


### PR DESCRIPTION
Reverts slackhq/kaldb#655.  Reopens #651.

There seems to be an issue limited to just the query nodes where this seems to end in a deadlock. 


```
"@timestamp":"2023-09-01T19:11:14.887Z","log.level":"INFO","log.message":"Creating new metadata store for partition - 19598_3, at path - /partitioned_snapshot/19598_3","process.thread.name":"main-EventThread","log.logger":"com.slack.kaldb.metadata.core.KaldbPartitioningMetadataStore"}
{"@timestamp":"2023-09-01T19:11:14.893Z","log.level":"INFO","log.message":"Creating new metadata store for partition - 19594_20, at path - /partitioned_snapshot/19594_20","process.thread.name":"main-EventThread","log.logger":"com.slack.kaldb.metadata.core.KaldbPartitioningMetadataStore"}
{"@timestamp":"2023-09-01T19:11:14.900Z","log.level":"INFO","log.message":"Creating new metadata store for partition - 19598_9, at path - /partitioned_snapshot/19598_9","process.thread.name":"main-EventThread","log.logger":"com.slack.kaldb.metadata.core.KaldbPartitioningMetadataStore"}
{"@timestamp":"2023-09-01T19:11:14.907Z","log.level":"INFO","log.message":"Creating new metadata store for partition - 19594_22, at path - /partitioned_snapshot/19594_22","process.thread.name":"main-EventThread","log.logger":"com.slack.kaldb.metadata.core.KaldbPartitioningMetadataStore"}
{"@timestamp":"2023-09-01T19:11:14.913Z","log.level":"INFO","log.message":"Creating new metadata store for partition - 19598_8, at path - /partitioned_snapshot/19598_8","process.thread.name":"main-EventThread","log.logger":"com.slack.kaldb.metadata.core.KaldbPartitioningMetadataStore"}
{"@timestamp":"2023-09-01T19:11:14.921Z","log.level":"INFO","log.message":"Creating new metadata store for partition - 19594_21, at path - /partitioned_snapshot/19594_21","process.thread.name":"main-EventThread","log.logger":"com.slack.kaldb.metadata.core.KaldbPartitioningMetadataStore"}
{"@timestamp":"2023-09-01T19:11:14.927Z","log.level":"INFO","log.message":"Creating new metadata store for partition - 19598_7, at path - /partitioned_snapshot/19598_7","process.thread.name":"main-EventThread","log.logger":"com.slack.kaldb.metadata.core.KaldbPartitioningMetadataStore"}
{"@timestamp":"2023-09-01T19:11:14.933Z","log.level":"INFO","log.message":"The metadata store for folder '/partitioned_snapshot' was initialized with 214 partitions","process.thread.name":"main","log.logger":"com.slack.kaldb.metadata.core.KaldbPartitioningMetadataStore"}
{"@timestamp":"2023-09-01T19:14:21.813Z","log.level":"INFO","log.message":"Running shutdown hook.","process.thread.name":"Thread-0","log.logger":"com.slack.kaldb.server.Kaldb"}
{"@timestamp":"2023-09-01T19:14:21.820Z","log.level":"ERROR","log.message":"ServiceManager shutdown timed out","process.thread.name":"Thread-0","log.logger":"com.slack.kaldb.server.Kaldb","error_type":"java.lang.NullPointerException","error_message":"Cannot invoke \"com.google.common.util.concurrent.ServiceManager.stopAsync()\" because \"this.serviceManager\" is null","error_stack_trace":"java.lang.NullPointerException: Cannot invoke \"com.google.common.util.concurrent.ServiceManager.stopAsync()\" because \"this.serviceManager\" is null\n\tat com.slack.kaldb.server.Kaldb.shutdown(Kaldb.java:422)\n\tat java.base/java.lang.Thread.run(Thread.java:833)\n","error_root_cause_class_name":"java.lang.NullPointerException","error_root_cause_message":"Cannot invoke \"com.google.common.util.concurrent.ServiceManager.stopAsync()\" because \"this.serviceManager\" is null","error_root_cause_stack_trace":"java.lang.NullPointerException: Cannot invoke \"com.google.common.util.concurrent.ServiceManager.stopAsync()\" because \"this.serviceManager\" is null\n\tat com.slack.kaldb.server.Kaldb.shutdown(Kaldb.java:422)\n\tat java.base/java.lang.Thread.run(Thread.java:833)\n"}
{"@timestamp":"2023-09-01T19:14:21.838Z","log.level":"INFO","log.message":"backgroundOperationsLoop exiting","process.thread.name":"Curator-Framework-0","log.logger":"org.apache.curator.framework.imps.CuratorFrameworkImpl"}
{"@timestamp":"2023-09-01T19:14:21.959Z","log.level":"INFO","log.message":"Session: 0x800000042c6f7e6 closed","process.thread.name":"Thread-0","log.logger":"org.apache.zookeeper.ZooKeeper"}
{"@timestamp":"2023-09-01T19:14:21.959Z","log.level":"INFO","log.message":"Shutting down LogManager","process.thread.name":"Thread-0","log.logger":"com.slack.kaldb.server.Kaldb"}
{"@timestamp":"2023-09-01T19:14:21.959Z","log.level":"INFO","log.message":"EventThread shut down for session: 0x800000042c6f7e6","process.thread.name":"main-EventThread","log.logger":"org.apache.zookeeper.ClientCnxn"}
```