### PR TITLE
Bump both the AWS SDK and AWS CRT deps

### DIFF
--- a/astra/pom.xml
+++ b/astra/pom.xml
@@ -30,7 +30,7 @@
         <opensearch.version>2.11.1</opensearch.version>
         <curator.version>5.8.0</curator.version>
         <log4j.version>2.25.4</log4j.version>
-        <aws.sdk.version>2.42.36</aws.sdk.version>
+        <aws.sdk.version>2.42.41</aws.sdk.version>
         <error.prone.version>2.49.0</error.prone.version>
         <junit.jupiter.version>6.0.3</junit.jupiter.version>
         <jetcd.version>0.8.6</jetcd.version>
@@ -377,7 +377,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.39.4</version>
+            <version>0.45.1</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/astra/src/test/java/com/slack/astra/blobfs/S3TestUtils.java
+++ b/astra/src/test/java/com/slack/astra/blobfs/S3TestUtils.java
@@ -5,7 +5,6 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
-import software.amazon.awssdk.services.s3.crt.S3CrtHttpConfiguration;
 
 public class S3TestUtils {
   /**
@@ -14,15 +13,12 @@ public class S3TestUtils {
    * @see com.adobe.testing.s3mock.testsupport.common.S3MockStarter
    */
   public static S3AsyncClient createS3CrtClient(String serviceEndpoint) {
-    return S3AsyncClient.crtBuilder()
+    return S3AsyncClient.builder()
         .region(Region.of("us-east-1"))
         .credentialsProvider(
             StaticCredentialsProvider.create(AwsBasicCredentials.create("foo", "bar")))
         .forcePathStyle(true)
-        .checksumValidationEnabled(false) // https://github.com/adobe/S3Mock/issues/1123
         .endpointOverride(URI.create(serviceEndpoint))
-        .httpConfiguration(
-            S3CrtHttpConfiguration.builder().trustAllCertificatesEnabled(true).build())
         .build();
   }
 }


### PR DESCRIPTION
###  Summary
We've had an issue for awhile now with the AWS SDK and AWS CRT dep bumps through Dependabot failing. It turns out that we need to bump both simultaneously since their implementations are so tightly coupled. It _also_ turns out that there's a pre-existing issue with `S3Mock` hanging due to an incompatibility. As such, this PR bumps all of those and fixes the incompatibility issue

### Requirements

* [X] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
