### PR TITLE
Rework schema queries to be quicker

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryService.java
@@ -7,8 +7,6 @@ import brave.Tracing;
 import brave.grpc.GrpcTracing;
 import brave.propagation.CurrentTraceContext;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.metadata.core.KaldbMetadataStoreChangeListener;
@@ -93,7 +91,6 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase implemen
   // include metadata that should always be present. The Armeria timeout is used at the top request,
   // distributed query is used as a deadline for all nodes to return, and the local query timeout
   // is used for controlling lucene future timeouts.
-  private final Duration requestTimeout;
   private final Duration defaultQueryTimeout;
   private final ScheduledExecutorService executorService =
       Executors.newSingleThreadScheduledExecutor();
@@ -116,7 +113,6 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase implemen
     this.searchMetadataStore = searchMetadataStore;
     this.snapshotMetadataStore = snapshotMetadataStore;
     this.datasetMetadataStore = datasetMetadataStore;
-    this.requestTimeout = requestTimeout;
     this.defaultQueryTimeout = defaultQueryTimeout;
     searchMetadataTotalChangeCounter = meterRegistry.counter(SEARCH_METADATA_TOTAL_CHANGE_COUNTER);
     this.distributedQueryApdexSatisfied = meterRegistry.counter(DISTRIBUTED_QUERY_APDEX_SATISFIED);
@@ -494,60 +490,74 @@ public class KaldbDistributedQueryService extends KaldbQueryServiceBase implemen
     Map<String, List<String>> nodesAndSnapshotsToQuery =
         getNodesAndSnapshotsToQuery(searchMetadataNodesMatchingQuery);
 
