### PR TITLE
Add io_uring dependency

### DIFF
--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -90,6 +90,12 @@
             <version>${armeria.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.netty.incubator</groupId>
+            <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+            <version>0.0.22.Final</version>
+            <classifier>linux-x86_64</classifier>
+        </dependency>
+        <dependency>
             <groupId>com.linecorp.armeria</groupId>
             <artifactId>armeria-grpc</artifactId>
             <version>${armeria.version}</version>


### PR DESCRIPTION
###  Summary

This re-introduces the `io_uring` dependency, originally introduced in #289, and later rolled back. This is an optional transport type, which can conditionally be trigged by using the following system property:

```bash
-Dcom.linecorp.armeria.transportType=io_uring
```

This was originally rolled back due to infrastructure limitations at the time, but since we now run a newer kernel we should be able to start taking advantage of this.