### PR TITLE
Create the rate limiter on startup

### DIFF
--- a/astra/src/main/java/com/slack/astra/bulkIngestApi/DatasetRateLimitingService.java
+++ b/astra/src/main/java/com/slack/astra/bulkIngestApi/DatasetRateLimitingService.java
@@ -120,6 +120,8 @@ public class DatasetRateLimitingService extends AbstractScheduledService {
 
   @Override
   protected void startUp() throws Exception {
+    updateDatasetMetadataList();
+
     datasetMetadataStore.addListener(datasetListener);
     this.preprocessorMetadataStore.addListener(preprocessorListener);
 


### PR DESCRIPTION
###  Summary
It looks like in the rate limiter refactor, we accidentally removed this line that creates the rate limiter on startup, which causes a race condition that can cause another NPE. This PR patches that

### Requirements

* [X] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
