### PR TITLE
Increase etcd lease renewal timeout

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -73,7 +73,7 @@ metadataStoreConfig:
     retryDelayMs: ${ASTRA_ETCD_RETRY_DELAY_MS:-100}
     operationsTimeoutMs: ${ASTRA_ETCD_OPERATIONS_TIMEOUT_MS:-60000}
     operationsMaxRetries: ${ASTRA_ETCD_OPERATIONS_MAX_RETRIES:-3}
-    ephemeralNodeTtlMs: ${ASTRA_ETCD_EPHEMERAL_NODE_TTL_MS:-60000}
+    ephemeralNodeTtlMs: ${ASTRA_ETCD_EPHEMERAL_NODE_TTL_MS:-90000}
     ephemeralNodeMaxRetries: ${ASTRA_ETCD_EPHEMERAL_NODE_MAX_RETRIES:-3}
   storeModes:
     DatasetMetadataStore: ${ASTRA_DATASET_METADATA_STORE_MODE:-ZOOKEEPER_CREATES}


### PR DESCRIPTION
###  Summary
We are seeing large or full cluster restarts due to slow etcd leader changes causing the Astra nodes to hit the ETCD ephemeral lease renewal timeout. This is a potentially temporary fix while we tune ETCD.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
