### PR TITLE
update armeria dependency

### DIFF
--- a/kaldb/pom.xml
+++ b/kaldb/pom.xml
@@ -21,7 +21,7 @@
         <protobuf.version>3.25.0</protobuf.version>
         <grpc.version>1.57.2</grpc.version>
         <micrometer.version>1.11.0</micrometer.version>
-        <armeria.version>1.25.2</armeria.version>
+        <armeria.version>1.26.2</armeria.version>
         <kafka.version>3.5.0</kafka.version>
         <jackson.version>2.15.2</jackson.version>
         <jackson.databind.version>2.15.3</jackson.databind.version>


### PR DESCRIPTION
###  Summary

Ran  `mvn dependency:tree` and netty has been upgraded. This addresses https://github.com/advisories/GHSA-xpw8-rcwv-8f8p

```
[INFO]    +- com.linecorp.armeria:armeria:jar:1.26.2:compile
[INFO]    |  +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.15.3:compile
[INFO]    |  +- io.netty:netty-transport:jar:4.1.100.Final:compile
[INFO]    |  |  +- io.netty:netty-common:jar:4.1.100.Final:compile
[INFO]    |  |  +- io.netty:netty-buffer:jar:4.1.100.Final:compile
[INFO]    |  |  \- io.netty:netty-resolver:jar:4.1.100.Final:compile
[INFO]    |  +- io.netty:netty-codec-haproxy:jar:4.1.100.Final:compile
[INFO]    |  |  \- io.netty:netty-codec:jar:4.1.100.Final:compile
[INFO]    |  +- io.netty:netty-codec-http2:jar:4.1.100.Final:compile
[INFO]    |  |  +- io.netty:netty-handler:jar:4.1.100.Final:compile
[INFO]    |  |  \- io.netty:netty-codec-http:jar:4.1.100.Final:compile
[INFO]    |  +- io.netty:netty-resolver-dns:jar:4.1.100.Final:compile
[INFO]    |  |  \- io.netty:netty-codec-dns:jar:4.1.100.Final:compile
[INFO]    |  +- org.reactivestreams:reactive-streams:jar:1.0.4:compile
[INFO]    |  +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
[INFO]    |  +- io.netty:netty-handler-proxy:jar:4.1.100.Final:runtime
[INFO]    |  |  \- io.netty:netty-codec-socks:jar:4.1.100.Final:runtime
[INFO]    |  +- io.netty:netty-transport-native-unix-common:jar:linux-x86_64:4.1.100.Final:runtime
[INFO]    |  +- io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.100.Final:runtime
[INFO]    |  |  +- io.netty:netty-transport-native-unix-common:jar:4.1.100.Final:compile
[INFO]    |  |  \- io.netty:netty-transport-classes-epoll:jar:4.1.100.Final:compile
[INFO]    |  +- io.netty:netty-transport-native-unix-common:jar:linux-aarch_64:4.1.100.Final:runtime
[INFO]    |  +- io.netty:netty-transport-native-epoll:jar:linux-aarch_64:4.1.100.Final:runtime
[INFO]    |  +- io.netty:netty-transport-native-unix-common:jar:osx-x86_64:4.1.100.Final:runtime
[INFO]    |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.100.Final:runtime
[INFO]    |  |  \- io.netty:netty-transport-classes-kqueue:jar:4.1.100.Final:runtime
[INFO]    |  +- io.netty:netty-resolver-dns-native-macos:jar:osx-x86_64:4.1.100.Final:runtime
[INFO]    |  |  \- io.netty:netty-resolver-dns-classes-macos:jar:4.1.100.Final:runtime
[INFO]    |  +- io.netty:netty-transport-native-unix-common:jar:osx-aarch_64:4.1.100.Final:runtime
[INFO]    |  +- io.netty:netty-transport-native-kqueue:jar:osx-aarch_64:4.1.100.Final:runtime
[INFO]    |  +- io.netty:netty-resolver-dns-native-macos:jar:osx-aarch_64:4.1.100.Final:runtime
[INFO]    |  +- io.netty:netty-tcnative-boringssl-static:jar:linux-x86_64:2.0.61.Final:runtime
[INFO]    |  |  \- io.netty:netty-tcnative-classes:jar:2.0.61.Final:runtime
[INFO]    |  +- io.netty:netty-tcnative-boringssl-static:jar:linux-aarch_64:2.0.61.Final:runtime
[INFO]    |  +- io.netty:netty-tcnative-boringssl-static:jar:osx-x86_64:2.0.61.Final:runtime
[INFO]    |  +- io.netty:netty-tcnative-boringssl-static:jar:osx-aarch_64:2.0.61.Final:runtime
[INFO]    |  +- io.netty:netty-tcnative-boringssl-static:jar:windows-x86_64:2.0.61.Final:runtime
```
