### PR TITLE
Bump timeout for flaky test

### DIFF
--- a/kaldb/src/test/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiServiceTest.java
@@ -224,7 +224,7 @@ public class ElasticsearchApiServiceTest {
             Resources.getResource("elasticsearchApi/multisearch_query_10results.ndjson"),
             Charset.defaultCharset());
     KaldbLocalQueryService<LogMessage> slowSearcher =
-        spy(new KaldbLocalQueryService<>(chunkManagerUtil.chunkManager, Duration.ofSeconds(3)));
+        spy(new KaldbLocalQueryService<>(chunkManagerUtil.chunkManager, Duration.ofSeconds(5)));
 
     // warmup to load OpenSearch plugins
     ElasticsearchApiService slowElasticsearchApiService = new ElasticsearchApiService(slowSearcher);


### PR DESCRIPTION
###  Summary

This appears to just be running over 3s, depending on specific executor and time the test runs. Bumping this timeout slightly as this is non-material to this specific test.