### PR TITLE
Properly close things if there was an exception loading the schema

### DIFF
--- a/astra/src/main/java/com/slack/astra/logstore/search/LogIndexSearcherImpl.java
+++ b/astra/src/main/java/com/slack/astra/logstore/search/LogIndexSearcherImpl.java
@@ -74,7 +74,14 @@ public class LogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
     this.searcherManager.addListener(refreshListener);
     // initialize the adapter with whatever the default schema is
 
-    openSearchAdapter.loadSchema();
+    try {
+      openSearchAdapter.loadSchema();
+    } catch (Exception e) {
+      LOG.error("Failed to load schema due to error:", e);
+      this.close();
+
+      throw new RuntimeException(e);
+    }
   }
 
   @Override


### PR DESCRIPTION
###  Summary
In trying to hunt down where our file handle leak was, we've found that when the schema gets loaded, if the schema is invalid (say it has too many fields), we throw an exception here and _don't_ properly close the resources. While that's a true higher up the call stack as well, this is meant to be a targeted PR to fix this exact issue without interfering with the current behavior elsewhere

### Requirements

* [X] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
