### PR TITLE
make rate limit error code configurable

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -141,3 +141,4 @@ preprocessorConfig:
   rateLimiterMaxBurstSeconds: ${PREPROCESSOR_RATE_LIMITER_MAX_BURST_SECONDS:-1}
   kafkaPartitionStickyTimeoutMs: ${KAFKA_PARTITION_STICKY_TIMEOUT_MS:-0}
   useBulkApi: ${KALDB_PREPROCESSOR_USE_BULK_API:-false}
+  rateLimitExceededErrorCode: ${KALDB_PREPROCESSOR_RATE_LIMIT_EXCEEDED_ERROR_CODE:-400}

--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -399,7 +399,11 @@ public class Kaldb {
         services.add(datasetRateLimitingService);
 
         BulkIngestApi openSearchBulkApiService =
-            new BulkIngestApi(bulkIngestKafkaProducer, datasetRateLimitingService, meterRegistry);
+            new BulkIngestApi(
+                bulkIngestKafkaProducer,
+                datasetRateLimitingService,
+                meterRegistry,
+                preprocessorConfig.getRateLimitExceededErrorCode());
         armeriaServiceBuilder.withAnnotatedService(openSearchBulkApiService);
       } else {
         PreprocessorService preprocessorService =

--- a/kaldb/src/main/proto/kaldb_configs.proto
+++ b/kaldb/src/main/proto/kaldb_configs.proto
@@ -270,4 +270,10 @@ message PreprocessorConfig {
   // we plan on moving everything to the bulk API and removing KafkaStreamConfig in the future
   KafkaConfig kafka_config = 9;
   bool use_bulk_api = 10;
+
+  // Make the rate limit exceeded error code confugurable
+  // We default to 400 to prioritize fresh logs and drop excess logs
+  // Set this to 429 for clients to retry the request after a delay
+  // Only used when we use the bulk API
+  int32 rate_limit_exceeded_error_code = 11;
 }

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbConfigTest.java
@@ -295,6 +295,7 @@ public class KaldbConfigTest {
     assertThat(preprocessorConfig.getDataTransformer()).isEqualTo("api_log");
     assertThat(preprocessorConfig.getRateLimiterMaxBurstSeconds()).isEqualTo(2);
     assertThat(preprocessorConfig.getUseBulkApi()).isEqualTo(false);
+    assertThat(preprocessorConfig.getRateLimitExceededErrorCode()).isEqualTo(400);
 
     final KaldbConfigs.KafkaConfig preprocessorKafkaConfig =
         config.getPreprocessorConfig().getKafkaConfig();
@@ -476,6 +477,7 @@ public class KaldbConfigTest {
     assertThat(preprocessorKafkaConfig.getKafkaTopic()).isEqualTo("test-topic");
 
     assertThat(preprocessorConfig.getUseBulkApi()).isEqualTo(true);
+    assertThat(preprocessorConfig.getRateLimitExceededErrorCode()).isEqualTo(429);
 
     final KaldbConfigs.ServerConfig preprocessorServerConfig = preprocessorConfig.getServerConfig();
     assertThat(preprocessorServerConfig.getServerPort()).isEqualTo(8085);

--- a/kaldb/src/test/java/com/slack/kaldb/util/TestingZKServer.java
+++ b/kaldb/src/test/java/com/slack/kaldb/util/TestingZKServer.java
@@ -1,0 +1,34 @@
+package com.slack.kaldb.util;
+
+import static org.assertj.core.api.Assertions.fail;
+
+import org.apache.curator.test.TestingServer;
+
+/**
+ * This class is responsible for creating a testing ZK server for testing purposes. We create the ZK
+ * server in a separate thread to avoid blocking the main thread. This improves the reliability of
+ * the tests i.e I can put a debug point while running a test and ZKServer won't get blocked.
+ * ZkServer getting blocked leads to a session expiry which will cause curator(the client) to
+ * disconnect and call the runtime halter
+ */
+public class TestingZKServer {
+
+  public static TestingServer createTestingServer() throws InterruptedException {
+    ZKTestingServer zkTestingServer = new ZKTestingServer();
+    Thread.ofVirtual().start(zkTestingServer).join();
+    return zkTestingServer.zkServer;
+  }
+
+  private static class ZKTestingServer implements Runnable {
+    public TestingServer zkServer;
+
+    @Override
+    public void run() {
+      try {
+        zkServer = new TestingServer();
+      } catch (Exception e) {
+        fail("Failed to start ZK server", e);
+      }
+    }
+  }
+}

--- a/kaldb/src/test/resources/test_config.json
+++ b/kaldb/src/test/resources/test_config.json
@@ -157,7 +157,8 @@
     "dataTransformer": "api_log",
     "rateLimiterMaxBurstSeconds": 2,
     "bootstrapServers": "localhost:9092",
-    "useBulkApi": false
+    "useBulkApi": false,
+    "rateLimitExceededErrorCode": 400
   },
   "clusterConfig": {
     "clusterName": "test_kaldb_json_cluster",

--- a/kaldb/src/test/resources/test_config.yaml
+++ b/kaldb/src/test/resources/test_config.yaml
@@ -128,6 +128,7 @@ preprocessorConfig:
   rateLimiterMaxBurstSeconds: 2
   bootstrapServers: localhost:9092
   useBulkApi: true
+  rateLimitExceededErrorCode: 429
 
 clusterConfig:
   clusterName: "test_kaldb_cluster"


### PR DESCRIPTION
###  Summary

We want to be able to configure how rate limit error HTTP code is sent back to clients. 

Some clients might want to drop logs ( say to prioritize fresh logs ) and some might retry. So making the code configurable