### PR TITLE
Fix replica assignment over-assigning

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaAssignmentService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ReplicaAssignmentService.java
@@ -187,20 +187,25 @@ public class ReplicaAssignmentService extends AbstractScheduledService {
               .stream()
               .flatMap(
                   (cacheSlotsPerHost) -> {
-                    int currentlyAssigned =
+                    int currentlyAssignedOrLoading =
                         cacheSlotsPerHost.stream()
                             .filter(
                                 cacheSlotMetadata ->
                                     cacheSlotMetadata.cacheSlotState.equals(
-                                        Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED))
+                                            Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED)
+                                        || cacheSlotMetadata.cacheSlotState.equals(
+                                            Metadata.CacheSlotMetadata.CacheSlotState.LOADING))
                             .toList()
                             .size();
+
                     return cacheSlotsPerHost.stream()
                         .filter(
                             cacheSlotMetadata ->
                                 cacheSlotMetadata.cacheSlotState.equals(
                                     Metadata.CacheSlotMetadata.CacheSlotState.FREE))
-                        .limit(Math.max(0, maxConcurrentAssignmentsPerNode - currentlyAssigned));
+                        .limit(
+                            Math.max(
+                                0, maxConcurrentAssignmentsPerNode - currentlyAssignedOrLoading));
                   })
               .collect(Collectors.toList());
 


### PR DESCRIPTION
###  Summary

Fixes a regression where with the new virtual threads refactor it was only limiting the concurrent ASSIGNED, and didn't consider the LOADING state.