### PR TITLE
Add final merge before uploading to S3

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadWriteChunk.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadWriteChunk.java
@@ -204,6 +204,7 @@ public abstract class ReadWriteChunk<T> implements Chunk<T> {
     logger.info("Started RW chunk pre-snapshot {}", chunkInfo);
     setReadOnly(true);
     commit();
+    logStore.finalMerge();
     logger.info("Finished RW chunk pre-snapshot {}", chunkInfo);
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/LogStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/LogStore.java
@@ -20,6 +20,8 @@ public interface LogStore<T> extends Closeable {
 
   void refresh();
 
+  void finalMerge();
+
   boolean isOpen();
 
   void cleanup() throws IOException;


### PR DESCRIPTION
###  Summary

Forces a final merge to a single segment prior to upload to S3, as these chunks are read only and we should have spare CPU to do a final merge on the indexers.