### PR TITLE
Surrounded the query gating code with a feature flag

### DIFF
--- a/astra/src/main/java/com/slack/astra/logstore/search/AstraDistributedQueryService.java
+++ b/astra/src/main/java/com/slack/astra/logstore/search/AstraDistributedQueryService.java
@@ -54,6 +54,8 @@ public class AstraDistributedQueryService extends AstraQueryServiceBase implemen
 
   private static final Logger LOG = LoggerFactory.getLogger(AstraDistributedQueryService.class);
 
+  public static final String ASTRA_ENABLE_QUERY_GATING_FLAG = "astra.enableQueryGating";
+
   private final SearchMetadataStore searchMetadataStore;
   private final SnapshotMetadataStore snapshotMetadataStore;
   private final DatasetMetadataStore datasetMetadataStore;
@@ -154,7 +156,8 @@ public class AstraDistributedQueryService extends AstraQueryServiceBase implemen
           .listSync()
           .forEach(
               searchMetadata -> {
-                if (searchMetadata.isSearchable()) {
+                if (!Boolean.getBoolean(ASTRA_ENABLE_QUERY_GATING_FLAG)
+                    || searchMetadata.isSearchable()) {
                   latestSearchServers.add(searchMetadata.url);
                 }
               });
@@ -245,7 +248,7 @@ public class AstraDistributedQueryService extends AstraQueryServiceBase implemen
         continue;
       }
 
-      if (!searchMetadata.isSearchable()) {
+      if (Boolean.getBoolean(ASTRA_ENABLE_QUERY_GATING_FLAG) && !searchMetadata.isSearchable()) {
         LOG.info(
             "Skipping searching search metadata={} because it's not searchable!",
             searchMetadata.name);


### PR DESCRIPTION
###  Summary
This PR surrounds the query gating code (though not the code that sets the metadata in ZK) with a feature flag to allow folks to choose whether to enable it or not.

### Requirements

* [X] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
