### PR TITLE
Fix flaky test - testDocumentInKafkaTransactionError

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/server/OpenSearchBulkIngestApi.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/OpenSearchBulkIngestApi.java
@@ -241,7 +241,7 @@ public class OpenSearchBulkIngestApi extends AbstractService {
     props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
     props.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
     props.put("transactional.id", transactionId);
-    props.put("linger.ms", 100);
+    props.put("linger.ms", 250);
     return new KafkaProducer<>(props);
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/server/OpenSearchBulkIngestApi.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/OpenSearchBulkIngestApi.java
@@ -241,6 +241,7 @@ public class OpenSearchBulkIngestApi extends AbstractService {
     props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
     props.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
     props.put("transactional.id", transactionId);
+    props.put("linger.ms", 100);
     return new KafkaProducer<>(props);
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/elasticsearchApi/OpenSearchBulkEndpointTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/elasticsearchApi/OpenSearchBulkEndpointTest.java
@@ -39,7 +39,6 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.opensearch.action.index.IndexRequest;
 import org.slf4j.Logger;
@@ -269,7 +268,6 @@ public class OpenSearchBulkEndpointTest {
   }
 
   @Test
-  @Disabled("Flaky test")
   public void testDocumentInKafkaTransactionError() throws Exception {
     updateDatasetThroughput(100_1000);
 
@@ -340,7 +338,10 @@ public class OpenSearchBulkEndpointTest {
                           .stream()
                           .findFirst()
                           .get();
-              LOG.debug("Current partitionOffset - {}", partitionOffset);
+              LOG.debug(
+                  "Current partitionOffset - {}. expecting offset to be - {}",
+                  partitionOffset,
+                  offset);
               return partitionOffset == offset;
             });
   }


### PR DESCRIPTION
###  Summary

I hardened the test to ensure timing issue doesn't mess with asserts with offsets.

Previously the assert for consumer offset depends on when kafka producer flushes documents to the broker. 

This PR also adds linger.ms to the producer to match what we have today
