### PR TITLE
Fix edge case of negative subList index in deleteChunksOverLimit

### DIFF
--- a/astra/src/main/java/com/slack/astra/chunkManager/IndexingChunkManager.java
+++ b/astra/src/main/java/com/slack/astra/chunkManager/IndexingChunkManager.java
@@ -325,6 +325,14 @@ public class IndexingChunkManager<T> extends ChunkManagerBase<T> {
 
     final int totalChunksToDelete = sortedChunks.size() - limit;
 
+    if (totalChunksToDelete <= 0) {
+      LOG.info(
+          "No snapshotted chunks over limit (sortedChunks={}, limit={}). Doing nothing.",
+          sortedChunks.size(),
+          limit);
+      return;
+    }
+
     final List<Chunk<T>> chunksToDelete = sortedChunks.subList(0, totalChunksToDelete);
 
     LOG.info("Number of chunks past limit of {} is {}", limit, chunksToDelete.size());


### PR DESCRIPTION
###  Summary

When the number of snapshotted chunks (those with chunkSnapshotTimeEpochMs > 0) is less than the configured limit, totalChunksToDelete becomes negative. This causes subList(0, negative) to throw IllegalArgumentException: fromIndex(0) > toIndex(-1).

The exception propagates up through the chunk rollover callback, which triggers RuntimeHalterImpl to kill the JVM. 

The fix adds a bounds check after computing totalChunksToDelete, returning early if there are no snapshotted chunks to delete.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
