### PR TITLE
Refactor read only chunk timeout

### DIFF
--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultUtilsTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultUtilsTest.java
@@ -404,6 +404,16 @@ public class SearchResultUtilsTest {
             KaldbSearch.SchemaDefinition.newBuilder()
                 .setType(KaldbSearch.FieldType.INTEGER)
                 .build());
+
+    assertThat(
+            SearchResultUtils.fromSchemaDefinitionProto(
+                KaldbSearch.SchemaDefinition.newBuilder()
+                    .setType(KaldbSearch.FieldType.ID)
+                    .build()))
+        .isEqualTo(FieldType.ID);
+    assertThat(SearchResultUtils.toSchemaDefinitionProto(FieldType.ID))
+        .isEqualTo(
+            KaldbSearch.SchemaDefinition.newBuilder().setType(KaldbSearch.FieldType.ID).build());
   }
 
   @Test


### PR DESCRIPTION
###  Summary

Refactors a deprecated class-level timeout, in favor of another global deprecated timeout. We need to remove both, but this prevents us from having separate values - especially since the one is set so aggressively.