### PR TITLE
fix: upload only IndexCommit files during chunk snapshot to S3

### DIFF
--- a/astra/src/main/java/com/slack/astra/blobfs/BlobStore.java
+++ b/astra/src/main/java/com/slack/astra/blobfs/BlobStore.java
@@ -3,9 +3,11 @@ package com.slack.astra.blobfs;
 import static software.amazon.awssdk.services.s3.model.ListObjectsV2Request.builder;
 
 import com.slack.astra.chunk.ReadWriteChunk;
+import java.io.File;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -18,13 +20,14 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Publisher;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
 import software.amazon.awssdk.transfer.s3.model.CompletedDirectoryDownload;
-import software.amazon.awssdk.transfer.s3.model.CompletedDirectoryUpload;
 import software.amazon.awssdk.transfer.s3.model.DownloadDirectoryRequest;
 import software.amazon.awssdk.transfer.s3.model.DownloadRequest;
-import software.amazon.awssdk.transfer.s3.model.UploadDirectoryRequest;
+import software.amazon.awssdk.transfer.s3.model.FileUpload;
+import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
 
 /**
  * Blob store abstraction for basic operations on chunk/snapshots on remote storage. All operations
@@ -33,6 +36,7 @@ import software.amazon.awssdk.transfer.s3.model.UploadDirectoryRequest;
  */
 public class BlobStore {
   private static final Logger LOG = LoggerFactory.getLogger(BlobStore.class);
+  private static final int MAX_CONCURRENT_UPLOADS = 100;
 
   protected final String bucketName;
   protected final S3AsyncClient s3AsyncClient;
@@ -45,46 +49,88 @@ public class BlobStore {
   }
 
   /**
-   * Uploads a directory to the object store by prefix
-   *
-   * @param prefix Prefix to store (ie, chunk id)
-   * @param directoryToUpload Directory to upload
-   * @throws IllegalStateException Thrown if any files fail to upload
-   * @throws RuntimeException Thrown when error is considered generally non-retryable
+   * Uploads all files in a directory to the object store by prefix. Primarily used by tests to
+   * stage data in S3. Production callers should prefer the 3-arg overload with an explicit file
+   * list to avoid race conditions with concurrent file deletions.
    */
   public void upload(String prefix, Path directoryToUpload) {
     assert prefix != null && !prefix.isEmpty();
     assert directoryToUpload.toFile().isDirectory();
-    assert Objects.requireNonNull(directoryToUpload.toFile().listFiles()).length > 0;
 
-    try {
-      CompletedDirectoryUpload upload =
-          transferManager
-              .uploadDirectory(
-                  UploadDirectoryRequest.builder()
-                      .source(directoryToUpload)
-                      .s3Prefix(prefix)
-                      .bucket(bucketName)
-                      .build())
-              .completionFuture()
-              .get();
-      if (!upload.failedTransfers().isEmpty()) {
-        // Log each failed transfer with its exception
-        upload
-            .failedTransfers()
-            .forEach(
-                failedFileUpload ->
-                    LOG.error(
-                        "Error attempting to upload file to S3", failedFileUpload.exception()));
+    File[] entries = directoryToUpload.toFile().listFiles();
+    assert entries != null && entries.length > 0;
 
-        throw new IllegalStateException(
-            String.format(
-                "Some files failed to upload - attempted to upload %s files, failed %s.",
-                Objects.requireNonNull(directoryToUpload.toFile().listFiles()).length,
-                upload.failedTransfers().size()));
+    List<String> fileNames = new ArrayList<>();
+    for (File file : entries) {
+      if (file.isFile()) {
+        fileNames.add(file.getName());
       }
-    } catch (ExecutionException | InterruptedException e) {
-      throw new RuntimeException(e);
+    }
+    upload(prefix, directoryToUpload, fileNames);
+  }
+
+  /**
+   * Uploads only the specified files from a directory to the object store by prefix. This prevents
+   * race conditions where files in the directory may be deleted by concurrent processes (e.g.,
+   * Lucene segment merges) between directory enumeration and file read.
+   *
+   * @param prefix Prefix to store (ie, chunk id)
+   * @param directoryToUpload Directory containing the files
+   * @param fileNames Collection of file names to upload (only these will be included)
+   * @throws IllegalStateException Thrown if any files fail to upload
+   * @throws RuntimeException Thrown when error is considered generally non-retryable
+   */
+  public void upload(String prefix, Path directoryToUpload, Collection<String> fileNames) {
+    assert prefix != null && !prefix.isEmpty();
+    assert directoryToUpload.toFile().isDirectory();
+    assert fileNames != null && !fileNames.isEmpty();
+
+    List<Exception> failures = new ArrayList<>();
+    List<String> keysBatch = new ArrayList<>(MAX_CONCURRENT_UPLOADS);
+    List<FileUpload> uploadsBatch = new ArrayList<>(MAX_CONCURRENT_UPLOADS);
+
+    for (String fileName : fileNames) {
+      Path filePath = directoryToUpload.resolve(fileName);
+      String key = prefix + "/" + fileName;
+      FileUpload fileUpload =
+          transferManager.uploadFile(
+              UploadFileRequest.builder()
+                  .putObjectRequest(PutObjectRequest.builder().bucket(bucketName).key(key).build())
+                  .source(filePath)
+                  .build());
+      keysBatch.add(key);
+      uploadsBatch.add(fileUpload);
+
+      if (uploadsBatch.size() >= MAX_CONCURRENT_UPLOADS) {
+        awaitUploads(uploadsBatch, keysBatch, failures);
+        uploadsBatch.clear();
+        keysBatch.clear();
+      }
+    }
+    if (!uploadsBatch.isEmpty()) {
+      awaitUploads(uploadsBatch, keysBatch, failures);
+    }
+
+    if (!failures.isEmpty()) {
+      throw new IllegalStateException(
+          String.format(
+              "Some files failed to upload - attempted to upload %s files, failed %s.",
+              fileNames.size(), failures.size()),
+          failures.get(0));
+    }
+  }
+
+  private void awaitUploads(List<FileUpload> uploads, List<String> keys, List<Exception> failures) {
+    for (int i = 0; i < uploads.size(); i++) {
+      try {
+        uploads.get(i).completionFuture().get();
+      } catch (ExecutionException e) {
+        LOG.error("Error attempting to upload file '{}' to S3", keys.get(i), e.getCause());
+        failures.add(e);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
+      }
     }
   }
 

--- a/astra/src/main/java/com/slack/astra/chunk/ReadWriteChunk.java
+++ b/astra/src/main/java/com/slack/astra/chunk/ReadWriteChunk.java
@@ -252,7 +252,7 @@ public abstract class ReadWriteChunk<T> implements Chunk<T> {
       }
       this.fileUploadAttempts.increment(filesToUpload.size());
       Timer.Sample snapshotTimer = Timer.start(meterRegistry);
-      blobStore.upload(chunkInfo.chunkId, dirPath);
+      blobStore.upload(chunkInfo.chunkId, dirPath, filesToUpload);
 
       snapshotTimer.stop(meterRegistry.timer(SNAPSHOT_TIMER));
       chunkInfo.setSizeInBytesOnDisk(totalBytes);

--- a/astra/src/test/java/com/slack/astra/blobfs/BlobStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/blobfs/BlobStoreTest.java
@@ -77,6 +77,33 @@ class BlobStoreTest {
   }
 
   @Test
+  void testUploadIgnoresUnlistedFileDeletedFromDirectory() throws IOException {
+    BlobStore blobStore = new BlobStore(s3Client, TEST_BUCKET);
+
+    Path directoryUpload = Files.createTempDirectory("");
+    Path listed = Files.createTempFile(directoryUpload, "", "");
+    try (FileWriter fileWriter = new FileWriter(listed.toFile())) {
+      fileWriter.write("committed segment");
+    }
+    // previously, the S3 upload logic took a whole directory as input
+    // and some files could get deleted before being uploaded. This would
+    // result in a FileNotFoundException of a file we didn't actually need.
+    // this simple unit test ensures that even though we pass the dir as
+    // an arg, only what was provided in the list is what we upload.
+    Path orphan = Files.createTempFile(directoryUpload, "", "");
+    try (FileWriter fileWriter = new FileWriter(orphan.toFile())) {
+      fileWriter.write("pre-merge orphan");
+    }
+    Files.delete(orphan);
+
+    String chunkId = UUID.randomUUID().toString();
+    blobStore.upload(chunkId, directoryUpload, List.of(listed.getFileName().toString()));
+
+    assertThat(blobStore.listFiles(chunkId))
+        .containsExactly(String.format("%s/%s", chunkId, listed.getFileName().toString()));
+  }
+
+  @Test
   void testUploadMissingListedFileThrows() throws IOException {
     BlobStore blobStore = new BlobStore(s3Client, TEST_BUCKET);
 

--- a/astra/src/test/java/com/slack/astra/blobfs/BlobStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/blobfs/BlobStoreTest.java
@@ -65,6 +65,7 @@ class BlobStoreTest {
       fileWriter.write("Example test");
     }
     // A second file exists in the directory but is intentionally not in the upload list.
+    // we expect it to not exist in S3. Only files in the list should et uploaded
     Path excluded = Files.createTempFile(directoryUpload, "", "");
     try (FileWriter fileWriter = new FileWriter(excluded.toFile())) {
       fileWriter.write("Should not be uploaded");
@@ -77,33 +78,6 @@ class BlobStoreTest {
   }
 
   @Test
-  void testUploadIgnoresUnlistedFileDeletedFromDirectory() throws IOException {
-    BlobStore blobStore = new BlobStore(s3Client, TEST_BUCKET);
-
-    Path directoryUpload = Files.createTempDirectory("");
-    Path listed = Files.createTempFile(directoryUpload, "", "");
-    try (FileWriter fileWriter = new FileWriter(listed.toFile())) {
-      fileWriter.write("committed segment");
-    }
-    // previously, the S3 upload logic took a whole directory as input
-    // and some files could get deleted before being uploaded. This would
-    // result in a FileNotFoundException of a file we didn't actually need.
-    // this simple unit test ensures that even though we pass the dir as
-    // an arg, only what was provided in the list is what we upload.
-    Path orphan = Files.createTempFile(directoryUpload, "", "");
-    try (FileWriter fileWriter = new FileWriter(orphan.toFile())) {
-      fileWriter.write("pre-merge orphan");
-    }
-    Files.delete(orphan);
-
-    String chunkId = UUID.randomUUID().toString();
-    blobStore.upload(chunkId, directoryUpload, List.of(listed.getFileName().toString()));
-
-    assertThat(blobStore.listFiles(chunkId))
-        .containsExactly(String.format("%s/%s", chunkId, listed.getFileName().toString()));
-  }
-
-  @Test
   void testUploadMissingListedFileThrows() throws IOException {
     BlobStore blobStore = new BlobStore(s3Client, TEST_BUCKET);
 
@@ -113,11 +87,7 @@ class BlobStoreTest {
       fileWriter.write("Example test");
     }
     String chunkId = UUID.randomUUID().toString();
-    // Listing a file that does not exist on disk must fail loudly rather than silently skipping it.
-    // The transfer manager rejects the missing source synchronously while the batch is being built,
-    // so this surfaces as an UncheckedIOException rather than the aggregated IllegalStateException
-    // used for async transfer failures. Production never hits this path because the IndexCommit
-    // snapshot guarantees every listed file exists for the duration of the upload.
+    // if we pass a file in the list, which does not exist, we should throw an exception
     assertThatThrownBy(
             () ->
                 blobStore.upload(

--- a/astra/src/test/java/com/slack/astra/blobfs/BlobStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/blobfs/BlobStoreTest.java
@@ -56,6 +56,51 @@ class BlobStoreTest {
   }
 
   @Test
+  void testUploadOnlyListedFiles() throws IOException {
+    BlobStore blobStore = new BlobStore(s3Client, TEST_BUCKET);
+
+    Path directoryUpload = Files.createTempDirectory("");
+    Path included = Files.createTempFile(directoryUpload, "", "");
+    try (FileWriter fileWriter = new FileWriter(included.toFile())) {
+      fileWriter.write("Example test");
+    }
+    // A second file exists in the directory but is intentionally not in the upload list.
+    Path excluded = Files.createTempFile(directoryUpload, "", "");
+    try (FileWriter fileWriter = new FileWriter(excluded.toFile())) {
+      fileWriter.write("Should not be uploaded");
+    }
+    String chunkId = UUID.randomUUID().toString();
+    blobStore.upload(chunkId, directoryUpload, List.of(included.getFileName().toString()));
+
+    assertThat(blobStore.listFiles(chunkId))
+        .containsExactly(String.format("%s/%s", chunkId, included.getFileName().toString()));
+  }
+
+  @Test
+  void testUploadMissingListedFileThrows() throws IOException {
+    BlobStore blobStore = new BlobStore(s3Client, TEST_BUCKET);
+
+    Path directoryUpload = Files.createTempDirectory("");
+    Path foo = Files.createTempFile(directoryUpload, "", "");
+    try (FileWriter fileWriter = new FileWriter(foo.toFile())) {
+      fileWriter.write("Example test");
+    }
+    String chunkId = UUID.randomUUID().toString();
+    // Listing a file that does not exist on disk must fail loudly rather than silently skipping it.
+    // The transfer manager rejects the missing source synchronously while the batch is being built,
+    // so this surfaces as an UncheckedIOException rather than the aggregated IllegalStateException
+    // used for async transfer failures. Production never hits this path because the IndexCommit
+    // snapshot guarantees every listed file exists for the duration of the upload.
+    assertThatThrownBy(
+            () ->
+                blobStore.upload(
+                    chunkId,
+                    directoryUpload,
+                    List.of(foo.getFileName().toString(), "does-not-exist")))
+        .isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
   void testUploadEmptyPrefix() throws IOException {
     BlobStore blobStore = new BlobStore(s3Client, TEST_BUCKET);
 


### PR DESCRIPTION
### Summary

Fixes an indexer crash during chunk snapshot to S3.

The previous implementation used `S3TransferManager.uploadDirectory()`, which scans the entire Lucene index directory at upload time. After `forceMerge(1)` during `preSnapshot()`, orphaned segment files briefly exist on disk before Lucene's `KeepOnlyLastCommitDeletionPolicy` reaps them. 

The directory scan discovers these files, but they get deleted before the SDK reads them, causing `NoSuchFileException` and crashing the indexer.

Now uploads only the specific files listed in the `IndexCommit`, the orphaned files should not be in the list, so the race disappears.

### Changes

- `BlobStore.upload` takes an explicit file list. uploads are capped at `MAX_CONCURRENT_UPLOADS` (100) in-flight at a time. This max concurrent is taken from the AWS SDK implementation.
- The 2-arg overload for upload is retained for test usage and delegates to the same implementation.
- Aggregated upload failures attach the first underlying exception as the cause for easier debugging.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).