### PR TITLE
Update disk or message rollover to use SegmentInfos

### DIFF
--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
@@ -1322,7 +1322,9 @@ public class IndexingChunkManagerTest {
     // Add first set of messages, wait for roll over, then add next set of messages.
     insertMessages(chunkManager, messages1, msgsPerChunk);
 
-    await().until(() -> getCount(RollOverChunkTask.ROLLOVERS_COMPLETED, metricsRegistry) == 1);
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .until(() -> getCount(RollOverChunkTask.ROLLOVERS_COMPLETED, metricsRegistry) == 1);
     checkMetadata(2, 1, 1, 1, 0);
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, metricsRegistry)).isEqualTo(3);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, metricsRegistry)).isEqualTo(0);
@@ -1336,7 +1338,9 @@ public class IndexingChunkManagerTest {
 
     insertMessages(chunkManager, messages2, msgsPerChunk);
 
-    await().until(() -> getCount(RollOverChunkTask.ROLLOVERS_COMPLETED, metricsRegistry) == 2);
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .until(() -> getCount(RollOverChunkTask.ROLLOVERS_COMPLETED, metricsRegistry) == 2);
     checkMetadata(4, 2, 2, 2, 0);
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, metricsRegistry)).isEqualTo(6);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, metricsRegistry)).isEqualTo(0);


### PR DESCRIPTION
###  Summary

Updates the disk or message rollover strategy to use the Lucene `SegmentInfos` API. This helps account for temporary files, pending deletes, and pending merges influencing the observed directory size. 

This should allow our chunk size on disk to be much closer to the target value. Note that this does use the last commit for this value, so long commit durations can result in overshooting the target value. Also note that any pending merges may still influence the final size on disk.