### PR TITLE
Index the `_id` field with encoding to be searchable

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/opensearch/OpenSearchAdapter.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/opensearch/OpenSearchAdapter.java
@@ -220,6 +220,8 @@ public class OpenSearchAdapter {
           tryRegisterField(mapperService, entry.getValue().name, b -> b.field("type", "text"));
         } else if (entry.getValue().fieldType == FieldType.STRING) {
           tryRegisterField(mapperService, entry.getValue().name, b -> b.field("type", "keyword"));
+        } else if (entry.getValue().fieldType == FieldType.ID) {
+          tryRegisterField(mapperService, entry.getValue().name, b -> b.field("type", "keyword"));
         } else if (entry.getValue().fieldType == FieldType.INTEGER) {
           tryRegisterField(mapperService, entry.getValue().name, b -> b.field("type", "integer"));
         } else if (entry.getValue().fieldType == FieldType.LONG) {

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
@@ -59,7 +59,6 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder<LogMes
     }
 
     String[] fieldsAsString = {
-      LogMessage.SystemField.ID.fieldName,
       LogMessage.SystemField.INDEX.fieldName,
       LogMessage.ReservedField.TYPE.fieldName,
       LogMessage.ReservedField.HOSTNAME.fieldName,
@@ -76,6 +75,14 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder<LogMes
     for (String fieldName : fieldsAsString) {
       fieldDefBuilder.put(
           fieldName, new LuceneFieldDef(fieldName, FieldType.STRING.name, false, true, true));
+    }
+
+    String[] fieldsAsIds = {
+      LogMessage.SystemField.ID.fieldName,
+    };
+    for (String fieldName : fieldsAsIds) {
+      fieldDefBuilder.put(
+          fieldName, new LuceneFieldDef(fieldName, FieldType.ID.name, false, true, true));
     }
 
     String[] fieldsAsLong = {

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/opensearch/OpenSearchAdapterTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/opensearch/OpenSearchAdapterTest.java
@@ -30,8 +30,10 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.IndexSortSortedNumericDocValuesRangeQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.opensearch.index.mapper.Uid;
 import org.opensearch.search.aggregations.AbstractAggregationBuilder;
 import org.opensearch.search.aggregations.Aggregator;
 import org.opensearch.search.aggregations.InternalAggregation;
@@ -402,6 +404,19 @@ public class OpenSearchAdapterTest {
 
     assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> collectorManager.newCollector());
+  }
+
+  @Test
+  public void shouldParseIdFieldSearch() throws Exception {
+    String idField = "_id";
+    String idValue = "1";
+    IndexSearcher indexSearcher = logStoreAndSearcherRule.logStore.getSearcherManager().acquire();
+    Query idQuery =
+        openSearchAdapter.buildQuery("foo", STR."\{idField}:\{idValue}", null, null, indexSearcher);
+    BytesRef queryStrBytes = new BytesRef(Uid.encodeId("1x").bytes);
+    // idQuery.toString="#_id:([fe 1f])"
+    // queryStrBytes.toString="[fe 1f]"
+    assertThat(idQuery.toString()).contains(queryStrBytes.toString());
   }
 
   @Test

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/opensearch/OpenSearchAdapterTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/opensearch/OpenSearchAdapterTest.java
@@ -413,7 +413,7 @@ public class OpenSearchAdapterTest {
     IndexSearcher indexSearcher = logStoreAndSearcherRule.logStore.getSearcherManager().acquire();
     Query idQuery =
         openSearchAdapter.buildQuery("foo", STR."\{idField}:\{idValue}", null, null, indexSearcher);
-    BytesRef queryStrBytes = new BytesRef(Uid.encodeId("1x").bytes);
+    BytesRef queryStrBytes = new BytesRef(Uid.encodeId("1").bytes);
     // idQuery.toString="#_id:([fe 1f])"
     // queryStrBytes.toString="[fe 1f]"
     assertThat(idQuery.toString()).contains(queryStrBytes.toString());

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/schema/DropPolicyTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/schema/DropPolicyTest.java
@@ -50,7 +50,7 @@ public class DropPolicyTest {
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();
     // Only string fields have doc values not text fields.
-    assertThat(docBuilder.getSchema().get("_id").fieldType.name).isEqualTo(FieldType.STRING.name);
+    assertThat(docBuilder.getSchema().get("_id").fieldType.name).isEqualTo(FieldType.ID.name);
     assertThat(
             testDocument.getFields().stream()
                 .filter(
@@ -96,7 +96,7 @@ public class DropPolicyTest {
     assertThat(MetricsUtil.getCount(CONVERT_FIELD_VALUE_COUNTER, meterRegistry)).isZero();
     assertThat(MetricsUtil.getCount(CONVERT_AND_DUPLICATE_FIELD_COUNTER, meterRegistry)).isZero();
     // Only string fields have doc values not text fields.
-    assertThat(docBuilder.getSchema().get("_id").fieldType.name).isEqualTo(FieldType.STRING.name);
+    assertThat(docBuilder.getSchema().get("_id").fieldType.name).isEqualTo(FieldType.ID.name);
     assertThat(
             testDocument.getFields().stream()
                 .filter(

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
@@ -1725,4 +1725,20 @@ public class LogIndexSearcherImplTest {
     assertThat(searchFailures.get()).isEqualTo(0);
     assertThat(successfulRuns.get()).isEqualTo(200);
   }
+
+  @Test
+  public void testSearchById() {
+    Instant time = Instant.ofEpochSecond(1593365471);
+    loadTestData(time);
+    SearchResult<LogMessage> index =
+        strictLogStore.logSearcher.search(
+            TEST_DATASET_NAME,
+            "_id:1",
+            time.toEpochMilli(),
+            time.plusSeconds(2).toEpochMilli(),
+            10,
+            new DateHistogramAggBuilder(
+                "1", LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName, "1s"));
+    assertThat(index.hits.size()).isEqualTo(1);
+  }
 }


### PR DESCRIPTION
###  Summary

We rely on OpenSearch to query for documents. Which means we translate our schema to their mappings API and then let the query parser form the query.

For `_id` fields, the query parser encodes the query string value ( which it also does during indexing )

This PR adds an ID field, currently just for the `_id` field to use and encodes the value so that queries work on it.

We want the least resistance in reworking our schema layer to play nicely with OpenSearch. In a future effort we have to rethink this and redo a lot of how to make fields configurable, how can it sit closer to OpenSearch etc.
