### PR TITLE
Create MetricsFactory to provide a centralized registry for metrics

### DIFF
--- a/astra/src/main/java/com/slack/astra/util/MetricsFactory.java
+++ b/astra/src/main/java/com/slack/astra/util/MetricsFactory.java
@@ -1,0 +1,49 @@
+package com.slack.astra.util;
+
+import com.slack.astra.proto.config.AstraConfigs;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import org.apache.logging.log4j.util.Strings;
+
+public class MetricsFactory {
+  private static PrometheusMeterRegistry _instance = null;
+
+  public static void init(AstraConfigs.AstraConfig config) {
+    if (_instance == null) {
+      _instance = initPrometheusMeterRegistry(config);
+    }
+  }
+
+  private static PrometheusMeterRegistry initPrometheusMeterRegistry(
+      AstraConfigs.AstraConfig config) {
+    PrometheusMeterRegistry prometheusMeterRegistry =
+        new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+    prometheusMeterRegistry
+        .config()
+        .commonTags(
+            "astra_cluster_name",
+            config.getClusterConfig().getClusterName(),
+            "astra_env",
+            config.getClusterConfig().getEnv(),
+            "astra_component",
+            getComponentTag(config));
+    return prometheusMeterRegistry;
+  }
+
+  private static String getComponentTag(AstraConfigs.AstraConfig config) {
+    String component;
+    if (config.getNodeRolesList().size() == 1) {
+      component = config.getNodeRolesList().get(0).toString();
+    } else {
+      component = Strings.join(config.getNodeRolesList(), '-');
+    }
+    return Strings.toRootLowerCase(component);
+  }
+
+  public static PrometheusMeterRegistry getRegistry() {
+    if (_instance == null) {
+      throw new IllegalStateException("MetricsFactory not initialized");
+    }
+    return _instance;
+  }
+}


### PR DESCRIPTION
This change extracts the Prometheus registry initialization code from Astra.java into a new MetricsFactory class that provides global access to the metrics registry. Similar to logging implementations, this allows components across the application to access a shared meter registry without having to pass it through constructors.

Benefits:
- Provides static access to metrics registry similar to the logger pattern
- Ensures consistent configuration of the registry across the application
- Centralizes tag management for better metrics organization
- Simplifies instantiation of meter objects in new components

###  Summary

Describe the goal of this PR. Mention any related Issue numbers.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
