### PR TITLE
Parse binary data as-is

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/bulkIngestApi/opensearch/BulkApiRequestParser.java
+++ b/kaldb/src/main/java/com/slack/kaldb/bulkIngestApi/opensearch/BulkApiRequestParser.java
@@ -1,5 +1,6 @@
 package com.slack.kaldb.bulkIngestApi.opensearch;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
 import com.slack.kaldb.writer.SpanFormatter;
 import com.slack.service.murron.trace.Trace;
@@ -79,7 +80,8 @@ public class BulkApiRequestParser {
         .toEpochMilli();
   }
 
-  protected static Trace.Span fromIngestDocument(IngestDocument ingestDocument) {
+  @VisibleForTesting
+  public static Trace.Span fromIngestDocument(IngestDocument ingestDocument) {
 
     long timestampInMillis = getTimestampFromIngestDocument(ingestDocument);
 
@@ -139,7 +141,8 @@ public class BulkApiRequestParser {
   }
 
   // only parse IndexRequests
-  protected static IngestDocument convertRequestToDocument(IndexRequest indexRequest) {
+  @VisibleForTesting
+  public static IngestDocument convertRequestToDocument(IndexRequest indexRequest) {
     String index = indexRequest.index();
     String id = indexRequest.id();
     String routing = indexRequest.routing();
@@ -153,7 +156,8 @@ public class BulkApiRequestParser {
     // and transform it
   }
 
-  protected static List<IndexRequest> parseBulkRequest(byte[] postBody) throws IOException {
+  @VisibleForTesting
+  public static List<IndexRequest> parseBulkRequest(byte[] postBody) throws IOException {
     List<IndexRequest> indexRequests = new ArrayList<>();
     BulkRequest bulkRequest = new BulkRequest();
     // calls parse under the hood

--- a/kaldb/src/main/java/com/slack/kaldb/writer/SpanFormatter.java
+++ b/kaldb/src/main/java/com/slack/kaldb/writer/SpanFormatter.java
@@ -195,7 +195,7 @@ public class SpanFormatter {
       } else if (valueType == 3) {
         jsonMap.put(key, tag.getVFloat64());
       } else if (valueType == 4) {
-        jsonMap.put(key, encodeBinaryTagValue(tag.getVBinary()));
+        jsonMap.put(key, tag.getVBinary().toStringUtf8());
       } else {
         LOG.warn("Skipping field with unknown value type {} with key {}", valueType, key);
       }

--- a/kaldb/src/test/java/com/slack/kaldb/writer/SpanFormatterTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/writer/SpanFormatterTest.java
@@ -3,15 +3,12 @@ package com.slack.kaldb.writer;
 import static com.slack.kaldb.testlib.SpanUtil.BINARY_TAG_VALUE;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.protobuf.ByteString;
 import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.testlib.SpanUtil;
 import com.slack.service.murron.trace.Trace;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -59,10 +56,7 @@ public class SpanFormatterTest {
     assertThat(source.get("int")).isEqualTo(1000L);
     assertThat(source.get("float")).isEqualTo(1001.2);
     String binaryTagValue = (String) source.get("binary");
-    assertThat(binaryTagValue)
-        .isEqualTo(SpanFormatter.encodeBinaryTagValue(ByteString.copyFromUtf8(BINARY_TAG_VALUE)));
-    assertThat(new String(Base64.getDecoder().decode(binaryTagValue), StandardCharsets.UTF_8))
-        .isEqualTo(BINARY_TAG_VALUE);
+    assertThat(binaryTagValue).isEqualTo(BINARY_TAG_VALUE);
   }
 
   @Test
@@ -104,10 +98,7 @@ public class SpanFormatterTest {
     assertThat(source.get("int")).isEqualTo(1000L);
     assertThat(source.get("float")).isEqualTo(1001.2);
     String binaryTagValue = (String) source.get("binary");
-    assertThat(binaryTagValue)
-        .isEqualTo(SpanFormatter.encodeBinaryTagValue(ByteString.copyFromUtf8(BINARY_TAG_VALUE)));
-    assertThat(new String(Base64.getDecoder().decode(binaryTagValue), StandardCharsets.UTF_8))
-        .isEqualTo(BINARY_TAG_VALUE);
+    assertThat(binaryTagValue).isEqualTo(BINARY_TAG_VALUE);
   }
 
   @Test
@@ -180,10 +171,7 @@ public class SpanFormatterTest {
       assertThat(source.get("int")).isEqualTo(1000L);
       assertThat(source.get("float")).isEqualTo(1001.2);
       String binaryTagValue = (String) source.get("binary");
-      assertThat(binaryTagValue)
-          .isEqualTo(SpanFormatter.encodeBinaryTagValue(ByteString.copyFromUtf8(BINARY_TAG_VALUE)));
-      assertThat(new String(Base64.getDecoder().decode(binaryTagValue), StandardCharsets.UTF_8))
-          .isEqualTo(BINARY_TAG_VALUE);
+      assertThat(binaryTagValue).isEqualTo(BINARY_TAG_VALUE);
     }
   }
 
@@ -230,10 +218,7 @@ public class SpanFormatterTest {
     assertThat(source.get("int")).isEqualTo(1000L);
     assertThat(source.get("float")).isEqualTo(1001.2);
     String binaryTagValue = (String) source.get("binary");
-    assertThat(binaryTagValue)
-        .isEqualTo(SpanFormatter.encodeBinaryTagValue(ByteString.copyFromUtf8(BINARY_TAG_VALUE)));
-    assertThat(new String(Base64.getDecoder().decode(binaryTagValue), StandardCharsets.UTF_8))
-        .isEqualTo(BINARY_TAG_VALUE);
+    assertThat(binaryTagValue).isEqualTo(BINARY_TAG_VALUE);
   }
 
   @Test


### PR DESCRIPTION
###  Summary

Some fields that are nested in the request, get encoded as binary data. This PR changes that to atleast be the string representation of the values.

In the future we want to support nested fields, though we have some support today it's not fully baked in to the bulk request parsing layer
