### PR TITLE
use virtual threads for blocking tasks

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
@@ -155,6 +155,8 @@ public class ArmeriaService extends AbstractIdleService {
                   });
       serverBuilder.decorator(
           MetricCollectingService.newDecorator(GrpcMeterIdPrefixFunction.of("grpc.service")));
+      serverBuilder.blockingTaskExecutor(
+          ArmeriaVirtualBlockingTaskExecutor.virtualBlockingTaskExecutor(), true);
       serverBuilder.service(searchBuilder.build());
       return this;
     }

--- a/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaVirtualBlockingTaskExecutor.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaVirtualBlockingTaskExecutor.java
@@ -1,0 +1,24 @@
+package com.slack.kaldb.server;
+
+import com.linecorp.armeria.common.util.BlockingTaskExecutor;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+
+// https://github.com/line/armeria/issues/4911
+public class ArmeriaVirtualBlockingTaskExecutor {
+
+  private static final ThreadFactory virtualThreadFactory =
+      Thread.ofVirtual().name("armeria-blocking-tasks-virtual-threads-", 0).factory();
+
+  private static final ScheduledThreadPoolExecutor scheduledThreadPoolExecutor =
+      new ScheduledThreadPoolExecutor(200, virtualThreadFactory);
+
+  private static final BlockingTaskExecutor blockingTaskExecutor =
+      BlockingTaskExecutor.of(scheduledThreadPoolExecutor);
+
+  public static BlockingTaskExecutor virtualBlockingTaskExecutor() {
+    return blockingTaskExecutor;
+  }
+
+  private ArmeriaVirtualBlockingTaskExecutor() {}
+}


### PR DESCRIPTION
###  Summary

Verified via break points, that the virtual thread pool gets uses for the zipkin service and the grpc services