### PR TITLE
Fix the unstable Github Action

### DIFF
--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -24,7 +24,7 @@ jobs:
             github.rest.git.updateRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: 'refs/tags/unstable',
+              ref: 'tags/unstable',
               force: true,
               sha: context.sha
             })


### PR DESCRIPTION
###  Summary
We've been having our Github Action that tags latest with `unstable` failing, despite using the API as the documentation describes. It looks like according to [this bug report](https://www.github.com/octokit/rest.js/issues/339), the issue is a bug in the underlying REST library and can be worked around by not passing in the tag as `refs/tags/{tag}`, but instead as `tags/{tag}`

### Requirements

* [X] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
