### PR TITLE
Improve flaky test execution

### DIFF
--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
@@ -406,6 +406,9 @@ public class KaldbDistributedQueryServiceTest {
     assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isEqualTo(2);
     assertThat(KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore).size()).isEqualTo(1);
 
+    await().until(() -> snapshotMetadataStore.listSync().size(), (size) -> size == 2);
+    await().until(() -> searchMetadataStore.listSync().size(), (size) -> size == 1);
+
     Map<String, List<String>> searchNodes =
         getSearchNodesToQuery(
             snapshotMetadataStore,


### PR DESCRIPTION
###  Summary

Improves a test race condition that can occur where the ZK cache hasn't populated the latest data.

https://github.com/slackhq/kaldb/actions/runs/6190424292/job/16806628109
