### PR TITLE
fix: log full stack trace for swallowed indexer write faults

### DIFF
--- a/astra/src/main/java/com/slack/astra/logstore/LuceneIndexStoreImpl.java
+++ b/astra/src/main/java/com/slack/astra/logstore/LuceneIndexStoreImpl.java
@@ -373,7 +373,7 @@ public class LuceneIndexStoreImpl implements LogStore {
             LOG.debug(
                 "Indexer finished final merge for: " + indexDirectory.getDirectory().toString());
           } catch (IOException e) {
-            log.error(
+            LOG.error(
                 "Indexer failed final merge for: " + indexDirectory.getDirectory().toString());
             handleNonFatal(e);
           }

--- a/astra/src/main/java/com/slack/astra/logstore/LuceneIndexStoreImpl.java
+++ b/astra/src/main/java/com/slack/astra/logstore/LuceneIndexStoreImpl.java
@@ -373,7 +373,8 @@ public class LuceneIndexStoreImpl implements LogStore {
             LOG.debug(
                 "Indexer finished final merge for: " + indexDirectory.getDirectory().toString());
           } catch (IOException e) {
-            log.error("Indexer failed final merge for: " + indexDirectory.getDirectory().toString());
+            log.error(
+                "Indexer failed final merge for: " + indexDirectory.getDirectory().toString());
             handleNonFatal(e);
           }
         });

--- a/astra/src/main/java/com/slack/astra/logstore/LuceneIndexStoreImpl.java
+++ b/astra/src/main/java/com/slack/astra/logstore/LuceneIndexStoreImpl.java
@@ -308,7 +308,8 @@ public class LuceneIndexStoreImpl implements LogStore {
 
   private void handleNonFatal(Throwable ex) {
     messagesFailedCounter.increment();
-    LOG.error(String.format("Exception %s processing", ex));
+    // Log the full stack trace
+    LOG.error("Exception processing", ex);
   }
 
   @Override
@@ -340,6 +341,7 @@ public class LuceneIndexStoreImpl implements LogStore {
             syncCommit();
             LOG.debug("Indexer finished commit for: " + indexDirectory.getDirectory().toString());
           } catch (IOException e) {
+            LOG.error("Indexer failed commit for: " + indexDirectory.getDirectory().toString());
             handleNonFatal(e);
           }
         });
@@ -354,6 +356,7 @@ public class LuceneIndexStoreImpl implements LogStore {
             syncRefresh();
             LOG.debug("Indexer finished refresh for: " + indexDirectory.getDirectory().toString());
           } catch (IOException e) {
+            LOG.error("Indexer failed refresh for: " + indexDirectory.getDirectory().toString());
             handleNonFatal(e);
           }
         });
@@ -370,6 +373,7 @@ public class LuceneIndexStoreImpl implements LogStore {
             LOG.debug(
                 "Indexer finished final merge for: " + indexDirectory.getDirectory().toString());
           } catch (IOException e) {
+            log.error("Indexer failed final merge for: " + indexDirectory.getDirectory().toString());
             handleNonFatal(e);
           }
         });


### PR DESCRIPTION
## Problem

There are cases of the following exception:
```
org.apache.lucene.store.AlreadyClosedException: FileLock invalidated by an external force: NativeFSLock(path=/astra_data/indices/d20133fa-243a-4d89-b854-da8aea80c271/write.lock,impl=sun.nio.ch.FileLockImpl[0:9223372036854775807 exclusive invalid],creationTime=2026-07-23T13:08:34.988668389Z) 	at org.apache.lucene.store.NativeFSLockFactory$NativeFSLock.ensureValid(NativeFSLockFactory.java:165) 	at org.apache.lucene.store.LockValidatingDirectoryWrapper.createOutput(LockValidatingDirectoryWrapper.java:42) 	at org.apache.lucene.index.ConcurrentMergeScheduler$1.createOutput(ConcurrentMergeScheduler.java:290) 	at org.apache.lucene.store.TrackingDirectoryWrapper.createOutput(TrackingDirectoryWrapper.java:41) 	at org.apache.lucene.codecs.lucene90.Lucene90DocValuesConsumer.<init>(Lucene90DocValuesConsumer.java:81) 	at org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat.fieldsConsumer(Lucene90DocValuesFormat.java:148) 	at org.apache.lucene.codecs.perfield.PerFieldDocValuesFormat$FieldsWriter.getInstance(PerFieldDocValuesFormat.java:231) 	at org.apache.lucene.codecs.perfield.PerFieldDocValuesFormat$FieldsWriter.merge(PerFieldDocValuesFormat.java:141) 	at org.apache.lucene.index.SegmentMerger.mergeDocValues(SegmentMerger.java:178) 	at org.apache.lucene.index.SegmentMerger.mergeWithLogging(SegmentMerger.java:298) 	at org.apache.lucene.index.SegmentMerger.merge(SegmentMerger.java:140) 	at org.apache.lucene.index.IndexWriter.mergeMiddle(IndexWriter.java:5158) 	at org.apache.lucene.index.IndexWriter.merge(IndexWriter.java:4698) 	at org.apache.lucene.index.IndexWriter$IndexWriterMergeSource.merge(IndexWriter.java:6450) 	at org.apache.lucene.index.ConcurrentMergeScheduler.doMerge(ConcurrentMergeScheduler.java:639) 	at com.slack.astra.logstore.AstraMergeScheduler.doMerge(AstraMergeScheduler.java:38) 	at org.apache.lucene.index.ConcurrentMergeScheduler$MergeThread.run(ConcurrentMergeScheduler.java:700)
```

The underlying cause is logged in:
```
Exception java.nio.channels.ClosedChannelException processing
```
But this log currently swallows the details as to what is potentially causing this.


## Change

More verbose logging.