### PR TITLE
Protect against impossible metadata store configurations

### DIFF
--- a/astra/src/main/java/com/slack/astra/metadata/core/AstraPartitioningMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/AstraPartitioningMetadataStore.java
@@ -48,6 +48,12 @@ public class AstraPartitioningMetadataStore<T extends AstraPartitionedMetadata>
       EtcdPartitioningMetadataStore<T> etcdStore,
       MetadataStoreMode mode,
       MeterRegistry meterRegistry) {
+    if (mode == MetadataStoreMode.ETCD_CREATES && etcdStore == null) {
+      throw new IllegalArgumentException("Mode is ETCD_CREATES but etcdStore is null");
+    }
+    if (mode == MetadataStoreMode.ZOOKEEPER_CREATES && zkStore == null) {
+      throw new IllegalArgumentException("Mode is ZOOKEEPER_CREATES but zkStore is null");
+    }
 
     this.zkStore = zkStore;
     this.etcdStore = etcdStore;


### PR DESCRIPTION
###  Summary
We recently ran into a situation where we accidentally had `ASTRA_ETCD_ENABLED: false`, but also had `ASTRA_DATASET_METADATA_STORE_MODE: ETCD_CREATES`. This was resulting in NPEs being thrown when the recovery nodes went to rollover a chunk. While the fix in our configuration was easy, it went undetected for longer than it should have. This PR fixes that and prevents the node from booting if an impossible metadata store configuration occurs. We already do similar checks in other places, this was just a gap in our logic

### Requirements

* [X] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
