### PR TITLE
Set ID if it's not present in the document

### DIFF
--- a/astra/src/main/java/com/slack/astra/bulkIngestApi/opensearch/BulkApiRequestParser.java
+++ b/astra/src/main/java/com/slack/astra/bulkIngestApi/opensearch/BulkApiRequestParser.java
@@ -72,7 +72,8 @@ public class BulkApiRequestParser {
 
     // See https://blog.mikemccandless.com/2014/05/choosing-fast-unique-identifier-uuid.html on how
     // to improve this
-    String id = Optional.ofNullable(sourceAndMetadata.get(IngestDocument.Metadata.ID.getFieldName()))
+    String id =
+        Optional.ofNullable(sourceAndMetadata.get(IngestDocument.Metadata.ID.getFieldName()))
             .map(String::valueOf)
             .orElse(UUID.randomUUID().toString());
 


### PR DESCRIPTION
###  Summary
Currently we're setting the `_id` to `"null"` if it's not present in the `IngestDocument`, rather than setting it to the UUID like we previously were. This PR restores that previous behavior

### Requirements

* [X] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
