### PR TITLE
Fix the unstable tagging Github Action

### DIFF
--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Update unstable tag
         uses: actions/github-script@v5
         with:


### PR DESCRIPTION
###  Summary
Apparently by default the Github Actions `checkout` action explicitly doesn't pull down tags, which this Action needs. It looks like to pull down tags, we need to add `fetch-depth` to be set to `0` (docs: https://github.com/actions/checkout?tab=readme-ov-file#fetch-all-history-for-all-tags-and-branches). As such, this PR adds that in

### Requirements

* [X] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
