### PR TITLE
Register OpenSearchBulkIngestApi as a service itself

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -393,10 +393,11 @@ public class Kaldb {
           new CloseableLifecycleManager(
               KaldbConfigs.NodeRole.PREPROCESSOR, List.of(datasetMetadataStore)));
 
-      LOG.info("TEST: getUseBulkApi=" + preprocessorConfig.getUseBulkApi());
       if (preprocessorConfig.getUseBulkApi()) {
-        armeriaServiceBuilder.withAnnotatedService(
-            new OpenSearchBulkIngestApi(datasetMetadataStore, preprocessorConfig, meterRegistry));
+        OpenSearchBulkIngestApi openSearchBulkApiService =
+            new OpenSearchBulkIngestApi(datasetMetadataStore, preprocessorConfig, meterRegistry);
+        armeriaServiceBuilder.withAnnotatedService(openSearchBulkApiService);
+        services.add(openSearchBulkApiService);
       } else {
         PreprocessorService preprocessorService =
             new PreprocessorService(datasetMetadataStore, preprocessorConfig, meterRegistry);

--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -393,6 +393,7 @@ public class Kaldb {
           new CloseableLifecycleManager(
               KaldbConfigs.NodeRole.PREPROCESSOR, List.of(datasetMetadataStore)));
 
+      LOG.info("TEST: getUseBulkApi=" + preprocessorConfig.getUseBulkApi());
       if (preprocessorConfig.getUseBulkApi()) {
         armeriaServiceBuilder.withAnnotatedService(
             new OpenSearchBulkIngestApi(datasetMetadataStore, preprocessorConfig, meterRegistry));

--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -394,6 +394,8 @@ public class Kaldb {
               KaldbConfigs.NodeRole.PREPROCESSOR, List.of(datasetMetadataStore)));
 
       if (preprocessorConfig.getUseBulkApi()) {
+        // TODO: using an armeria service that is also a guava service does not look elegant
+        // explore ways where we can control the lifecycle without the need for a guava service here
         OpenSearchBulkIngestApi openSearchBulkApiService =
             new OpenSearchBulkIngestApi(datasetMetadataStore, preprocessorConfig, meterRegistry);
         armeriaServiceBuilder.withAnnotatedService(openSearchBulkApiService);

--- a/kaldb/src/main/java/com/slack/kaldb/server/OpenSearchBulkIngestApi.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/OpenSearchBulkIngestApi.java
@@ -99,7 +99,8 @@ public class OpenSearchBulkIngestApi extends AbstractService {
       List<DatasetMetadata> datasetMetadataToProcesses =
           filterValidDatasetMetadata(datasetMetadataList);
 
-      checkArgument(!datasetMetadataToProcesses.isEmpty(), "dataset metadata list must not be empty");
+      checkArgument(
+          !datasetMetadataToProcesses.isEmpty(), "dataset metadata list must not be empty");
 
       this.throughputSortedDatasets = sortDatasetsOnThroughput(datasetMetadataToProcesses);
       this.rateLimiterPredicate =
@@ -126,11 +127,12 @@ public class OpenSearchBulkIngestApi extends AbstractService {
       boolean initializeRateLimitWarm) {
 
     checkArgument(
-            !preprocessorConfig.getBootstrapServers().isEmpty(),
-            "Kafka bootstrapServers must be provided");
+        !preprocessorConfig.getBootstrapServers().isEmpty(),
+        "Kafka bootstrapServers must be provided");
 
-    checkArgument(!Strings.isEmpty(preprocessorConfig.getDownstreamTopic()),
-            "Kafka bootstrapServers must be provided");
+    checkArgument(
+        !Strings.isEmpty(preprocessorConfig.getDownstreamTopic()),
+        "Kafka downstreamTopic must be provided");
 
     this.datasetMetadataStore = datasetMetadataStore;
     this.preprocessorConfig = preprocessorConfig;

--- a/kaldb/src/main/java/com/slack/kaldb/server/OpenSearchBulkIngestApi.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/OpenSearchBulkIngestApi.java
@@ -12,10 +12,7 @@ import static com.slack.kaldb.preprocessor.PreprocessorService.sortDatasetsOnThr
 
 import com.google.common.util.concurrent.AbstractService;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.annotation.Blocking;
-import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Post;
 import com.slack.kaldb.elasticsearchApi.BulkIngestResponse;
 import com.slack.kaldb.metadata.core.KaldbMetadataStoreChangeListener;
@@ -155,53 +152,6 @@ public class OpenSearchBulkIngestApi extends AbstractService {
     // see "zombie fencing" https://www.confluent.io/blog/transactions-apache-kafka/
     this.kafkaProducer = createKafkaTransactionProducer(UUID.randomUUID().toString());
     this.kafkaProducer.initTransactions();
-  }
-
-  // along with the bulk API we also need to expose some node info that logstash needs info from
-  @Get("/")
-  public HttpResponse getNodeInfo() {
-    String output =
-        """
-                {
-                  "name" : "node_name",
-                  "cluster_name" : "cluster_name",
-                  "cluster_uuid" : "uuid",
-                  "version" : {
-                    "number" : "7.12.0",
-                    "build_flavor" : "default",
-                    "build_type" : "deb",
-                    "build_hash" : "78722783c38caa25a70982b5b042074cde5d3b3a",
-                    "build_date" : "2021-04-02T00:53:29.130908562Z",
-                    "build_snapshot" : false,
-                    "lucene_version" : "8.8.0",
-                    "minimum_wire_compatibility_version" : "6.8.0",
-                    "minimum_index_compatibility_version" : "6.0.0-beta1"
-                  },
-                  "tagline" : "You Know, for Search"
-                }
-                """;
-    return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, output);
-  }
-
-  @Get("/_license")
-  public HttpResponse getLicenseInfo() {
-    String output =
-        """
-                    {
-                      "license" : {
-                        "status" : "active",
-                        "uid" : "8afdc262-f37a-4b48-ad2e-68e224180640",
-                        "type" : "basic",
-                        "issue_date" : "2020-12-07T23:59:22.009Z",
-                        "issue_date_in_millis" : 1607385562009,
-                        "max_nodes" : 1000,
-                        "issued_to" : "cluster_name",
-                        "issuer" : "elasticsearch",
-                        "start_date_in_millis" : -1
-                      }
-                    }
-                    """;
-    return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, output);
   }
 
   /**

--- a/kaldb/src/main/java/com/slack/kaldb/server/OpenSearchBulkIngestApi.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/OpenSearchBulkIngestApi.java
@@ -1,6 +1,7 @@
 package com.slack.kaldb.server;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static com.linecorp.armeria.common.HttpStatus.INTERNAL_SERVER_ERROR;
 import static com.linecorp.armeria.common.HttpStatus.TOO_MANY_REQUESTS;
 import static com.slack.kaldb.metadata.dataset.DatasetMetadata.MATCH_ALL_SERVICE;
@@ -99,8 +100,7 @@ public class OpenSearchBulkIngestApi extends AbstractService {
       List<DatasetMetadata> datasetMetadataToProcesses =
           filterValidDatasetMetadata(datasetMetadataList);
 
-      checkArgument(
-          !datasetMetadataToProcesses.isEmpty(), "dataset metadata list must not be empty");
+      checkState(!datasetMetadataToProcesses.isEmpty(), "dataset metadata list must not be empty");
 
       this.throughputSortedDatasets = sortDatasetsOnThroughput(datasetMetadataToProcesses);
       this.rateLimiterPredicate =


### PR DESCRIPTION
###  Summary

Small fixes
1. Register OpenSearchBulkIngestApi as a service itself so that the `doStart/doStop` methods get invoked
2. some safety checks to ensure we always start with correct configs
