### PR TITLE
Fix build in GHA

### DIFF
--- a/astra/src/test/java/com/slack/astra/chunkManager/CachingChunkManagerTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkManager/CachingChunkManagerTest.java
@@ -81,7 +81,6 @@ public class CachingChunkManagerTest {
 
   @BeforeEach
   public void startup() throws Exception {
-    System.out.println("Test change");
     meterRegistry = new SimpleMeterRegistry();
     testingServer = new TestingServer();
 


### PR DESCRIPTION
###  Summary
Currently builds in GHA are broken for some reason. We believe this was caused by the `ubuntu-latest` version we're pinned on being updated from 22.04 to 24.04 over the holiday break. This change pins it back to 22.04

### Requirements
* [X] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
