### PR TITLE
Fix incorrect unit in recovery timeout

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
@@ -304,7 +304,7 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
     try {
       cacheSlotMetadataStore
           .updateNonFreeCacheSlotState(cacheSlotMetadata, newState)
-          .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.MILLISECONDS);
+          .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
       return true;
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
       LOG.error("Error setting chunk metadata state", e);


### PR DESCRIPTION
###  Summary

Fixes a regression introduce in #768 where the unit change was overlooked.