### PR TITLE
etcd: replace fixed-delay watch retry with exponential backoff + jitter

### DIFF
--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
@@ -1066,6 +1066,13 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
           storeFolder,
           currentRevision + 1);
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      if (isClosing || Thread.currentThread().isInterrupted()) {
+        LOG.warn(
+            "Ignoring revision fetch error during shutdown for store {}: {}",
+            storeFolder,
+            e.getMessage());
+        return;
+      }
       LOG.error("Failed to get current revision for watch setup on store {}", storeFolder, e);
       watchRetryError.increment();
       if (!scheduleRetryWithBackoff(

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
@@ -1067,9 +1067,6 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
           currentRevision + 1);
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
       LOG.error("Failed to get current revision for watch setup on store {}", storeFolder, e);
-      if (e instanceof InterruptedException) {
-        Thread.currentThread().interrupt();
-      }
       watchRetryError.increment();
       if (!scheduleRetryWithBackoff(
           retryState.errorBackoff,

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
@@ -2,6 +2,8 @@ package com.slack.astra.metadata.core;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.slack.astra.proto.config.AstraConfigs.EtcdConfig;
+import com.slack.astra.util.ExponentialBackOff;
+import com.slack.astra.util.FatalErrorHandler;
 import com.slack.astra.util.RuntimeHalterImpl;
 import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.Client;
@@ -13,13 +15,18 @@ import io.etcd.jetcd.options.GetOption;
 import io.etcd.jetcd.options.PutOption;
 import io.etcd.jetcd.options.WatchOption;
 import io.etcd.jetcd.watch.WatchEvent;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import java.io.Closeable;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
@@ -30,6 +37,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,16 +88,41 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
   protected final boolean shouldCache;
   protected final MetadataSerializer<T> serializer;
   private final long etcdOperationTimeoutMs;
-  private final int etcdOperationsMaxRetries;
-  private final long retryDelayMs;
+  private final long retryTotalDurationMs;
+  private final long maxRetryDelayMs;
+  private final long initialRetryIntervalMs;
+  private final ExponentialBackOff keepAliveBackoff;
+
+  /** Fetch the current etcd revision (keysOnly) and watch from there. Does not touch the cache. */
+  private static final long REVISION_LATEST = 0;
+
+  /**
+   * Re-list all keys from etcd, diff against the in-memory cache, and watch from the list revision.
+   * Used on compaction recovery where the watcher's old revision has been compacted away.
+   */
+  private static final long REVISION_RESYNC = -1;
+
+  static final long DEFAULT_RETRY_TOTAL_DURATION_MS = 60_000;
+  static final long DEFAULT_MAX_RETRY_DELAY_MS = 10_000;
+  static final long DEFAULT_INITIAL_RETRY_INTERVAL_MS = 2_000;
+
+  private static volatile FatalErrorHandler fatalErrorHandler = new RuntimeHalterImpl();
+
+  static void setFatalErrorHandler(FatalErrorHandler handler) {
+    fatalErrorHandler = handler;
+  }
+
+  static void resetFatalErrorHandler() {
+    fatalErrorHandler = new RuntimeHalterImpl();
+  }
+
+  static long positiveOrDefault(long value, long defaultValue) {
+    return value > 0 ? value : defaultValue;
+  }
 
   private final MeterRegistry meterRegistry;
 
   private final CountDownLatch cacheInitialized = new CountDownLatch(1);
-
-  // These fields are no longer used but kept for compatibility
-  private volatile Thread cacheInitThread = null;
-  private volatile Thread leaseInitThread = null;
 
   private final String ASTRA_ETCD_CREATE_CALL = "astra_etcd_create_call";
   private final String ASTRA_ETCD_HAS_CALL = "astra_etcd_has_call";
@@ -103,6 +136,10 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
   private final String ASTRA_ETCD_LEASE_REFRESH_HANDLER_FIRED =
       "astra_etcd_lease_refresh_handler_fired";
 
+  private static final String ASTRA_ETCD_WATCH_RETRY = "astra_etcd_watch_retry";
+  private static final String ASTRA_ETCD_WATCH_RETRY_DELAY = "astra_etcd_watch_retry_delay";
+  private static final String ASTRA_ETCD_RESYNC_SKIP = "astra_etcd_resync_skip";
+
   private final Counter createCall;
   private final Counter hasCall;
   private final Counter deleteCall;
@@ -113,6 +150,11 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
   private final Counter removedListener;
   private final Counter cacheInitHandlerFired;
   private final Counter leaseRefreshHandlerFired;
+  private final Counter watchRetryError;
+  private final Counter watchRetryCompaction;
+  private final Counter watchRetryGracefulStop;
+  private final Timer watchRetryDelay;
+  private final Counter resyncSkip;
 
   /** Constructor that accepts an external etcd client instance with default persistent mode. */
   public EtcdMetadataStore(
@@ -151,9 +193,14 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
     this.ephemeralTtlMs = config.getEphemeralNodeTtlMs();
     this.etcdOperationTimeoutMs = config.getOperationsTimeoutMs();
 
-    // Store retry configuration for watch operations
-    this.etcdOperationsMaxRetries = Math.max(0, config.getOperationsMaxRetries());
-    this.retryDelayMs = Math.max(0, config.getRetryDelayMs());
+    this.retryTotalDurationMs =
+        positiveOrDefault(config.getRetryTotalDurationMs(), DEFAULT_RETRY_TOTAL_DURATION_MS);
+    this.maxRetryDelayMs =
+        positiveOrDefault(config.getMaxRetryDelayMs(), DEFAULT_MAX_RETRY_DELAY_MS);
+    this.initialRetryIntervalMs =
+        positiveOrDefault(config.getInitialRetryIntervalMs(), DEFAULT_INITIAL_RETRY_INTERVAL_MS);
+    this.keepAliveBackoff =
+        new ExponentialBackOff(initialRetryIntervalMs, maxRetryDelayMs, retryTotalDurationMs);
 
     String store = "/" + storeFolder.split("/")[1];
     this.createCall = this.meterRegistry.counter(ASTRA_ETCD_CREATE_CALL, "store", store);
@@ -168,6 +215,15 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
         this.meterRegistry.counter(ASTRA_ETCD_CACHE_INIT_HANDLER_FIRED, "store", store);
     this.leaseRefreshHandlerFired =
         this.meterRegistry.counter(ASTRA_ETCD_LEASE_REFRESH_HANDLER_FIRED, "store", store);
+    this.watchRetryError =
+        this.meterRegistry.counter(ASTRA_ETCD_WATCH_RETRY, "store", store, "reason", "error");
+    this.watchRetryCompaction =
+        this.meterRegistry.counter(ASTRA_ETCD_WATCH_RETRY, "store", store, "reason", "compaction");
+    this.watchRetryGracefulStop =
+        this.meterRegistry.counter(
+            ASTRA_ETCD_WATCH_RETRY, "store", store, "reason", "graceful_stop");
+    this.watchRetryDelay = this.meterRegistry.timer(ASTRA_ETCD_WATCH_RETRY_DELAY, "store", store);
+    this.resyncSkip = this.meterRegistry.counter(ASTRA_ETCD_RESYNC_SKIP, "store", store);
 
     if (etcdClient == null) {
       throw new IllegalArgumentException("External etcd client must be provided");
@@ -182,7 +238,7 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
     // Initialize watch retry executor - scheduled cached thread pool that scales to 0
     this.watchRetryExecutor =
         Executors.newScheduledThreadPool(
-            0, // Use 0 core threads so it can scale down completely
+            1,
             r -> {
               Thread t = new Thread(r);
               t.setDaemon(true);
@@ -226,6 +282,70 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
     }
   }
 
+  /** Closes a watcher, suppressing any exception. */
+  private static void closeQuietly(Watcher watcher) {
+    if (watcher != null) {
+      try {
+        watcher.close();
+      } catch (Exception e) {
+        LOG.debug("Error closing watcher", e);
+      }
+    }
+  }
+
+  static void handleFatalAsync(Throwable error, String threadNameSuffix) {
+    LOG.error("Fatal error detected ({}), initiating shutdown", threadNameSuffix, error);
+    Thread t = new Thread(() -> fatalErrorHandler.handleFatal(error));
+    t.setName("etcd-fatal-" + threadNameSuffix);
+    t.setDaemon(true);
+    t.start();
+  }
+
+  /**
+   * Attempts to schedule a retry using the given backoff. Returns true if a retry was scheduled,
+   * false if the backoff budget is exhausted (caller should handle escalation).
+   */
+  private boolean scheduleRetryWithBackoff(
+      ExponentialBackOff backoff, Runnable retryAction, String context) {
+    long delayMs = backoff.nextBackOffMillis();
+    if (delayMs == ExponentialBackOff.STOP) {
+      return false;
+    }
+    watchRetryDelay.record(delayMs, TimeUnit.MILLISECONDS);
+    LOG.warn(
+        "{} — retrying in {} ms ({} ms elapsed)", context, delayMs, backoff.getElapsedTimeMs());
+    try {
+      watchRetryExecutor.schedule(retryAction, delayMs, TimeUnit.MILLISECONDS);
+    } catch (java.util.concurrent.RejectedExecutionException e) {
+      LOG.warn("Retry executor already shut down for {}, retry not scheduled", storeFolder);
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Detects whether a watch error is caused by etcd key-space compaction. When etcd compacts, any
+   * watcher holding a revision older than the compacted revision gets an OUT_OF_RANGE error.
+   */
+  static boolean isCompactionError(Throwable error) {
+    if (error instanceof StatusRuntimeException sre) {
+      return sre.getStatus().getCode() == Status.Code.OUT_OF_RANGE;
+    }
+    String msg = error.getMessage();
+    return msg != null && msg.contains("compacted");
+  }
+
+  /**
+   * Detects whether a watch error is a graceful GOAWAY from an etcd node shutting down cleanly.
+   * This is not a real error — it's HTTP/2's way of saying "I'm leaving, reconnect elsewhere." The
+   * error message from jetcd looks like: "Connection closed after GOAWAY. HTTP/2 error code:
+   * NO_ERROR, debug data: graceful_stop"
+   */
+  static boolean isGracefulStop(Throwable error) {
+    String msg = error.getMessage();
+    return msg != null && msg.contains("NO_ERROR") && msg.contains("graceful_stop");
+  }
+
   /** Creates KeepAlive GRPC connection and handles error and completed cases */
   private void startKeepAlive() {
     this.etcdClient
@@ -239,6 +359,7 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
                     "Received keepAlive response for lease {}, TTL: {}",
                     response.getID(),
                     response.getTTL());
+                keepAliveBackoff.reset();
                 leaseRefreshHandlerFired.increment();
               }
 
@@ -250,16 +371,33 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
                       sharedLeaseId);
                   return;
                 }
-                LOG.error(
-                    "Error in keepAlive stream for shared lease {}: {}",
+                long delayMs = keepAliveBackoff.nextBackOffMillis();
+                if (delayMs == ExponentialBackOff.STOP) {
+                  LOG.error(
+                      "KeepAlive retry budget exhausted for lease {} after {} ms — failing fatally",
+                      sharedLeaseId,
+                      keepAliveBackoff.getElapsedTimeMs());
+                  handleFatalAsync(t, "keepalive-" + sharedLeaseId);
+                  return;
+                }
+                LOG.warn(
+                    "KeepAlive error for lease {}: {}. Retrying in {} ms ({} ms elapsed)",
                     sharedLeaseId,
-                    t.getMessage());
-                startKeepAlive();
+                    t.getMessage(),
+                    delayMs,
+                    keepAliveBackoff.getElapsedTimeMs());
+                try {
+                  watchRetryExecutor.schedule(
+                      EtcdMetadataStore.this::startKeepAlive, delayMs, TimeUnit.MILLISECONDS);
+                } catch (java.util.concurrent.RejectedExecutionException e) {
+                  LOG.warn(
+                      "Retry executor shut down during keepalive retry for lease {}",
+                      sharedLeaseId);
+                }
               }
 
               @Override
-              public void
-                  onCompleted() { // not the same as a shutdown, we want to restart the connection
+              public void onCompleted() {
                 if (isClosing) {
                   LOG.debug(
                       "KeepAlive stream completed during shutdown for lease {}, not restarting",
@@ -267,7 +405,14 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
                   return;
                 }
                 LOG.warn("KeepAlive stream completed for shared lease {}", sharedLeaseId);
-                startKeepAlive();
+                if (!scheduleRetryWithBackoff(
+                    keepAliveBackoff,
+                    EtcdMetadataStore.this::startKeepAlive,
+                    "keepalive-" + sharedLeaseId)) {
+                  handleFatalAsync(
+                      new RuntimeException("keepAlive stream completed, retry budget exhausted"),
+                      "keepalive-" + sharedLeaseId);
+                }
               }
             });
   }
@@ -296,6 +441,11 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
       return keyStr.substring((storeFolder + "/").length());
     }
     return keyStr;
+  }
+
+  /** Returns true if the key is a direct child of storeFolder (not a nested descendant). */
+  private boolean isDirectChild(ByteSequence key) {
+    return !keyToName(key).contains("/");
   }
 
   /**
@@ -817,24 +967,62 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
   }
 
   /**
+   * Two-tier backoff state for watch retry logic. Transient errors (GOAWAY, compaction) share one
+   * budget; when exhausted they escalate to the error tier. Error budget exhaustion is fatal.
+   */
+  static class WatchRetryState {
+    final ExponentialBackOff transientBackoff;
+    final ExponentialBackOff errorBackoff;
+    private final long initialIntervalMs;
+
+    WatchRetryState(long initialIntervalMs, long maxIntervalMs, long maxElapsedMs) {
+      this.initialIntervalMs = initialIntervalMs;
+      this.transientBackoff =
+          new ExponentialBackOff(initialIntervalMs, maxIntervalMs, maxElapsedMs);
+      this.errorBackoff = new ExponentialBackOff(initialIntervalMs, maxIntervalMs, maxElapsedMs);
+    }
+
+    /**
+     * Resets both backoff tiers if the watcher was alive long enough to be considered healthy. A
+     * watcher that survived more than 2x the initial retry interval is treated as a new disruption
+     * episode.
+     */
+    void resetIfNewEpisode(long watcherCreatedTimeMs) {
+      long timeSinceCreation = System.currentTimeMillis() - watcherCreatedTimeMs;
+      if (timeSinceCreation > initialIntervalMs * 2) {
+        transientBackoff.reset();
+        errorBackoff.reset();
+      }
+    }
+  }
+
+  /**
    * Adds a listener for metadata changes.
    *
    * @param listener The listener to add
    */
   public void addListener(AstraMetadataStoreChangeListener<T> listener) {
-    addListener(listener, 0, 0);
+    addListener(
+        listener,
+        REVISION_LATEST,
+        new WatchRetryState(initialRetryIntervalMs, maxRetryDelayMs, retryTotalDurationMs));
   }
 
   /**
-   * Internal method to add a listener with retry logic.
+   * Internal method to add a listener with retry logic. Transient errors (GOAWAY, compaction) share
+   * one backoff budget; when exhausted they escalate to the error tier. Error budget exhaustion is
+   * fatal.
    *
    * @param listener The listener to add
-   * @param attemptNumber The current attempt number (0-based)
-   * @param startRevision The ETCD revision number to start at (0 will get current revision of the
-   *     db)
+   * @param startRevision The ETCD revision number to start at. {@link #REVISION_LATEST} fetches
+   *     current revision (keysOnly). {@link #REVISION_RESYNC} triggers a full cache resync
+   *     (compaction recovery).
+   * @param retryState Two-tier backoff state carried across retries
    */
   private void addListener(
-      AstraMetadataStoreChangeListener<T> listener, int attemptNumber, long startRevision) {
+      AstraMetadataStoreChangeListener<T> listener,
+      long startRevision,
+      WatchRetryState retryState) {
     this.addedListener.increment();
 
     if (!shouldCache) {
@@ -855,8 +1043,9 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
     WatchOption watchOption;
     long currentRevision = startRevision;
     try {
-      // only get currentRevision if a revision hasn't been specified
-      if (startRevision == 0) {
+      if (startRevision == REVISION_RESYNC) {
+        currentRevision = resyncCacheFromEtcd(listener);
+      } else if (startRevision == REVISION_LATEST) {
         currentRevision =
             etcdClient
                 .getKVClient()
@@ -877,13 +1066,31 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
           storeFolder,
           currentRevision + 1);
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      LOG.error("Failed to get current revision for watch setup on attempt {}", attemptNumber, e);
-      // Fallback to basic watch without revision
-      watchOption = WatchOption.builder().withPrefix(prefix).build();
+      LOG.error("Failed to get current revision for watch setup on store {}", storeFolder, e);
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
+      watchRetryError.increment();
+      if (!scheduleRetryWithBackoff(
+          retryState.errorBackoff,
+          () -> addListener(listener, REVISION_RESYNC, retryState),
+          "Revision fetch failed for store " + storeFolder + ": " + e.getMessage())) {
+        LOG.error(
+            "Watch retry budget exhausted for store {} after {} ms — failing fatally",
+            storeFolder,
+            retryState.errorBackoff.getElapsedTimeMs());
+        handleFatalAsync(e, storeFolder);
+      }
+      return;
     }
 
     // Create a watcher for this listener
     long finalCurrentRevision = currentRevision + 1;
+    // Records when this watcher was created. Used to distinguish new disruption episodes from
+    // continuations of the same failure: if the watcher was alive longer than 2x the base retry
+    // delay, a subsequent error is a new episode and the retry window resets.
+    long watcherCreatedTimeMs = System.currentTimeMillis();
+    AtomicReference<Watcher> watcherRef = new AtomicReference<>();
     Watcher watcher =
         etcdClient
             .getWatchClient()
@@ -937,62 +1144,80 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
                       });
                 },
                 error -> {
-                  // This is an enhancement to the retry logic for watchers, as there appears to be
-                  // an issue in jetcd
-                  // https://github.com/etcd-io/jetcd/issues/1352
-                  LOG.error(
-                      "Watch failed for store {} on attempt {}: {}",
-                      storeFolder,
-                      attemptNumber,
-                      error.getMessage());
+                  if (isClosing) {
+                    LOG.debug("Ignoring watch error during shutdown for {}", storeFolder);
+                    return;
+                  }
 
-                  // Close the failed watcher
                   String listenerKey = String.valueOf(System.identityHashCode(listener));
                   Watcher existingWatcher = watchers.remove(listenerKey);
-                  if (existingWatcher != null) {
-                    try {
-                      existingWatcher.close();
-                    } catch (Exception e) {
-                      LOG.debug("Error closing failed watcher", e);
+                  closeQuietly(existingWatcher != null ? existingWatcher : watcherRef.get());
+
+                  // GOAWAY: server is shutting down cleanly, reconnect with backoff.
+                  if (isGracefulStop(error)) {
+                    watchRetryGracefulStop.increment();
+                    if (scheduleRetryWithBackoff(
+                        retryState.transientBackoff,
+                        () -> addListener(listener, finalCurrentRevision, retryState),
+                        "Watch for store "
+                            + storeFolder
+                            + " received GOAWAY: "
+                            + error.getMessage())) {
+                      return;
                     }
-                  }
-
-                  // Retry if we haven't exceeded max attempts
-                  if (attemptNumber < etcdOperationsMaxRetries) {
-                    long delayMs = retryDelayMs > 0 ? retryDelayMs : 1000;
-                    LOG.info(
-                        "Retrying watch establishment for store {} in {} ms (attempt {} of {})",
-                        storeFolder,
-                        delayMs,
-                        attemptNumber + 1,
-                        etcdOperationsMaxRetries);
-
-                    // Schedule retry using the dedicated watch retry executor with delay
-                    // retry with the same revision number so we don't miss events on this async
-                    // operation
-                    watchRetryExecutor.schedule(
-                        () -> addListener(listener, attemptNumber + 1, finalCurrentRevision),
-                        delayMs,
-                        TimeUnit.MILLISECONDS);
-                  } else {
                     LOG.error(
-                        "Failed to establish watch for store {} after {} attempts, failing fatally",
+                        "Transient retry budget exhausted for store {} after {} ms"
+                            + " — treating as real error",
                         storeFolder,
-                        etcdOperationsMaxRetries);
-                    new RuntimeHalterImpl().handleFatal(error);
+                        retryState.transientBackoff.getElapsedTimeMs());
+                    retryState.transientBackoff.reset();
+                  } else if (isCompactionError(error)) {
+                    // Compaction: revision is behind, need full resync.
+                    watchRetryCompaction.increment();
+                    if (scheduleRetryWithBackoff(
+                        retryState.transientBackoff,
+                        () -> addListener(listener, REVISION_RESYNC, retryState),
+                        "Watch for store "
+                            + storeFolder
+                            + " received compaction error: "
+                            + error.getMessage())) {
+                      return;
+                    }
+                    LOG.error(
+                        "Transient retry budget exhausted for store {} after {} ms"
+                            + " — treating as real error",
+                        storeFolder,
+                        retryState.transientBackoff.getElapsedTimeMs());
+                    retryState.transientBackoff.reset();
                   }
+
+                  retryState.resetIfNewEpisode(watcherCreatedTimeMs);
+
+                  watchRetryError.increment();
+                  if (scheduleRetryWithBackoff(
+                      retryState.errorBackoff,
+                      () -> addListener(listener, finalCurrentRevision, retryState),
+                      "Watch failed for store " + storeFolder + ": " + error.getMessage())) {
+                    return;
+                  }
+
+                  LOG.error(
+                      "Watch retry budget exhausted for store {} after {} ms — failing fatally",
+                      storeFolder,
+                      retryState.errorBackoff.getElapsedTimeMs());
+                  handleFatalAsync(error, storeFolder);
                 });
 
