### PR TITLE
Update AWS SDK, remove fixed executor for cache assignments

### DIFF
--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -29,7 +29,7 @@
         <opensearch.version>2.7.0</opensearch.version>
         <curator.version>5.5.0</curator.version>
         <log4j.version>2.20.0</log4j.version>
-        <aws.sdk.version>2.20.116</aws.sdk.version>
+        <aws.sdk.version>2.21.2</aws.sdk.version>
         <error.prone.version>2.16</error.prone.version>
         <junit.jupiter.version>5.10.0</junit.jupiter.version>
     </properties>
@@ -323,7 +323,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.22.1</version>
+            <version>0.27.4</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -17,7 +17,6 @@ import static org.awaitility.Awaitility.await;
 
 import brave.Tracing;
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.slack.kaldb.blobfs.LocalBlobFs;
 import com.slack.kaldb.blobfs.s3.S3CrtBlobFs;
 import com.slack.kaldb.blobfs.s3.S3TestUtils;
@@ -138,8 +137,7 @@ public class ReadOnlyChunkImplTest {
             cacheSlotMetadataStore,
             replicaMetadataStore,
             snapshotMetadataStore,
-            searchMetadataStore,
-            MoreExecutors.newDirectExecutorService());
+            searchMetadataStore);
 
     // wait for chunk to register
     await()
@@ -268,8 +266,7 @@ public class ReadOnlyChunkImplTest {
             cacheSlotMetadataStore,
             replicaMetadataStore,
             snapshotMetadataStore,
-            searchMetadataStore,
-            MoreExecutors.newDirectExecutorService());
+            searchMetadataStore);
 
     // wait for chunk to register
     await()
@@ -335,8 +332,7 @@ public class ReadOnlyChunkImplTest {
             cacheSlotMetadataStore,
             replicaMetadataStore,
             snapshotMetadataStore,
-            searchMetadataStore,
-            MoreExecutors.newDirectExecutorService());
+            searchMetadataStore);
 
     // wait for chunk to register
     await()
@@ -403,8 +399,7 @@ public class ReadOnlyChunkImplTest {
             cacheSlotMetadataStore,
             replicaMetadataStore,
             snapshotMetadataStore,
-            searchMetadataStore,
-            MoreExecutors.newDirectExecutorService());
+            searchMetadataStore);
 
     // wait for chunk to register
     await()


### PR DESCRIPTION
###  Summary
Updates the AWS SDK to disable our temp proxy bypass, removed fixed executor for cache assignments as this is now handled in the manager during assignments.