### PR TITLE
Handle a race condition in rate limiter creation

### DIFF
--- a/astra/src/main/java/com/slack/astra/bulkIngestApi/DatasetRateLimitingService.java
+++ b/astra/src/main/java/com/slack/astra/bulkIngestApi/DatasetRateLimitingService.java
@@ -76,7 +76,7 @@ public class DatasetRateLimitingService extends AbstractScheduledService {
     }
 
     // Only recreate the rate limiter if we have to
-    if (preprocessorCountValue == lastKnownPreprocessorCount) {
+    if (preprocessorCountValue == lastKnownPreprocessorCount && rateLimiterPredicate != null) {
       return;
     }
 


### PR DESCRIPTION
###  Summary
There's a slight race condition in our new rate limiting code where we can end up skipping creating the rate limiter (due to the initial value and the returned value from the `listSync` being the same when a cluster is spinning up from scratch), which eventually triggers an NPE. This PR fixes that by always creating a rate limiter if one currently doesn't exist

### Requirements

* [X] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