-    List<ListenableFuture<KaldbSearch.SchemaResult>> queryServers = new ArrayList<>(stubs.size());
-
-    List<Map.Entry<String, List<String>>> limitedNodesToQuery =
-        nodesAndSnapshotsToQuery.entrySet().stream().limit(LIMIT_SCHEMA_NODES_TO_QUERY).toList();
-    for (Map.Entry<String, List<String>> searchNode : limitedNodesToQuery) {
-      KaldbServiceGrpc.KaldbServiceFutureStub stub = getStub(searchNode.getKey());
-      if (stub == null) {
-        // TODO: insert a failed result in the results object that we return from this method
-        // mimicing
-        continue;
-      }
-
-      KaldbSearch.SchemaRequest localSearchReq =
-          distribSchemaReq.toBuilder().addAllChunkIds(searchNode.getValue()).build();
-
-      // make sure all underlying futures finish executing (successful/cancelled/failed/other)
-      // and cannot be pending when the successfulAsList.get(SAME_TIMEOUT_MS) runs
-      ListenableFuture<KaldbSearch.SchemaResult> schemaRequest =
-          stub.withDeadlineAfter(defaultQueryTimeout.toMillis(), TimeUnit.MILLISECONDS)
-              .withInterceptors(
-                  GrpcTracing.newBuilder(Tracing.current()).build().newClientInterceptor())
-              .schema(localSearchReq);
-      queryServers.add(schemaRequest);
-    }
-    ListenableFuture<List<KaldbSearch.SchemaResult>> searchFuture =
-        Futures.successfulAsList(queryServers);
+    CurrentTraceContext currentTraceContext = Tracing.current().currentTraceContext();
     try {
-      List<KaldbSearch.SchemaResult> searchResults =
-          searchFuture.get(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
-      KaldbSearch.SchemaResult.Builder schemaBuilder = KaldbSearch.SchemaResult.newBuilder();
-      searchResults.forEach(
-          schemaResult ->
-              schemaBuilder.putAllFieldDefinition(schemaResult.getFieldDefinitionMap()));
-      return schemaBuilder.build();
-    } catch (TimeoutException e) {
-      // We provide a deadline to the stub of "defaultQueryTimeout" - if this is sufficiently lower
-      // than the request timeout, we would expect searchFuture.get(requestTimeout) to never throw
-      // an exception. This however doesn't necessarily hold true if the query node is CPU
-      // saturated, and there is not enough cpu time to fail the pending stub queries that have
-      // exceeded their deadline - causing the searchFuture get to fail with a timeout.
-      LOG.error(
-          "Schema failed with timeout exception. This is potentially due to CPU saturation of the query node.",
-          e);
-      span.error(e);
-      return KaldbSearch.SchemaResult.newBuilder().build();
+      try (var scope = new StructuredTaskScope<KaldbSearch.SchemaResult>()) {
+        List<StructuredTaskScope.Subtask<KaldbSearch.SchemaResult>> searchSubtasks =
+            nodesAndSnapshotsToQuery.entrySet().stream()
+                .limit(LIMIT_SCHEMA_NODES_TO_QUERY)
+                .map(
+                    (searchNode) ->
+                        scope.fork(
+                            currentTraceContext.wrap(
+                                () -> {
+                                  KaldbServiceGrpc.KaldbServiceFutureStub stub =
+                                      getStub(searchNode.getKey());
+
+                                  if (stub == null) {
+                                    // TODO: insert a failed result in the results object that we
+                                    // return from this method
+                                    return null;
+                                  }
+
+                                  KaldbSearch.SchemaRequest localSearchReq =
+                                      distribSchemaReq.toBuilder()
+                                          .addAllChunkIds(searchNode.getValue())
+                                          .build();
+
+                                  return stub.withDeadlineAfter(
+                                          defaultQueryTimeout.toMillis(), TimeUnit.MILLISECONDS)
+                                      .withInterceptors(
+                                          GrpcTracing.newBuilder(Tracing.current())
+                                              .build()
+                                              .newClientInterceptor())
+                                      .schema(localSearchReq)
+                                      .get();
+                                })))
+                .toList();
+
+        try {
+          scope.joinUntil(Instant.now().plusSeconds(defaultQueryTimeout.toSeconds()));
+        } catch (TimeoutException timeoutException) {
+          scope.shutdown();
+          scope.join();
+        }
+
+        KaldbSearch.SchemaResult.Builder schemaBuilder = KaldbSearch.SchemaResult.newBuilder();
+        // List<KaldbSearch.SchemaResult> response = new ArrayList(searchSubtasks.size());
+        for (StructuredTaskScope.Subtask<KaldbSearch.SchemaResult> schemaResult : searchSubtasks) {
+          try {
+            if (schemaResult.state().equals(StructuredTaskScope.Subtask.State.SUCCESS)) {
+              if (schemaResult.get() != null) {
+                schemaBuilder.putAllFieldDefinition(schemaResult.get().getFieldDefinitionMap());
+              } else {
+                // todo - log
+              }
+            } else {
+              // todo - log
+            }
+          } catch (Exception e) {
+            LOG.error("Error fetching search result", e);
+            // todo
+          }
+        }
+        return schemaBuilder.build();
+      }
     } catch (Exception e) {
-      LOG.error("Schema failed with ", e);
+      LOG.error("Search failed with ", e);
       span.error(e);
       return KaldbSearch.SchemaResult.newBuilder().build();
     } finally {
-      // always request future cancellation, so that any exceptions or incomplete futures don't
-      // continue to consume CPU on work that will not be used
-      searchFuture.cancel(false);
-      LOG.debug("Finished distributed search for request: {}", distribSchemaReq);
       span.finish();
     }
   }


### PR DESCRIPTION
###  Summary

When building schema for the autocomplete we currently query up to 5 nodes, and then attempt to merge them into a single view of the possible fields. This is susceptible to individual nodes being slow and causing poor query performance, which you can see in the example trace below.

![image](https://github.com/slackhq/kaldb/assets/771133/2a9f5ec1-bb94-4181-b79c-33f7891b9a3d)

As we do not necessarily need all nodes to respond (a single node responding is likely to be sufficient), and this should be an in-memory map result we can aggressively cap the timeout. I've currently left this as a system property, which we may explore moving to a config value at a later date if it's deemed a useful config to expose.

I've also reworked the schema endpoint to use structured concurrency as well, similar to that was done for the search functionality in #704