### PR TITLE
Lower default `CacheNodeSearchabilityService` config value to 1 min

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -102,7 +102,7 @@ managerConfig:
     replicaLifespanMins: ${ASTRA_MANAGER_REPLICA_RESTORE_LIFESPAN_MINS:-60}
     replicaSets: [${ASTRA_MANAGER_REPLICA_SETS:-rep1}]
   cacheNodeSearchabilityServiceConfig:
-    schedulePeriodMins: ${ASTRA_MANAGER_SEARCHABILITY_PERIOD_MINS:-15}
+    schedulePeriodMins: ${ASTRA_MANAGER_SEARCHABILITY_PERIOD_MINS:-1}
   cacheNodeAssignmentServiceConfig:
     schedulePeriodMins: ${ASTRA_MANAGER_ASSIGNMENT_PERIOD_MINS:-15}
     replicaSets: [${ASTRA_MANAGER_REPLICA_SETS:-rep1}]


### PR DESCRIPTION
###  Summary
Lowers it to 1 min instead of 15 min

### Requirements

* [X] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
