### PR TITLE
remove armeria max connections setting

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/ArmeriaService.java
@@ -62,14 +62,9 @@ public class ArmeriaService extends AbstractIdleService {
       this.serviceName = serviceName;
       this.serverBuilder = Server.builder().http(port);
 
-      initializeLimits();
       initializeCompression();
       initializeLogging();
       initializeManagementEndpoints(prometheusMeterRegistry);
-    }
-
-    private void initializeLimits() {
-      serverBuilder.maxNumConnections(MAX_CONNECTIONS);
     }
 
     private void initializeCompression() {


### PR DESCRIPTION
###  Summary

We've recently reworked the query layer to be able to handle more requests in parallel. Let's remove the max connections setting for now so that we don't limit incoming requests and if we find bottlenecks we'll address it as soon as we notice it
