### PR TITLE
Use virtual threads for queries

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/ChunkManagerBase.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/ChunkManagerBase.java
@@ -68,11 +68,7 @@ public abstract class ChunkManagerBase<T> extends AbstractIdleService implements
     return MoreExecutors.listeningDecorator(
         Executors.newFixedThreadPool(
             Math.max(1, Runtime.getRuntime().availableProcessors() - 2),
-            new ThreadFactoryBuilder()
-                .setNameFormat("chunk-manager-query-%d")
-                .setUncaughtExceptionHandler(
-                    (t, e) -> LOG.error("Exception on thread {}: {}", t.getName(), e))
-                .build()));
+            Thread.ofVirtual().name("chunk-manager-query-", 0).factory()));
   }
 
   /*


### PR DESCRIPTION
###  Summary

Use virtual threads for query execution.

We don't have a way to set an uncaught exception handler ( https://github.com/slackhq/kaldb/pull/419#discussion_r1029502410 for when it was added ) . But I think we don't need it? 

This thread pool is only used for queries, and we already catch all Exceptions? https://github.com/slackhq/kaldb/blob/314a4b0409b2812a30b12eee32aed78fd75358ff/kaldb/src/main/java/com/slack/kaldb/chunkManager/ChunkManagerBase.java#L124-L136


Let's take the example of a CACHE node today. We have 200 chunks that we load onto it in production which means a single query creates 200 threads. Using virtual threads for this can be beneficial.

Once we get this merged, we might want to revisit the number of parallel chunks we can search today. CPU/2 seems low but I know we did some testing back in the day to come up with this. 
