### PR TITLE
make bytebuddy available at runtime as well

### DIFF
--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -446,7 +446,6 @@
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
             <version>1.14.8</version>
-            <scope>test</scope>
         </dependency>
 
         <!-- BlobFs test dependencies -->


### PR DESCRIPTION
###  Summary

Should have caught this locally but with the java 21 change we made bytebuddy scope to test only. That means it wasn't available at runtime leading to us failing with the following error on startup

```
Exception in thread "main" java.lang.NoClassDefFoundError: net/bytebuddy/description/type/TypeDefinition
	at org.curioswitch.common.protobuf.json.MessageMarshaller$Builder.build(MessageMarshaller.java:437)
	at com.linecorp.armeria.server.grpc.UnframedGrpcErrorHandlers.<clinit>(UnframedGrpcErrorHandlers.java:85)
	at com.linecorp.armeria.server.grpc.UnframedGrpcErrorHandler.ofJson(UnframedGrpcErrorHandler.java:57)
	at com.linecorp.armeria.server.grpc.HttpJsonTranscodingOptionsBuilder.<init>(HttpJsonTranscodingOptionsBuilder.java:44)
	at com.linecorp.armeria.server.grpc.HttpJsonTranscodingOptions.builder(HttpJsonTranscodingOptions.java:35)
	at com.linecorp.armeria.server.grpc.DefaultHttpJsonTranscodingOptions.<clinit>(DefaultHttpJsonTranscodingOptions.java:26)
	at com.linecorp.armeria.server.grpc.HttpJsonTranscodingOptions.of(HttpJsonTranscodingOptions.java:42)
	at com.linecorp.armeria.server.grpc.GrpcServiceBuilder.<init>(GrpcServiceBuilder.java:133)
	at com.linecorp.armeria.server.grpc.GrpcService.builder(GrpcService.java:56)
	at com.slack.kaldb.server.ArmeriaService$Builder.withGrpcService(ArmeriaService.java:135)
	at com.slack.kaldb.server.Kaldb.getServices(Kaldb.java:293)
	at com.slack.kaldb.server.Kaldb.start(Kaldb.java:139)
	at com.slack.kaldb.server.Kaldb.main(Kaldb.java:99)
Caused by: java.lang.ClassNotFoundException: net.bytebuddy.description.type.TypeDefinition
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	... 13 more
```
