### PR TITLE
Fix uberjar builds to address Lucene class not found exception

### DIFF
--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -618,6 +618,7 @@
                                         implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>com.slack.kaldb.server.Kaldb</Main-Class>
+                                        <Multi-Release>true</Multi-Release>
                                     </manifestEntries>
                                 </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>


### PR DESCRIPTION
###  Summary

Addresses a runtime issue after loading chunks, where we could get class not found exceptions due to the uberjar packaging settings. 

```
Exception in thread "" java.lang.LinkageError: MemorySegmentIndexInputProvider is missing in Lucene JAR file
	at org.apache.lucene.store.MMapDirectory.lookupProvider(MMapDirectory.java:437)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:319)
	at org.apache.lucene.store.MMapDirectory.doPrivileged(MMapDirectory.java:395)
	at org.apache.lucene.store.MMapDirectory.<clinit>(MMapDirectory.java:448)
	at com.slack.kaldb.logstore.search.LogIndexSearcherImpl.searcherManagerFromPath(LogIndexSearcherImpl.java:57)
	at com.slack.kaldb.chunk.ReadOnlyChunkImpl.handleChunkAssignment(ReadOnlyChunkImpl.java:230)
	at com.slack.kaldb.chunk.ReadOnlyChunkImpl.lambda$cacheNodeListener$0(ReadOnlyChunkImpl.java:145)
	at java.base/java.lang.VirtualThread.run(VirtualThread.java:309)
Caused by: java.lang.ClassNotFoundException: org.apache.lucene.store.MemorySegmentIndexInputProvider
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:534)
	at java.base/java.lang.Class.forName(Class.java:513)
	at java.base/java.lang.invoke.MethodHandles$Lookup.findClass(MethodHandles.java:2869)
	at org.apache.lucene.store.MMapDirectory.lookupProvider(MMapDirectory.java:422)
	... 7 more
```

This is as discussed here https://github.com/apache/lucene/issues/12307, and the fix mentioned in that thread here https://stackoverflow.com/questions/53049346/is-log4j2-compatible-with-java-11/54713830#54713830 is to enable multi-release on the shade plugin.