### PR TITLE
Add ID field to search protobuf

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultUtils.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultUtils.java
@@ -655,6 +655,8 @@ public class SearchResultUtils {
       return FieldType.BOOLEAN;
     } else if (protoSchemaDefinition.getType().equals(KaldbSearch.FieldType.DOUBLE)) {
       return FieldType.DOUBLE;
+    } else if (protoSchemaDefinition.getType().equals(KaldbSearch.FieldType.ID)) {
+      return FieldType.ID;
     } else {
       throw new IllegalArgumentException(
           String.format("Field type %s is not a supported type", protoSchemaDefinition.getType()));
@@ -678,6 +680,8 @@ public class SearchResultUtils {
       schemaBuilder.setType(KaldbSearch.FieldType.BOOLEAN);
     } else if (fieldType.equals(FieldType.DOUBLE)) {
       schemaBuilder.setType(KaldbSearch.FieldType.DOUBLE);
+    } else if (fieldType.equals(FieldType.ID)) {
+      schemaBuilder.setType(KaldbSearch.FieldType.ID);
     } else {
       throw new IllegalArgumentException(
           String.format("Field type %s is not a supported type", fieldType));

--- a/kaldb/src/main/proto/kaldb_search.proto
+++ b/kaldb/src/main/proto/kaldb_search.proto
@@ -247,6 +247,7 @@ enum FieldType {
   FLOAT = 4;
   BOOLEAN = 5;
   DOUBLE = 6;
+  ID = 7;
 }
 
 message SchemaDefinition {

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultUtilsTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultUtilsTest.java
@@ -404,6 +404,16 @@ public class SearchResultUtilsTest {
             KaldbSearch.SchemaDefinition.newBuilder()
                 .setType(KaldbSearch.FieldType.INTEGER)
                 .build());
+
+    assertThat(
+            SearchResultUtils.fromSchemaDefinitionProto(
+                KaldbSearch.SchemaDefinition.newBuilder()
+                    .setType(KaldbSearch.FieldType.ID)
+                    .build()))
+        .isEqualTo(FieldType.ID);
+    assertThat(SearchResultUtils.toSchemaDefinitionProto(FieldType.ID))
+        .isEqualTo(
+            KaldbSearch.SchemaDefinition.newBuilder().setType(KaldbSearch.FieldType.ID).build());
   }
 
   @Test


### PR DESCRIPTION
###  Summary

Adds protobuf support for the new ID field, as this is causing exceptions throughout the pipeline.

```java
java.lang.IllegalArgumentException: No enum constant com.slack.kaldb.metadata.schema.FieldType.ID
	at java.base/java.lang.Enum.valueOf(Enum.java:293)
	at com.slack.kaldb.metadata.schema.FieldType.valueOf(FieldType.java:33)
	at com.slack.kaldb.metadata.schema.LuceneFieldDef.<init>(LuceneFieldDef.java:18)
	at com.slack.kaldb.metadata.schema.LuceneFieldDefSerializer.fromLuceneFieldDefProto(LuceneFieldDefSerializer.java:27)
	at com.slack.kaldb.metadata.schema.ChunkSchemaSerializer.fromChunkSchemaProto(ChunkSchemaSerializer.java:32)
	at com.slack.kaldb.metadata.schema.ChunkSchemaSerializer.fromJsonStr(ChunkSchemaSerializer.java:53)
	at com.slack.kaldb.metadata.schema.ChunkSchema.deserializeFile(ChunkSchema.java:27)
	at com.slack.kaldb.chunk.ReadOnlyChunkImpl.handleChunkAssignment(ReadOnlyChunkImpl.java:230)
	at com.slack.kaldb.chunk.ReadOnlyChunkImpl.lambda$cacheNodeListener$0(ReadOnlyChunkImpl.java:146)
	at java.base/java.lang.VirtualThread.run(VirtualThread.java:309)
```