### PR TITLE
Fix rounding error in HPA autoscaler

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/clusterManager/ClusterHpaMetricService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/clusterManager/ClusterHpaMetricService.java
@@ -1,5 +1,6 @@
 package com.slack.kaldb.clusterManager;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.AbstractScheduledService;
 import com.slack.kaldb.metadata.cache.CacheSlotMetadataStore;
 import com.slack.kaldb.metadata.hpa.HpaMetricMetadata;
@@ -142,7 +143,8 @@ public class ClusterHpaMetricService extends AbstractScheduledService {
     }
   }
 
-  private static double calculateDemandFactor(
+  @VisibleForTesting
+  protected static double calculateDemandFactor(
       long totalCacheSlotCapacity, long totalReplicaDemand) {
     if (totalCacheSlotCapacity == 0) {
       // we have no provisioned capacity, so cannot determine a value
@@ -154,8 +156,8 @@ public class ClusterHpaMetricService extends AbstractScheduledService {
     }
     // demand factor will be < 1 indicating a scale-down demand, and > 1 indicating a scale-up
     double rawDemandFactor = (double) (totalReplicaDemand) / (totalCacheSlotCapacity);
-    // round to 2 decimals
-    return (double) Math.round(rawDemandFactor * 100) / 100;
+    // round up to 2 decimals
+    return Math.ceil(rawDemandFactor * 100) / 100;
   }
 
   /** Updates or inserts an (ephemeral) HPA metric for the cache nodes. This is NOT threadsafe. */

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ClusterHpaMetricServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ClusterHpaMetricServiceTest.java
@@ -321,4 +321,11 @@ class ClusterHpaMetricServiceTest {
     // 2 replicas, 0 slots (will log an error and return a default no-op)
     assertThat(rep2Metadata.getValue()).isEqualTo(1);
   }
+
+  @Test
+  void testDemandFactorRounding() {
+    assertThat(ClusterHpaMetricService.calculateDemandFactor(100, 98)).isEqualTo(0.98);
+    assertThat(ClusterHpaMetricService.calculateDemandFactor(98, 100)).isEqualTo(1.03);
+    assertThat(ClusterHpaMetricService.calculateDemandFactor(9999, 10000)).isEqualTo(1.01);
+  }
 }


### PR DESCRIPTION
###  Summary

Fixes a rounding issue in the current HPA autoscaling logic when running in sufficiently large clusters. This HPA approach has some significant limitations as compared to a proper Kubernetes operator, which may be the route we end up taking long term.