-    // Store the watcher so we can close it later
+    watcherRef.set(watcher);
     watchers.put(String.valueOf(System.identityHashCode(listener)), watcher);
 
-    if (attemptNumber == 0) {
+    boolean isRetry =
+        retryState.transientBackoff.getElapsedTimeMs() > 0
+            || retryState.errorBackoff.getElapsedTimeMs() > 0;
+    if (!isRetry) {
       LOG.info("Successfully established initial watch for store {}", storeFolder);
     } else {
-      LOG.info(
-          "Successfully re-established watch for store {} after {} retries",
-          storeFolder,
-          attemptNumber);
+      LOG.info("Successfully re-established watch for store {}", storeFolder);
     }
   }
 
@@ -1079,8 +1304,7 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
         LOG.debug("Store {} had key {}", storeFolder, keyStr);
 
         // Only include direct children of the store folder
-        if (keyStr.startsWith(storeFolder + "/")
-            && !keyStr.substring((storeFolder + "/").length()).contains("/")) {
+        if (isDirectChild(kv.getKey())) {
           try {
             String json = kv.getValue().toString(StandardCharsets.UTF_8);
             T node = serializer.fromJsonStr(json);
@@ -1116,6 +1340,79 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
     // as initialized on success or interruption, not on errors.
   }
 
+  /**
+   * Re-lists all keys under the given prefix from etcd and resyncs the in-memory cache. Used on
+   * compaction recovery where the watcher's old revision has been compacted away, meaning events
+   * were missed and the cache is stale.
+   *
+   * <p>Detects deletes (keys in old cache but absent from etcd), repopulates the cache, and
+   * notifies the listener for every node so downstream consumers can react to any changes that
+   * occurred during the gap.
+   *
+   * @return the etcd revision from the list response, suitable for starting a watch from revision+1
+   */
+  private long resyncCacheFromEtcd(AstraMetadataStoreChangeListener<T> listener)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    ByteSequence prefix = ByteSequence.from(storeFolder + "/", StandardCharsets.UTF_8);
+    GetResponse getResponse =
+        etcdClient
+            .getKVClient()
+            .get(prefix, GetOption.builder().withPrefix(prefix).build())
+            .get(etcdOperationTimeoutMs, TimeUnit.MILLISECONDS);
+
+    long listRevision = getResponse.getHeader().getRevision();
+
+    // Build the new state from etcd and collect names for delete detection
+    Set<String> newKeys = new HashSet<>();
+    List<T> newNodes = new ArrayList<>();
+    for (KeyValue kv : getResponse.getKvs()) {
+      if (isDirectChild(kv.getKey())) {
+        try {
+          String json = kv.getValue().toString(StandardCharsets.UTF_8);
+          T node = serializer.fromJsonStr(json);
+          newKeys.add(node.getName());
+          newNodes.add(node);
+        } catch (InvalidProtocolBufferException e) {
+          LOG.error("Failed to deserialize node during compaction resync: {}", kv.getKey(), e);
+          resyncSkip.increment();
+        }
+      }
+    }
+
+    // Update cache: remove deleted keys, repopulate current nodes
+    List<T> deletedNodes = new ArrayList<>();
+    for (String oldKey : cache.keySet()) {
+      if (!newKeys.contains(oldKey)) {
+        T deletedNode = cache.remove(oldKey);
+        if (deletedNode != null) {
+          deletedNodes.add(deletedNode);
+        }
+      }
+    }
+    for (T node : newNodes) {
+      cache.put(node.getName(), node);
+    }
+
+    // Dispatch notifications through WATCH_EVENT_EXECUTOR for ordering consistency
+    WATCH_EVENT_EXECUTOR.execute(
+        () -> {
+          for (T deleted : deletedNodes) {
+            listener.onMetadataStoreChanged(deleted);
+          }
+          for (T node : newNodes) {
+            listener.onMetadataStoreChanged(node);
+          }
+        });
+
+    LOG.info(
+        "Compaction resync for store {} complete: {} nodes from etcd at revision {}",
+        storeFolder,
+        newNodes.size(),
+        listRevision);
+
+    return listRevision;
+  }
+
   @Override
   public void close() {
     LOG.info("Closing etcd clients and watchers");
@@ -1131,26 +1428,13 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
       cacheInitialized.countDown();
     }
 
-    // Terminate the cache initialization thread if it's still running
-    if (cacheInitThread != null && cacheInitThread.isAlive()) {
-      LOG.info("Interrupting cache initialization thread");
-      cacheInitThread.interrupt();
-      // No need to wait - virtual threads are cheap to discard
-    }
-
-    // Terminate the init thread if it's sitll running
-    if (leaseInitThread != null && leaseInitThread.isAlive()) {
-      LOG.info("Interrupting lease initialization thread");
-      leaseInitThread.interrupt();
-      // No need to wait - virtual threads are cheap to discard
-    }
-
     // Shut down watch retry executor
     if (watchRetryExecutor != null) {
       watchRetryExecutor.shutdownNow();
       try {
         watchRetryExecutor.awaitTermination(5, TimeUnit.SECONDS);
-      } catch (InterruptedException ignored) {
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
       }
     }
 

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStore.java
@@ -4,9 +4,11 @@ import static com.slack.astra.server.AstraConfig.DEFAULT_START_STOP_DURATION;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.slack.astra.proto.config.AstraConfigs;
+import com.slack.astra.util.ExponentialBackOff;
 import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.Watch;
+import io.etcd.jetcd.kv.GetResponse;
 import io.etcd.jetcd.options.GetOption;
 import io.etcd.jetcd.options.WatchOption;
 import io.etcd.jetcd.watch.WatchEvent;
@@ -16,6 +18,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -25,8 +28,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,11 +56,14 @@ import org.slf4j.LoggerFactory;
 public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
     implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(EtcdPartitioningMetadataStore.class);
+  private static final long REVISION_LATEST = 0;
+  private static final long REVISION_RESYNC = -1;
+
   private final Map<String, EtcdMetadataStore<T>> metadataStoreMap = new ConcurrentHashMap<>();
   private final ExecutorService executorService;
-  // Listeners are managed through the listenerMap instead of a list
 
   protected final String storeFolder;
+  private final String storeFolderPrefix;
   private final EtcdCreateMode createMode;
   protected final MetadataSerializer<T> serializer;
   private final List<String> partitionFilters;
@@ -64,6 +73,15 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
   private final Watch watchClient;
   private final Map<String, AstraMetadataStoreChangeListener<T>> listenerMap =
       new ConcurrentHashMap<>();
+
+  private final ScheduledExecutorService watchRetryExecutor;
+  private final long retryTotalDurationMs;
+  private final long maxRetryDelayMs;
+  private final long initialRetryIntervalMs;
+  private final ReentrantLock watchLock = new ReentrantLock();
+  private Watch.Watcher partitionWatcher;
+  private volatile boolean closing = false;
+  private volatile boolean closingPartitionWatcher = false;
 
   /**
    * Constructor for EtcdPartitioningMetadataStore with default empty partition filters.
@@ -107,56 +125,44 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
     this.etcdClient = etcdClient;
     this.watchClient = etcdClient.getWatchClient();
     this.storeFolder = storeFolder;
+    this.storeFolderPrefix = storeFolder + "/";
     this.createMode = createMode;
     this.serializer = serializer;
     this.partitionFilters = partitionFilters;
     this.etcdConfig = etcdConfig;
     this.meterRegistry = meterRegistry;
+    this.retryTotalDurationMs =
+        EtcdMetadataStore.positiveOrDefault(
+            etcdConfig.getRetryTotalDurationMs(),
+            EtcdMetadataStore.DEFAULT_RETRY_TOTAL_DURATION_MS);
+    this.maxRetryDelayMs =
+        EtcdMetadataStore.positiveOrDefault(
+            etcdConfig.getMaxRetryDelayMs(), EtcdMetadataStore.DEFAULT_MAX_RETRY_DELAY_MS);
+    this.initialRetryIntervalMs =
+        EtcdMetadataStore.positiveOrDefault(
+            etcdConfig.getInitialRetryIntervalMs(),
+            EtcdMetadataStore.DEFAULT_INITIAL_RETRY_INTERVAL_MS);
     this.executorService =
         Executors.newSingleThreadExecutor(
             new ThreadFactoryBuilder()
                 .setNameFormat("etcd-watcher-" + storeFolder + "-%d")
                 .build());
+    this.watchRetryExecutor =
+        Executors.newScheduledThreadPool(
+            1,
+            r -> {
+              Thread t = new Thread(r);
+              t.setDaemon(true);
+              t.setName("etcd-partition-watch-retry-" + storeFolder);
+              return t;
+            });
 
-    Watch.Listener watcher = buildWatcher();
+    startPartitionWatch(
+        REVISION_LATEST,
+        new EtcdMetadataStore.WatchRetryState(
+            initialRetryIntervalMs, maxRetryDelayMs, retryTotalDurationMs));
 
-    // register watchers for when partitions are added or removed
     ByteSequence storeFolderKey = ByteSequence.from(storeFolder, StandardCharsets.UTF_8);
-
-    // Get the current revision before starting the watch to prevent race conditions
-    // We start watching from the next revision to ensure we capture all events
-    // that occur during and after watch setup
-    WatchOption watchOption;
-    try {
-      long currentRevision =
-          etcdClient
-              .getKVClient()
-              .get(
-                  storeFolderKey,
-                  GetOption.builder().withPrefix(storeFolderKey).withKeysOnly(true).build())
-              .get(etcdConfig.getConnectionTimeoutMs(), TimeUnit.MILLISECONDS)
-              .getHeader()
-              .getRevision();
-
-      // Create watch option starting from the current revision
-      // This ensures we don't miss events that occur during watch registration
-      // and that we don't replay the last event
-      watchOption =
-          WatchOption.builder()
-              .withPrefix(storeFolderKey)
-              .withRevision(currentRevision + 1)
-              .build();
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      LOG.error("Failed to get current revision for watch setup on store {}", storeFolder, e);
-      // Fallback to basic watch without revision
-      watchOption = WatchOption.builder().withPrefix(storeFolderKey).build();
-    }
-
-    LOG.debug("Adding watch client for folder: {} with prefix option", storeFolderKey);
-    watchClient.watch(storeFolderKey, watchOption, watcher);
-
-    // Init stores for each existing partition - similar to how ZookeeperPartitioningMetadataStore
-    // works
     etcdClient
         .getKVClient()
         .get(storeFolderKey, GetOption.builder().isPrefix(true).build())
@@ -167,9 +173,7 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
                 // The storeFolder does not yet exist in etcd
                 return CompletableFuture.completedFuture(List.<String>of());
               } else {
-                // Get all direct children (partitions) of the storeFolder
-                ByteSequence prefix =
-                    ByteSequence.from(String.format("%s/", storeFolder), StandardCharsets.UTF_8);
+                ByteSequence prefix = ByteSequence.from(storeFolderPrefix, StandardCharsets.UTF_8);
                 return etcdClient
                     .getKVClient()
                     .get(prefix, GetOption.builder().isPrefix(true).build())
@@ -182,22 +186,9 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
                               .forEach(
                                   kv -> {
                                     String keyStr = kv.getKey().toString(StandardCharsets.UTF_8);
-                                    if (keyStr.startsWith(String.format("%s/", storeFolder))) {
-                                      // Extract partition name (the first segment after
-                                      // storeFolder)
-                                      String remaining =
-                                          keyStr.substring(
-                                              String.format("%s/", storeFolder).length());
-                                      int slashIdx = remaining.indexOf('/');
-                                      if (slashIdx > 0) {
-                                        String partition = remaining.substring(0, slashIdx);
-                                        if (!children.contains(partition)) {
-                                          children.add(partition);
-                                        }
-                                      } else if (!remaining.isEmpty()) {
-                                        // This is a partition with no children yet
-                                        children.add(remaining);
-                                      }
+                                    String partition = extractPartition(keyStr);
+                                    if (partition != null && !children.contains(partition)) {
+                                      children.add(partition);
                                     }
                                   });
                           return children;
@@ -233,116 +224,305 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
   }
 
   /**
-   * Builds a watcher that is responsible for updating our internal metadata stores to match what is
-   * stored in etcd.
+   * Starts (or restarts) the partition-discovery watch. On error or completion, the watch is
+   * re-established using two-tier exponential backoff matching the per-partition pattern in {@link
+   * EtcdMetadataStore}.
    *
-   * <p>This method creates stores internally when they are detected in etcd storing them to the
-   * store map, and handles partition deletions only when explicitly detected.
+   * @param startRevision {@link #REVISION_LATEST} to fetch current revision, {@link
+   *     #REVISION_RESYNC} to re-scan etcd first
+   * @param retryState two-tier backoff state carried across retries
    */
-  private Watch.Listener buildWatcher() {
-    return new Watch.Listener() {
-      @Override
-      public void onNext(WatchResponse watchResponse) {
-        if (!executorService.isShutdown()) {
-          executorService.submit(
-              () -> {
-                LOG.debug(
-                    "Watch event received: {} events for store {}",
-                    watchResponse.getEvents().size(),
-                    storeFolder);
+  private void startPartitionWatch(
+      long startRevision, EtcdMetadataStore.WatchRetryState retryState) {
+    if (closing) {
+      return;
+    }
 
-                // Check for any creation or deletion of partition directories
-                for (WatchEvent event : watchResponse.getEvents()) {
-                  String keyStr = event.getKeyValue().getKey().toString(StandardCharsets.UTF_8);
-                  LOG.debug("Processing watch event: {} for key: {}", event.getEventType(), keyStr);
+    ByteSequence storeFolderKey = ByteSequence.from(storeFolder, StandardCharsets.UTF_8);
 
-                  // Only process events relevant to our partitions
-                  if (keyStr.startsWith(String.format("%s/", storeFolder))) {
-                    // This is a change to a partition or its content
-                    String remaining = keyStr.substring(String.format("%s/", storeFolder).length());
-                    int slashIdx = remaining.indexOf('/');
-                    String partition = slashIdx > 0 ? remaining.substring(0, slashIdx) : remaining;
-                    LOG.debug("Identified partition '{}' from key: {}", partition, keyStr);
+    long currentRevision;
+    try {
+      if (startRevision == REVISION_RESYNC) {
+        currentRevision = resyncPartitionsFromEtcd();
+      } else if (startRevision == REVISION_LATEST) {
+        currentRevision =
+            etcdClient
+                .getKVClient()
+                .get(
+                    storeFolderKey,
+                    GetOption.builder().withPrefix(storeFolderKey).withKeysOnly(true).build())
+                .get(etcdConfig.getConnectionTimeoutMs(), TimeUnit.MILLISECONDS)
+                .getHeader()
+                .getRevision();
+      } else {
+        currentRevision = startRevision;
+      }
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      LOG.error("Failed to get current revision for partition watch on store {}", storeFolder, e);
+      handleWatchError(e, startRevision, retryState);
+      return;
+    }
 
-                    // If we have partition filters, skip partitions not in our filter
-                    if (!partitionFilters.isEmpty() && !partitionFilters.contains(partition)) {
-                      continue;
-                    }
+    WatchOption watchOption =
+        WatchOption.builder().withPrefix(storeFolderKey).withRevision(currentRevision + 1).build();
 
-                    // Handle PUT events - create metadata store if needed
-                    if (event.getEventType() == WatchEvent.EventType.PUT) {
-                      LOG.debug(
-                          "PUT event detected, creating/updating metadata store for partition: {}",
-                          partition);
-                      getOrCreateMetadataStore(partition);
-                    }
-                    // Handle DELETE events
-                    else if (event.getEventType() == WatchEvent.EventType.DELETE) {
-                      LOG.debug("DELETE event detected for key: {}", keyStr);
-                      handlePartitionDeletion(partition);
-                    }
-                  } else {
-                    LOG.debug("Ignoring event for key outside our store folder: {}", keyStr);
+    long finalCurrentRevision = currentRevision + 1;
+    long watcherCreatedTimeMs = System.currentTimeMillis();
+
+    // Lock only around the close-old/create-new/assign sequence to prevent concurrent
+    // watcher creation while allowing RPCs above to proceed without holding the lock.
+    watchLock.lock();
+    try {
+      if (closing) {
+        return;
+      }
+
+      closePartitionWatcherLocked();
+
+      LOG.debug(
+          "Starting partition watch for folder {} at revision {}",
+          storeFolder,
+          finalCurrentRevision);
+
+      partitionWatcher =
+          watchClient.watch(
+              storeFolderKey,
+              watchOption,
+              new Watch.Listener() {
+                @Override
+                public void onNext(WatchResponse watchResponse) {
+                  if (!executorService.isShutdown()) {
+                    executorService.submit(() -> processWatchEvents(watchResponse));
                   }
                 }
+
+                @Override
+                public void onError(Throwable throwable) {
+                  if (closing) {
+                    LOG.debug("Ignoring watch error during shutdown for {}", storeFolder);
+                    return;
+                  }
+                  if (closingPartitionWatcher) {
+                    LOG.debug(
+                        "Ignoring watch error during deliberate watcher close for {}: {}",
+                        storeFolder,
+                        throwable.getMessage());
+                    return;
+                  }
+                  closePartitionWatcher();
+                  retryState.resetIfNewEpisode(watcherCreatedTimeMs);
+                  handleWatchError(throwable, finalCurrentRevision, retryState);
+                }
+
+                @Override
+                public void onCompleted() {
+                  if (closing) {
+                    LOG.debug("Ignoring watch completion during shutdown for {}", storeFolder);
+                    return;
+                  }
+                  if (closingPartitionWatcher) {
+                    LOG.debug(
+                        "Ignoring watch completion during deliberate watcher close for {}",
+                        storeFolder);
+                    return;
+                  }
+                  LOG.warn("Partition watch completed unexpectedly for {}", storeFolder);
+                  closePartitionWatcher();
+                  retryState.resetIfNewEpisode(watcherCreatedTimeMs);
+                  handleWatchError(
+                      new RuntimeException("partition watch completed unexpectedly"),
+                      finalCurrentRevision,
+                      retryState);
+                }
               });
-        }
+    } finally {
+      watchLock.unlock();
+    }
+
+    boolean isRetry =
+        retryState.transientBackoff.getElapsedTimeMs() > 0
+            || retryState.errorBackoff.getElapsedTimeMs() > 0;
+    if (!isRetry) {
+      LOG.info("Successfully established initial partition watch for store {}", storeFolder);
+    } else {
+      LOG.info("Successfully re-established partition watch for store {}", storeFolder);
+    }
+  }
+
+  private void closePartitionWatcher() {
+    watchLock.lock();
+    try {
+      closePartitionWatcherLocked();
+    } finally {
+      watchLock.unlock();
+    }
+  }
+
+  private void closePartitionWatcherLocked() {
+    Watch.Watcher old = partitionWatcher;
+    if (old != null) {
+      closingPartitionWatcher = true;
+      try {
+        old.close();
+      } catch (Exception e) {
+        LOG.debug("Error closing partition watcher", e);
+      } finally {
+        closingPartitionWatcher = false;
+      }
+      partitionWatcher = null;
+    }
+  }
+
+  /**
+   * Handles a partition watch error or completion by classifying the error and scheduling a retry
+   * with two-tier exponential backoff. Transient errors (GOAWAY, compaction) share one budget; when
+   * exhausted they escalate to the error tier. Error budget exhaustion is fatal.
+   */
+  private void handleWatchError(
+      Throwable error, long lastRevision, EtcdMetadataStore.WatchRetryState retryState) {
+    if (EtcdMetadataStore.isGracefulStop(error)) {
+      if (scheduleRetryWithBackoff(
+          retryState.transientBackoff,
+          () -> startPartitionWatch(lastRevision, retryState),
+          "Partition watch for store " + storeFolder + " received GOAWAY: " + error.getMessage())) {
+        return;
+      }
+      LOG.error(
+          "Transient retry budget exhausted for partition watch on store {} after {} ms"
+              + " — treating as real error",
+          storeFolder,
+          retryState.transientBackoff.getElapsedTimeMs());
+      retryState.transientBackoff.reset();
+    } else if (EtcdMetadataStore.isCompactionError(error)) {
+      if (scheduleRetryWithBackoff(
+          retryState.transientBackoff,
+          () -> startPartitionWatch(REVISION_RESYNC, retryState),
+          "Partition watch for store "
+              + storeFolder
+              + " received compaction error: "
+              + error.getMessage())) {
+        return;
+      }
+      LOG.error(
+          "Transient retry budget exhausted for partition watch on store {} after {} ms"
+              + " — treating as real error",
+          storeFolder,
+          retryState.transientBackoff.getElapsedTimeMs());
+      retryState.transientBackoff.reset();
+    }
+
+    if (scheduleRetryWithBackoff(
+        retryState.errorBackoff,
+        () -> startPartitionWatch(lastRevision, retryState),
+        "Partition watch failed for store " + storeFolder + ": " + error.getMessage())) {
+      return;
+    }
+
+    LOG.error(
+        "Partition watch retry budget exhausted for store {} after {} ms — failing fatally",
+        storeFolder,
+        retryState.errorBackoff.getElapsedTimeMs());
+    EtcdMetadataStore.handleFatalAsync(error, "partition-watch-" + storeFolder);
+  }
+
+  private boolean scheduleRetryWithBackoff(
+      ExponentialBackOff backoff, Runnable retryAction, String context) {
+    long delayMs = backoff.nextBackOffMillis();
+    if (delayMs == ExponentialBackOff.STOP) {
+      return false;
+    }
+    LOG.warn(
+        "{} — retrying in {} ms ({} ms elapsed)", context, delayMs, backoff.getElapsedTimeMs());
+    try {
+      watchRetryExecutor.schedule(retryAction, delayMs, TimeUnit.MILLISECONDS);
+    } catch (java.util.concurrent.RejectedExecutionException e) {
+      LOG.warn("Retry executor already shut down for {}, retry not scheduled", storeFolder);
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Processes watch events for partition discovery. Creates stores for new partitions and handles
+   * partition deletions.
+   */
+  private void processWatchEvents(WatchResponse watchResponse) {
+    LOG.debug(
+        "Watch event received: {} events for store {}",
+        watchResponse.getEvents().size(),
+        storeFolder);
+
+    for (WatchEvent event : watchResponse.getEvents()) {
+      String keyStr = event.getKeyValue().getKey().toString(StandardCharsets.UTF_8);
+      LOG.debug("Processing watch event: {} for key: {}", event.getEventType(), keyStr);
+
+      String partition = extractPartition(keyStr);
+      if (partition == null) {
+        LOG.debug("Ignoring event for key outside our store folder: {}", keyStr);
+        continue;
       }
 
-      /**
-       * Handles deletion of a partition root path by checking if the store is empty and then
-       * removing it if appropriate.
-       *
-       * @param partition The partition identifier that was deleted
-       */
-      private void handlePartitionDeletion(String partition) {
-        if (!metadataStoreMap.containsKey(partition)) {
-          LOG.debug("Ignoring deletion of unknown partition: {}", partition);
-          return;
-        }
+      LOG.debug("Identified partition '{}' from key: {}", partition, keyStr);
 
-        // Get the store and check if it has any cached items
-        EtcdMetadataStore<T> store = metadataStoreMap.get(partition);
-
-        try {
-          store
-              .listAsync()
-              .thenAcceptAsync(
-                  (items) -> {
-                    if (items.isEmpty()) {
-                      LOG.info("Closing unused store for deleted partition: {}", partition);
-                      metadataStoreMap.remove(partition);
-                      store.close();
-                    } else {
-                      // This could indicate a race condition where we have items in memory
-                      // that haven't been persisted to etcd yet, or the deletion was partial
-                      LOG.warn(
-                          "Detected deletion event on partition {}, but store still has {} cached elements. Keeping store active.",
-                          partition,
-                          items.size());
-                    }
-                  });
-        } catch (Exception e) {
-          // Safeguard against failures that could leave the store in a broken state
-          LOG.error("Error checking partition store for deletion: {}", partition, e);
-          // If we fail to check the store, it's likely in a bad state, so close it
-          // This may be aggressive but prevents resource leaks
-          metadataStoreMap.remove(partition);
-          store.close();
-        }
+      if (!partitionFilters.isEmpty() && !partitionFilters.contains(partition)) {
+        continue;
       }
 
-      @Override
-      public void onError(Throwable throwable) {
-        LOG.error("Error in etcd watcher for {}", storeFolder, throwable);
+      if (event.getEventType() == WatchEvent.EventType.PUT) {
+        LOG.debug(
+            "PUT event detected, creating/updating metadata store for partition: {}", partition);
+        getOrCreateMetadataStore(partition);
+      } else if (event.getEventType() == WatchEvent.EventType.DELETE) {
+        LOG.debug("DELETE event detected for key: {}", keyStr);
+        handlePartitionDeletion(partition);
       }
+    }
+  }
 
-      @Override
-      public void onCompleted() {
-        LOG.warn(
-            "Etcd watch completed for {} - object {}", storeFolder, System.identityHashCode(this));
-      }
-    };
+  /**
+   * Extracts the partition identifier from a full etcd key under this store's folder. Returns null
+   * if the key does not start with the store folder prefix or is empty after stripping.
+   */
+  private String extractPartition(String keyStr) {
+    if (!keyStr.startsWith(storeFolderPrefix)) {
+      return null;
+    }
+    String remaining = keyStr.substring(storeFolderPrefix.length());
+    if (remaining.isEmpty()) {
+      return null;
+    }
+    int slashIdx = remaining.indexOf('/');
+    return slashIdx > 0 ? remaining.substring(0, slashIdx) : remaining;
+  }
+
+  private void handlePartitionDeletion(String partition) {
+    EtcdMetadataStore<T> store = metadataStoreMap.get(partition);
+    if (store == null) {
+      LOG.debug("Ignoring deletion of unknown partition: {}", partition);
+      return;
+    }
+
+    try {
+      store
+          .listAsync()
+          .thenAcceptAsync(
+              (items) -> {
+                if (items.isEmpty()) {
+                  LOG.info("Closing unused store for deleted partition: {}", partition);
+                  metadataStoreMap.remove(partition);
+                  store.close();
+                } else {
+                  LOG.warn(
+                      "Detected deletion event on partition {}, but store still has {} cached elements. Keeping store active.",
+                      partition,
+                      items.size());
+                }
+              });
+    } catch (Exception e) {
+      LOG.error("Error checking partition store for deletion: {}", partition, e);
+      metadataStoreMap.remove(partition);
+      store.close();
+    }
   }
 
   public CompletionStage<String> createAsync(T metadataNode) {
@@ -527,40 +707,70 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
    */
   private Set<String> getPartitionsFromEtcd() {
     try {
-      // Get all keys with the store prefix
-      ByteSequence prefix =
-          ByteSequence.from(String.format("%s/", storeFolder), StandardCharsets.UTF_8);
-      io.etcd.jetcd.options.GetOption getOption =
-          io.etcd.jetcd.options.GetOption.builder().isPrefix(true).build();
-
-      // Execute the query synchronously
-      io.etcd.jetcd.kv.GetResponse getResponse =
+      ByteSequence prefix = ByteSequence.from(storeFolderPrefix, StandardCharsets.UTF_8);
+      GetResponse getResponse =
           etcdClient
               .getKVClient()
-              .get(prefix, getOption)
+              .get(prefix, GetOption.builder().isPrefix(true).withKeysOnly(true).build())
               .get(etcdConfig.getConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
 
-      // Extract partition names from the keys
-      Set<String> partitions = new java.util.HashSet<>();
-      for (io.etcd.jetcd.KeyValue kv : getResponse.getKvs()) {
-        String keyStr = kv.getKey().toString(StandardCharsets.UTF_8);
-        if (keyStr.startsWith(String.format("%s/", storeFolder))) {
-          String remaining = keyStr.substring(String.format("%s/", storeFolder).length());
-          int slashIdx = remaining.indexOf('/');
-          String partition = slashIdx > 0 ? remaining.substring(0, slashIdx) : remaining;
-
-          // Only add if it's not empty and matches our filters
-          if (!partition.isEmpty()
-              && (partitionFilters.isEmpty() || partitionFilters.contains(partition))) {
-            partitions.add(partition);
-          }
-        }
-      }
-
-      return partitions;
+      return extractPartitionsFromResponse(getResponse);
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
       throw new InternalMetadataStoreException("Error fetching partitions from etcd", e);
     }
+  }
+
+  private Set<String> extractPartitionsFromResponse(GetResponse getResponse) {
+    Set<String> partitions = new HashSet<>();
+    for (io.etcd.jetcd.KeyValue kv : getResponse.getKvs()) {
+      String keyStr = kv.getKey().toString(StandardCharsets.UTF_8);
+      String partition = extractPartition(keyStr);
+      if (partition != null
+          && (partitionFilters.isEmpty() || partitionFilters.contains(partition))) {
+        partitions.add(partition);
+      }
+    }
+    return partitions;
+  }
+
+  /**
+   * Re-scans etcd for partitions and ensures each one has a metadata store. Used on watch recovery
+   * (compaction or gap) to discover partitions created while the watch was down.
+   *
+   * @return the etcd revision from the list response, suitable for starting a watch from revision+1
+   */
+  private long resyncPartitionsFromEtcd()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    ByteSequence prefix = ByteSequence.from(storeFolderPrefix, StandardCharsets.UTF_8);
+    GetResponse getResponse =
+        etcdClient
+            .getKVClient()
+            .get(prefix, GetOption.builder().isPrefix(true).withKeysOnly(true).build())
+            .get(etcdConfig.getConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
+
+    long listRevision = getResponse.getHeader().getRevision();
+
+    Set<String> discoveredPartitions = extractPartitionsFromResponse(getResponse);
+    discoveredPartitions.forEach(this::getOrCreateMetadataStore);
+
+    // Remove stores for partitions that no longer exist in etcd
+    for (String existing : metadataStoreMap.keySet()) {
+      if (!discoveredPartitions.contains(existing)) {
+        EtcdMetadataStore<T> staleStore = metadataStoreMap.remove(existing);
+        if (staleStore != null) {
+          LOG.info("Removing stale partition store during resync: {}", existing);
+          staleStore.close();
+        }
+      }
+    }
+
+    LOG.info(
+        "Partition resync for store {} complete: {} partitions from etcd at revision {}",
+        storeFolder,
+        discoveredPartitions.size(),
+        listRevision);
+
+    return listRevision;
   }
 
   /**
@@ -582,21 +792,48 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
           "Partitioning metadata store using filters that does not include provided partition");
     }
 
-    // Create a new store for this partition or return existing one
-    return metadataStoreMap.computeIfAbsent(
-        partition,
-        (p1) -> {
-          String path = String.format("%s/%s", storeFolder, p1);
-          LOG.debug(
-              "Creating new etcd metadata store for partition - {}, at path - {}", partition, path);
+    AtomicBoolean created = new AtomicBoolean(false);
 
-          EtcdMetadataStore<T> newStore =
-              new EtcdMetadataStore<>(
-                  path, etcdConfig, true, meterRegistry, serializer, createMode, etcdClient);
-          listenerMap.forEach((_, listener) -> newStore.addListener(listener));
+    EtcdMetadataStore<T> store =
+        metadataStoreMap.computeIfAbsent(
+            partition,
+            (p1) -> {
+              String path = String.format("%s/%s", storeFolder, p1);
+              LOG.debug(
+                  "Creating new etcd metadata store for partition - {}, at path - {}",
+                  partition,
+                  path);
 
-          return newStore;
-        });
+              EtcdMetadataStore<T> newStore =
+                  new EtcdMetadataStore<>(
+                      path, etcdConfig, true, meterRegistry, serializer, createMode, etcdClient);
+              listenerMap.forEach((_, listener) -> newStore.addListener(listener));
+
+              created.set(true);
+              return newStore;
+            });
+
+    if (created.get()) {
+      List<T> cachedItems = store.listSync();
+      if (!cachedItems.isEmpty()) {
+        LOG.info(
+            "Notifying {} listeners of {} pre-existing items in new partition {}",
+            listenerMap.size(),
+            cachedItems.size(),
+            partition);
+        for (T item : cachedItems) {
+          for (AstraMetadataStoreChangeListener<T> listener : listenerMap.values()) {
+            try {
+              listener.onMetadataStoreChanged(item);
+            } catch (Exception e) {
+              LOG.warn("Listener notification failed for partition {}", partition, e);
+            }
+          }
+        }
+      }
+    }
+
+    return store;
   }
 
   /**
@@ -669,10 +906,12 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
         listenerMap.size(),
         metadataStoreMap.size());
 
+    closing = true;
+    closePartitionWatcher();
+
     // Remove all listeners and close all stores
     new ArrayList<>(listenerMap.values()).forEach(this::removeListener);
 
-    // All watchers are automatically closed when the client is closed
     executorService.shutdownNow();
     try {
       executorService.awaitTermination(DEFAULT_START_STOP_DURATION.toSeconds(), TimeUnit.SECONDS);
@@ -680,7 +919,14 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
       LOG.warn("Interrupted while waiting for close", e);
     }
 
-    metadataStoreMap.forEach((ignored, store) -> store.close());
+    watchRetryExecutor.shutdownNow();
+    try {
+      watchRetryExecutor.awaitTermination(5, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+
+    metadataStoreMap.forEach((_, store) -> store.close());
 
     // Clear the maps
     listenerMap.clear();

--- a/astra/src/main/java/com/slack/astra/util/ExponentialBackOff.java
+++ b/astra/src/main/java/com/slack/astra/util/ExponentialBackOff.java
@@ -1,0 +1,85 @@
+package com.slack.astra.util;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.LongSupplier;
+
+/**
+ * Stateful exponential backoff with proportional jitter. Each call to {@link #nextBackOffMillis()}
+ * returns a randomized delay and advances the internal interval by the multiplier. Returns {@link
+ * #STOP} when the elapsed time since the first call exceeds the configured maximum.
+ *
+ * <p>The randomization applies ±{@code RANDOMIZATION_FACTOR} around the current interval (e.g.
+ * ±50%), so jitter scales proportionally with the backoff. The multiplier advances the base
+ * interval each call, and overflow is avoided by capping before multiplication.
+ *
+ * <p>All public methods are synchronized for safe use from concurrent gRPC callback and retry
+ * threads.
+ */
+public class ExponentialBackOff {
+  private static final double RANDOMIZATION_FACTOR = 0.5;
+  private static final double MULTIPLIER = 1.5;
+  public static final long STOP = -1L;
+
+  private final long initialIntervalMillis;
+  private final long maxIntervalMillis;
+  private final long maxElapsedTimeMillis;
+  private final LongSupplier clock;
+  private long currentIntervalMillis;
+  private long startTimeMs;
+
+  public ExponentialBackOff(
+      long initialIntervalMillis, long maxIntervalMillis, long maxElapsedTimeMillis) {
+    this(initialIntervalMillis, maxIntervalMillis, maxElapsedTimeMillis, System::currentTimeMillis);
+  }
+
+  public ExponentialBackOff(
+      long initialIntervalMillis,
+      long maxIntervalMillis,
+      long maxElapsedTimeMillis,
+      LongSupplier clock) {
+    this.initialIntervalMillis = initialIntervalMillis;
+    this.maxIntervalMillis = maxIntervalMillis;
+    this.maxElapsedTimeMillis = maxElapsedTimeMillis;
+    this.clock = clock;
+    reset();
+  }
+
+  public synchronized void reset() {
+    this.currentIntervalMillis = initialIntervalMillis;
+    this.startTimeMs = -1;
+  }
+
+  public synchronized long getElapsedTimeMs() {
+    if (startTimeMs < 0) {
+      return 0;
+    }
+    return clock.getAsLong() - startTimeMs;
+  }
+
+  public synchronized long nextBackOffMillis() {
+    long now = clock.getAsLong();
+    if (startTimeMs < 0) {
+      startTimeMs = now;
+    }
+    if (now - startTimeMs >= maxElapsedTimeMillis) {
+      return STOP;
+    }
+
+    // Randomize ±RANDOMIZATION_FACTOR around current interval
+    double delta = RANDOMIZATION_FACTOR * currentIntervalMillis;
+    double minInterval = currentIntervalMillis - delta;
+    double maxInterval = currentIntervalMillis + delta;
+    long randomized =
+        (long)
+            (minInterval + ThreadLocalRandom.current().nextDouble() * (maxInterval - minInterval));
+
+    // Advance interval for next call (overflow-safe)
+    if (currentIntervalMillis >= this.maxIntervalMillis / MULTIPLIER) {
+      currentIntervalMillis = this.maxIntervalMillis;
+    } else {
+      currentIntervalMillis = (long) (currentIntervalMillis * MULTIPLIER);
+    }
+
+    return randomized;
+  }
+}

--- a/astra/src/main/proto/astra_configs.proto
+++ b/astra/src/main/proto/astra_configs.proto
@@ -96,6 +96,15 @@ message EtcdConfig {
   int32 ephemeral_node_ttl_ms = 11;
   // Max number of retries for ephemeral nodes
   int32 ephemeral_node_max_retries = 12;
+  // Maximum total time to keep retrying watch operations before giving up (ms).
+  // When 0, Java applies a default of 60000 ms.
+  int32 retry_total_duration_ms = 13;
+  // Maximum backoff delay between watch retries (ms). Used as the cap for
+  // exponential backoff with jitter.
+  int32 max_retry_delay_ms = 14;
+  // Initial interval for exponential backoff (ms). The first retry delay is
+  // randomized around this value; subsequent intervals grow by a multiplier.
+  int32 initial_retry_interval_ms = 15;
 }
 
 // Configuration for Zookeeper metadata store.

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaDeletionServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaDeletionServiceTest.java
@@ -134,6 +134,7 @@ public class ReplicaDeletionServiceTest {
   public void shutdown() throws IOException {
     cacheSlotMetadataStore.close();
     replicaMetadataStore.close();
+    cacheNodeMetadataStore.close();
     curatorFramework.unwrap().close();
     etcdClient.close();
 

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaRestoreServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaRestoreServiceTest.java
@@ -127,10 +127,11 @@ public class ReplicaRestoreServiceTest {
 
   @AfterEach
   public void tearDown() throws IOException {
-    meterRegistry.close();
-    testingServer.close();
-    if (etcdClient != null) etcdClient.close();
+    replicaMetadataStore.close();
     curatorFramework.unwrap().close();
+    if (etcdClient != null) etcdClient.close();
+    testingServer.close();
+    meterRegistry.close();
   }
 
   @Test

--- a/astra/src/test/java/com/slack/astra/metadata/core/EtcdMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/core/EtcdMetadataStoreTest.java
@@ -9,6 +9,8 @@ import com.slack.astra.testlib.TestEtcdClusterFactory;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.ClientBuilder;
 import io.etcd.jetcd.launcher.EtcdCluster;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.charset.StandardCharsets;
@@ -530,6 +532,9 @@ public class EtcdMetadataStoreTest {
             .setNamespace("test")
             .setEphemeralNodeTtlMs(1000) // Short TTL
             .setEphemeralNodeMaxRetries(1) // Only 1 retry attempt
+            .setRetryTotalDurationMs(5000)
+            .setMaxRetryDelayMs(1000)
+            .setInitialRetryIntervalMs(100)
             .build();
 
     // Create client for failure test
@@ -716,5 +721,57 @@ public class EtcdMetadataStoreTest {
       testClient.close();
       testMeterRegistry.close();
     }
+  }
+
+  @Test
+  public void testIsGracefulStop() {
+    // Exact message produced by jetcd when etcd sends GOAWAY with NO_ERROR
+    assertThat(
+            EtcdMetadataStore.isGracefulStop(
+                new RuntimeException(
+                    "Connection closed after GOAWAY. HTTP/2 error code: NO_ERROR, debug data: graceful_stop")))
+        .isTrue();
+
+    // Must contain both NO_ERROR and graceful_stop
+    assertThat(
+            EtcdMetadataStore.isGracefulStop(
+                new RuntimeException(
+                    "Connection closed after GOAWAY. HTTP/2 error code: NO_ERROR, debug data: something_else")))
+        .isFalse();
+
+    assertThat(
+            EtcdMetadataStore.isGracefulStop(
+                new RuntimeException("Connection closed after GOAWAY. debug data: graceful_stop")))
+        .isFalse();
+
+    // Other error types should not match
+    assertThat(EtcdMetadataStore.isGracefulStop(new RuntimeException("connection refused")))
+        .isFalse();
+
+    assertThat(EtcdMetadataStore.isGracefulStop(new RuntimeException((String) null))).isFalse();
+  }
+
+  @Test
+  public void testIsCompactionError() {
+    // gRPC OUT_OF_RANGE status
+    assertThat(
+            EtcdMetadataStore.isCompactionError(
+                new StatusRuntimeException(Status.OUT_OF_RANGE.withDescription("compacted"))))
+        .isTrue();
+
+    // Message-based detection
+    assertThat(
+            EtcdMetadataStore.isCompactionError(
+                new RuntimeException("etcd revision has been compacted")))
+        .isTrue();
+
+    // Non-compaction errors
+    assertThat(
+            EtcdMetadataStore.isCompactionError(
+                new StatusRuntimeException(Status.UNAVAILABLE.withDescription("connection reset"))))
+        .isFalse();
+
+    assertThat(EtcdMetadataStore.isCompactionError(new RuntimeException("connection refused")))
+        .isFalse();
   }
 }

--- a/astra/src/test/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStoreTest.java
@@ -5,6 +5,7 @@ import static org.awaitility.Awaitility.await;
 
 import com.slack.astra.proto.config.AstraConfigs;
 import com.slack.astra.testlib.TestEtcdClusterFactory;
+import com.slack.astra.util.CountingFatalErrorHandler;
 import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.launcher.EtcdCluster;
@@ -153,6 +154,9 @@ public class EtcdPartitioningMetadataStoreTest {
             .setOperationsMaxRetries(3)
             .setOperationsTimeoutMs(3000)
             .setRetryDelayMs(100)
+            .setRetryTotalDurationMs(5000)
+            .setMaxRetryDelayMs(1000)
+            .setInitialRetryIntervalMs(100)
             .setNamespace("test")
             .build();
 
@@ -177,9 +181,9 @@ public class EtcdPartitioningMetadataStoreTest {
 
   @AfterEach
   public void tearDown() throws IOException {
-    // Close the store and meter registry
     store.close();
     meterRegistry.close();
+    EtcdMetadataStore.resetFatalErrorHandler();
   }
 
   @Test
@@ -432,6 +436,9 @@ public class EtcdPartitioningMetadataStoreTest {
             .setOperationsMaxRetries(3)
             .setOperationsTimeoutMs(3000)
             .setRetryDelayMs(100)
+            .setRetryTotalDurationMs(5000)
+            .setMaxRetryDelayMs(1000)
+            .setInitialRetryIntervalMs(100)
             .setNamespace("test")
             .build();
 
@@ -484,6 +491,105 @@ public class EtcdPartitioningMetadataStoreTest {
       assertThat(partitionMap).hasSize(2);
       assertThat(partitionMap.get("partition1")).hasSize(1);
       assertThat(partitionMap.get("partition2")).hasSize(1);
+    }
+  }
+
+  private Client createNamespacedAdminClient() {
+    return Client.builder()
+        .endpoints(
+            etcdCluster.clientEndpoints().stream().map(Object::toString).toArray(String[]::new))
+        .namespace(ByteSequence.from("test", StandardCharsets.UTF_8))
+        .build();
+  }
+
+  private void advanceAndCompact(Client adminClient, int writes) throws Exception {
+    ByteSequence key = ByteSequence.from("/compact-trigger", StandardCharsets.UTF_8);
+    ByteSequence val = ByteSequence.from("v", StandardCharsets.UTF_8);
+    long revision = 0;
+    for (int i = 0; i < writes; i++) {
+      revision =
+          adminClient
+              .getKVClient()
+              .put(key, val)
+              .get(3, TimeUnit.SECONDS)
+              .getHeader()
+              .getRevision();
+    }
+    adminClient.getKVClient().compact(revision).get(3, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Regression test for the partition watch retry self-poisoning bug. When a compaction error
+   * occurs, the retry cycle should recover the watcher without exhausting the error budget. Before
+   * the fix, closePartitionWatcherLocked() -> old.close() triggered onCompleted() which fed a
+   * synthetic RuntimeException into the error budget, causing fatal halts during etcd node rolls.
+   */
+  @Test
+  public void testWatchRecoveryAfterCompaction() throws Exception {
+    CountingFatalErrorHandler fatalHandler = new CountingFatalErrorHandler();
+    EtcdMetadataStore.setFatalErrorHandler(fatalHandler);
+
+    store.createSync(new TestPartitionedMetadata("item1", "p1", "data1"));
+    await().atMost(5, TimeUnit.SECONDS).until(() -> store.hasPartition("p1"));
+
+    try (Client adminClient = createNamespacedAdminClient()) {
+      advanceAndCompact(adminClient, 10);
+
+      store.createSync(new TestPartitionedMetadata("item2", "p2", "data2"));
+      await().atMost(Duration.ofSeconds(10)).until(() -> store.hasPartition("p2"));
+
+      assertThat(fatalHandler.getCount()).isEqualTo(0);
+    }
+  }
+
+  /**
+   * Verifies that multiple compaction events don't cumulatively exhaust the retry budget. Each
+   * recovery should reset the backoff state, allowing indefinite compaction resilience.
+   */
+  @Test
+  public void testRepeatedCompactionDoesNotExhaustBudget() throws Exception {
+    CountingFatalErrorHandler fatalHandler = new CountingFatalErrorHandler();
+    EtcdMetadataStore.setFatalErrorHandler(fatalHandler);
+
+    store.createSync(new TestPartitionedMetadata("base", "p0", "data0"));
+    await().atMost(5, TimeUnit.SECONDS).until(() -> store.hasPartition("p0"));
+
+    try (Client adminClient = createNamespacedAdminClient()) {
+      for (int cycle = 1; cycle <= 3; cycle++) {
+        advanceAndCompact(adminClient, 10);
+
+        String partition = "cycle" + cycle;
+        store.createSync(new TestPartitionedMetadata("item-" + cycle, partition, "data-" + cycle));
+        await().atMost(Duration.ofSeconds(10)).until(() -> store.hasPartition(partition));
+      }
+
+      assertThat(fatalHandler.getCount()).isEqualTo(0);
+    }
+  }
+
+  /**
+   * Exercises a large revision gap by writing 50 keys before compacting, then verifies the watcher
+   * recovers and new data is accessible via findSync.
+   */
+  @Test
+  public void testWatchRecoveryAfterMultipleTransientErrors() throws Exception {
+    CountingFatalErrorHandler fatalHandler = new CountingFatalErrorHandler();
+    EtcdMetadataStore.setFatalErrorHandler(fatalHandler);
+
+    store.createSync(new TestPartitionedMetadata("seed1", "init-p", "seed-data"));
+    await().atMost(5, TimeUnit.SECONDS).until(() -> store.hasPartition("init-p"));
+
+    try (Client adminClient = createNamespacedAdminClient()) {
+      advanceAndCompact(adminClient, 50);
+
+      store.createSync(new TestPartitionedMetadata("post-compact", "new-p", "new-data"));
+      await().atMost(Duration.ofSeconds(10)).until(() -> store.hasPartition("new-p"));
+
+      TestPartitionedMetadata result = store.findSync("post-compact");
+      assertThat(result).isNotNull();
+      assertThat(result.getData()).isEqualTo("new-data");
+
+      assertThat(fatalHandler.getCount()).isEqualTo(0);
     }
   }
 }

--- a/astra/src/test/java/com/slack/astra/server/AstraConfigTest.java
+++ b/astra/src/test/java/com/slack/astra/server/AstraConfigTest.java
@@ -229,6 +229,9 @@ public class AstraConfigTest {
     assertThat(etcdConfig.getOperationsTimeoutMs()).isEqualTo(60000);
     assertThat(etcdConfig.getEphemeralNodeTtlMs()).isEqualTo(60000);
     assertThat(etcdConfig.getEphemeralNodeMaxRetries()).isEqualTo(3);
+    assertThat(etcdConfig.getRetryTotalDurationMs()).isEqualTo(60000);
+    assertThat(etcdConfig.getMaxRetryDelayMs()).isEqualTo(10000);
+    assertThat(etcdConfig.getInitialRetryIntervalMs()).isEqualTo(2000);
 
     final AstraConfigs.CacheConfig cacheConfig = config.getCacheConfig();
     final AstraConfigs.ServerConfig cacheServerConfig = cacheConfig.getServerConfig();
@@ -416,6 +419,9 @@ public class AstraConfigTest {
     assertThat(etcdConfig.getOperationsTimeoutMs()).isEqualTo(60000);
     assertThat(etcdConfig.getEphemeralNodeTtlMs()).isEqualTo(60000);
     assertThat(etcdConfig.getEphemeralNodeMaxRetries()).isEqualTo(3);
+    assertThat(etcdConfig.getRetryTotalDurationMs()).isEqualTo(60000);
+    assertThat(etcdConfig.getMaxRetryDelayMs()).isEqualTo(10000);
+    assertThat(etcdConfig.getInitialRetryIntervalMs()).isEqualTo(2000);
 
     final AstraConfigs.CacheConfig cacheConfig = config.getCacheConfig();
     final AstraConfigs.ServerConfig cacheServerConfig = cacheConfig.getServerConfig();

--- a/astra/src/test/java/com/slack/astra/testlib/AstraConfigUtil.java
+++ b/astra/src/test/java/com/slack/astra/testlib/AstraConfigUtil.java
@@ -80,6 +80,9 @@ public class AstraConfigUtil {
             .setNamespace(metadataPathPrefix) // Use same namespace as ZK pathPrefix for consistency
             .setEphemeralNodeTtlMs(3000)
             .setEphemeralNodeMaxRetries(3)
+            .setRetryTotalDurationMs(60000)
+            .setMaxRetryDelayMs(10000)
+            .setInitialRetryIntervalMs(2000)
             .build();
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()

--- a/astra/src/test/java/com/slack/astra/util/ExponentialBackOffTest.java
+++ b/astra/src/test/java/com/slack/astra/util/ExponentialBackOffTest.java
@@ -1,0 +1,89 @@
+package com.slack.astra.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+
+public class ExponentialBackOffTest {
+
+  @Test
+  public void testExponentialBackOff() {
+    // initialInterval=1000, maxInterval=10000, maxElapsed=60000
+    ExponentialBackOff backoff = new ExponentialBackOff(1000, 10000, 60000);
+
+    // First call should return a value randomized around the initial interval (±50%)
+    for (int trial = 0; trial < 20; trial++) {
+      backoff.reset();
+      long delay = backoff.nextBackOffMillis();
+      // With ±50% randomization around 1000ms: range is [500, 1500]
+      assertThat(delay).isBetween(500L, 1500L);
+    }
+
+    // Verify the progression grows with the 1.5x multiplier
+    backoff.reset();
+    for (int i = 0; i < 5; i++) {
+      long delay = backoff.nextBackOffMillis();
+      assertThat(delay).isNotEqualTo(ExponentialBackOff.STOP);
+      // Each call's range center should be >= previous (on average)
+      // Just verify the delay is positive and within max bounds
+      assertThat(delay).isGreaterThan(0L);
+      // Max possible is maxInterval * 1.5 (±50% of capped interval)
+      assertThat(delay).isLessThanOrEqualTo(15000L);
+    }
+  }
+
+  @Test
+  public void testExponentialBackOffCapsAtMax() {
+    // initialInterval=5000, maxInterval=10000 — should cap quickly
+    ExponentialBackOff backoff = new ExponentialBackOff(5000, 10000, 60000);
+
+    backoff.nextBackOffMillis(); // interval advances to 7500
+    backoff.nextBackOffMillis(); // interval advances to 10000 (capped)
+    // Third call should be randomized around 10000: [5000, 15000]
+    for (int trial = 0; trial < 20; trial++) {
+      ExponentialBackOff b = new ExponentialBackOff(5000, 10000, 60000);
+      b.nextBackOffMillis();
+      b.nextBackOffMillis();
+      long delay = b.nextBackOffMillis();
+      assertThat(delay).isBetween(5000L, 15000L);
+    }
+  }
+
+  @Test
+  public void testExponentialBackOffStopsAfterBudget() {
+    // Use a controllable clock so the test doesn't depend on wall-clock time
+    AtomicLong fakeClock = new AtomicLong(0);
+    ExponentialBackOff backoff = new ExponentialBackOff(100, 500, 200, fakeClock::get);
+
+    // First call starts the timer at t=0, should succeed
+    long delay = backoff.nextBackOffMillis();
+    assertThat(delay).isNotEqualTo(ExponentialBackOff.STOP);
+
+    // Advance clock past budget
+    fakeClock.set(250);
+    delay = backoff.nextBackOffMillis();
+    assertThat(delay).isEqualTo(ExponentialBackOff.STOP);
+    assertThat(backoff.getElapsedTimeMs()).isGreaterThanOrEqualTo(200);
+  }
+
+  @Test
+  public void testExponentialBackOffReset() {
+    AtomicLong fakeClock = new AtomicLong(0);
+    ExponentialBackOff backoff = new ExponentialBackOff(1000, 10000, 60000, fakeClock::get);
+
+    // Advance a few times, simulating time passing
+    backoff.nextBackOffMillis();
+    fakeClock.set(5000);
+    backoff.nextBackOffMillis();
+    assertThat(backoff.getElapsedTimeMs()).isGreaterThan(0);
+
+    // Reset should bring it back to initial state
+    backoff.reset();
+    assertThat(backoff.getElapsedTimeMs()).isEqualTo(0);
+
+    // Next call should be around initial interval again
+    long delay = backoff.nextBackOffMillis();
+    assertThat(delay).isBetween(500L, 1500L);
+  }
+}

--- a/astra/src/test/resources/test_config.json
+++ b/astra/src/test/resources/test_config.json
@@ -78,7 +78,10 @@
       "operationsTimeoutMs": 60000,
       "operationsMaxRetries": 3,
       "ephemeralNodeTtlMs": 60000,
-      "ephemeralNodeMaxRetries": 3
+      "ephemeralNodeMaxRetries": 3,
+      "retryTotalDurationMs": 60000,
+      "maxRetryDelayMs": 10000,
+      "initialRetryIntervalMs": 2000
     },
     "storeModes": {
       "DatasetMetadataStore": "ETCD_CREATES",

--- a/astra/src/test/resources/test_config.yaml
+++ b/astra/src/test/resources/test_config.yaml
@@ -68,6 +68,9 @@ metadataStoreConfig:
     operationsMaxRetries: 3
     ephemeralNodeTtlMs: 60000
     ephemeralNodeMaxRetries: 3
+    retryTotalDurationMs: 60000
+    maxRetryDelayMs: 10000
+    initialRetryIntervalMs: 2000
   storeModes:
     DatasetMetadataStore: ETCD_CREATES
     SnapshotMetadataStore: ETCD_CREATES

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -78,6 +78,9 @@ metadataStoreConfig:
     operationsMaxRetries: ${ASTRA_ETCD_OPERATIONS_MAX_RETRIES:-3}
     ephemeralNodeTtlMs: ${ASTRA_ETCD_EPHEMERAL_NODE_TTL_MS:-60000}
     ephemeralNodeMaxRetries: ${ASTRA_ETCD_EPHEMERAL_NODE_MAX_RETRIES:-3}
+    retryTotalDurationMs: ${ASTRA_ETCD_RETRY_TOTAL_DURATION_MS:-60000}
+    maxRetryDelayMs: ${ASTRA_ETCD_MAX_RETRY_DELAY_MS:-10000}
+    initialRetryIntervalMs: ${ASTRA_ETCD_INITIAL_RETRY_INTERVAL_MS:-2000}
   storeModes:
     DatasetMetadataStore: ${ASTRA_DATASET_METADATA_STORE_MODE:-ZOOKEEPER_CREATES}
     SnapshotMetadataStore: ${ASTRA_SNAPSHOT_METADATA_STORE_MODE:-ZOOKEEPER_CREATES}


### PR DESCRIPTION
## Summary

- Replace fixed-delay watch retry with stateful ExponentialBackOff: 1.5x multiplier, ±50% proportional jitter, time-budgeted retry windows
- Two-tier retry: transient errors (GOAWAY, compaction) share one budget, escalate to error tier on exhaustion. Error budget exhaustion is fatal
- No more 10 retries x 1 second fixed interval.
- Compaction recovery via `REVISION_RESYNC`: re-lists keys from etcd, detects deletes, repopulates cache, notifies listeners. Handles the GOAWAY → OUT_OF_RANGE chain during etcd rolling updates (rejoined members have no history before their snapshot revision)
- Partition discovery watcher (`EtcdPartitioningMetadataStore`) now has full retry/backoff parity with per-partition content watchers
- KeepAlive errors use exponential backoff instead of immediate retry spin-loop
- Fix `ScheduledThreadPoolExecutor(0)` silently dropping scheduled tasks (corePoolSize must be >= 1)
- Remove dead `cacheInitThread`/`leaseInitThread` fields
- Extract helpers: `isDirectChild`, `extractPartition`, `handleFatalAsync` (package-visible), `scheduleRetryWithBackoff`
- New proto fields: `retry_total_duration_ms`, `max_retry_delay_ms`, `initial_retry_interval_ms`

## Motivation

During etcd rolling updates, all watchers on the departing node receive GOAWAY or disconnect simultaneously. The previous retry logic used fixed count + fixed delay (10 retries at 1s), then fatal. The new backoff spreads reconnections with jitter and independent time-budgeted windows per error category.

When a rejoined etcd member has compacted past the watcher's held revision (common during rolling updates since the member rebuilds from a leader snapshot), the watcher now resyncs from etcd instead of retrying with a stale revision or watching from HEAD with a gap.

## Test plan

* [x]  Unit tests for ExponentialBackOff: progression, cap, budget exhaustion (STOP), reset
* [x]  Unit tests for `isGracefulStop` and `isCompactionError` classification
* [x]  Integration tests for EtcdPartitioningMetadataStore with new retry config
* [x]  Deploy to dev environments, and trigger manual tests of: killing etcd pods, kill etcd leader member, replace astra pods, rolling etcd upgrades (as of 4/29 - all of these cases have succeeded)

## Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).