### PR TITLE
Introduce int and float types to trace.proto

### DIFF
--- a/kaldb/src/main/proto/trace.proto
+++ b/kaldb/src/main/proto/trace.proto
@@ -21,6 +21,8 @@ enum ValueType {
   INT64   = 2;
   FLOAT64 = 3;
   BINARY  = 4;
+  INT32   = 5;
+  FLOAT32 = 6;
 };
 
 message KeyValue {
@@ -31,6 +33,8 @@ message KeyValue {
   int64     v_int64   = 5;
   double    v_float64 = 6;
   bytes     v_binary  = 7;
+  int32     v_int32   = 8;
+  float     v_float32 = 9;
 }
 
 // A span defines a single event in a trace.


### PR DESCRIPTION
###  Summary

Part 1 - Introduce int and float types to trace.proto

**Kaldb Schema PR breakdown** - 5 part series to introduce schema configs to Kaldb
1. introduce a concept of int and float to trace.proto
2. remove the concept of index transformer - it's always trace.span
3. use trace.span to create lucene documents instead of LogMessage
4. insert schema info to trace.proto in the preprocssor
5. leverage schema in the indexer