### PR TITLE
Improve flaky tests

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/server/OpenSearchBulkIngestApi.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/OpenSearchBulkIngestApi.java
@@ -62,7 +62,7 @@ public class OpenSearchBulkIngestApi extends AbstractService {
 
   private final PreprocessorRateLimiter rateLimiter;
   private BiPredicate<String, List<Trace.Span>> rateLimiterPredicate;
-  private List<DatasetMetadata> throughputSortedDatasets;
+  protected List<DatasetMetadata> throughputSortedDatasets;
 
   private final Timer configReloadTimer;
 

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
@@ -72,6 +72,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -313,15 +314,16 @@ public class IndexingChunkManagerTest {
     // after the rollover
     final File dataDirectory = new File(indexerConfig.getDataDirectory());
     final File indexDirectory = new File(dataDirectory.getAbsolutePath() + "/indices");
-    File[] filesBeforeRollover = indexDirectory.listFiles();
-    assertThat(filesBeforeRollover).isNotNull();
 
+    // files before rollover may or may-not be null, depending on other test timing
+    int filesBeforeRollover =
+        Optional.ofNullable(indexDirectory.listFiles()).orElse(new File[] {}).length;
     chunkManager.rollOverActiveChunk();
 
     // Ensure data on disk is NOT deleted.
     File[] filesAfterRollover = indexDirectory.listFiles();
     assertThat(filesAfterRollover).isNotNull();
-    assertThat(filesBeforeRollover.length == filesAfterRollover.length).isTrue();
+    assertThat(filesBeforeRollover == filesAfterRollover.length).isTrue();
   }
 
   @Test


### PR DESCRIPTION
###  Summary

Fixes the following flaky tests that are causing the current build pipeline some difficulty:

* `OpenSearchBulkEndpointTest.testBulkApiBasic`
* `IndexingChunkManagerTest.testDeleteStaleDataDoesNothingWhenGivenLimitLessThan0`