### PR TITLE
respect user provided timestamp

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/bulkIngestApi/BulkIngestApi.java
+++ b/kaldb/src/main/java/com/slack/kaldb/bulkIngestApi/BulkIngestApi.java
@@ -28,8 +28,10 @@ public class BulkIngestApi {
   private final DatasetRateLimitingService datasetRateLimitingService;
   private final MeterRegistry meterRegistry;
   private final Counter incomingByteTotal;
+  private final Counter incomingDocsTotal;
   private final Timer bulkIngestTimer;
   private final String BULK_INGEST_INCOMING_BYTE_TOTAL = "kaldb_preprocessor_incoming_byte";
+  private final String BULK_INGEST_INCOMING_BYTE_DOCS = "kaldb_preprocessor_incoming_docs";
   private final String BULK_INGEST_TIMER = "kaldb_preprocessor_bulk_ingest";
 
   public BulkIngestApi(
@@ -41,6 +43,7 @@ public class BulkIngestApi {
     this.datasetRateLimitingService = datasetRateLimitingService;
     this.meterRegistry = meterRegistry;
     this.incomingByteTotal = meterRegistry.counter(BULK_INGEST_INCOMING_BYTE_TOTAL);
+    this.incomingDocsTotal = meterRegistry.counter(BULK_INGEST_INCOMING_BYTE_DOCS);
     this.bulkIngestTimer = meterRegistry.timer(BULK_INGEST_TIMER);
   }
 
@@ -70,6 +73,7 @@ public class BulkIngestApi {
       }
 
       for (Map.Entry<String, List<Trace.Span>> indexDocs : docs.entrySet()) {
+        incomingDocsTotal.increment(indexDocs.getValue().size());
         final String index = indexDocs.getKey();
         if (!datasetRateLimitingService.tryAcquire(index, indexDocs.getValue())) {
           BulkIngestResponse response = new BulkIngestResponse(0, 0, "rate limit exceeded");

--- a/kaldb/src/main/java/com/slack/kaldb/bulkIngestApi/opensearch/BulkApiRequestParser.java
+++ b/kaldb/src/main/java/com/slack/kaldb/bulkIngestApi/opensearch/BulkApiRequestParser.java
@@ -4,8 +4,11 @@ import com.google.protobuf.ByteString;
 import com.slack.kaldb.writer.SpanFormatter;
 import com.slack.service.murron.trace.Trace;
 import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -36,12 +39,38 @@ public class BulkApiRequestParser {
     return convertIndexRequestToTraceFormat(parseBulkRequest(postBody));
   }
 
-  protected static Trace.Span fromIngestDocument(IngestDocument ingestDocument) {
-    ZonedDateTime timestamp =
-        (ZonedDateTime)
+  /**
+   * We need users to be able to specify the timestamp field and unit. For now we will do the
+   * following: 1. Check to see if the "timestamp" field exists and if it does parse that as a long
+   * in millis 2. Check if a field called `@timestamp` exists and parse that as a date (since
+   * logstash sets that) 3. Use the current time from the ingestMetadata
+   */
+  public static long getTimestampFromIngestDocument(IngestDocument ingestDocument) {
+    if (ingestDocument.hasField("timestamp") || ingestDocument.hasField("_timestamp")) {
+      // assumption that the provided timestamp is in millis
+      // at some point both th unit and field need to be configurable
+      return ingestDocument.getFieldValue("timestamp", Long.class);
+    }
+
+    if (ingestDocument.hasField("@timestamp")) {
+      String dateString = ingestDocument.getFieldValue("@timestamp", String.class);
+      LocalDateTime localDateTime =
+          LocalDateTime.parse(dateString, DateTimeFormatter.ISO_DATE_TIME);
+      Instant instant = localDateTime.toInstant(ZoneOffset.UTC);
+      return instant.toEpochMilli();
+    }
+
+    return ((ZonedDateTime)
             ingestDocument
                 .getIngestMetadata()
-                .getOrDefault("timestamp", ZonedDateTime.now(ZoneOffset.UTC));
+                .getOrDefault("timestamp", ZonedDateTime.now(ZoneOffset.UTC)))
+        .toInstant()
+        .toEpochMilli();
+  }
+
+  protected static Trace.Span fromIngestDocument(IngestDocument ingestDocument) {
+
+    long timestampInMillis = getTimestampFromIngestDocument(ingestDocument);
 
     Map<String, Object> sourceAndMetadata = ingestDocument.getSourceAndMetadata();
     String id = (String) sourceAndMetadata.get(IngestDocument.Metadata.ID.getFieldName());
@@ -56,7 +85,7 @@ public class BulkApiRequestParser {
     spanBuilder.setId(ByteString.copyFrom(id.getBytes()));
     // Trace.Span proto expects duration in microseconds today
     spanBuilder.setTimestamp(
-        TimeUnit.MICROSECONDS.convert(timestamp.toInstant().toEpochMilli(), TimeUnit.MILLISECONDS));
+        TimeUnit.MICROSECONDS.convert(timestampInMillis, TimeUnit.MILLISECONDS));
 
     // Remove the following internal metadata fields that OpenSearch adds
     sourceAndMetadata.remove(IngestDocument.Metadata.ROUTING.getFieldName());

--- a/kaldb/src/main/java/com/slack/kaldb/bulkIngestApi/opensearch/BulkApiRequestParser.java
+++ b/kaldb/src/main/java/com/slack/kaldb/bulkIngestApi/opensearch/BulkApiRequestParser.java
@@ -46,10 +46,15 @@ public class BulkApiRequestParser {
    * logstash sets that) 3. Use the current time from the ingestMetadata
    */
   public static long getTimestampFromIngestDocument(IngestDocument ingestDocument) {
-    if (ingestDocument.hasField("timestamp") || ingestDocument.hasField("_timestamp")) {
-      // assumption that the provided timestamp is in millis
-      // at some point both th unit and field need to be configurable
+    // assumption that the provided timestamp is in millis
+    // at some point both th unit and field need to be configurable
+    // when we do that, remember to change the called to appropriately remove the field
+    if (ingestDocument.hasField("timestamp")) {
       return ingestDocument.getFieldValue("timestamp", Long.class);
+    }
+
+    if (ingestDocument.hasField("_timestamp")) {
+      return ingestDocument.getFieldValue("_timestamp", Long.class);
     }
 
     if (ingestDocument.hasField("@timestamp")) {
@@ -91,9 +96,13 @@ public class BulkApiRequestParser {
     sourceAndMetadata.remove(IngestDocument.Metadata.ROUTING.getFieldName());
     sourceAndMetadata.remove(IngestDocument.Metadata.VERSION.getFieldName());
     sourceAndMetadata.remove(IngestDocument.Metadata.VERSION_TYPE.getFieldName());
-    // these two fields don't need to be tags as they have been explicitly set already
+
+    // these fields don't need to be tags as they have been explicitly set already
     sourceAndMetadata.remove(IngestDocument.Metadata.ID.getFieldName());
     sourceAndMetadata.remove(IngestDocument.Metadata.INDEX.getFieldName());
+    sourceAndMetadata.remove("timestamp");
+    sourceAndMetadata.remove("_timestamp");
+    sourceAndMetadata.remove("@timestamp");
 
     sourceAndMetadata.forEach(
         (key, value) -> spanBuilder.addTags(SpanFormatter.convertKVtoProto(key, value)));

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
@@ -284,7 +284,7 @@ public class IndexingChunkManagerTest {
             metricsRegistry, 10 * 1024 * 1024 * 1024L, 1000000L);
 
     KaldbConfigs.IndexerConfig indexerConfig =
-        KaldbConfigUtil.makeIndexerConfig(TEST_PORT, 1000, "log_message", 100, -1, 0);
+        KaldbConfigUtil.makeIndexerConfig(TEST_PORT, 1000, "log_message", 100, -1, 10_000);
     initChunkManager(
         chunkRollOverStrategy,
         S3_TEST_BUCKET,
@@ -312,8 +312,7 @@ public class IndexingChunkManagerTest {
 
     // Get the count of the amount of indices so that we can confirm we've cleaned them up
     // after the rollover
-    final File dataDirectory = new File(indexerConfig.getDataDirectory());
-    final File indexDirectory = new File(dataDirectory.getAbsolutePath() + "/indices");
+    final File indexDirectory = tmpPath.resolve("indices").toFile();
 
     // files before rollover may or may-not be null, depending on other test timing
     int filesBeforeRollover =

--- a/kaldb/src/test/resources/opensearchRequest/bulk/index_simple.ndjson
+++ b/kaldb/src/test/resources/opensearchRequest/bulk/index_simple.ndjson
@@ -1,2 +1,2 @@
 { "index" : { "_index" : "test", "_id" : "1" } }
-{ "field1" : "value1", "field2" : "value2" }
+{ "field1" : "value1", "field2" : "value2"}

--- a/kaldb/src/test/resources/opensearchRequest/bulk/index_simple_with_ts.ndjson
+++ b/kaldb/src/test/resources/opensearchRequest/bulk/index_simple_with_ts.ndjson
@@ -1,0 +1,2 @@
+{ "index" : { "_index" : "test", "_id" : "1" } }
+{ "field1" : "value1", "field2" : "value2", "@timestamp": "2120-03-12T09:54:39.544Z" }


### PR DESCRIPTION
###  Summary

This PR aims to read several timestamp fields if provided in the ingest document and respect that value instead of always generating the timestamp recorded at ingest time

The main motivation is when logstash sends data it adds a `@timestamp` field and we want to respect that value