### PR TITLE
Fix terms aggregations on indexers

### DIFF
--- a/astra/src/main/java/com/slack/astra/logstore/LuceneIndexStoreImpl.java
+++ b/astra/src/main/java/com/slack/astra/logstore/LuceneIndexStoreImpl.java
@@ -144,7 +144,10 @@ public class LuceneIndexStoreImpl implements LogStore {
     RedactionFilterDirectoryReader reader =
         new RedactionFilterDirectoryReader(
             DirectoryReader.open(indexWriter.get(), false, false), fieldRedactionMetadataStore);
-    OpenSearchDirectoryReader openSearchDirectoryReader = OpenSearchDirectoryReader.wrap(reader, ShardId.fromString("[shard-index][%d]".formatted(UUID.fromString(id).hashCode())));
+    OpenSearchDirectoryReader openSearchDirectoryReader =
+        OpenSearchDirectoryReader.wrap(
+            reader,
+            ShardId.fromString("[shard-index][%d]".formatted(UUID.fromString(id).hashCode())));
     this.searcherManager = new SearcherManager(openSearchDirectoryReader, null);
 
     scheduledCommit.scheduleWithFixedDelay(


### PR DESCRIPTION
###  Summary
After we swapped out our custom aggregation logic for OpenSearch's, we've been running into issues with terms aggregations on indexers. After diving deep into the code, it looks like OpenSearch expects ValueSource aggregations to be wrapped in an `OpenSearchDirectoryReader`. As such, this PR wraps it in that class, providing the Astra index id as the "shard id" (since that's the closest approximation we have to a shard). 

### Requirements

* [X] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
