### PR TITLE
add enable-preview to the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ RUN cd /work; mvn package -DskipTests
 FROM amazoncorretto:21
 COPY --from=build /work/kaldb/target/kaldb.jar /
 COPY --from=build /work/config/config.yaml /
-ENTRYPOINT [ "java", "-jar", "./kaldb.jar", "config.yaml" ]
+ENTRYPOINT [ "java", "--enable-preview", "-jar", "./kaldb.jar", "config.yaml" ]


### PR DESCRIPTION
###  Summary
Fixes https://github.com/slackhq/kaldb/issues/775

Dockerfile missing flag enable-preview causes runtime error. This allows the docker image to be run.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
