### PR TITLE
Fix bug in bulk ingest API when document has special chars

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/preprocessor/ingest/OpenSearchBulkApiRequestParser.java
+++ b/kaldb/src/main/java/com/slack/kaldb/preprocessor/ingest/OpenSearchBulkApiRequestParser.java
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit;
 import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.index.IndexRequest;
-import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.index.VersionType;
 import org.opensearch.ingest.IngestDocument;
 import org.slf4j.Logger;
@@ -105,8 +105,8 @@ public class OpenSearchBulkApiRequestParser {
     List<IndexRequest> indexRequests = new ArrayList<>();
     BulkRequest bulkRequest = new BulkRequest();
     // calls parse under the hood
-    bulkRequest.add(
-        postBody.getBytes(StandardCharsets.UTF_8), 0, postBody.length(), null, XContentType.JSON);
+    byte[] bytes = postBody.getBytes(StandardCharsets.UTF_8);
+    bulkRequest.add(bytes, 0, bytes.length, null, MediaTypeRegistry.JSON);
     List<DocWriteRequest<?>> requests = bulkRequest.requests();
     for (DocWriteRequest<?> request : requests) {
       if (request.opType() == DocWriteRequest.OpType.INDEX) {

--- a/kaldb/src/main/java/com/slack/kaldb/server/OpenSearchBulkIngestApi.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/OpenSearchBulkIngestApi.java
@@ -173,6 +173,12 @@ public class OpenSearchBulkIngestApi extends AbstractService {
   @Post("/_bulk")
   public HttpResponse addDocument(String bulkRequest) {
     try {
+      System.out.println("bulk request payload start");
+      System.out.println(bulkRequest);
+      System.out.println("bulk request payload end");
+      if (!bulkRequest.endsWith("\n")) {
+        bulkRequest = bulkRequest + "\n";
+      }
       List<IndexRequest> indexRequests =
           OpenSearchBulkApiRequestParser.parseBulkRequest(bulkRequest);
       Map<String, List<Trace.Span>> docs =

--- a/kaldb/src/main/java/com/slack/kaldb/server/OpenSearchBulkIngestApi.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/OpenSearchBulkIngestApi.java
@@ -173,12 +173,6 @@ public class OpenSearchBulkIngestApi extends AbstractService {
   @Post("/_bulk")
   public HttpResponse addDocument(String bulkRequest) {
     try {
-      System.out.println("bulk request payload start");
-      System.out.println(bulkRequest);
-      System.out.println("bulk request payload end");
-      if (!bulkRequest.endsWith("\n")) {
-        bulkRequest = bulkRequest + "\n";
-      }
       List<IndexRequest> indexRequests =
           OpenSearchBulkApiRequestParser.parseBulkRequest(bulkRequest);
       Map<String, List<Trace.Span>> docs =

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/ingest/OpenSearchBulkRequestTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/ingest/OpenSearchBulkRequestTest.java
@@ -115,6 +115,28 @@ public class OpenSearchBulkRequestTest {
   }
 
   @Test
+  public void testIndexRequestWithSpecialChars() throws Exception {
+    String rawRequest = getRawQueryString("index_request_with_special_chars");
+    List<IndexRequest> indexRequests = OpenSearchBulkApiRequestParser.parseBulkRequest(rawRequest);
+    assertThat(indexRequests.size()).isEqualTo(1);
+    Map<String, List<Trace.Span>> indexDocs =
+        OpenSearchBulkApiRequestParser.convertIndexRequestToTraceFormat(indexRequests);
+    assertThat(indexDocs.keySet().size()).isEqualTo(1);
+    assertThat(indexDocs.get("index_name").size()).isEqualTo(1);
+
+    assertThat(indexDocs.get("index_name").get(0).getId().toStringUtf8()).isNotNull();
+    assertThat(indexDocs.get("index_name").get(0).getTagsList().size()).isEqualTo(4);
+    assertThat(
+            indexDocs.get("index_name").get(0).getTagsList().stream()
+                .filter(
+                    keyValue ->
+                        keyValue.getKey().equals("service_name")
+                            && keyValue.getVStr().equals("index_name"))
+                .count())
+        .isEqualTo(1);
+  }
+
+  @Test
   public void testBulkRequests() throws Exception {
     String rawRequest = getRawQueryString("bulk_requests");
     List<IndexRequest> indexRequests = OpenSearchBulkApiRequestParser.parseBulkRequest(rawRequest);

--- a/kaldb/src/test/resources/opensearchRequest/bulk/index_request_with_special_chars.ndjson
+++ b/kaldb/src/test/resources/opensearchRequest/bulk/index_request_with_special_chars.ndjson
@@ -1,0 +1,2 @@
+{"index":{"_id":null,"_index":"index_name","routing":null}}
+{"pid":17097,"@version":"1","message_fields":{"path":"/userportal/Controller?mode=8700&operation=1&datagrid=179&json={\"ðŸ¦ž\":\"test\"}"}}


### PR DESCRIPTION
###  Summary

This was a fun one to track down - We need to pass the correct string length which needs to take into account special chars