### PR TITLE
Add detection of invalid recovery tasks on recovery nodes

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
@@ -211,27 +211,50 @@ public class RecoveryService extends AbstractIdleService {
    * fails. To break this cycle add a enqueue_count value to recovery task so we can stop recovering
    * it if the task fails a certain number of times.
    */
-  private void handleRecoveryTaskAssignment(RecoveryNodeMetadata recoveryNodeMetadata) {
+  protected void handleRecoveryTaskAssignment(RecoveryNodeMetadata recoveryNodeMetadata) {
     try {
       setRecoveryNodeMetadataState(Metadata.RecoveryNodeMetadata.RecoveryNodeState.RECOVERING);
       RecoveryTaskMetadata recoveryTaskMetadata =
           recoveryTaskMetadataStore.getSync(recoveryNodeMetadata.recoveryTaskName);
 
-      boolean success = handleRecoveryTask(recoveryTaskMetadata);
-      if (success) {
-        // delete the completed recovery task on success
+      if (!isValidRecoveryTask(recoveryTaskMetadata)) {
+        LOG.error(
+            "Invalid recovery task detected, skipping and deleting invalid task {}",
+            recoveryTaskMetadata);
         recoveryTaskMetadataStore.deleteSync(recoveryTaskMetadata.name);
         setRecoveryNodeMetadataState(Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE);
-        recoveryNodeAssignmentSuccess.increment();
-      } else {
-        setRecoveryNodeMetadataState(Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE);
         recoveryNodeAssignmentFailed.increment();
+      } else {
+        boolean success = handleRecoveryTask(recoveryTaskMetadata);
+        if (success) {
+          // delete the completed recovery task on success
+          recoveryTaskMetadataStore.deleteSync(recoveryTaskMetadata.name);
+          setRecoveryNodeMetadataState(Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE);
+          recoveryNodeAssignmentSuccess.increment();
+        } else {
+          setRecoveryNodeMetadataState(Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE);
+          recoveryNodeAssignmentFailed.increment();
+        }
       }
     } catch (Exception e) {
       setRecoveryNodeMetadataState(Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE);
       LOG.error("Failed to complete recovery node task assignment", e);
       recoveryNodeAssignmentFailed.increment();
     }
+  }
+
+  /**
+   * Attempts a final sanity-check on the recovery task to prevent a bad task from halting the
+   * recovery pipeline. Bad state should be ideally prevented at the creation, as well as prior to
+   * assignment, but this can be considered a final fail-safe if invalid recovery tasks somehow made
+   * it this far.
+   */
+  private boolean isValidRecoveryTask(RecoveryTaskMetadata recoveryTaskMetadata) {
+    // todo - consider adding further invalid recovery task detections
+    if (recoveryTaskMetadata.endOffset <= recoveryTaskMetadata.startOffset) {
+      return false;
+    }
+    return true;
   }
 
   /**

--- a/kaldb/src/main/java/com/slack/kaldb/server/RecoveryTaskCreator.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/RecoveryTaskCreator.java
@@ -218,8 +218,10 @@ public class RecoveryTaskCreator {
       } else if (indexerConfig.getCreateRecoveryTasksOnStart()
           && indexerConfig.getReadFromLocationOnStart()
               == KaldbConfigs.KafkaOffsetLocation.LATEST) {
-        // todo - this appears to be able to create recovery tasks that have a start and end
-        // position of 0, which is invalid
+        // Todo - this appears to be able to create recovery tasks that have a start and end
+        // position of 0, which is invalid. This seems to occur when new clusters are initialized,
+        // and is  especially problematic when indexers are created but never get assigned (ie,
+        // deploy 5, only assign 3).
         LOG.info(
             "CreateRecoveryTasksOnStart is set and ReadLocationOnStart is set to current. Reading from current and"
                 + " spinning up recovery tasks");

--- a/kaldb/src/main/java/com/slack/kaldb/server/RecoveryTaskCreator.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/RecoveryTaskCreator.java
@@ -218,6 +218,8 @@ public class RecoveryTaskCreator {
       } else if (indexerConfig.getCreateRecoveryTasksOnStart()
           && indexerConfig.getReadFromLocationOnStart()
               == KaldbConfigs.KafkaOffsetLocation.LATEST) {
+        // todo - this appears to be able to create recovery tasks that have a start and end
+        // position of 0, which is invalid
         LOG.info(
             "CreateRecoveryTasksOnStart is set and ReadLocationOnStart is set to current. Reading from current and"
                 + " spinning up recovery tasks");


### PR DESCRIPTION
###  Summary

Add detection for previously created bad recovery tasks. This should be solved in several places, but should unblock current deploys were bad recovery tasks exist.