### PR TITLE
Add extra debug logging for chunk downloads

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
@@ -240,7 +240,14 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
 
       searchMetadata =
           registerSearchMetadata(searchMetadataStore, searchContext, snapshotMetadata.name);
-      assignmentTimer.stop(chunkAssignmentTimerSuccess);
+      long durationNanos = assignmentTimer.stop(chunkAssignmentTimerSuccess);
+
+      LOG.info(
+          "Downloaded chunk with snapshot id '{}' at path '{}' in {} seconds, was {}",
+          snapshotMetadata.snapshotId,
+          snapshotMetadata.snapshotPath,
+          TimeUnit.SECONDS.convert(durationNanos, TimeUnit.NANOSECONDS),
+          FileUtils.byteCountToDisplaySize(FileUtils.sizeOfDirectory(dataDirectory.toFile())));
     } catch (Exception e) {
       // if any error occurs during the chunk assignment, try to release the slot for re-assignment,
       // disregarding any errors


### PR DESCRIPTION
###  Summary

Adds an extra debug logging statement for chunk downloads that provide information about the size, path, etc to more easily run down errant chunks.

```
Downloaded chunk with snapshot id 'bar' at path 'path' in 0 seconds, was 12 KB
```