### PR TITLE
Bump hardcoded max rollover time, allow overriding default

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/RecoveryChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/RecoveryChunkManager.java
@@ -41,7 +41,8 @@ import org.slf4j.LoggerFactory;
 public class RecoveryChunkManager<T> extends ChunkManagerBase<T> {
   private static final Logger LOG = LoggerFactory.getLogger(RecoveryChunkManager.class);
   // This field controls the maximum amount of time we wait for a rollover to complete.
-  private static final int MAX_ROLLOVER_MINUTES = 20;
+  private static final int MAX_ROLLOVER_MINUTES =
+      Integer.parseInt(System.getProperty("kalDb.recovery.maxRolloverMins", "90"));
 
   private final ChunkFactory<T> recoveryChunkFactory;
   private final ChunkRolloverFactory chunkRolloverFactory;


### PR DESCRIPTION
###  Summary

Bumps hardcoded max rollover time, and allows overriding default. This was too aggressive depending on specific cluster configurations.